### PR TITLE
[codex] Fix port branch cleanup

### DIFF
--- a/.github/workflows/cleanup-port-branches.yml
+++ b/.github/workflows/cleanup-port-branches.yml
@@ -1,0 +1,23 @@
+name: Cleanup Port Branches
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  delete-merged-port-branch:
+    if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'port/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Delete closed port branch
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          PORT_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Cleaning up remote port branch $PORT_BRANCH from PR #$PR_NUMBER"
+          gh api -X DELETE repos/${{ github.repository }}/git/refs/heads/"$PORT_BRANCH" || \
+            echo "Port branch $PORT_BRANCH was already removed or is protected."

--- a/.github/workflows/pr-porting.yml
+++ b/.github/workflows/pr-porting.yml
@@ -47,6 +47,17 @@ jobs:
           
           # Fetch all active branches
           gh api repos/${{ github.repository }}/branches --paginate > branches.json
+
+          # Resolve the original PR commits so port branches only carry the
+          # intended change set instead of every commit missing from target.
+          git fetch origin pull/"$PR_NUMBER"/head:refs/remotes/origin/pr/"$PR_NUMBER"
+          gh api repos/${{ github.repository }}/pulls/"$PR_NUMBER"/commits --paginate > pr-commits.json
+          mapfile -t PR_COMMIT_SHAS < <(jq -r '.[].sha' pr-commits.json)
+
+          if [[ ${#PR_COMMIT_SHAS[@]} -eq 0 ]]; then
+            echo "No source PR commits found for #$PR_NUMBER. Aborting."
+            exit 1
+          fi
           
           TARGETS=()
           
@@ -91,24 +102,42 @@ jobs:
               continue
             fi
 
-            # Check if there are any commits to port
             git fetch origin "$TARGET"
-            COMMITS=$(git log origin/"$TARGET"..origin/"$BASE_BRANCH" --oneline)
-            if [[ -z "$COMMITS" ]]; then
-              echo "No new commits to port to $TARGET (Target already contains these changes). Skipping."
+            git checkout -B "$PORT_BRANCH" origin/"$TARGET"
+
+            COMMITS_TO_PICK=()
+            for SHA in "${PR_COMMIT_SHAS[@]}"; do
+              if git merge-base --is-ancestor "$SHA" origin/"$TARGET"; then
+                echo "Commit $SHA already exists on $TARGET. Skipping it."
+                continue
+              fi
+              COMMITS_TO_PICK+=("$SHA")
+            done
+
+            if [[ ${#COMMITS_TO_PICK[@]} -eq 0 ]]; then
+              echo "No source PR commits need porting to $TARGET. Skipping."
+              git checkout "$BASE_BRANCH"
+              git branch -D "$PORT_BRANCH" || true
               continue
             fi
 
-            # Create a temporary branch from the merged state
-            git checkout -b "$PORT_BRANCH" origin/"$BASE_BRANCH"
-            git push origin "$PORT_BRANCH"
+            if ! git cherry-pick "${COMMITS_TO_PICK[@]}"; then
+              echo "FAILED: Could not cherry-pick commits onto $TARGET"
+              git cherry-pick --abort || true
+              FAILURES+=("$TARGET")
+              git checkout "$BASE_BRANCH"
+              git branch -D "$PORT_BRANCH" || true
+              continue
+            fi
+
+            git push --force-with-lease origin "$PORT_BRANCH"
 
             # Create the PR from the new temporary branch
             if ! gh pr create \
               --head "$PORT_BRANCH" \
               --base "$TARGET" \
               --title "[Port] $PR_TITLE to $TARGET" \
-              --body "Automated port of merge into $BASE_BRANCH. Original PR: #$PR_NUMBER"; then
+              --body "Automated port of the original commits from PR #$PR_NUMBER into $TARGET after merge into $BASE_BRANCH."; then
               echo "FAILED: Could not create PR for $TARGET"
               FAILURES+=("$TARGET")
               # Cleanup the failed branch
@@ -119,6 +148,7 @@ jobs:
 
             # Always return to main context for next loop
             git checkout "$BASE_BRANCH"
+            git branch -D "$PORT_BRANCH" || true
           done
 
           # --- Cleanup Original Branch ---


### PR DESCRIPTION
## Summary
This change fixes the automated PR porting workflow so it only ports the original merged PR commits, and it adds automatic cleanup for generated `port/*` remote branches after those port PRs are closed.

## User impact
Before this change, merging a small dependency-update PR into `main` could generate port PRs that looked like massive branch-sync PRs instead of clean dependency bumps. That made the port PRs noisy, risky to review, and more likely to conflict with work already in progress on `beta` or feature branches. It also left temporary `port/*` branches behind on the remote, which cluttered the branch list over time.

## Root cause
The existing porting workflow created each port branch from the merged base branch (`main` or `beta`) and compared full branch divergence against the target branch. That meant the generated port PR branch inherited all commits missing from the target instead of only the commits from the original merged PR. In cases like a squash-merged Dependabot PR, the resulting port PR bundled unrelated history and produced a messy diff. Separately, auto-generated `port/*` branches did not have a dedicated cleanup path after their PRs were finished.

## Fix
The main workflow in `.github/workflows/pr-porting.yml` now queries the original PR's commit list from GitHub, starts each temporary port branch from the target branch, and cherry-picks only the commits that are not already present on that target. That keeps port PRs scoped to the original change instead of replaying all missing base-branch history.

The workflow still skips targets that already contain the relevant commits, aborts and reports failures on cherry-pick conflicts, and deletes the temporary local branch after each attempt. In addition, a new workflow at `.github/workflows/cleanup-port-branches.yml` listens for closed `port/*` pull requests and deletes the corresponding remote branch. This keeps auto-generated port branches available while the PR is active, but removes them once they are no longer needed.

## Validation
I reviewed the current porting workflow behavior against PR #112 and updated the logic to address that exact failure mode. I also ran `git diff --check` on the workflow changes to verify the patch structure stayed clean.

## Notes
This PR is based on `beta`, matching the current review flow in this repo. The new cleanup workflow is limited to same-repo `port/*` branches so it does not touch normal feature branches or forks.
