### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -1,5 +1,8 @@
 name: Deploy Production to VPS
 
+permissions:
+  contents: read
+
 # Triggers on every push to main (including the automated promote-beta-to-main push)
 # and can also be triggered manually from the GitHub Actions tab.
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/WxboySuper/Graphical-Forecast-Creator/security/code-scanning/4](https://github.com/WxboySuper/Graphical-Forecast-Creator/security/code-scanning/4)

In general, the fix is to explicitly define a minimal `permissions` block for the workflow or for individual jobs, so the `GITHUB_TOKEN` has only the scopes it actually needs. Since this workflow does not interact with the GitHub API, it can safely limit permissions to `contents: read`, or even `permissions: {}` if you prefer to fully disable the token. Following the CodeQL suggestion and common practice, we’ll set `permissions: contents: read` at the workflow root so it applies to all jobs.

Concretely, in `.github/workflows/deploy-main-to-vps.yml`, add a `permissions` section near the top level (alongside `name` and `on`), e.g. between lines 1 and 5. No imports or extra methods are needed because this is just a YAML configuration change. We will not alter any existing steps or behavior; the only change is to explicitly limit `GITHUB_TOKEN` to read-only repository contents, which is sufficient for checkout and does not grant write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
