### PR TITLE
Add Privacy Policy modal and acceptance flow integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { useCycleHistoryPersistence } from './utils/cycleHistoryPersistence';
 import { AppLayout } from './components/Layout';
 import { HomePage, ForecastPage, DiscussionPage, VerificationPage, ComingSoonPage } from './pages';
 import ToSModal, { hasAcceptedToS } from './components/ToS/ToSModal';
+import PrivacyPolicyModal, { hasAcceptedPrivacyPolicy } from './components/PrivacyPolicy/PrivacyPolicyModal';
 
 // Launch gate: set VITE_COMING_SOON=true in the public build to enable pre-launch mode.
 // The app auto-unlocks at the launch date/time regardless of the env var.
@@ -68,8 +69,12 @@ function App() {
   const showComingSoon = COMING_SOON_MODE && !isLaunched;
   // ToS gate: only shown after launch (not during coming-soon mode)
   const [tosAccepted, setTosAccepted] = useState(() => showComingSoon || hasAcceptedToS());
+  const [privacyAccepted, setPrivacyAccepted] = useState(() => showComingSoon || hasAcceptedPrivacyPolicy());
   const handleAcceptToS = useCallback(() => {
     setTosAccepted(true);
+  }, []);
+  const handleAcceptPrivacyPolicy = useCallback(() => {
+    setPrivacyAccepted(true);
   }, []);
 
   return (
@@ -78,7 +83,10 @@ function App() {
         {!showComingSoon && !tosAccepted && (
           <ToSModal onAccept={handleAcceptToS} />
         )}
-        {(!showComingSoon && tosAccepted) && <AppHooks />}
+        {!showComingSoon && tosAccepted && !privacyAccepted && (
+          <PrivacyPolicyModal onAccept={handleAcceptPrivacyPolicy} />
+        )}
+        {(!showComingSoon && tosAccepted && privacyAccepted) && <AppHooks />}
         <Routes>
           {showComingSoon ? (
             <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,46 +63,81 @@ const AppHooks = () => {
   return null;
 };
 
-// Main App with Router
-function App() {
-  const isLaunched = useLaunchGate();
-  const showComingSoon = COMING_SOON_MODE && !isLaunched;
-  // ToS gate: only shown after launch (not during coming-soon mode)
-  const [tosAccepted, setTosAccepted] = useState(() => showComingSoon || hasAcceptedToS());
-  const [privacyAccepted, setPrivacyAccepted] = useState(() => showComingSoon || hasAcceptedPrivacyPolicy());
+interface AgreementGateProps {
+  showComingSoon: boolean;
+}
+
+/** Handles the launch-dependent agreement flow before the main app is allowed to initialize. */
+const AgreementGate: React.FC<AgreementGateProps> = ({ showComingSoon }) => {
+  const [tosAccepted, setTosAccepted] = useState(() => hasAcceptedToS());
+  const [privacyAccepted, setPrivacyAccepted] = useState(() => hasAcceptedPrivacyPolicy());
+
   const handleAcceptToS = useCallback(() => {
     setTosAccepted(true);
   }, []);
+
   const handleAcceptPrivacyPolicy = useCallback(() => {
     setPrivacyAccepted(true);
   }, []);
 
+  useEffect(() => {
+    if (showComingSoon) {
+      return;
+    }
+
+    setTosAccepted(hasAcceptedToS());
+    setPrivacyAccepted(hasAcceptedPrivacyPolicy());
+  }, [showComingSoon]);
+
+  if (showComingSoon || !tosAccepted) {
+    return showComingSoon ? null : <ToSModal onAccept={handleAcceptToS} />;
+  }
+
+  if (!privacyAccepted) {
+    return <PrivacyPolicyModal onAccept={handleAcceptPrivacyPolicy} />;
+  }
+
+  return <AppHooks />;
+};
+
+interface AppRoutesProps {
+  showComingSoon: boolean;
+}
+
+/** Selects between the public launch gate routes and the full application routes. */
+const AppRoutes: React.FC<AppRoutesProps> = ({ showComingSoon }) => {
+  if (showComingSoon) {
+    return (
+      <Routes>
+        <Route index element={<ComingSoonPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    );
+  }
+
+  return (
+    <Routes>
+      <Route element={<AppLayout />}>
+        <Route index element={<HomePage />} />
+        <Route path="forecast" element={<ForecastPage />} />
+        <Route path="discussion" element={<DiscussionPage />} />
+        <Route path="verification" element={<VerificationPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Route>
+    </Routes>
+  );
+};
+
+// Main App with Router
+function App() {
+  const isLaunched = useLaunchGate();
+  const showComingSoon = COMING_SOON_MODE && !isLaunched;
+
   return (
     <Provider store={store}>
       <BrowserRouter>
-        {!showComingSoon && !tosAccepted && (
-          <ToSModal onAccept={handleAcceptToS} />
-        )}
-        {!showComingSoon && tosAccepted && !privacyAccepted && (
-          <PrivacyPolicyModal onAccept={handleAcceptPrivacyPolicy} />
-        )}
-        {(!showComingSoon && tosAccepted && privacyAccepted) && <AppHooks />}
-        <Routes>
-          {showComingSoon ? (
-            <>
-              <Route index element={<ComingSoonPage />} />
-              <Route path="*" element={<Navigate to="/" replace />} />
-            </>
-          ) : (
-            <Route element={<AppLayout />}>
-              <Route index element={<HomePage />} />
-              <Route path="forecast" element={<ForecastPage />} />
-              <Route path="discussion" element={<DiscussionPage />} />
-              <Route path="verification" element={<VerificationPage />} />
-              <Route path="*" element={<Navigate to="/" replace />} />
-            </Route>
-          )}
-        </Routes>
+        <AgreementGate showComingSoon={showComingSoon} />
+        <AppRoutes showComingSoon={showComingSoon} />
       </BrowserRouter>
     </Provider>
   );

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -165,6 +165,7 @@ export const AppLayout: React.FC = () => {
     return <ToSModal viewOnly onClose={onClose} onAccept={onAccept} />;
   };
 
+  /** Keeps the view-only privacy policy modal wiring out of the main layout JSX. */
   const PrivacyViewer: React.FC<{ show: boolean; onClose: () => void; onAccept: () => void }> = ({ show, onClose, onAccept }) => {
     if (!show) return null;
     return <PrivacyPolicyModal viewOnly onClose={onClose} onAccept={onAccept} />;

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { Navbar } from './Navbar';
 import Documentation from '../Documentation/Documentation';
 import { ToastManager } from '../Toast/Toast';
 import ToSModal from '../ToS/ToSModal';
+import PrivacyPolicyModal from '../PrivacyPolicy/PrivacyPolicyModal';
 import { AlertBanner } from '../AlertBanner';
 import { RootState } from '../../store';
 import { v4 as uuidv4 } from 'uuid';
@@ -38,6 +39,7 @@ export const useAppLayout = () => {
 export const AppLayout: React.FC = () => {
   const [showDocumentation, setShowDocumentation] = useState(false);
   const [showTermsViewer, setShowTermsViewer] = useState(false);
+  const [showPrivacyViewer, setShowPrivacyViewer] = useState(false);
   const [toasts, setToasts] = useState<ToastItem[]>([]);
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
   const navigate = useNavigate();
@@ -63,6 +65,10 @@ export const AppLayout: React.FC = () => {
     setShowTermsViewer(true);
   }, []);
 
+  const handleViewPrivacyPolicy = useCallback(() => {
+    setShowPrivacyViewer(true);
+  }, []);
+
   // Note: The ToS modal in "view-only" mode does not have an accept button, so we don't need a handler for acceptance. The user can only close the modal after viewing the terms.
   const handleCloseDocumentation = useCallback(() => {
     setShowDocumentation(false);
@@ -73,8 +79,16 @@ export const AppLayout: React.FC = () => {
     setShowTermsViewer(false);
   }, []);
 
+  const handleClosePrivacyViewer = useCallback(() => {
+    setShowPrivacyViewer(false);
+  }, []);
+
   // Example of a file load handler that could be passed down to child components (like the forecast editor)
   const handleViewOnlyToSAccept = useCallback(() => {
+    // View-only modal does not need accept behavior.
+  }, []);
+
+  const handleViewOnlyPrivacyAccept = useCallback(() => {
     // View-only modal does not need accept behavior.
   }, []);
 
@@ -151,6 +165,11 @@ export const AppLayout: React.FC = () => {
     return <ToSModal viewOnly onClose={onClose} onAccept={onAccept} />;
   };
 
+  const PrivacyViewer: React.FC<{ show: boolean; onClose: () => void; onAccept: () => void }> = ({ show, onClose, onAccept }) => {
+    if (!show) return null;
+    return <PrivacyPolicyModal viewOnly onClose={onClose} onAccept={onAccept} />;
+  };
+
   return (
     <AppLayoutContext.Provider value={{ addToast }}>
       <div className={cn('min-h-screen bg-background text-foreground', darkMode && 'dark-mode')}>
@@ -158,6 +177,7 @@ export const AppLayout: React.FC = () => {
           onToggleDocumentation={toggleDocumentation}
           showDocumentation={showDocumentation}
           onViewTerms={handleViewTerms}
+          onViewPrivacyPolicy={handleViewPrivacyPolicy}
         />
 
         <AlertBanner />
@@ -176,6 +196,7 @@ export const AppLayout: React.FC = () => {
         <ToastManager toasts={toasts} onDismiss={removeToast} />
 
         <TermsViewer show={showTermsViewer} onClose={handleCloseTermsViewer} onAccept={handleViewOnlyToSAccept} />
+        <PrivacyViewer show={showPrivacyViewer} onClose={handleClosePrivacyViewer} onAccept={handleViewOnlyPrivacyAccept} />
       </div>
     </AppLayoutContext.Provider>
   );

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -9,6 +9,7 @@ interface NavbarProps {
   onToggleDocumentation?: () => void;
   showDocumentation?: boolean;
   onViewTerms?: () => void;
+  onViewPrivacyPolicy?: () => void;
 }
 
 // The Navbar component provides a consistent navigation interface across the application.
@@ -16,6 +17,7 @@ export const Navbar: React.FC<NavbarProps> = ({
   onToggleDocumentation,
   showDocumentation,
   onViewTerms,
+  onViewPrivacyPolicy,
 }) => {
   const dispatch = useDispatch();
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
@@ -36,6 +38,7 @@ export const Navbar: React.FC<NavbarProps> = ({
             darkMode={darkMode}
             showDocumentation={showDocumentation}
             onViewTerms={onViewTerms}
+            onViewPrivacyPolicy={onViewPrivacyPolicy}
             onToggleDocumentation={onToggleDocumentation}
             onToggleDarkMode={handleToggleDarkMode}
           />

--- a/src/components/Layout/NavbarSections.tsx
+++ b/src/components/Layout/NavbarSections.tsx
@@ -12,6 +12,7 @@ import {
   Github,
   Twitter,
   FileText,
+  Shield,
 } from 'lucide-react';
 import { Button } from '../ui/button';
 import {
@@ -32,6 +33,7 @@ interface RightActionsProps {
   darkMode: boolean;
   showDocumentation?: boolean;
   onViewTerms?: () => void;
+  onViewPrivacyPolicy?: () => void;
   onToggleDocumentation?: () => void;
   onToggleDarkMode: () => void;
 }
@@ -135,6 +137,7 @@ export const RightActions: React.FC<RightActionsProps> = ({
   darkMode,
   showDocumentation,
   onViewTerms,
+  onViewPrivacyPolicy,
   onToggleDocumentation,
   onToggleDarkMode,
 }) => (
@@ -158,6 +161,22 @@ export const RightActions: React.FC<RightActionsProps> = ({
       </TooltipTrigger>
       <TooltipContent>
         <p>Terms of Service</p>
+      </TooltipContent>
+    </Tooltip>
+
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onViewPrivacyPolicy}
+          aria-label="Privacy Policy"
+        >
+          <Shield className="h-5 w-5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>Privacy Policy</p>
       </TooltipContent>
     </Tooltip>
 

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.css
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.css
@@ -1,0 +1,185 @@
+.privacy-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.privacy-modal {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  width: 100%;
+  max-width: 680px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+}
+
+.privacy-modal-header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.privacy-modal-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.privacy-close-view-btn {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  margin-top: -2px;
+}
+
+.privacy-close-view-btn:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.privacy-modal-header h2 {
+  margin: 0 0 4px 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.privacy-modal-header p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.privacy-modal-body {
+  overflow-y: auto;
+  padding: 20px 24px;
+  flex: 1;
+  font-size: 0.85rem;
+  line-height: 1.65;
+  color: var(--text-primary);
+}
+
+.privacy-modal-body h3 {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin: 18px 0 6px;
+  color: var(--text-primary);
+}
+
+.privacy-modal-body h3:first-child {
+  margin-top: 0;
+}
+
+.privacy-modal-body p {
+  margin: 0 0 10px;
+  color: var(--text-secondary);
+}
+
+.privacy-modal-body ul {
+  margin: 6px 0 10px 20px;
+  padding: 0;
+  color: var(--text-secondary);
+}
+
+.privacy-modal-body ul li {
+  margin-bottom: 4px;
+}
+
+.privacy-modal-body strong {
+  color: var(--text-primary);
+}
+
+.privacy-modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-color);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.privacy-checkbox-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.privacy-checkbox-row input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  margin-top: 2px;
+  accent-color: var(--button-bg);
+  cursor: pointer;
+}
+
+.privacy-button-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.privacy-btn-decline {
+  padding: 8px 18px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.privacy-btn-decline:hover {
+  background: var(--bg-tertiary);
+}
+
+.privacy-btn-accept {
+  padding: 8px 22px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  border: none;
+  background: var(--button-bg);
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.privacy-btn-accept:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.privacy-btn-accept:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.privacy-modal-body a {
+  color: var(--button-bg);
+  text-decoration: underline;
+}
+
+.privacy-modal-body a:hover {
+  opacity: 0.8;
+}

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import './PrivacyPolicyModal.css';
+
+// Bump this version string whenever the Privacy Policy changes materially.
+// Users who accepted an older version will be asked to re-accept.
+const PRIVACY_POLICY_VERSION = '1.0.0';
+const STORAGE_KEY = 'gfc-privacy-policy-accepted';
+
+/** Returns true if the user has accepted the current version of the Privacy Policy. */
+export function hasAcceptedPrivacyPolicy(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === PRIVACY_POLICY_VERSION;
+  } catch {
+    return false;
+  }
+}
+
+// Records acceptance of the current Privacy Policy version in localStorage.
+function acceptPrivacyPolicy(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, PRIVACY_POLICY_VERSION);
+  } catch {
+    // localStorage unavailable — allow usage anyway
+  }
+}
+
+interface PrivacyPolicyModalProps {
+  onAccept: () => void;
+  viewOnly?: boolean;
+  onClose?: () => void;
+}
+
+/** Renders the current in-app Privacy Policy content for both acceptance and view-only modes. */
+const PrivacyPolicyContent: React.FC = () => (
+  <>
+    <p>
+      <strong>TL;DR:</strong> Your local forecasts stay on your device. If you choose to make an account, we only
+      collect what is strictly necessary to sync your work and securely manage your subscription.
+    </p>
+
+    <h3>1. Local-First by Default</h3>
+    <p>
+      If you use Graphical Forecast Creator (GFC) without creating an account, all of your forecast data, preferences,
+      and cycle history remain stored locally on your device. We do not have access to this data.
+    </p>
+
+    <h3>2. Account &amp; Authentication Data</h3>
+    <p>
+      If you choose to create an account to sync your settings or use premium features, we authenticate you via
+      Firebase Auth. We use essential session cookies strictly to keep you logged in and we store:
+    </p>
+    <ul>
+      <li>Your email address.</li>
+      <li>Your authentication provider (Google, GitHub, or Email/Password).</li>
+      <li>Basic profile information (name/avatar).</li>
+    </ul>
+
+    <h3>3. Premium Cloud Storage &amp; Encryption</h3>
+    <p>
+      If you subscribe to GFC Premium and actively use Cloud Saves, your forecast cycles, metadata, and discussions are
+      stored securely, encrypted in transit and at rest, via Firebase. This data is stored strictly to provide
+      cross-device synchronization. We do not sell this data or use it for advertising.
+    </p>
+
+    <h3>4. Payment Information</h3>
+    <p>
+      All payments are processed securely by Stripe. GFC does not collect, process, or store your credit card numbers
+      or banking details. We only receive your subscription status and billing tier from Stripe to unlock your premium
+      features.
+    </p>
+
+    <h3>5. Product Analytics</h3>
+    <p>
+      To monitor the health of the application, we collect anonymous, aggregate telemetry such as daily active users,
+      total cloud saves, and verification sessions run. <strong>We do not log raw IP addresses for product analytics</strong>,
+      and your forecast payload contents are never exposed to our metrics dashboard.
+    </p>
+
+    <h3>6. Data Retention &amp; Deletion</h3>
+    <p>
+      You own your data. You have the right to delete your account and associated cloud data at any time. Upon account
+      deletion, your cloud-hosted cycles and profile data will be permanently removed from our Firebase servers. Your
+      local, offline saves will remain completely untouched on your device.
+    </p>
+
+    <h3>7. Age Restrictions</h3>
+    <p>
+      GFC is intended for general audiences and is not directed at children under the age of 13. By creating an
+      account, you confirm you are 13 years of age or older.
+    </p>
+
+    <h3>8. Security &amp; Breach Notification</h3>
+    <p>
+      We rely on enterprise-grade infrastructure from Google (Firebase) and Stripe to keep your data safe. In the
+      unlikely event of a data breach that compromises your account information, we will notify affected users via
+      email as quickly as legally and technically possible.
+    </p>
+
+    <h3>9. Policy Changes &amp; Contact</h3>
+    <p>
+      We may update this policy as GFC evolves. Significant changes will be communicated via in-app notices or email.
+      For privacy questions, or to request manual data deletion, contact us at{' '}
+      <a href="mailto:alex@weatherboysuper.com">alex@weatherboysuper.com</a>.
+    </p>
+  </>
+);
+
+/** Renders the footer used when the privacy policy is opened in view-only mode. */
+const PrivacyPolicyViewOnlyFooter: React.FC<{ onClose?: () => void }> = ({ onClose }) => (
+  <div className="privacy-modal-footer">
+    <div className="privacy-button-row">
+      <button className="privacy-btn-accept" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  </div>
+);
+
+/** Renders the footer used when the user must acknowledge the privacy policy before continuing. */
+const PrivacyPolicyAcceptanceFooter: React.FC<{
+  checked: boolean;
+  onCheckedChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onDecline: () => void;
+  onAccept: () => void;
+}> = ({ checked, onCheckedChange, onDecline, onAccept }) => (
+  <div className="privacy-modal-footer">
+    <label className="privacy-checkbox-row">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onCheckedChange}
+      />
+      I have read and agree to the Privacy Policy. I understand what data stays local, what data may be stored for
+      hosted features, and how GFC handles anonymous product analytics.
+    </label>
+    <div className="privacy-button-row">
+      <button className="privacy-btn-decline" onClick={onDecline}>
+        Decline
+      </button>
+      <button className="privacy-btn-accept" onClick={onAccept} disabled={!checked}>
+        Accept &amp; Continue
+      </button>
+    </div>
+  </div>
+);
+
+/** Displays the GFC Privacy Policy in either acceptance or read-only mode. */
+const PrivacyPolicyModal: React.FC<PrivacyPolicyModalProps> = ({ onAccept, viewOnly = false, onClose }) => {
+  const [checked, setChecked] = useState(false);
+
+  /** Accepts the current policy version and lets the user continue into the app. */
+  const handleAccept = () => {
+    if (!checked) return;
+    acceptPrivacyPolicy();
+    onAccept();
+  };
+
+  /** Redirects away from the app when the user declines the required privacy agreement. */
+  const handleDecline = () => {
+    window.location.href = 'https://weather.gov';
+  };
+
+  /** Keeps local checkbox state in sync with the acceptance form. */
+  const handleCheckedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.target.checked);
+  };
+
+  return (
+    <div className="privacy-backdrop" role="dialog" aria-modal="true" aria-labelledby="privacy-title">
+      <div className="privacy-modal">
+        <div className="privacy-modal-header">
+          <div className="privacy-modal-header-row">
+            <div>
+              <h2 id="privacy-title">Privacy Policy</h2>
+              <p>Please read and accept before using Graphical Forecast Creator &mdash; Last Updated March 2026</p>
+            </div>
+            {viewOnly && (
+              <button className="privacy-close-view-btn" onClick={onClose} aria-label="Close">
+                &times;
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="privacy-modal-body">
+          <PrivacyPolicyContent />
+        </div>
+
+        {viewOnly ? (
+          <PrivacyPolicyViewOnlyFooter onClose={onClose} />
+        ) : (
+          <PrivacyPolicyAcceptanceFooter
+            checked={checked}
+            onCheckedChange={handleCheckedChange}
+            onDecline={handleDecline}
+            onAccept={handleAccept}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PrivacyPolicyModal;

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -109,7 +109,7 @@ const PrivacyPolicyContent: React.FC = () => (
 const PrivacyPolicyViewOnlyFooter: React.FC<{ onClose?: () => void }> = ({ onClose }) => (
   <div className="privacy-modal-footer">
     <div className="privacy-button-row">
-      <button className="privacy-btn-accept" onClick={onClose}>
+      <button className="privacy-btn-decline" onClick={onClose}>
         Close
       </button>
     </div>
@@ -144,6 +144,23 @@ const PrivacyPolicyAcceptanceFooter: React.FC<{
   </div>
 );
 
+/** Renders the privacy policy title block and optional close action. */
+const PrivacyPolicyHeader: React.FC<{ viewOnly: boolean; onClose?: () => void }> = ({ viewOnly, onClose }) => (
+  <div className="privacy-modal-header">
+    <div className="privacy-modal-header-row">
+      <div>
+        <h2 id="privacy-title">Privacy Policy</h2>
+        <p>Please read and accept before using Graphical Forecast Creator &mdash; Last Updated March 2026</p>
+      </div>
+      {viewOnly && (
+        <button className="privacy-close-view-btn" onClick={onClose} aria-label="Close">
+          &times;
+        </button>
+      )}
+    </div>
+  </div>
+);
+
 /** Displays the GFC Privacy Policy in either acceptance or read-only mode. */
 const PrivacyPolicyModal: React.FC<PrivacyPolicyModalProps> = ({ onAccept, viewOnly = false, onClose }) => {
   const [checked, setChecked] = useState(false);
@@ -168,20 +185,7 @@ const PrivacyPolicyModal: React.FC<PrivacyPolicyModalProps> = ({ onAccept, viewO
   return (
     <div className="privacy-backdrop" role="dialog" aria-modal="true" aria-labelledby="privacy-title">
       <div className="privacy-modal">
-        <div className="privacy-modal-header">
-          <div className="privacy-modal-header-row">
-            <div>
-              <h2 id="privacy-title">Privacy Policy</h2>
-              <p>Please read and accept before using Graphical Forecast Creator &mdash; Last Updated March 2026</p>
-            </div>
-            {viewOnly && (
-              <button className="privacy-close-view-btn" onClick={onClose} aria-label="Close">
-                &times;
-              </button>
-            )}
-          </div>
-        </div>
-
+        <PrivacyPolicyHeader viewOnly={viewOnly} onClose={onClose} />
         <div className="privacy-modal-body">
           <PrivacyPolicyContent />
         </div>


### PR DESCRIPTION
This pull request introduces a comprehensive in-app Privacy Policy acceptance flow, similar to the existing Terms of Service (ToS) modal. Users must now explicitly acknowledge the Privacy Policy before accessing the application, and can also view the policy at any time via the navigation bar. The changes include a new modal component, state management for acceptance, UI integration, and a new icon/button in the navbar.

**Privacy Policy Acceptance Flow:**

- Added a new `PrivacyPolicyModal` component, including logic for versioning, localStorage acceptance tracking, and both acceptance and view-only modes (`src/components/PrivacyPolicy/PrivacyPolicyModal.tsx`, `src/components/PrivacyPolicy/PrivacyPolicyModal.css`). [[1]](diffhunk://#diff-1672a5140344b5a7303d93fe4604f6ffd3faac16a05f5d226b7863bf4010ebbcR1-R204) [[2]](diffhunk://#diff-dd0c6c2a200e0431f09b05fa7359790ee0af3e4181afa41874b6195991289c5cR1-R185)
- Integrated Privacy Policy acceptance into the main app flow: users must accept both ToS and Privacy Policy before proceeding (`src/App.tsx`). [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R22) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R72-R89)

**UI Integration & Navigation:**

- Added state and handlers in `AppLayout` for opening/closing the Privacy Policy modal, and provided a reusable viewer for view-only access (`src/components/Layout/AppLayout.tsx`). [[1]](diffhunk://#diff-8a57f9e3cacd56fdb143c2a4862cbeff0da9a72dee37905f020b42457b23fd62R8) [[2]](diffhunk://#diff-8a57f9e3cacd56fdb143c2a4862cbeff0da9a72dee37905f020b42457b23fd62R42) [[3]](diffhunk://#diff-8a57f9e3cacd56fdb143c2a4862cbeff0da9a72dee37905f020b42457b23fd62R68-R71) [[4]](diffhunk://#diff-8a57f9e3cacd56fdb143c2a4862cbeff0da9a72dee37905f020b42457b23fd62R82-R94) [[5]](diffhunk://#diff-8a57f9e3cacd56fdb143c2a4862cbeff0da9a72dee37905f020b42457b23fd62R168-R180) [[6]](diffhunk://#diff-8a57f9e3cacd56fdb143c2a4862cbeff0da9a72dee37905f020b42457b23fd62R199)
- Updated the `Navbar` and `NavbarSections` to include a new Shield icon button that opens the Privacy Policy modal, and passed the necessary handler props (`src/components/Layout/Navbar.tsx`, `src/components/Layout/NavbarSections.tsx`). [[1]](diffhunk://#diff-d818841494d353abbcdec1048ccd5f5b235017bc2cc62d147573093e07178cc1R12-R20) [[2]](diffhunk://#diff-d818841494d353abbcdec1048ccd5f5b235017bc2cc62d147573093e07178cc1R41) [[3]](diffhunk://#diff-b8cd2d4f8ac700436a0071063d79054a2026447701c0420359a263d62e8243f0R15) [[4]](diffhunk://#diff-b8cd2d4f8ac700436a0071063d79054a2026447701c0420359a263d62e8243f0R36) [[5]](diffhunk://#diff-b8cd2d4f8ac700436a0071063d79054a2026447701c0420359a263d62e8243f0R140) [[6]](diffhunk://#diff-b8cd2d4f8ac700436a0071063d79054a2026447701c0420359a263d62e8243f0R167-R182)

These changes ensure users are informed about data handling practices and can easily review the Privacy Policy at any time.