### PR TITLE
Implement HomeHero component with onboarding and resume copy

### DIFF
--- a/src/components/CycleManager/CycleHistoryModal.tsx
+++ b/src/components/CycleManager/CycleHistoryModal.tsx
@@ -174,6 +174,10 @@ const CycleHistoryModal: React.FC<CycleHistoryModalProps> = ({ isOpen, onClose }
   };
 
   const getDaySummary = (cycle: SavedCycle) => {
+    if (typeof cycle.stats?.forecastDays === 'number') {
+      return cycle.stats.forecastDays > 0 ? `${cycle.stats.forecastDays} forecast day${cycle.stats.forecastDays === 1 ? '' : 's'}` : 'No polygons';
+    }
+
     // Extract day keys, then filter to those with any feature maps that have size > 0
     const keys = Object.keys(cycle.forecastCycle.days);
     if (keys.length === 0) return 'No data';

--- a/src/components/CycleManager/CycleHistoryModal.tsx
+++ b/src/components/CycleManager/CycleHistoryModal.tsx
@@ -173,6 +173,7 @@ const CycleHistoryModal: React.FC<CycleHistoryModalProps> = ({ isOpen, onClose }
     setConfirmAction(null);
   };
 
+  /** Builds a short saved-cycle summary, preferring cached stats metadata when it is available. */
   const getDaySummary = (cycle: SavedCycle) => {
     if (typeof cycle.stats?.forecastDays === 'number') {
       return cycle.stats.forecastDays > 0 ? `${cycle.stats.forecastDays} forecast day${cycle.stats.forecastDays === 1 ? '' : 's'}` : 'No polygons';

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -10,10 +10,10 @@ interface FirebaseClientConfig {
 }
 
 const firebaseClientConfig: FirebaseClientConfig = {
-  apiKey: __GFC_FIREBASE_CONFIG__.apiKey ?? '',
-  authDomain: __GFC_FIREBASE_CONFIG__.authDomain ?? '',
-  projectId: __GFC_FIREBASE_CONFIG__.projectId ?? '',
-  appId: __GFC_FIREBASE_CONFIG__.appId ?? '',
+  apiKey: __GFC_FIREBASE_API_KEY__ ?? '',
+  authDomain: __GFC_FIREBASE_AUTH_DOMAIN__ ?? '',
+  projectId: __GFC_FIREBASE_PROJECT_ID__ ?? '',
+  appId: __GFC_FIREBASE_APP_ID__ ?? '',
 };
 
 /** True when the hosted auth configuration required for Firebase sign-in is present. */

--- a/src/pages/AccountPage.test.tsx
+++ b/src/pages/AccountPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { AccountPage } from './AccountPage';
 
@@ -30,7 +30,70 @@ describe('AccountPage', () => {
       </BrowserRouter>
     );
 
-    expect(screen.getByText(/Hosted Accounts Are Disabled/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Account$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Local-only mode/i })).toBeInTheDocument();
     expect(screen.getByText(/running in local-only mode/i)).toBeInTheDocument();
+  });
+
+  test('shows confirm password only in create-account mode', () => {
+    mockUseAuth.mockReturnValue({
+      hostedAuthEnabled: true,
+      status: 'signed_out',
+      settingsSyncStatus: 'idle',
+      user: null,
+      syncedSettings: null,
+      error: null,
+      signInWithGoogle: jest.fn(),
+      signInWithEmail: jest.fn(),
+      signUpWithEmail: jest.fn(),
+      signOutUser: jest.fn(),
+      updateSyncedSettings: jest.fn(),
+    });
+
+    render(
+      <BrowserRouter>
+        <AccountPage />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByLabelText(/Confirm Password/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Create Account/i }));
+
+    expect(screen.getByLabelText(/Confirm Password/i)).toBeInTheDocument();
+  });
+
+  test('shows a simplified signed-in account view with one sync status badge', () => {
+    mockUseAuth.mockReturnValue({
+      hostedAuthEnabled: true,
+      status: 'signed_in',
+      settingsSyncStatus: 'synced',
+      user: {
+        email: 'alex@example.com',
+        displayName: 'Alex',
+        providerData: [{ providerId: 'google.com' }],
+      },
+      syncedSettings: {
+        defaultForecasterName: 'Alex',
+      },
+      error: null,
+      signInWithGoogle: jest.fn(),
+      signInWithEmail: jest.fn(),
+      signUpWithEmail: jest.fn(),
+      signOutUser: jest.fn(),
+      updateSyncedSettings: jest.fn(),
+    });
+
+    render(
+      <BrowserRouter>
+        <AccountPage />
+      </BrowserRouter>
+    );
+
+    expect(screen.getAllByText('alex@example.com')).toHaveLength(2);
+    expect(screen.getAllByText('Google')).toHaveLength(2);
+    expect(screen.getByDisplayValue('Alex')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign Out/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/^Synced$/i)).toHaveLength(1);
   });
 });

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -52,28 +52,42 @@ const renderSaveDefaultsButtonLabel = (savingDefaults: boolean): React.ReactNode
   </>
 );
 
+/** Decorative background accents shared by the account hero. */
+const AccountHeroBackdrop: React.FC = () => (
+  <>
+    <div className="pointer-events-none absolute -top-20 -right-20 h-56 w-56 rounded-full bg-primary/10 blur-3xl" />
+    <div className="pointer-events-none absolute -bottom-12 -left-12 h-40 w-40 rounded-full bg-primary/8 blur-2xl" />
+  </>
+);
+
+/** Main content stack inside the account hero shell. */
+const AccountHeroContent: React.FC<{
+  description: string;
+  children?: React.ReactNode;
+}> = ({ description, children }) => (
+  <div className="relative">
+    <div className="space-y-4">
+      <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
+        <CircleUserRound className="h-4 w-4" />
+        Account
+      </div>
+      <div className="space-y-3">
+        <h1 className="text-4xl font-extrabold tracking-tight text-foreground md:text-5xl">Account</h1>
+        <p className="max-w-3xl text-base leading-relaxed text-muted-foreground md:text-lg">{description}</p>
+      </div>
+      {children}
+    </div>
+  </div>
+);
+
 /** Shared hero used for signed-in, signed-out, and local-only account states. */
 const AccountHero: React.FC<{
   description: string;
   children?: React.ReactNode;
 }> = ({ description, children }) => (
   <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-gradient-to-br from-primary/10 via-background to-background p-8 md:p-10">
-    <div className="pointer-events-none absolute -top-20 -right-20 h-56 w-56 rounded-full bg-primary/10 blur-3xl" />
-    <div className="pointer-events-none absolute -bottom-12 -left-12 h-40 w-40 rounded-full bg-primary/8 blur-2xl" />
-
-    <div className="relative">
-      <div className="space-y-4">
-        <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
-          <CircleUserRound className="h-4 w-4" />
-          Account
-        </div>
-        <div className="space-y-3">
-          <h1 className="text-4xl font-extrabold tracking-tight text-foreground md:text-5xl">Account</h1>
-          <p className="max-w-3xl text-base leading-relaxed text-muted-foreground md:text-lg">{description}</p>
-        </div>
-        {children}
-      </div>
-    </div>
+    <AccountHeroBackdrop />
+    <AccountHeroContent description={description}>{children}</AccountHeroContent>
   </div>
 );
 
@@ -108,6 +122,71 @@ const SummaryTile: React.FC<{ label: string; value: string }> = ({ label, value 
   </div>
 );
 
+/** Small two-column summary row for the signed-in profile card. */
+const ProfileSummaryGrid: React.FC<{
+  email: string;
+  providerLabels: string[];
+}> = ({ email, providerLabels }) => (
+  <div className="grid gap-4 md:grid-cols-2">
+    <SummaryTile label="Email" value={email} />
+    <SummaryTile
+      label="Sign-in Method"
+      value={providerLabels.length > 0 ? providerLabels.join(', ') : 'Unavailable'}
+    />
+  </div>
+);
+
+/** Editable byline section for the signed-in account card. */
+const DiscussionDefaultsSection: React.FC<{
+  defaultForecasterName: string;
+  setDefaultForecasterName: React.Dispatch<React.SetStateAction<string>>;
+}> = ({ defaultForecasterName, setDefaultForecasterName }) => (
+  <div className="rounded-2xl border border-border/80 bg-muted/20 p-5">
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold text-foreground">Discussion defaults</h2>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        Set the name that should prefill the forecaster field when you write a discussion.
+      </p>
+    </div>
+
+    <div className="mt-5 space-y-3">
+      <label htmlFor="default-forecaster-name" className="text-sm font-medium text-foreground">
+        Default forecaster name
+      </label>
+      <Input
+        id="default-forecaster-name"
+        type="text"
+        value={defaultForecasterName}
+        onChange={(e) => setDefaultForecasterName(e.target.value)}
+        placeholder="Your name or preferred byline"
+        maxLength={100}
+      />
+    </div>
+  </div>
+);
+
+/** Bottom action row for saving defaults and ending the current session. */
+const SignedInActionRow: React.FC<{
+  savingDefaults: boolean;
+  saveMessage: string | null;
+  onSaveDefaults: () => void;
+  onSignOut: () => void;
+}> = ({ savingDefaults, saveMessage, onSaveDefaults, onSignOut }) => (
+  <div className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <Button onClick={onSaveDefaults} disabled={savingDefaults}>
+        {renderSaveDefaultsButtonLabel(savingDefaults)}
+      </Button>
+      {saveMessage ? <p className="text-sm text-muted-foreground">{saveMessage}</p> : null}
+    </div>
+
+    <Button variant="outline" onClick={onSignOut}>
+      <LogOut className="mr-2 h-4 w-4" />
+      Sign Out
+    </Button>
+  </div>
+);
+
 /** Signed-in primary card with the only profile setting exposed in Phase 2. */
 const SignedInPrimaryCard: React.FC<{
   email: string;
@@ -134,52 +213,20 @@ const SignedInPrimaryCard: React.FC<{
       <CardDescription>
         Keep your sign-in details and your default discussion byline ready wherever you open GFC.
       </CardDescription>
-      <div className="grid gap-4 md:grid-cols-2">
-        <SummaryTile label="Email" value={email} />
-        <SummaryTile
-          label="Sign-in Method"
-          value={providerLabels.length > 0 ? providerLabels.join(', ') : 'Unavailable'}
-        />
-      </div>
+      <ProfileSummaryGrid email={email} providerLabels={providerLabels} />
     </CardHeader>
 
     <CardContent className="space-y-6">
-      <div className="rounded-2xl border border-border/80 bg-muted/20 p-5">
-        <div className="space-y-2">
-          <h2 className="text-lg font-semibold text-foreground">Discussion defaults</h2>
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            Set the name that should prefill the forecaster field when you write a discussion.
-          </p>
-        </div>
-
-        <div className="mt-5 space-y-3">
-          <label htmlFor="default-forecaster-name" className="text-sm font-medium text-foreground">
-            Default forecaster name
-          </label>
-          <Input
-            id="default-forecaster-name"
-            type="text"
-            value={defaultForecasterName}
-            onChange={(e) => setDefaultForecasterName(e.target.value)}
-            placeholder="Your name or preferred byline"
-            maxLength={100}
-          />
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <Button onClick={onSaveDefaults} disabled={savingDefaults}>
-            {renderSaveDefaultsButtonLabel(savingDefaults)}
-          </Button>
-          {saveMessage ? <p className="text-sm text-muted-foreground">{saveMessage}</p> : null}
-        </div>
-
-        <Button variant="outline" onClick={onSignOut}>
-          <LogOut className="mr-2 h-4 w-4" />
-          Sign Out
-        </Button>
-      </div>
+      <DiscussionDefaultsSection
+        defaultForecasterName={defaultForecasterName}
+        setDefaultForecasterName={setDefaultForecasterName}
+      />
+      <SignedInActionRow
+        savingDefaults={savingDefaults}
+        saveMessage={saveMessage}
+        onSaveDefaults={onSaveDefaults}
+        onSignOut={onSignOut}
+      />
     </CardContent>
   </Card>
 );
@@ -450,6 +497,27 @@ const SignedOutSupportCard: React.FC = () => (
   </Card>
 );
 
+/** Shared local-only card body used when hosted accounts are disabled. */
+const LocalOnlyCard: React.FC = () => (
+  <Card className="border-border/80 bg-card/95 shadow-sm">
+    <CardHeader className="space-y-2">
+      <CardTitle className="text-2xl">Local-only mode</CardTitle>
+      <CardDescription>
+        Hosted accounts are turned off here, but the full local forecasting workflow is still ready to go.
+      </CardDescription>
+    </CardHeader>
+    <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+        Forecast drawing, discussions, verification, imports, exports, and local history keep working exactly as
+        expected.
+      </p>
+      <Button asChild variant="outline">
+        <Link to="/">Back to Home</Link>
+      </Button>
+    </CardContent>
+  </Card>
+);
+
 /** Signed-out account experience focused on a clean auth flow plus one concise reassurance card. */
 const SignedOutAccountView: React.FC = () => {
   const { signInWithEmail, signInWithGoogle, signUpWithEmail, error, status } = useAuth();
@@ -548,24 +616,7 @@ const SignedOutAccountView: React.FC = () => {
 const DisabledStateView: React.FC = () => (
   <div className="space-y-8">
     <AccountHero description="This deployment is running in local-only mode. You can still use every core GFC workflow without signing in." />
-
-    <Card className="border-border/80 bg-card/95 shadow-sm">
-      <CardHeader className="space-y-2">
-        <CardTitle className="text-2xl">Local-only mode</CardTitle>
-        <CardDescription>
-          Hosted accounts are turned off here, but the full local forecasting workflow is still ready to go.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">
-          Forecast drawing, discussions, verification, imports, exports, and local history keep working exactly as
-          expected.
-        </p>
-        <Button asChild variant="outline">
-          <Link to="/">Back to Home</Link>
-        </Button>
-      </CardContent>
-    </Card>
+    <LocalOnlyCard />
   </div>
 );
 

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -1,11 +1,19 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { CircleUserRound, Cloud, LoaderCircle, LogOut, Mail, ShieldCheck } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { CircleUserRound, Cloud, LoaderCircle, LogOut, Mail } from 'lucide-react';
+import { Badge, type BadgeProps } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Input } from '../components/ui/input';
 import { useAuth } from '../auth/AuthProvider';
 
 type AuthMode = 'sign_in' | 'sign_up';
+type SyncStatus = ReturnType<typeof useAuth>['settingsSyncStatus'];
+
+interface SyncStatusMeta {
+  label: string;
+  variant: BadgeProps['variant'];
+}
 
 /** Maps Firebase provider ids to short labels for the account UI. */
 const getProviderLabel = (providerId: string): string => {
@@ -19,94 +27,91 @@ const getProviderLabel = (providerId: string): string => {
   }
 };
 
-/** Turns the raw sync status enum into copy for the account page. */
-const getSettingsSyncCopy = (settingsSyncStatus: ReturnType<typeof useAuth>['settingsSyncStatus']): string => {
+/** Converts the raw settings status into the one compact badge shown on the signed-in account page. */
+const getSyncStatusMeta = (settingsSyncStatus: SyncStatus): SyncStatusMeta => {
   switch (settingsSyncStatus) {
     case 'synced':
-      return 'Profile and settings sync are active across signed-in sessions.';
+      return { label: 'Synced', variant: 'success' };
     case 'syncing':
-      return 'Syncing your account settings...';
+      return { label: 'Syncing', variant: 'secondary' };
     case 'error':
-      return 'Settings sync hit an error. Local mode is still safe.';
-    case 'idle':
-      return 'Waiting to start syncing settings.';
+      return { label: 'Needs Attention', variant: 'warning' };
     case 'disabled':
-      return 'Hosted sync is disabled for this deployment.';
+      return { label: 'Local Only', variant: 'outline' };
+    case 'idle':
     default:
-      return '';
+      return { label: 'Ready', variant: 'secondary' };
   }
 };
 
 /** Renders the save button label while optionally showing a loading spinner. */
 const renderSaveDefaultsButtonLabel = (savingDefaults: boolean): React.ReactNode => (
   <>
-    {savingDefaults ? <LoaderCircle className="h-4 w-4 mr-2 animate-spin" /> : null}
-    Save Defaults
+    {savingDefaults ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : null}
+    Save Changes
   </>
 );
 
-/** Handles the small synced discussion-default form used in the signed-in account view. */
-const DiscussionDefaultsCard: React.FC<{
-  defaultForecasterName: string;
-  setDefaultForecasterName: React.Dispatch<React.SetStateAction<string>>;
-  savingDefaults: boolean;
-  saveMessage: string | null;
-  onSave: () => void;
-}> = ({ defaultForecasterName, setDefaultForecasterName, savingDefaults, saveMessage, onSave }) => (
-  <div className="rounded-lg border border-border bg-muted/20 p-4 space-y-3">
-    <p className="text-sm font-medium text-foreground">Discussion Defaults</p>
-    <div className="space-y-2">
-      <label htmlFor="default-forecaster-name" className="text-sm text-muted-foreground">
-        Default forecaster name
-      </label>
-      <input
-        id="default-forecaster-name"
-        type="text"
-        value={defaultForecasterName}
-        onChange={(e) => setDefaultForecasterName(e.target.value)}
-        className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
-        placeholder="Your name or preferred byline"
-        maxLength={100}
-      />
-    </div>
-    <div className="flex items-center gap-3">
-      <Button variant="outline" onClick={onSave} disabled={savingDefaults}>
-        {renderSaveDefaultsButtonLabel(savingDefaults)}
-      </Button>
-      {saveMessage && <p className="text-sm text-muted-foreground">{saveMessage}</p>}
+/** Shared hero used for signed-in, signed-out, and local-only account states. */
+const AccountHero: React.FC<{
+  description: string;
+  children?: React.ReactNode;
+}> = ({ description, children }) => (
+  <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-gradient-to-br from-primary/10 via-background to-background p-8 md:p-10">
+    <div className="pointer-events-none absolute -top-20 -right-20 h-56 w-56 rounded-full bg-primary/10 blur-3xl" />
+    <div className="pointer-events-none absolute -bottom-12 -left-12 h-40 w-40 rounded-full bg-primary/8 blur-2xl" />
+
+    <div className="relative">
+      <div className="space-y-4">
+        <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
+          <CircleUserRound className="h-4 w-4" />
+          Account
+        </div>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-extrabold tracking-tight text-foreground md:text-5xl">Account</h1>
+          <p className="max-w-3xl text-base leading-relaxed text-muted-foreground md:text-lg">{description}</p>
+        </div>
+        {children}
+      </div>
     </div>
   </div>
 );
 
-/** Shows the basic account identity and hosted sync status cards. */
-const AccountOverviewGrid: React.FC<{
+/** Shows the signed-in identity details as compact chips under the account hero. */
+const AccountIdentityChips: React.FC<{
   email: string;
   providerLabels: string[];
-  settingsSyncStatus: ReturnType<typeof useAuth>['settingsSyncStatus'];
-}> = ({ email, providerLabels, settingsSyncStatus }) => (
-  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-    <div className="rounded-lg border border-border bg-muted/30 p-4">
-      <p className="text-xs uppercase tracking-wide text-muted-foreground">Email</p>
-      <p className="mt-2 text-sm font-medium text-foreground">{email}</p>
-    </div>
-    <div className="rounded-lg border border-border bg-muted/30 p-4">
-      <p className="text-xs uppercase tracking-wide text-muted-foreground">Providers</p>
-      <p className="mt-2 text-sm font-medium text-foreground">
-        {providerLabels.length > 0 ? providerLabels.join(', ') : 'Unavailable'}
-      </p>
-    </div>
-    <div className="rounded-lg border border-border bg-muted/30 p-4 md:col-span-2">
-      <p className="text-xs uppercase tracking-wide text-muted-foreground">Settings Sync</p>
-      <p className="mt-2 text-sm font-medium text-foreground">{getSettingsSyncCopy(settingsSyncStatus)}</p>
-    </div>
+  statusMeta?: SyncStatusMeta;
+}> = ({ email, providerLabels, statusMeta }) => (
+  <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+    <span className="rounded-full border border-border bg-background/80 px-3 py-1.5 font-medium text-foreground">
+      {email}
+    </span>
+    {providerLabels.map((provider) => (
+      <span key={provider} className="rounded-full border border-border bg-background/70 px-3 py-1.5">
+        {provider}
+      </span>
+    ))}
+    {statusMeta ? (
+      <Badge variant={statusMeta.variant} className="px-3 py-1.5 text-xs uppercase tracking-[0.18em]">
+        {statusMeta.label}
+      </Badge>
+    ) : null}
   </div>
 );
 
-/** Keeps the signed-in account overview card shallow and focused. */
+/** Small summary tile that keeps the profile card readable and compact. */
+const SummaryTile: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="rounded-2xl border border-border/80 bg-muted/25 p-4">
+    <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{label}</p>
+    <p className="mt-3 text-sm font-semibold text-foreground">{value}</p>
+  </div>
+);
+
+/** Signed-in primary card with the only profile setting exposed in Phase 2. */
 const SignedInPrimaryCard: React.FC<{
   email: string;
   providerLabels: string[];
-  settingsSyncStatus: ReturnType<typeof useAuth>['settingsSyncStatus'];
   defaultForecasterName: string;
   setDefaultForecasterName: React.Dispatch<React.SetStateAction<string>>;
   savingDefaults: boolean;
@@ -116,7 +121,6 @@ const SignedInPrimaryCard: React.FC<{
 }> = ({
   email,
   providerLabels,
-  settingsSyncStatus,
   defaultForecasterName,
   setDefaultForecasterName,
   savingDefaults,
@@ -124,100 +128,68 @@ const SignedInPrimaryCard: React.FC<{
   onSaveDefaults,
   onSignOut,
 }) => (
-  <Card className="xl:col-span-2 border-border bg-card">
-    <CardHeader>
-      <CardTitle className="flex items-center gap-2 text-xl">
-        <CircleUserRound className="h-5 w-5 text-primary" />
-        Account Overview
-      </CardTitle>
+  <Card className="border-border/80 bg-card/95 shadow-sm">
+    <CardHeader className="space-y-3">
+      <CardTitle className="text-2xl">Profile & Preferences</CardTitle>
       <CardDescription>
-        This is the Phase 2 foundation shell for hosted accounts, profile sync, and cross-device settings.
+        Keep your sign-in details and your default discussion byline ready wherever you open GFC.
       </CardDescription>
+      <div className="grid gap-4 md:grid-cols-2">
+        <SummaryTile label="Email" value={email} />
+        <SummaryTile
+          label="Sign-in Method"
+          value={providerLabels.length > 0 ? providerLabels.join(', ') : 'Unavailable'}
+        />
+      </div>
     </CardHeader>
-    <CardContent className="space-y-5">
-      <AccountOverviewGrid email={email} providerLabels={providerLabels} settingsSyncStatus={settingsSyncStatus} />
 
-      <div className="rounded-lg border border-border bg-muted/20 p-4 space-y-2">
-        <p className="text-sm font-medium text-foreground">What your account does today</p>
-        <p className="text-sm text-muted-foreground">
-          Your sign-in now creates a hosted profile, keeps core app preferences in sync, and stores a default
-          forecaster byline that can follow you across devices.
-        </p>
+    <CardContent className="space-y-6">
+      <div className="rounded-2xl border border-border/80 bg-muted/20 p-5">
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold text-foreground">Discussion defaults</h2>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Set the name that should prefill the forecaster field when you write a discussion.
+          </p>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <label htmlFor="default-forecaster-name" className="text-sm font-medium text-foreground">
+            Default forecaster name
+          </label>
+          <Input
+            id="default-forecaster-name"
+            type="text"
+            value={defaultForecasterName}
+            onChange={(e) => setDefaultForecasterName(e.target.value)}
+            placeholder="Your name or preferred byline"
+            maxLength={100}
+          />
+        </div>
       </div>
 
-      <DiscussionDefaultsCard
-        defaultForecasterName={defaultForecasterName}
-        setDefaultForecasterName={setDefaultForecasterName}
-        savingDefaults={savingDefaults}
-        saveMessage={saveMessage}
-        onSave={onSaveDefaults}
-      />
+      <div className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Button onClick={onSaveDefaults} disabled={savingDefaults}>
+            {renderSaveDefaultsButtonLabel(savingDefaults)}
+          </Button>
+          {saveMessage ? <p className="text-sm text-muted-foreground">{saveMessage}</p> : null}
+        </div>
 
-      <Button variant="outline" onClick={onSignOut}>
-        <LogOut className="h-4 w-4 mr-2" />
-        Sign Out
-      </Button>
+        <Button variant="outline" onClick={onSignOut}>
+          <LogOut className="mr-2 h-4 w-4" />
+          Sign Out
+        </Button>
+      </div>
     </CardContent>
   </Card>
 );
 
-/** Contains the signed-in account side cards that explain scope and future phases. */
-const SignedInSidebar: React.FC = () => (
-  <div className="space-y-6">
-    <Card className="border-border bg-card">
-      <CardHeader>
-        <CardTitle className="text-lg">Plan & Metrics</CardTitle>
-        <CardDescription>Reserved for premium status and user metrics in later phases.</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground">
-          Free account sync is live in Phase 2. Billing and account metrics will land in later v1.4.0 phases.
-        </p>
-      </CardContent>
-    </Card>
-
-    <Card className="border-border bg-card">
-      <CardHeader>
-        <CardTitle className="text-lg">Hosted Sync Promise</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground">
-          Signing in adds convenience, not lock-in. Local forecasting, exports, verification, and history remain
-          available even when you never create an account.
-        </p>
-      </CardContent>
-    </Card>
-  </div>
-);
-
-/** Displays a short explanation when hosted accounts are unavailable in the current deployment. */
-const DisabledStateCard: React.FC = () => (
-  <Card className="border-border bg-card">
-    <CardHeader>
-      <CardTitle className="flex items-center gap-2 text-xl">
-        <ShieldCheck className="h-5 w-5 text-primary" />
-        Hosted Accounts Are Disabled
-      </CardTitle>
-      <CardDescription>
-        This deployment is running in local-only mode. You can still use every core GFC workflow without signing in.
-      </CardDescription>
-    </CardHeader>
-    <CardContent className="space-y-4">
-      <p className="text-sm text-muted-foreground leading-relaxed">
-        When hosted auth is configured, this page will offer Google sign-in plus email/password accounts for syncing
-        profile and settings data across devices.
-      </p>
-      <Button asChild variant="outline">
-        <Link to="/">Back to Home</Link>
-      </Button>
-    </CardContent>
-  </Card>
-);
-
-/** Shows the current signed-in account basics plus the first free synced settings controls. */
-const SignedInAccountCard: React.FC = () => {
+/** Signed-in account experience focused on identity, defaults, and session control. */
+const SignedInAccountView: React.FC = () => {
   const { user, signOutUser, settingsSyncStatus, syncedSettings, updateSyncedSettings } = useAuth();
-  const [defaultForecasterName, setDefaultForecasterName] = useState(() => syncedSettings?.defaultForecasterName ?? user?.displayName ?? '');
+  const [defaultForecasterName, setDefaultForecasterName] = useState(
+    () => syncedSettings?.defaultForecasterName ?? user?.displayName ?? ''
+  );
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [savingDefaults, setSavingDefaults] = useState(false);
 
@@ -225,6 +197,7 @@ const SignedInAccountCard: React.FC = () => {
     () => (user?.providerData ?? []).map((provider) => getProviderLabel(provider.providerId)).filter(Boolean),
     [user]
   );
+  const statusMeta = getSyncStatusMeta(settingsSyncStatus);
 
   useEffect(() => {
     setDefaultForecasterName(syncedSettings?.defaultForecasterName ?? user?.displayName ?? '');
@@ -239,24 +212,19 @@ const SignedInAccountCard: React.FC = () => {
       await updateSyncedSettings({
         defaultForecasterName: defaultForecasterName.trim(),
       });
-      setSaveMessage('Default forecaster synced.');
+      setSaveMessage('Saved to your account.');
     } catch (error) {
-      setSaveMessage(error instanceof Error ? error.message : 'Unable to save defaults right now.');
+      setSaveMessage(error instanceof Error ? error.message : 'Unable to save right now.');
     } finally {
       setSavingDefaults(false);
     }
   };
 
-  /** Bridges the async save routine into a plain button click handler. */
+  /** Wraps the async save action for a button click without leaking promise handling into JSX. */
   const handleSaveDefaultsClick = () => {
     handleSaveDefaults().catch(() => {
       // Save feedback is already surfaced by handleSaveDefaults.
     });
-  };
-
-  /** Wraps the async save action for a button click without leaking promise handling into JSX. */
-  const onSaveDefaultsClick = () => {
-    handleSaveDefaultsClick();
   };
 
   /** Wraps sign-out for button usage while shared auth state handles any failure messaging. */
@@ -267,63 +235,71 @@ const SignedInAccountCard: React.FC = () => {
   };
 
   return (
-    <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+    <div className="space-y-8">
+      <AccountHero
+        description="Keep your profile and app defaults ready across devices while the core forecasting workflow stays yours."
+      >
+        <AccountIdentityChips
+          email={user?.email ?? 'Unavailable'}
+          providerLabels={providerLabels}
+          statusMeta={statusMeta}
+        />
+      </AccountHero>
+
       <SignedInPrimaryCard
         email={user?.email ?? 'Unavailable'}
         providerLabels={providerLabels}
-        settingsSyncStatus={settingsSyncStatus}
         defaultForecasterName={defaultForecasterName}
         setDefaultForecasterName={setDefaultForecasterName}
         savingDefaults={savingDefaults}
         saveMessage={saveMessage}
-        onSaveDefaults={onSaveDefaultsClick}
+        onSaveDefaults={handleSaveDefaultsClick}
         onSignOut={handleSignOutClick}
       />
-      <SignedInSidebar />
     </div>
   );
 };
 
-/** Keeps the sign-in primary card shallow while preserving the current auth flow. */
+/** Shared sign-in header for the signed-out account flow. */
 const SignInCardHeader: React.FC = () => (
-  <CardHeader>
-    <CardTitle className="flex items-center gap-2 text-xl">
-      <CircleUserRound className="h-5 w-5 text-primary" />
-      Sign In to Sync Settings
-    </CardTitle>
+  <CardHeader className="space-y-3">
+    <CardTitle className="text-2xl">Sign in or create an account</CardTitle>
     <CardDescription>
-      Use Google or email/password to keep your profile and app preferences ready across devices without changing the
-      local-first forecasting workflow.
+      Keep your profile and app defaults ready across devices. Signing in is optional, and core forecasting stays free.
     </CardDescription>
   </CardHeader>
 );
 
-/** Renders the email/password form inside the hosted sign-in card. */
+/** Email and password form used for both sign-in and account creation. */
 const EmailAuthForm: React.FC<{
   mode: AuthMode;
   email: string;
   password: string;
+  confirmPassword: string;
   isBusy: boolean;
   formError: string | null;
   authError: string | null;
   onModeChange: (mode: AuthMode) => void;
   onEmailChange: (email: string) => void;
   onPasswordChange: (password: string) => void;
+  onConfirmPasswordChange: (password: string) => void;
   onEmailSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
 }> = ({
   mode,
   email,
   password,
+  confirmPassword,
   isBusy,
   formError,
   authError,
   onModeChange,
   onEmailChange,
   onPasswordChange,
+  onConfirmPasswordChange,
   onEmailSubmit,
 }) => (
-  <>
-    <div className="flex items-center gap-3 text-xs uppercase tracking-wide text-muted-foreground">
+  <div className="space-y-5">
+    <div className="flex items-center gap-3 text-xs uppercase tracking-[0.18em] text-muted-foreground">
       <div className="h-px flex-1 bg-border" />
       <span>Email / Password</span>
       <div className="h-px flex-1 bg-border" />
@@ -343,77 +319,97 @@ const EmailAuthForm: React.FC<{
         <label htmlFor="account-email" className="text-sm font-medium text-foreground">
           Email
         </label>
-        <input
+        <Input
           id="account-email"
           type="email"
           value={email}
           onChange={(e) => onEmailChange(e.target.value)}
-          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
           autoComplete="email"
           required
         />
       </div>
+
       <div className="space-y-2">
         <label htmlFor="account-password" className="text-sm font-medium text-foreground">
           Password
         </label>
-        <input
+        <Input
           id="account-password"
           type="password"
           value={password}
           onChange={(e) => onPasswordChange(e.target.value)}
-          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
           autoComplete={mode === 'sign_in' ? 'current-password' : 'new-password'}
           minLength={6}
           required
         />
       </div>
 
-      {(formError || authError) && (
-        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      {mode === 'sign_up' ? (
+        <div className="space-y-2">
+          <label htmlFor="account-confirm-password" className="text-sm font-medium text-foreground">
+            Confirm Password
+          </label>
+          <Input
+            id="account-confirm-password"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => onConfirmPasswordChange(e.target.value)}
+            autoComplete="new-password"
+            minLength={6}
+            required
+          />
+        </div>
+      ) : null}
+
+      {formError || authError ? (
+        <div className="rounded-xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive">
           {formError ?? authError}
         </div>
-      )}
+      ) : null}
 
       <Button type="submit" disabled={isBusy}>
-        {isBusy ? <LoaderCircle className="h-4 w-4 mr-2 animate-spin" /> : <Mail className="h-4 w-4 mr-2" />}
+        {isBusy ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : <Mail className="mr-2 h-4 w-4" />}
         {mode === 'sign_in' ? 'Sign In with Email' : 'Create Account'}
       </Button>
     </form>
-  </>
+  </div>
 );
 
-/** Keeps the sign-in primary card shallow while preserving the current auth flow. */
+/** Primary signed-out auth card. */
 const SignInPrimaryCard: React.FC<{
   isBusy: boolean;
   mode: AuthMode;
   email: string;
   password: string;
+  confirmPassword: string;
   formError: string | null;
   authError: string | null;
   onGoogleSignIn: () => void;
   onModeChange: (mode: AuthMode) => void;
   onEmailChange: (email: string) => void;
   onPasswordChange: (password: string) => void;
+  onConfirmPasswordChange: (password: string) => void;
   onEmailSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
 }> = ({
   isBusy,
   mode,
   email,
   password,
+  confirmPassword,
   formError,
   authError,
   onGoogleSignIn,
   onModeChange,
   onEmailChange,
   onPasswordChange,
+  onConfirmPasswordChange,
   onEmailSubmit,
 }) => (
-  <Card className="xl:col-span-2 border-border bg-card">
+  <Card className="border-border/80 bg-card/95 shadow-sm">
     <SignInCardHeader />
-    <CardContent className="space-y-4">
+    <CardContent className="space-y-6">
       <Button variant="outline" className="w-full justify-center" onClick={onGoogleSignIn} disabled={isBusy}>
-        <Cloud className="h-4 w-4 mr-2" />
+        <Cloud className="mr-2 h-4 w-4" />
         Continue with Google
       </Button>
 
@@ -421,62 +417,67 @@ const SignInPrimaryCard: React.FC<{
         mode={mode}
         email={email}
         password={password}
+        confirmPassword={confirmPassword}
         isBusy={isBusy}
         formError={formError}
         authError={authError}
         onModeChange={onModeChange}
         onEmailChange={onEmailChange}
         onPasswordChange={onPasswordChange}
+        onConfirmPasswordChange={onConfirmPasswordChange}
         onEmailSubmit={onEmailSubmit}
       />
     </CardContent>
   </Card>
 );
 
-/** Contains the signed-out reassurance cards that explain the free/local-first promise. */
-const SignInSidebar: React.FC = () => (
-  <div className="space-y-6">
-    <Card className="border-border bg-card">
-      <CardHeader>
-        <CardTitle className="text-lg">What Stays Free</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground">
-          Forecast creation, local autosave, local history, import/export, discussions, and verification still work
-          without any account at all.
-        </p>
-      </CardContent>
-    </Card>
-
-    <Card className="border-border bg-card">
-      <CardHeader>
-        <CardTitle className="text-lg">What Sign-In Adds</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground">
-          Phase 2 starts with identity and account scaffolding so profile sync and cross-device settings can be added
-          safely before premium cloud storage arrives.
-        </p>
-      </CardContent>
-    </Card>
-  </div>
+/** Single supporting card for signed-out users so the page stays helpful without turning into marketing clutter. */
+const SignedOutSupportCard: React.FC = () => (
+  <Card className="border-border/80 bg-card/95 shadow-sm">
+    <CardHeader className="space-y-2">
+      <CardTitle className="text-lg">What Signing In Helps With</CardTitle>
+    </CardHeader>
+    <CardContent className="space-y-4">
+      <ul className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+        <li>Keep your map and app preferences ready across devices.</li>
+        <li>Store the forecaster name you want prefilled in discussions.</li>
+        <li>Use the same account on different machines without changing the local workflow.</li>
+      </ul>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        Forecasting, discussions, exports, verification, and local history remain available with or without an account.
+      </p>
+    </CardContent>
+  </Card>
 );
 
-/** Allows users to sign in with Google or email/password when hosted auth is enabled. */
-const SignInCard: React.FC = () => {
+/** Signed-out account experience focused on a clean auth flow plus one concise reassurance card. */
+const SignedOutAccountView: React.FC = () => {
   const { signInWithEmail, signInWithGoogle, signUpWithEmail, error, status } = useAuth();
   const [mode, setMode] = useState<AuthMode>('sign_in');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
   const isBusy = submitting || status === 'loading';
 
+  useEffect(() => {
+    if (mode === 'sign_in') {
+      setConfirmPassword('');
+    }
+  }, [mode]);
+
   /** Handles email/password sign-in or sign-up based on the selected account mode. */
   const handleEmailSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setFormError(null);
+
+    if (mode === 'sign_up' && password !== confirmPassword) {
+      setFormError('Passwords do not match.');
+      return;
+    }
+
     setSubmitting(true);
 
     try {
@@ -486,6 +487,7 @@ const SignInCard: React.FC = () => {
         await signUpWithEmail(email, password);
       }
       setPassword('');
+      setConfirmPassword('');
     } catch (nextError) {
       setFormError(nextError instanceof Error ? nextError.message : 'Unable to complete that request right now.');
     } finally {
@@ -507,62 +509,76 @@ const SignInCard: React.FC = () => {
     }
   };
 
-  /** Bridges the async Google sign-in routine into a plain button click handler. */
+  /** Wraps Google sign-in for button usage without inline promise handling in JSX. */
   const handleGoogleSignInClick = () => {
     handleGoogleSignIn().catch(() => {
       // Form feedback is already handled by handleGoogleSignIn.
     });
   };
 
-  /** Wraps Google sign-in for button usage without inline promise handling in JSX. */
-  const onGoogleSignInClick = () => {
-    handleGoogleSignInClick();
-  };
-
   return (
-    <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-      <SignInPrimaryCard
-        isBusy={isBusy}
-        mode={mode}
-        email={email}
-        password={password}
-        formError={formError}
-        authError={error}
-        onGoogleSignIn={onGoogleSignInClick}
-        onModeChange={setMode}
-        onEmailChange={setEmail}
-        onPasswordChange={setPassword}
-        onEmailSubmit={handleEmailSubmit}
-      />
-      <SignInSidebar />
+    <div className="space-y-8">
+      <AccountHero description="Sign in to keep your profile and defaults ready across devices. Core forecasting stays free with or without an account." />
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <SignInPrimaryCard
+            isBusy={isBusy}
+            mode={mode}
+            email={email}
+            password={password}
+            confirmPassword={confirmPassword}
+            formError={formError}
+            authError={error}
+            onGoogleSignIn={handleGoogleSignInClick}
+            onModeChange={setMode}
+            onEmailChange={setEmail}
+            onPasswordChange={setPassword}
+            onConfirmPasswordChange={setConfirmPassword}
+            onEmailSubmit={handleEmailSubmit}
+          />
+        </div>
+        <SignedOutSupportCard />
+      </div>
     </div>
   );
 };
 
-/** Account landing page for Phase 2 hosted sign-in and future synced settings. */
+/** Local-only fallback for deployments where hosted accounts are intentionally disabled. */
+const DisabledStateView: React.FC = () => (
+  <div className="space-y-8">
+    <AccountHero description="This deployment is running in local-only mode. You can still use every core GFC workflow without signing in." />
+
+    <Card className="border-border/80 bg-card/95 shadow-sm">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-2xl">Local-only mode</CardTitle>
+        <CardDescription>
+          Hosted accounts are turned off here, but the full local forecasting workflow is still ready to go.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+          Forecast drawing, discussions, verification, imports, exports, and local history keep working exactly as
+          expected.
+        </p>
+        <Button asChild variant="outline">
+          <Link to="/">Back to Home</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+/** Production-facing account page for hosted sign-in, synced defaults, and local-only fallback. */
 const AccountPage: React.FC = () => {
-  const { hostedAuthEnabled, status, settingsSyncStatus } = useAuth();
+  const { hostedAuthEnabled, status } = useAuth();
 
   return (
     <div className="h-full overflow-auto bg-gradient-to-br from-background via-background to-muted/20">
-      <div className="max-w-7xl mx-auto p-8 space-y-8">
-        <div className="space-y-3">
-          <p className="text-sm font-medium uppercase tracking-[0.24em] text-primary">Phase 2</p>
-          <h1 className="text-4xl font-extrabold tracking-tight text-foreground">Accounts and Settings Sync</h1>
-          <p className="max-w-3xl text-base text-muted-foreground leading-relaxed">
-            Accounts are optional. This page is the first hosted-service foundation for cross-device continuity, while
-            the forecasting experience remains fully usable in local-only mode.
-          </p>
-          {hostedAuthEnabled && (
-            <p className="text-sm text-muted-foreground">
-              Current sync status: <span className="font-medium text-foreground">{settingsSyncStatus}</span>
-            </p>
-          )}
-        </div>
-
-        {!hostedAuthEnabled && <DisabledStateCard />}
-        {hostedAuthEnabled && status === 'signed_in' && <SignedInAccountCard />}
-        {hostedAuthEnabled && status !== 'signed_in' && <SignInCard />}
+      <div className="mx-auto max-w-7xl space-y-6 p-6 md:p-8">
+        {!hostedAuthEnabled ? <DisabledStateView /> : null}
+        {hostedAuthEnabled && status === 'signed_in' ? <SignedInAccountView /> : null}
+        {hostedAuthEnabled && status !== 'signed_in' ? <SignedOutAccountView /> : null}
       </div>
     </div>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useMemo } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React, { useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import { Bot } from 'lucide-react';
 import { RootState } from '../store';
@@ -7,10 +7,11 @@ import { selectForecastCycle, setForecastDay, resetForecasts, importForecastCycl
 import CycleHistoryModal from '../components/CycleManager/CycleHistoryModal';
 import ConfirmationModal from '../components/DrawingTools/ConfirmationModal';
 import type { AddToastFn } from '../components/Layout';
+import { useAuth } from '../auth/AuthProvider';
 
 import { computeHomeStats, formatCycleDate } from './homeUtils';
 import { createFileHandlers } from '../hooks/useFileLoader';
-import HomeHero from './home/HomeHero';
+import HomeHero, { type HomeVariant } from './home/HomeHero';
 import Dashboard from './home/Dashboard';
 import MainGrid from './home/MainGrid';
 import RecentCycles from './home/RecentCycles';
@@ -20,27 +21,43 @@ interface PageContext {
   addToast: AddToastFn;
 }
 
-/** AI development disclosure banner shown at the bottom of the home page. */
+/** Maintainer note kept at the bottom of the home page without dominating the product message. */
 const AIDisclosure: React.FC = () => (
   <div className="flex items-start gap-3 rounded-xl border border-border bg-muted/30 px-5 py-4 text-sm text-muted-foreground">
-    <Bot className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground/70" />
+    <Bot className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground/70" />
     <p className="leading-relaxed">
       <span className="font-medium text-foreground">AI Development Disclosure:</span>{' '}
       AI was used in the development of this project. All code has been reviewed by the maintainer
       (Alex / WeatherboySuper) to ensure quality and correctness; however, bugs or issues may still
       be present. If you encounter a problem, please report it via{' '}
-      <a href="https://github.com/WxboySuper/Graphical-Forecast-Creator/issues" target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground transition-colors">GitHub Issues</a>
+      <a
+        href="https://github.com/WxboySuper/Graphical-Forecast-Creator/issues"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline transition-colors hover:text-foreground"
+      >
+        GitHub Issues
+      </a>
       {' '}or the{' '}
-      <a href="https://discord.gg/SGk37rg8sz" target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground transition-colors">GFC Support Discord</a>.
+      <a
+        href="https://discord.gg/SGk37rg8sz"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline transition-colors hover:text-foreground"
+      >
+        GFC Support Discord
+      </a>
+      .
     </p>
   </div>
 );
 
-/** Main home page component showing the hero, dashboard stats, forecast grid, recent cycles, and AI disclosure. */
+/** Main home page with auth-aware landing variants and a workflow-first forecast layout. */
 const HomePage: React.FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { addToast } = useOutletContext<PageContext>();
+  const { hostedAuthEnabled, status } = useAuth();
   const forecastCycle = useSelector(selectForecastCycle);
   const savedCycles = useSelector((state: RootState) => state.forecast.savedCycles);
   const isSaved = useSelector((state: RootState) => state.forecast.isSaved);
@@ -48,9 +65,15 @@ const HomePage: React.FC = () => {
   const [showHistoryModal, setShowHistoryModal] = useState(false);
   const [confirmNewCycle, setConfirmNewCycle] = useState(false);
 
-  const { fileInputRef, handleFileSelect, handleOpenFilePicker, handleSave: doSave } = createFileHandlers({ addToast, dispatch, forecastCycle });
+  const { fileInputRef, handleFileSelect, handleOpenFilePicker, handleSave: doSave } = createFileHandlers({
+    addToast,
+    dispatch,
+    forecastCycle,
+  });
 
-  const stats = useMemo(() => computeHomeStats(forecastCycle, savedCycles.length), [forecastCycle, savedCycles.length]);
+  const stats = useMemo(() => computeHomeStats(forecastCycle, savedCycles), [forecastCycle, savedCycles]);
+  const formattedDate = useMemo(() => formatCycleDate(forecastCycle.cycleDate), [forecastCycle.cycleDate]);
+  const variant: HomeVariant = hostedAuthEnabled && status === 'signed_in' ? 'signed_in' : 'signed_out';
 
   /** Resets the forecast cycle, prompting for confirmation if there are unsaved changes. */
   const handleNewCycle = () => {
@@ -92,16 +115,24 @@ const HomePage: React.FC = () => {
   /** Extracts the day from the button's data attribute and starts forecast editing for that day. */
   const handleQuickStartClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const day = Number(e.currentTarget.dataset.day);
-    if (Number.isNaN(day)) return;
+    if (Number.isNaN(day)) {
+      return;
+    }
     handleQuickStart(day as DayType);
   };
 
   /** Loads a recent saved cycle from the history by its ID stored on the button's data attribute. */
   const handleLoadRecentCycleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const cycleId = e.currentTarget.dataset.cycleId;
-    if (!cycleId) return;
+    if (!cycleId) {
+      return;
+    }
+
     const cycle = savedCycles.find((item) => item.id === cycleId);
-    if (!cycle) return;
+    if (!cycle) {
+      return;
+    }
+
     dispatch(importForecastCycle(cycle.forecastCycle));
     addToast('Cycle loaded from history', 'success');
   };
@@ -116,28 +147,79 @@ const HomePage: React.FC = () => {
   /** Cancels the new cycle confirmation dialog without discarding the current cycle. */
   const handleCancelNewCycle = () => setConfirmNewCycle(false);
 
-  const formattedDate = useMemo(() => formatCycleDate(forecastCycle.cycleDate), [forecastCycle.cycleDate]);
-
   return (
     <div className="h-full overflow-auto bg-gradient-to-br from-background via-background to-muted/20">
-      <div className="max-w-7xl mx-auto p-8 space-y-10">
-        <HomeHero onStart={handleNavigateForecast} onWriteDiscussion={handleNavigateDiscussion} onViewAccount={handleNavigateAccount} />
-        <Dashboard stats={stats} />
-        <MainGrid
+      <div className="mx-auto max-w-7xl space-y-6 p-6 md:p-8">
+        <HomeHero
+          variant={variant}
           formattedDate={formattedDate}
-          isSaved={isSaved}
-          forecastCycle={forecastCycle}
-          stats={stats}
-          onQuickStartClick={handleQuickStartClick}
-          onNavigateForecast={handleNavigateForecast}
-          onNavigateDiscussion={handleNavigateDiscussion}
-          onNewCycle={handleNewCycle}
-          onSave={handleSave}
-          onOpenFile={openFilePicker}
+          hasSavedCycles={savedCycles.length > 0}
+          savedCyclesCount={savedCycles.length}
+          onStart={handleNavigateForecast}
+          onWriteDiscussion={handleNavigateDiscussion}
+          onViewAccount={handleNavigateAccount}
           onOpenHistory={handleOpenHistoryModal}
         />
 
-        <RecentCycles savedCycles={savedCycles} onLoad={handleLoadRecentCycleClick} onOpenHistory={handleOpenHistoryModal} />
+        {variant === 'signed_in' ? (
+          <>
+            <div className="grid items-start gap-6 lg:grid-cols-3">
+              <div className="lg:col-span-2">
+                <MainGrid
+                  variant={variant}
+                  formattedDate={formattedDate}
+                  isSaved={isSaved}
+                  forecastCycle={forecastCycle}
+                  stats={stats}
+                  onQuickStartClick={handleQuickStartClick}
+                  onNavigateForecast={handleNavigateForecast}
+                  onNavigateDiscussion={handleNavigateDiscussion}
+                  onNewCycle={handleNewCycle}
+                  onSave={handleSave}
+                  onOpenFile={openFilePicker}
+                  onOpenHistory={handleOpenHistoryModal}
+                />
+              </div>
+              <RecentCycles
+                variant="compact"
+                savedCycles={savedCycles}
+                onLoad={handleLoadRecentCycleClick}
+                onOpenHistory={handleOpenHistoryModal}
+              />
+            </div>
+
+            <Dashboard variant={variant} stats={stats} />
+          </>
+        ) : (
+          <>
+            <div className="grid items-stretch gap-6 lg:grid-cols-3">
+              <div className="lg:col-span-2">
+                <MainGrid
+                  variant={variant}
+                  formattedDate={formattedDate}
+                  isSaved={isSaved}
+                  forecastCycle={forecastCycle}
+                  stats={stats}
+                  onQuickStartClick={handleQuickStartClick}
+                  onNavigateForecast={handleNavigateForecast}
+                  onNavigateDiscussion={handleNavigateDiscussion}
+                  onNewCycle={handleNewCycle}
+                  onSave={handleSave}
+                  onOpenFile={openFilePicker}
+                  onOpenHistory={handleOpenHistoryModal}
+                />
+              </div>
+              <Dashboard variant={variant} stats={stats} />
+            </div>
+
+            <RecentCycles
+              variant="section"
+              savedCycles={savedCycles}
+              onLoad={handleLoadRecentCycleClick}
+              onOpenHistory={handleOpenHistoryModal}
+            />
+          </>
+        )}
 
         <AIDisclosure />
       </div>
@@ -145,7 +227,14 @@ const HomePage: React.FC = () => {
       <input ref={fileInputRef} type="file" accept=".json" onChange={handleFileSelect} className="hidden" />
 
       <CycleHistoryModal isOpen={showHistoryModal} onClose={handleCloseHistoryModal} />
-      <ConfirmationModal isOpen={confirmNewCycle} title="Start New Cycle" message="You have unsaved changes. Start a new cycle anyway?" onConfirm={handleConfirmNewCycle} onCancel={handleCancelNewCycle} confirmLabel="Start New Cycle" />
+      <ConfirmationModal
+        isOpen={confirmNewCycle}
+        title="Start New Cycle"
+        message="You have unsaved changes. Start a new cycle anyway?"
+        onConfirm={handleConfirmNewCycle}
+        onCancel={handleCancelNewCycle}
+        confirmLabel="Start New Cycle"
+      />
     </div>
   );
 };

--- a/src/pages/home/Dashboard.tsx
+++ b/src/pages/home/Dashboard.tsx
@@ -1,69 +1,149 @@
 import React from 'react';
-import { Card } from '../../components/ui/card';
-import { Calendar, Layers, TrendingUp } from 'lucide-react';
-import { DayType } from '../../types/outlooks';
+import { CalendarDays, Layers3, Route, ShieldCheck } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import type { DayType } from '../../types/outlooks';
+import type { HomeVariant } from './HomeHero';
 
 interface Stats {
   daysWithData: DayType[];
   totalOutlooks: number;
   totalFeatures: number;
   savedCyclesCount: number;
+  totalForecastsMade: number;
+  totalCyclesMade: number;
+  forecastStreak: number;
 }
 
-/** Displays a quick-stats dashboard grid and feature highlight cards for the home page. */
-export const Dashboard: React.FC<{ stats: Stats }> = ({ stats }) => {
-  const featureCards = [
-    {
-      title: 'Polygon Drawing',
-      description: 'Draw, edit, and remove outlook polygons directly on the forecast map for each supported day and hazard type.',
-    },
-    {
-      title: 'Discussion Editor',
-      description: 'Write forecast discussions with guided and freeform editing tools, then export the finished text with your package.',
-    },
-    {
-      title: 'Forecast Verification',
-      description: 'Compare saved outlooks against storm reports with visual overlays and summary metrics for hits and misses.',
-    },
-    {
-      title: 'Cycle Manager',
-      description: 'Save forecast cycles, reopen previous work, and copy outlooks between days or older forecast packages.',
-    },
-  ];
+interface Props {
+  stats: Stats;
+  variant: HomeVariant;
+}
 
-  return (
-    <>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {[
-          {
-            icon: <Calendar className="h-6 w-6 text-primary" />, title: 'Days with Data', value: stats.daysWithData.length,
-          },
-          { icon: <Layers className="h-6 w-6 text-success" />, title: 'Outlook Maps', value: stats.totalOutlooks },
-          { icon: <TrendingUp className="h-6 w-6 text-warning" />, title: 'Total Features', value: stats.totalFeatures },
-          { icon: <Calendar className="h-6 w-6" />, title: 'Saved Cycles', value: stats.savedCyclesCount },
-        ].map(({ icon, title, value }) => (
-          <Card key={title} className="p-6 bg-card border-border hover:shadow-lg transition-shadow">
-            <div className="flex items-center gap-4">
-              <div className="p-3 bg-primary/10 rounded-lg">{icon}</div>
-              <div>
-                <p className="text-2xl font-bold text-foreground">{value}</p>
-                <p className="text-sm text-muted-foreground">{title}</p>
-              </div>
-            </div>
-          </Card>
+/** Shared compact stat card for the redesigned landing page. */
+const SnapshotCard: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  value: string;
+}> = ({ icon, title, value }) => (
+  <Card className="border-border/80 bg-card/95 shadow-sm">
+    <CardContent className="flex items-center gap-4 p-5">
+      <div className="rounded-2xl bg-primary/10 p-3 text-primary">{icon}</div>
+      <div>
+        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{title}</p>
+        <p className="mt-2 text-2xl font-bold text-foreground">{value}</p>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+/** Dedicated getting-started guidance for first-time or signed-out users. */
+const GettingStartedPanel: React.FC = () => (
+  <section className="space-y-4">
+    <div className="space-y-2">
+      <h2 className="text-xl font-semibold text-foreground">Getting Started</h2>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        GFC works best when you treat it like a package workspace: start a cycle, build the map, then write the
+        discussion while the setup is still fresh.
+      </p>
+    </div>
+    <div className="space-y-4">
+      {[
+        {
+          step: '1',
+          title: 'Start or load a cycle',
+          copy: 'Begin with a fresh package or reopen one you already saved locally.',
+        },
+        {
+          step: '2',
+          title: 'Open the forecast map',
+          copy: 'Use the day buttons to jump straight into the map and start sketching outlook areas.',
+        },
+        {
+          step: '3',
+          title: 'Write the discussion',
+          copy: 'Once the graphics are set, head into the discussion editor to build the text side of the package.',
+        },
+      ].map(({ step, title, copy }) => (
+        <div key={step} className="flex gap-4 rounded-2xl border border-border/80 bg-muted/20 p-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 font-semibold text-primary">
+            {step}
+          </div>
+          <div className="space-y-1">
+            <h3 className="font-medium text-foreground">{title}</h3>
+            <p className="text-sm leading-relaxed text-muted-foreground">{copy}</p>
+          </div>
+        </div>
         ))}
+    </div>
+  </section>
+);
+
+/** Compact workflow snapshot for signed-in users returning to active work. */
+const SignedInSnapshotStrip: React.FC<{ stats: Stats }> = ({ stats }) => (
+  <div className="grid gap-4 md:grid-cols-3">
+    <SnapshotCard
+      icon={<CalendarDays className="h-5 w-5" />}
+      title="Streak"
+      value={`${stats.forecastStreak}`}
+    />
+    <SnapshotCard
+      icon={<Layers3 className="h-5 w-5" />}
+      title="Total Forecasts Made"
+      value={`${stats.totalForecastsMade}`}
+    />
+    <SnapshotCard
+      icon={<Route className="h-5 w-5" />}
+      title="Total Cycles Made"
+      value={`${stats.totalCyclesMade}`}
+    />
+  </div>
+);
+
+/** Secondary signed-out sidebar that keeps guidance and a few grounded stats close by. */
+const SignedOutSidebar: React.FC<{ stats: Stats }> = ({ stats }) => (
+  <Card className="h-full border-border/80 bg-card/95 shadow-sm">
+    <CardContent className="flex h-full flex-col gap-5 p-6">
+      <GettingStartedPanel />
+
+      <div className="rounded-2xl border border-border/80 bg-muted/10 p-5">
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-foreground">At a Glance</h3>
+          <p className="text-sm text-muted-foreground">What is already in this local workspace right now.</p>
+        </div>
+        <div className="mt-4 space-y-3">
+          <div className="flex items-center justify-between rounded-xl border border-border/80 bg-background/80 px-4 py-3">
+            <span className="text-sm text-muted-foreground">Days with outlooks</span>
+            <span className="font-semibold text-foreground">{stats.daysWithData.length}</span>
+          </div>
+          <div className="flex items-center justify-between rounded-xl border border-border/80 bg-background/80 px-4 py-3">
+            <span className="text-sm text-muted-foreground">Mapped outlooks</span>
+            <span className="font-semibold text-foreground">{stats.totalOutlooks}</span>
+          </div>
+          <div className="flex items-center justify-between rounded-xl border border-border/80 bg-background/80 px-4 py-3">
+            <span className="text-sm text-muted-foreground">Saved cycles</span>
+            <span className="font-semibold text-foreground">{stats.savedCyclesCount}</span>
+          </div>
+        </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
-        {featureCards.map(({ title, description }) => (
-          <Card key={title} className="p-6 bg-card border-border hover:shadow-lg transition-shadow space-y-3">
-            <h3 className="font-semibold text-foreground">{title}</h3>
-            <p className="text-sm text-muted-foreground leading-relaxed">{description}</p>
-          </Card>
-        ))}
+      <div className="mt-auto rounded-2xl border border-border/80 bg-muted/10 p-5">
+        <h3 className="text-lg font-semibold text-foreground">Still Local-First</h3>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          You can start forecasting, save cycle files, and export work immediately. Accounts are optional and only add
+          convenience, not gatekeeping.
+        </p>
       </div>
-    </>
-  );
+    </CardContent>
+  </Card>
+);
+
+/** Secondary home-page content that changes based on whether the user is returning to work or onboarding. */
+export const Dashboard: React.FC<Props> = ({ stats, variant }) => {
+  if (variant === 'signed_in') {
+    return <SignedInSnapshotStrip stats={stats} />;
+  }
+
+  return <SignedOutSidebar stats={stats} />;
 };
 
 export default Dashboard;

--- a/src/pages/home/Dashboard.tsx
+++ b/src/pages/home/Dashboard.tsx
@@ -131,15 +131,6 @@ const AtAGlancePanel: React.FC<{ stats: Stats }> = ({ stats }) => (
   </div>
 );
 
-/** Shared body layout for the signed-out sidebar card. */
-const SignedOutSidebarContent: React.FC<{ stats: Stats }> = ({ stats }) => (
-  <CardContent className="flex h-full flex-col gap-5 p-6">
-    <GettingStartedPanel />
-    <AtAGlancePanel stats={stats} />
-    <LocalFirstPanel />
-  </CardContent>
-);
-
 /** Short reassurance block for the signed-out sidebar footer. */
 const LocalFirstPanel: React.FC = () => (
   <div className="mt-auto rounded-2xl border border-border/80 bg-muted/10 p-5">
@@ -149,6 +140,15 @@ const LocalFirstPanel: React.FC = () => (
       convenience, not gatekeeping.
     </p>
   </div>
+);
+
+/** Shared body layout for the signed-out sidebar card. */
+const SignedOutSidebarContent: React.FC<{ stats: Stats }> = ({ stats }) => (
+  <CardContent className="flex h-full flex-col gap-5 p-6">
+    <GettingStartedPanel />
+    <AtAGlancePanel stats={stats} />
+    <LocalFirstPanel />
+  </CardContent>
 );
 
 /** Secondary signed-out sidebar that keeps guidance and a few grounded stats close by. */

--- a/src/pages/home/Dashboard.tsx
+++ b/src/pages/home/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { CalendarDays, Layers3, Route, ShieldCheck } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { CalendarDays, Layers3, Route } from 'lucide-react';
+import { Card, CardContent } from '../../components/ui/card';
 import type { DayType } from '../../types/outlooks';
 import type { HomeVariant } from './HomeHero';
 
@@ -36,6 +36,23 @@ const SnapshotCard: React.FC<{
   </Card>
 );
 
+/** One numbered getting-started step inside the signed-out sidebar. */
+const GettingStartedStep: React.FC<{
+  step: string;
+  title: string;
+  copy: string;
+}> = ({ step, title, copy }) => (
+  <div className="flex gap-4 rounded-2xl border border-border/80 bg-muted/20 p-4">
+    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 font-semibold text-primary">
+      {step}
+    </div>
+    <div className="space-y-1">
+      <h3 className="font-medium text-foreground">{title}</h3>
+      <p className="text-sm leading-relaxed text-muted-foreground">{copy}</p>
+    </div>
+  </div>
+);
+
 /** Dedicated getting-started guidance for first-time or signed-out users. */
 const GettingStartedPanel: React.FC = () => (
   <section className="space-y-4">
@@ -64,16 +81,8 @@ const GettingStartedPanel: React.FC = () => (
           copy: 'Once the graphics are set, head into the discussion editor to build the text side of the package.',
         },
       ].map(({ step, title, copy }) => (
-        <div key={step} className="flex gap-4 rounded-2xl border border-border/80 bg-muted/20 p-4">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 font-semibold text-primary">
-            {step}
-          </div>
-          <div className="space-y-1">
-            <h3 className="font-medium text-foreground">{title}</h3>
-            <p className="text-sm leading-relaxed text-muted-foreground">{copy}</p>
-          </div>
-        </div>
-        ))}
+        <GettingStartedStep key={step} step={step} title={title} copy={copy} />
+      ))}
     </div>
   </section>
 );
@@ -99,41 +108,53 @@ const SignedInSnapshotStrip: React.FC<{ stats: Stats }> = ({ stats }) => (
   </div>
 );
 
+/** Small row inside the signed-out "At a Glance" block. */
+const AtAGlanceRow: React.FC<{ label: string; value: number }> = ({ label, value }) => (
+  <div className="flex items-center justify-between rounded-xl border border-border/80 bg-background/80 px-4 py-3">
+    <span className="text-sm text-muted-foreground">{label}</span>
+    <span className="font-semibold text-foreground">{value}</span>
+  </div>
+);
+
+/** Lower stats panel for signed-out users. */
+const AtAGlancePanel: React.FC<{ stats: Stats }> = ({ stats }) => (
+  <div className="rounded-2xl border border-border/80 bg-muted/10 p-5">
+    <div className="space-y-2">
+      <h3 className="text-lg font-semibold text-foreground">At a Glance</h3>
+      <p className="text-sm text-muted-foreground">What is already in this local workspace right now.</p>
+    </div>
+    <div className="mt-4 space-y-3">
+      <AtAGlanceRow label="Days with outlooks" value={stats.daysWithData.length} />
+      <AtAGlanceRow label="Mapped outlooks" value={stats.totalOutlooks} />
+      <AtAGlanceRow label="Saved cycles" value={stats.savedCyclesCount} />
+    </div>
+  </div>
+);
+
+/** Shared body layout for the signed-out sidebar card. */
+const SignedOutSidebarContent: React.FC<{ stats: Stats }> = ({ stats }) => (
+  <CardContent className="flex h-full flex-col gap-5 p-6">
+    <GettingStartedPanel />
+    <AtAGlancePanel stats={stats} />
+    <LocalFirstPanel />
+  </CardContent>
+);
+
+/** Short reassurance block for the signed-out sidebar footer. */
+const LocalFirstPanel: React.FC = () => (
+  <div className="mt-auto rounded-2xl border border-border/80 bg-muted/10 p-5">
+    <h3 className="text-lg font-semibold text-foreground">Still Local-First</h3>
+    <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+      You can start forecasting, save cycle files, and export work immediately. Accounts are optional and only add
+      convenience, not gatekeeping.
+    </p>
+  </div>
+);
+
 /** Secondary signed-out sidebar that keeps guidance and a few grounded stats close by. */
 const SignedOutSidebar: React.FC<{ stats: Stats }> = ({ stats }) => (
   <Card className="h-full border-border/80 bg-card/95 shadow-sm">
-    <CardContent className="flex h-full flex-col gap-5 p-6">
-      <GettingStartedPanel />
-
-      <div className="rounded-2xl border border-border/80 bg-muted/10 p-5">
-        <div className="space-y-2">
-          <h3 className="text-lg font-semibold text-foreground">At a Glance</h3>
-          <p className="text-sm text-muted-foreground">What is already in this local workspace right now.</p>
-        </div>
-        <div className="mt-4 space-y-3">
-          <div className="flex items-center justify-between rounded-xl border border-border/80 bg-background/80 px-4 py-3">
-            <span className="text-sm text-muted-foreground">Days with outlooks</span>
-            <span className="font-semibold text-foreground">{stats.daysWithData.length}</span>
-          </div>
-          <div className="flex items-center justify-between rounded-xl border border-border/80 bg-background/80 px-4 py-3">
-            <span className="text-sm text-muted-foreground">Mapped outlooks</span>
-            <span className="font-semibold text-foreground">{stats.totalOutlooks}</span>
-          </div>
-          <div className="flex items-center justify-between rounded-xl border border-border/80 bg-background/80 px-4 py-3">
-            <span className="text-sm text-muted-foreground">Saved cycles</span>
-            <span className="font-semibold text-foreground">{stats.savedCyclesCount}</span>
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-auto rounded-2xl border border-border/80 bg-muted/10 p-5">
-        <h3 className="text-lg font-semibold text-foreground">Still Local-First</h3>
-        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-          You can start forecasting, save cycle files, and export work immediately. Accounts are optional and only add
-          convenience, not gatekeeping.
-        </p>
-      </div>
-    </CardContent>
+    <SignedOutSidebarContent stats={stats} />
   </Card>
 );
 

--- a/src/pages/home/HomeHero.test.tsx
+++ b/src/pages/home/HomeHero.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import HomeHero from './HomeHero';
+
+describe('HomeHero', () => {
+  const baseProps = {
+    formattedDate: 'Friday, March 27, 2026',
+    hasSavedCycles: true,
+    savedCyclesCount: 3,
+    onStart: jest.fn(),
+    onWriteDiscussion: jest.fn(),
+    onViewAccount: jest.fn(),
+    onOpenHistory: jest.fn(),
+  };
+
+  test('shows onboarding-focused copy for signed-out users', () => {
+    render(<HomeHero {...baseProps} variant="signed_out" />);
+
+    expect(screen.getByText(/Build outlook packages without fighting the tooling/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Start Forecast/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Account & Sync/i })).toBeInTheDocument();
+    expect(screen.getByText(/What This Helps With/i)).toBeInTheDocument();
+  });
+
+  test('shows resume-focused copy for signed-in users', () => {
+    render(<HomeHero {...baseProps} variant="signed_in" />);
+
+    expect(screen.getByText(/Pick up the next cycle without hunting through menus/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Continue Forecast/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Open Saved Cycles/i })).toBeInTheDocument();
+    expect(screen.getByText(/Today In GFC/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/home/HomeHero.tsx
+++ b/src/pages/home/HomeHero.tsx
@@ -152,8 +152,31 @@ const HeroSummaryCard: React.FC<{
   );
 };
 
-/** Forecast-oriented landing-page hero with tailored copy for signed-in and signed-out users. */
-export const HomeHero: React.FC<Props> = ({
+/** Shared card shell that preserves the current home-hero look while reducing JSX depth in the main component. */
+const HeroShell: React.FC<{
+  variant: HomeVariant;
+  children: React.ReactNode;
+}> = ({ variant, children }) => (
+  <div
+    className={`relative overflow-hidden rounded-[2rem] border border-primary/20 bg-gradient-to-br from-primary/12 via-background to-background ${
+      variant === 'signed_in' ? 'p-8 md:px-12 md:py-12' : 'p-8 md:p-12'
+    }`}
+  >
+    <HeroBackdrop />
+    {children}
+  </div>
+);
+
+/** Shared decorative background shapes for the home hero card. */
+const HeroBackdrop: React.FC = () => (
+  <>
+    <div className="absolute -top-16 -right-12 h-64 w-64 rounded-full bg-primary/10 blur-3xl pointer-events-none" />
+    <div className="absolute -bottom-16 -left-10 h-56 w-56 rounded-full bg-primary/8 blur-3xl pointer-events-none" />
+  </>
+);
+
+/** Main left-hand content stack for the home hero. */
+const HeroMainContent: React.FC<Props> = ({
   variant,
   formattedDate,
   hasSavedCycles,
@@ -166,51 +189,69 @@ export const HomeHero: React.FC<Props> = ({
   const copy = getHeroCopy(variant);
 
   return (
-    <div
-      className={`relative overflow-hidden rounded-[2rem] border border-primary/20 bg-gradient-to-br from-primary/12 via-background to-background ${
-        variant === 'signed_in' ? 'p-8 md:px-12 md:py-12' : 'p-8 md:p-12'
-      }`}
-    >
-      <div className="absolute -top-16 -right-12 h-64 w-64 rounded-full bg-primary/10 blur-3xl pointer-events-none" />
-      <div className="absolute -bottom-16 -left-10 h-56 w-56 rounded-full bg-primary/8 blur-3xl pointer-events-none" />
+    <div className="space-y-10 py-2 lg:col-span-2 lg:pr-6 lg:py-4">
+      <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
+        <Map className="h-4 w-4" />
+        {copy.eyebrow}
+      </div>
 
-      <div className="relative grid gap-8 lg:grid-cols-3 lg:items-start lg:gap-10">
-        <div className="space-y-10 py-2 lg:col-span-2 lg:pr-6 lg:py-4">
-          <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
-            <Map className="h-4 w-4" />
-            {copy.eyebrow}
-          </div>
-
-          <div className="space-y-8">
-            <h1 className="max-w-3xl text-4xl font-extrabold leading-tight tracking-tight text-foreground md:text-5xl">
-              {copy.title}
-            </h1>
-            <div className="pt-1">
-              <p className="max-w-2xl text-base leading-relaxed text-muted-foreground md:text-lg">
-                {copy.description}
-              </p>
-            </div>
-          </div>
-
-          <div className="pt-3">
-            <HeroActions
-              variant={variant}
-              formattedDate={formattedDate}
-              hasSavedCycles={hasSavedCycles}
-              savedCyclesCount={savedCyclesCount}
-              onStart={onStart}
-              onWriteDiscussion={onWriteDiscussion}
-              onViewAccount={onViewAccount}
-              onOpenHistory={onOpenHistory}
-            />
-          </div>
+      <div className="space-y-8">
+        <h1 className="max-w-3xl text-4xl font-extrabold leading-tight tracking-tight text-foreground md:text-5xl">
+          {copy.title}
+        </h1>
+        <div className="pt-1">
+          <p className="max-w-2xl text-base leading-relaxed text-muted-foreground md:text-lg">
+            {copy.description}
+          </p>
         </div>
+      </div>
+
+      <div className="pt-3">
+        <HeroActions
+          variant={variant}
+          formattedDate={formattedDate}
+          hasSavedCycles={hasSavedCycles}
+          savedCyclesCount={savedCyclesCount}
+          onStart={onStart}
+          onWriteDiscussion={onWriteDiscussion}
+          onViewAccount={onViewAccount}
+          onOpenHistory={onOpenHistory}
+        />
+      </div>
+    </div>
+  );
+};
+
+/** Forecast-oriented landing-page hero with tailored copy for signed-in and signed-out users. */
+export const HomeHero: React.FC<Props> = ({
+  variant,
+  formattedDate,
+  hasSavedCycles,
+  savedCyclesCount,
+  onStart,
+  onWriteDiscussion,
+  onViewAccount,
+  onOpenHistory,
+}) => {
+  return (
+    <HeroShell variant={variant}>
+      <div className="relative grid gap-8 lg:grid-cols-3 lg:items-start lg:gap-10">
+        <HeroMainContent
+          variant={variant}
+          formattedDate={formattedDate}
+          hasSavedCycles={hasSavedCycles}
+          savedCyclesCount={savedCyclesCount}
+          onStart={onStart}
+          onWriteDiscussion={onWriteDiscussion}
+          onViewAccount={onViewAccount}
+          onOpenHistory={onOpenHistory}
+        />
 
         <div className="lg:pt-2">
           <HeroSummaryCard variant={variant} formattedDate={formattedDate} savedCyclesCount={savedCyclesCount} />
         </div>
       </div>
-    </div>
+    </HeroShell>
   );
 };
 

--- a/src/pages/home/HomeHero.tsx
+++ b/src/pages/home/HomeHero.tsx
@@ -152,6 +152,14 @@ const HeroSummaryCard: React.FC<{
   );
 };
 
+/** Shared decorative background shapes for the home hero card. */
+const HeroBackdrop: React.FC = () => (
+  <>
+    <div className="absolute -top-16 -right-12 h-64 w-64 rounded-full bg-primary/10 blur-3xl pointer-events-none" />
+    <div className="absolute -bottom-16 -left-10 h-56 w-56 rounded-full bg-primary/8 blur-3xl pointer-events-none" />
+  </>
+);
+
 /** Shared card shell that preserves the current home-hero look while reducing JSX depth in the main component. */
 const HeroShell: React.FC<{
   variant: HomeVariant;
@@ -165,14 +173,6 @@ const HeroShell: React.FC<{
     <HeroBackdrop />
     {children}
   </div>
-);
-
-/** Shared decorative background shapes for the home hero card. */
-const HeroBackdrop: React.FC = () => (
-  <>
-    <div className="absolute -top-16 -right-12 h-64 w-64 rounded-full bg-primary/10 blur-3xl pointer-events-none" />
-    <div className="absolute -bottom-16 -left-10 h-56 w-56 rounded-full bg-primary/8 blur-3xl pointer-events-none" />
-  </>
 );
 
 /** Main left-hand content stack for the home hero. */

--- a/src/pages/home/HomeHero.tsx
+++ b/src/pages/home/HomeHero.tsx
@@ -1,66 +1,213 @@
 import React from 'react';
+import { ArrowRight, CircleUserRound, Clock3, FileText, History, Map, ShieldCheck } from 'lucide-react';
 import { Button } from '../../components/ui/button';
-import { ArrowRight, FileText, Cloud, CircleUserRound } from 'lucide-react';
+
+export type HomeVariant = 'signed_in' | 'signed_out';
 
 interface Props {
+  variant: HomeVariant;
+  formattedDate: string;
+  hasSavedCycles: boolean;
+  savedCyclesCount: number;
   onStart: () => void;
   onWriteDiscussion: () => void;
   onViewAccount: () => void;
+  onOpenHistory: () => void;
 }
 
-/** Renders the main headline with primary-colored text highlight. */
-const HeroHeadline: React.FC = () => (
-  <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight text-foreground leading-tight">
-    Draw professional<br />
-    <span className="text-primary">severe weather outlooks.</span>
-  </h1>
-);
+interface HeroStatRow {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}
 
-/** Left-hand content panel: app badge, headline, description, and CTA buttons. */
-const HeroLeftPanel: React.FC<Pick<Props, 'onStart' | 'onWriteDiscussion' | 'onViewAccount'>> = ({ onStart, onWriteDiscussion, onViewAccount }) => (
-  <div className="space-y-5 flex-1">
-    <div className="inline-flex items-center gap-2 bg-primary/10 border border-primary/25 rounded-full px-4 py-1.5 text-sm font-medium text-primary">
-      <Cloud className="h-4 w-4" />
-      Graphical Forecast Creator
-    </div>
-    <div className="space-y-3">
-      <HeroHeadline />
-      <p className="text-lg text-muted-foreground max-w-xl leading-relaxed">
-        Create probabilistic severe weather outlooks for Days 1–8, write forecast discussions,
-        and verify your predictions — right in your browser, no sign-in required.
-      </p>
-    </div>
-    <div className="flex flex-wrap gap-3">
-      <Button size="lg" onClick={onStart}>
-        Start Drawing
-        <ArrowRight className="h-4 w-4 ml-2" />
+/** Returns the home hero title and supporting copy for the active auth state. */
+const getHeroCopy = (variant: HomeVariant) => {
+  if (variant === 'signed_in') {
+    return {
+      eyebrow: 'Forecast Workspace',
+      title: 'Pick up the next cycle without hunting through menus.',
+      description:
+        'Resume the package already in progress, reopen a saved cycle, or jump straight into the discussion editor when it is time to write.',
+    };
+  }
+
+  return {
+    eyebrow: 'Built For Forecast Workflow',
+    title: 'Build outlook packages without fighting the tooling.',
+    description:
+      'GFC keeps drawing, cycle management, discussions, and verification in one place so you can focus on the forecast instead of bouncing between tools.',
+  };
+};
+
+/** Builds the small right-hand hero summary card for the current landing-page variant. */
+const getHeroStats = (
+  variant: HomeVariant,
+  formattedDate: string,
+  savedCyclesCount: number
+): HeroStatRow[] => {
+  if (variant === 'signed_in') {
+    return [
+      {
+        icon: <Clock3 className="h-4 w-4 text-primary" />,
+        label: 'Current cycle',
+        value: formattedDate,
+      },
+      {
+        icon: <History className="h-4 w-4 text-primary" />,
+        label: 'Saved cycles',
+        value: `${savedCyclesCount}`,
+      },
+      {
+        icon: <FileText className="h-4 w-4 text-primary" />,
+        label: 'Best next move',
+        value: 'Resume the map or open a saved package.',
+      },
+    ];
+  }
+
+  return [
+    {
+      icon: <Map className="h-4 w-4 text-primary" />,
+      label: 'Draw outlooks',
+      value: 'Jump into the map and sketch Day 1 through Day 8 packages.',
+    },
+    {
+      icon: <FileText className="h-4 w-4 text-primary" />,
+      label: 'Write discussions',
+      value: 'Keep the narrative side of the package right next to the graphics.',
+    },
+    {
+      icon: <ShieldCheck className="h-4 w-4 text-primary" />,
+      label: 'Check your work',
+      value: 'Come back later and verify packages against reports.',
+    },
+  ];
+};
+
+/** Shared action row for the hero, tailored to the signed-in or signed-out workflow. */
+const HeroActions: React.FC<Props> = ({
+  variant,
+  hasSavedCycles,
+  onStart,
+  onWriteDiscussion,
+  onViewAccount,
+  onOpenHistory,
+}) => (
+  <div className="flex flex-wrap gap-3">
+    <Button size="lg" onClick={onStart}>
+      {variant === 'signed_in' ? 'Continue Forecast' : 'Start Forecast'}
+      <ArrowRight className="h-4 w-4 ml-2" />
+    </Button>
+    <Button size="lg" variant="outline" onClick={onWriteDiscussion}>
+      <FileText className="h-4 w-4 mr-2" />
+      Write Discussion
+    </Button>
+    {variant === 'signed_in' && hasSavedCycles ? (
+      <Button size="lg" variant="ghost" onClick={onOpenHistory}>
+        <History className="h-4 w-4 mr-2" />
+        Open Saved Cycles
       </Button>
-      <Button size="lg" variant="outline" onClick={onWriteDiscussion}>
-        <FileText className="h-4 w-4 mr-2" />
-        Write a Discussion
-      </Button>
+    ) : null}
+    {variant === 'signed_out' ? (
       <Button size="lg" variant="ghost" onClick={onViewAccount}>
         <CircleUserRound className="h-4 w-4 mr-2" />
         Account &amp; Sync
       </Button>
-    </div>
+    ) : null}
   </div>
 );
 
-/** Hero section for the home page with a headline, CTA buttons, and outlook level badge preview. */
-export const HomeHero: React.FC<Props> = ({ onStart, onWriteDiscussion, onViewAccount }) => {
+/** Compact right-side summary card that gives the hero a more grounded, operational feel. */
+const HeroSummaryCard: React.FC<{
+  variant: HomeVariant;
+  formattedDate: string;
+  savedCyclesCount: number;
+}> = ({ variant, formattedDate, savedCyclesCount }) => {
+  const stats = getHeroStats(variant, formattedDate, savedCyclesCount);
+
   return (
-    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-primary/10 via-primary/5 to-background border border-primary/20 p-10 md:p-14">
-      <div className="absolute -top-16 -right-16 h-64 w-64 rounded-full bg-primary/8 blur-3xl pointer-events-none" />
-      <div className="absolute -bottom-10 -left-10 h-48 w-48 rounded-full bg-primary/5 blur-2xl pointer-events-none" />
-      <div className="relative flex flex-col md:flex-row items-start md:items-center gap-8">
-        <HeroLeftPanel onStart={onStart} onWriteDiscussion={onWriteDiscussion} onViewAccount={onViewAccount} />
-        <div className="hidden lg:flex flex-col gap-2 shrink-0 select-none">
-          {[ 'HIGH','MDT','ENH','SLGT','MRGL','TSTM' ].map((label) => (
-            <div key={label} className="w-24 text-center px-4 py-2 rounded-lg border font-bold text-sm tracking-wide bg-muted/10">
+    <div className="w-full rounded-3xl border border-primary/20 bg-background/80 p-6 shadow-sm backdrop-blur">
+      <div className="space-y-1">
+        <p className="text-xs uppercase tracking-[0.22em] text-primary">
+          {variant === 'signed_in' ? 'Today In GFC' : 'What This Helps With'}
+        </p>
+        <h2 className="text-lg font-semibold text-foreground">
+          {variant === 'signed_in' ? 'Get back into the package quickly.' : 'A single workspace for the full package.'}
+        </h2>
+      </div>
+
+      <div className="mt-5 space-y-4">
+        {stats.map(({ icon, label, value }) => (
+          <div key={label} className="rounded-2xl border border-border/70 bg-muted/25 p-4">
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+              {icon}
               {label}
             </div>
-          ))}
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/** Forecast-oriented landing-page hero with tailored copy for signed-in and signed-out users. */
+export const HomeHero: React.FC<Props> = ({
+  variant,
+  formattedDate,
+  hasSavedCycles,
+  savedCyclesCount,
+  onStart,
+  onWriteDiscussion,
+  onViewAccount,
+  onOpenHistory,
+}) => {
+  const copy = getHeroCopy(variant);
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-[2rem] border border-primary/20 bg-gradient-to-br from-primary/12 via-background to-background ${
+        variant === 'signed_in' ? 'p-8 md:px-12 md:py-12' : 'p-8 md:p-12'
+      }`}
+    >
+      <div className="absolute -top-16 -right-12 h-64 w-64 rounded-full bg-primary/10 blur-3xl pointer-events-none" />
+      <div className="absolute -bottom-16 -left-10 h-56 w-56 rounded-full bg-primary/8 blur-3xl pointer-events-none" />
+
+      <div className="relative grid gap-8 lg:grid-cols-3 lg:items-start lg:gap-10">
+        <div className="space-y-10 py-2 lg:col-span-2 lg:pr-6 lg:py-4">
+          <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
+            <Map className="h-4 w-4" />
+            {copy.eyebrow}
+          </div>
+
+          <div className="space-y-8">
+            <h1 className="max-w-3xl text-4xl font-extrabold leading-tight tracking-tight text-foreground md:text-5xl">
+              {copy.title}
+            </h1>
+            <div className="pt-1">
+              <p className="max-w-2xl text-base leading-relaxed text-muted-foreground md:text-lg">
+                {copy.description}
+              </p>
+            </div>
+          </div>
+
+          <div className="pt-3">
+            <HeroActions
+              variant={variant}
+              formattedDate={formattedDate}
+              hasSavedCycles={hasSavedCycles}
+              savedCyclesCount={savedCyclesCount}
+              onStart={onStart}
+              onWriteDiscussion={onWriteDiscussion}
+              onViewAccount={onViewAccount}
+              onOpenHistory={onOpenHistory}
+            />
+          </div>
+        </div>
+
+        <div className="lg:pt-2">
+          <HeroSummaryCard variant={variant} formattedDate={formattedDate} savedCyclesCount={savedCyclesCount} />
         </div>
       </div>
     </div>

--- a/src/pages/home/MainGrid.tsx
+++ b/src/pages/home/MainGrid.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
-import { Card } from '../../components/ui/card';
-import { Clock, CheckCircle2, AlertTriangle, Map as MapIcon, FileText, ArrowRight, Zap, Calendar, Save, Upload, History, Cloud } from 'lucide-react';
+import { AlertTriangle, ArrowRight, Calendar, CheckCircle2, Clock3, FileText, History, Layers3, Map, Save, Upload } from 'lucide-react';
 import type { DayType, ForecastCycle } from '../../types/outlooks';
 import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
 import { cn } from '../../lib/utils';
+import type { HomeVariant } from './HomeHero';
 
 interface HomeStats {
   daysWithData: DayType[];
   totalOutlooks: number;
   totalFeatures: number;
   savedCyclesCount: number;
+  totalForecastsMade: number;
+  totalCyclesMade: number;
+  forecastStreak: number;
 }
 
 interface Props {
+  variant: HomeVariant;
   formattedDate: string;
   isSaved: boolean;
   forecastCycle: ForecastCycle;
@@ -26,33 +31,68 @@ interface Props {
   onOpenHistory: () => void;
 }
 
-/** Card header showing the cycle title, formatted date, and current save status. */
-const CyclePanelHeader: React.FC<{ formattedDate: string; isSaved: boolean }> = ({ formattedDate, isSaved }) => (
-  <div className="flex items-center justify-between">
-    <div>
-      <h2 className="text-2xl font-semibold text-foreground flex items-center gap-2">
-        <Clock className="h-6 w-6 text-primary" />
-        Current Forecast Cycle
-      </h2>
-      <p className="text-sm text-muted-foreground mt-1">{formattedDate}</p>
+/** Header copy for the main current-cycle card. */
+const getWorkspaceCopy = (variant: HomeVariant) => {
+  if (variant === 'signed_in') {
+    return {
+      description: 'Resume the package already in progress, switch days, or jump into the next step without losing context.',
+      primaryAction: 'Continue Forecast',
+    };
+  }
+
+  return {
+    description: 'Start here whether you are sketching a fresh package or reopening older local work.',
+    primaryAction: 'Open Forecast Map',
+  };
+};
+
+/** Compact stat tile used to keep the current-cycle card informative without dashboard clutter. */
+const WorkspaceStat: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}> = ({ icon, label, value }) => (
+  <div className="rounded-2xl border border-border/80 bg-muted/25 p-4">
+    <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+      {icon}
+      {label}
     </div>
-    <div className="flex items-center gap-2">
-      {!isSaved && (
-        <span className="flex items-center gap-1 text-warning text-sm font-medium">
-          <AlertTriangle className="h-4 w-4" />
-          Unsaved
-        </span>
-      )}
-      {isSaved && (
-        <span className="flex items-center gap-1 text-success text-sm font-medium">
-          <CheckCircle2 className="h-4 w-4" />
-          Saved
-        </span>
-      )}
-    </div>
+    <p className="mt-3 text-lg font-semibold text-foreground">{value}</p>
   </div>
 );
-/** Renders a day-button grid item for the forecast day selector. */
+
+/** Header showing the current cycle and save state. */
+const CurrentCycleHeader: React.FC<{
+  variant: HomeVariant;
+  formattedDate: string;
+  isSaved: boolean;
+}> = ({ variant, formattedDate, isSaved }) => {
+  const copy = getWorkspaceCopy(variant);
+
+  return (
+    <CardHeader className="space-y-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <CardTitle className="text-2xl">Current Forecast Cycle</CardTitle>
+          <CardDescription className="max-w-2xl">{copy.description}</CardDescription>
+        </div>
+        <div className="flex min-h-20 self-start rounded-full border border-border/80 bg-background/80 px-4 py-2 text-sm font-medium md:min-w-40 md:items-center md:justify-center">
+          <span className={cn('inline-flex items-center gap-2 text-center', isSaved ? 'text-success' : 'text-warning')}>
+            {isSaved ? <CheckCircle2 className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
+            {isSaved ? 'Saved locally' : 'Unsaved changes'}
+          </span>
+        </div>
+      </div>
+
+      <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/8 px-4 py-1.5 text-sm text-muted-foreground">
+        <Clock3 className="h-4 w-4 text-primary" />
+        {formattedDate}
+      </div>
+    </CardHeader>
+  );
+};
+
+/** Individual day button for jumping directly into a forecast day. */
 const DayButton: React.FC<{
   day: number;
   hasData: boolean;
@@ -60,32 +100,36 @@ const DayButton: React.FC<{
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }> = ({ day, hasData, isCurrent, onClick }) => (
   <button
-    key={day}
     data-day={day}
     onClick={onClick}
     className={cn(
-      'relative p-4 rounded-lg border-2 transition-all',
-      'hover:shadow-md hover:scale-105',
-      hasData ? 'bg-primary/10 border-primary' : 'bg-muted/30 border-border',
+      'rounded-2xl border px-3 py-4 text-left transition-all hover:-translate-y-0.5 hover:border-primary hover:shadow-sm',
+      hasData ? 'border-primary/30 bg-primary/8' : 'border-border/80 bg-background/70',
       isCurrent && 'ring-2 ring-primary ring-offset-2'
     )}
   >
-    <div className="text-center">
+    <div className="space-y-1">
+      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Day</p>
       <p className="text-2xl font-bold text-foreground">{day}</p>
+      <p className="text-xs text-muted-foreground">{hasData ? 'Outlooks started' : 'Ready to edit'}</p>
     </div>
   </button>
 );
 
-/** Days-with-outlooks label and 1–8 day selector grid. */
+/** Selector for the active forecast day. */
 const CycleDayGrid: React.FC<{
   daysWithData: DayType[];
   currentDay: number;
   onDayClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }> = ({ daysWithData, currentDay, onDayClick }) => (
-  <div>
-    <h3 className="text-sm font-medium text-muted-foreground mb-3">Days with Outlooks</h3>
-    <div className="grid grid-cols-8 gap-2">
-      {[1,2,3,4,5,6,7,8].map((day) => (
+  <div className="space-y-3">
+    <div className="space-y-1">
+      <h3 className="text-sm font-medium text-foreground">Jump to a forecast day</h3>
+      <p className="text-sm text-muted-foreground">Pick a day below to head straight into the map editor.</p>
+    </div>
+
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 xl:grid-cols-8">
+      {[1, 2, 3, 4, 5, 6, 7, 8].map((day) => (
         <DayButton
           key={day}
           day={day}
@@ -98,93 +142,129 @@ const CycleDayGrid: React.FC<{
   </div>
 );
 
-/** Continue Forecast and Write Discussion navigation buttons. */
-const CycleNavButtons: React.FC<{
+/** Primary workflow actions that move the user back into the main forecast flow. */
+const PrimaryActions: React.FC<{
+  variant: HomeVariant;
   onNavigateForecast: () => void;
   onNavigateDiscussion: () => void;
-}> = ({ onNavigateForecast, onNavigateDiscussion }) => (
-  <div className="grid grid-cols-2 gap-3">
-    <Button variant="outline" className="h-auto py-4 flex-col gap-2" onClick={onNavigateForecast}>
-      <MapIcon className="h-5 w-5" />
-      <span>Continue Forecast</span>
-      <ArrowRight className="h-4 w-4 text-muted-foreground" />
-    </Button>
-    <Button variant="outline" className="h-auto py-4 flex-col gap-2" onClick={onNavigateDiscussion}>
-      <FileText className="h-5 w-5" />
-      <span>Write Discussion</span>
-      <ArrowRight className="h-4 w-4 text-muted-foreground" />
-    </Button>
-  </div>
-);
+}> = ({ variant, onNavigateForecast, onNavigateDiscussion }) => {
+  const copy = getWorkspaceCopy(variant);
 
-/** New cycle, save, load, and history quick-action buttons. */
-const QuickActionsList: React.FC<{
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      <Button className="h-auto justify-between rounded-2xl px-5 py-4 text-left" onClick={onNavigateForecast}>
+        <span className="flex items-center gap-3">
+          <Map className="h-4 w-4" />
+          {copy.primaryAction}
+        </span>
+        <ArrowRight className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="outline"
+        className="h-auto justify-between rounded-2xl px-5 py-4 text-left"
+        onClick={onNavigateDiscussion}
+      >
+        <span className="flex items-center gap-3">
+          <FileText className="h-4 w-4" />
+          Write Discussion
+        </span>
+        <ArrowRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+};
+
+/** Secondary utility actions for file and cycle management. */
+const UtilityActions: React.FC<{
   onNewCycle: () => void;
   onSave: () => void;
   onOpenFile: () => void;
   onOpenHistory: () => void;
 }> = ({ onNewCycle, onSave, onOpenFile, onOpenHistory }) => (
-  <div className="space-y-2">
-    <Button variant="default" className="w-full justify-start h-auto py-3" onClick={onNewCycle}>
-      <Calendar className="h-4 w-4 mr-2" />
-      New Forecast Cycle
-    </Button>
-    <Button variant="outline" className="w-full justify-start h-auto py-3" onClick={onSave}>
-      <Save className="h-4 w-4 mr-2" />
-      Save Current Cycle
-    </Button>
-    <Button variant="outline" className="w-full justify-start h-auto py-3" onClick={onOpenFile}>
-      <Upload className="h-4 w-4 mr-2" />
-      Load Cycle from File
-    </Button>
-    <Button variant="outline" className="w-full justify-start h-auto py-3" onClick={onOpenHistory}>
-      <History className="h-4 w-4 mr-2" />
-      View Cycle History
-    </Button>
-  </div>
-);
+  <div className="space-y-3 rounded-2xl border border-border/80 bg-muted/15 p-5">
+    <div className="space-y-1">
+      <h3 className="text-sm font-medium text-foreground">Cycle tools</h3>
+      <p className="text-sm text-muted-foreground">Keep the package moving without leaving the landing page.</p>
+    </div>
 
-/** Forecast Map and Discussion Editor ghost navigation buttons. */
-const NavigateSection: React.FC<{
-  onNavigateForecast: () => void;
-  onNavigateDiscussion: () => void;
-}> = ({ onNavigateForecast, onNavigateDiscussion }) => (
-  <div className="pt-4 border-t border-border">
-    <h3 className="text-sm font-medium text-muted-foreground mb-2">Navigate</h3>
-    <div className="space-y-2">
-      <Button variant="ghost" className="w-full justify-start" onClick={onNavigateForecast}>
-        <Cloud className="h-4 w-4 mr-2 text-foreground" />
-        Forecast Map
+    <div className="grid gap-3 sm:grid-cols-2">
+      <Button variant="outline" className="justify-start rounded-xl" onClick={onNewCycle}>
+        <Calendar className="h-4 w-4 mr-2" />
+        Start New Cycle
       </Button>
-      <Button variant="ghost" className="w-full justify-start" onClick={onNavigateDiscussion}>
-        <FileText className="h-4 w-4 mr-2 text-btn-discussion" />
-        Discussion Editor
+      <Button variant="outline" className="justify-start rounded-xl" onClick={onSave}>
+        <Save className="h-4 w-4 mr-2" />
+        Save Cycle File
+      </Button>
+      <Button variant="outline" className="justify-start rounded-xl" onClick={onOpenFile}>
+        <Upload className="h-4 w-4 mr-2" />
+        Load From File
+      </Button>
+      <Button variant="outline" className="justify-start rounded-xl" onClick={onOpenHistory}>
+        <History className="h-4 w-4 mr-2" />
+        Open Cycle History
       </Button>
     </div>
   </div>
 );
 
-/** Main dashboard grid combining the current forecast cycle panel, quick actions, and navigation. */
-export const MainGrid: React.FC<Props> = ({ formattedDate, isSaved, forecastCycle, stats, onQuickStartClick, onNavigateForecast, onNavigateDiscussion, onNewCycle, onSave, onOpenFile, onOpenHistory }) => {
-  return (
-    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-      <Card className="lg:col-span-2 p-6 bg-card border-border">
-        <div className="space-y-6">
-          <CyclePanelHeader formattedDate={formattedDate} isSaved={isSaved} />
-          <CycleDayGrid daysWithData={stats.daysWithData} currentDay={forecastCycle.currentDay} onDayClick={onQuickStartClick} />
-          <CycleNavButtons onNavigateForecast={onNavigateForecast} onNavigateDiscussion={onNavigateDiscussion} />
-        </div>
-      </Card>
-      <Card className="p-6 bg-card border-border space-y-4">
-        <h2 className="text-xl font-semibold text-foreground flex items-center gap-2">
-          <Zap className="h-5 w-5 text-warning" />
-          Quick Actions
-        </h2>
-        <QuickActionsList onNewCycle={onNewCycle} onSave={onSave} onOpenFile={onOpenFile} onOpenHistory={onOpenHistory} />
-        <NavigateSection onNavigateForecast={onNavigateForecast} onNavigateDiscussion={onNavigateDiscussion} />
-      </Card>
-    </div>
-  );
-};
+/** Workflow-first card for the current cycle and the most common forecast actions. */
+export const MainGrid: React.FC<Props> = ({
+  variant,
+  formattedDate,
+  isSaved,
+  forecastCycle,
+  stats,
+  onQuickStartClick,
+  onNavigateForecast,
+  onNavigateDiscussion,
+  onNewCycle,
+  onSave,
+  onOpenFile,
+  onOpenHistory,
+}) => (
+  <Card className="border-border/80 bg-card/95 shadow-sm">
+    <CurrentCycleHeader variant={variant} formattedDate={formattedDate} isSaved={isSaved} />
+
+    <CardContent className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-3">
+        <WorkspaceStat
+          icon={<Clock3 className="h-4 w-4 text-primary" />}
+          label="Active day"
+          value={`Day ${forecastCycle.currentDay}`}
+        />
+        <WorkspaceStat
+          icon={<Map className="h-4 w-4 text-primary" />}
+          label="Days with outlooks"
+          value={`${stats.daysWithData.length}`}
+        />
+        <WorkspaceStat
+          icon={<Layers3 className="h-4 w-4 text-primary" />}
+          label="Mapped outlooks"
+          value={`${stats.totalOutlooks}`}
+        />
+      </div>
+
+      <CycleDayGrid
+        daysWithData={stats.daysWithData}
+        currentDay={forecastCycle.currentDay}
+        onDayClick={onQuickStartClick}
+      />
+
+      <PrimaryActions
+        variant={variant}
+        onNavigateForecast={onNavigateForecast}
+        onNavigateDiscussion={onNavigateDiscussion}
+      />
+
+      <UtilityActions
+        onNewCycle={onNewCycle}
+        onSave={onSave}
+        onOpenFile={onOpenFile}
+        onOpenHistory={onOpenHistory}
+      />
+    </CardContent>
+  </Card>
+);
 
 export default MainGrid;

--- a/src/pages/home/RecentCycles.tsx
+++ b/src/pages/home/RecentCycles.tsx
@@ -11,8 +11,17 @@ interface Props {
   variant?: 'compact' | 'section';
 }
 
+interface RecentCyclesContentProps {
+  savedCycles: SavedCycle[];
+  onLoad: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onOpenHistory: () => void;
+}
+
 /** Formats saved-cycle timestamps consistently for the home page. */
 const formatSavedCycleTime = (timestamp: string): string => new Date(timestamp).toLocaleString();
+
+/** True when there are no saved cycles to display. */
+const hasNoSavedCycles = (savedCycles: SavedCycle[]): boolean => savedCycles.length === 0;
 
 /** Card row used in the compact recent-cycles sidebar. */
 const CompactCycleRow: React.FC<{
@@ -74,6 +83,65 @@ const EmptyRecentCyclesCard: React.FC = () => (
   </Card>
 );
 
+/** Compact recent-cycle sidebar used on the signed-in landing page. */
+const CompactRecentCycles: React.FC<RecentCyclesContentProps> = ({
+  savedCycles,
+  onLoad,
+  onOpenHistory,
+}) => (
+  <Card className="border-border/80 bg-card/95 shadow-sm">
+    <CardHeader className="space-y-2">
+      <CardTitle className="text-xl">Recent Cycles</CardTitle>
+      <CardDescription>Jump back into a saved package without leaving the landing page.</CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-4">
+      {savedCycles.slice(0, 4).map((cycle) => (
+        <CompactCycleRow key={cycle.id} cycle={cycle} onLoad={onLoad} />
+      ))}
+
+      <Button variant="outline" className="w-full" onClick={onOpenHistory}>
+        View Full History
+      </Button>
+    </CardContent>
+  </Card>
+);
+
+/** Wider recent-cycle section used lower on the signed-out landing page. */
+const SectionRecentCycles: React.FC<RecentCyclesContentProps> = ({
+  savedCycles,
+  onLoad,
+  onOpenHistory,
+}) => (
+  <Card className="border-border/80 bg-card/95 shadow-sm">
+    <CardHeader className="space-y-2">
+      <CardTitle className="flex items-center gap-2 text-2xl">
+        <History className="h-5 w-5 text-primary" />
+        Recent Local Cycles
+      </CardTitle>
+      <CardDescription>
+        Saved packages stay easy to reopen, which makes it simpler to compare setups or continue older work.
+      </CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {savedCycles.slice(0, 6).map((cycle) => (
+          <SectionCycleTile key={cycle.id} cycle={cycle} onLoad={onLoad} />
+        ))}
+      </div>
+
+      {savedCycles.length > 6 ? (
+        <Button variant="outline" className="w-full" onClick={onOpenHistory}>
+          View All {savedCycles.length} Cycles
+        </Button>
+      ) : null}
+    </CardContent>
+  </Card>
+);
+
+/** Returns the right empty-state behavior for the current recent-cycle variant. */
+const renderEmptyRecentCycles = (variant: Props['variant']) =>
+  variant === 'compact' ? <EmptyRecentCyclesCard /> : null;
+
 /** Recent cycle list, shown as either a prominent section or a compact resume sidebar. */
 export const RecentCycles: React.FC<Props> = ({
   savedCycles,
@@ -81,59 +149,14 @@ export const RecentCycles: React.FC<Props> = ({
   onOpenHistory,
   variant = 'section',
 }) => {
-  if ((!savedCycles || savedCycles.length === 0) && variant === 'section') {
-    return null;
+  if (hasNoSavedCycles(savedCycles)) {
+    return renderEmptyRecentCycles(variant);
   }
 
-  if ((!savedCycles || savedCycles.length === 0) && variant === 'compact') {
-    return <EmptyRecentCyclesCard />;
-  }
-
-  if (variant === 'compact') {
-    return (
-      <Card className="border-border/80 bg-card/95 shadow-sm">
-        <CardHeader className="space-y-2">
-          <CardTitle className="text-xl">Recent Cycles</CardTitle>
-          <CardDescription>Jump back into a saved package without leaving the landing page.</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {savedCycles.slice(0, 4).map((cycle) => (
-            <CompactCycleRow key={cycle.id} cycle={cycle} onLoad={onLoad} />
-          ))}
-
-          <Button variant="outline" className="w-full" onClick={onOpenHistory}>
-            View Full History
-          </Button>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  return (
-    <Card className="border-border/80 bg-card/95 shadow-sm">
-      <CardHeader className="space-y-2">
-        <CardTitle className="flex items-center gap-2 text-2xl">
-          <History className="h-5 w-5 text-primary" />
-          Recent Local Cycles
-        </CardTitle>
-        <CardDescription>
-          Saved packages stay easy to reopen, which makes it simpler to compare setups or continue older work.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-5">
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {savedCycles.slice(0, 6).map((cycle) => (
-            <SectionCycleTile key={cycle.id} cycle={cycle} onLoad={onLoad} />
-          ))}
-        </div>
-
-        {savedCycles.length > 6 ? (
-          <Button variant="outline" className="w-full" onClick={onOpenHistory}>
-            View All {savedCycles.length} Cycles
-          </Button>
-        ) : null}
-      </CardContent>
-    </Card>
+  return variant === 'compact' ? (
+    <CompactRecentCycles savedCycles={savedCycles} onLoad={onLoad} onOpenHistory={onOpenHistory} />
+  ) : (
+    <SectionRecentCycles savedCycles={savedCycles} onLoad={onLoad} onOpenHistory={onOpenHistory} />
   );
 };
 

--- a/src/pages/home/RecentCycles.tsx
+++ b/src/pages/home/RecentCycles.tsx
@@ -1,32 +1,138 @@
 import React from 'react';
-import { Card } from '../../components/ui/card';
 import { History } from 'lucide-react';
 import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
 import type { SavedCycle } from '../../store/forecastSlice';
 
-/** Displays the most recently saved forecast cycles as a card grid with a load button per cycle. */
-export const RecentCycles: React.FC<{ savedCycles: SavedCycle[]; onLoad: (e: React.MouseEvent<HTMLButtonElement>) => void; onOpenHistory: () => void; }> = ({ savedCycles, onLoad, onOpenHistory }) => {
-  if (!savedCycles || savedCycles.length === 0) return null;
-  return (
-    <Card className="p-6 bg-card border-border">
-      <h2 className="text-xl font-semibold text-foreground mb-4 flex items-center gap-2">
-        <History className="h-5 w-5 text-btn-cycle" />
-        Recent Saved Cycles
-      </h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {savedCycles.slice(0,6).map((cycle) => (
-          <button key={cycle.id} className="p-4 bg-muted/30 rounded-lg border border-border hover:border-primary hover:shadow-md transition-all text-left" data-cycle-id={cycle.id} onClick={onLoad}>
-            <div className="flex items-start justify-between mb-2">
-              <p className="font-medium text-foreground">{cycle.cycleDate}</p>
-              {cycle.label && (<span className="text-xs bg-primary/10 text-primary px-2 py-1 rounded">{cycle.label}</span>)}
-            </div>
-            <p className="text-xs text-muted-foreground">{new Date(cycle.timestamp).toLocaleString()}</p>
-          </button>
-        ))}
+interface Props {
+  savedCycles: SavedCycle[];
+  onLoad: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onOpenHistory: () => void;
+  variant?: 'compact' | 'section';
+}
+
+/** Formats saved-cycle timestamps consistently for the home page. */
+const formatSavedCycleTime = (timestamp: string): string => new Date(timestamp).toLocaleString();
+
+/** Card row used in the compact recent-cycles sidebar. */
+const CompactCycleRow: React.FC<{
+  cycle: SavedCycle;
+  onLoad: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}> = ({ cycle, onLoad }) => (
+  <button
+    data-cycle-id={cycle.id}
+    onClick={onLoad}
+    className="w-full rounded-2xl border border-border/80 bg-muted/20 px-4 py-4 text-left transition-all hover:border-primary hover:shadow-sm"
+  >
+    <div className="flex items-start justify-between gap-3">
+      <div className="space-y-1">
+        <p className="font-medium text-foreground">{cycle.cycleDate}</p>
+        <p className="text-xs text-muted-foreground">{formatSavedCycleTime(cycle.timestamp)}</p>
       </div>
-      {savedCycles.length > 6 && (
-        <Button variant="outline" className="w-full mt-4" onClick={onOpenHistory}>View All {savedCycles.length} Cycles</Button>
-      )}
+      <span className="text-xs font-medium text-primary">Resume</span>
+    </div>
+    {cycle.label ? <p className="mt-3 text-sm text-muted-foreground">{cycle.label}</p> : null}
+  </button>
+);
+
+/** Card tile used by the wider recent-cycles section for signed-out or shared local history. */
+const SectionCycleTile: React.FC<{
+  cycle: SavedCycle;
+  onLoad: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}> = ({ cycle, onLoad }) => (
+  <button
+    data-cycle-id={cycle.id}
+    onClick={onLoad}
+    className="rounded-2xl border border-border/80 bg-muted/20 p-4 text-left transition-all hover:-translate-y-0.5 hover:border-primary hover:shadow-sm"
+  >
+    <div className="flex items-start justify-between gap-3">
+      <div className="space-y-1">
+        <p className="font-medium text-foreground">{cycle.cycleDate}</p>
+        <p className="text-xs text-muted-foreground">{formatSavedCycleTime(cycle.timestamp)}</p>
+      </div>
+      {cycle.label ? (
+        <span className="rounded-full border border-primary/20 bg-primary/10 px-2 py-1 text-[11px] font-medium text-primary">
+          {cycle.label}
+        </span>
+      ) : null}
+    </div>
+  </button>
+);
+
+/** Empty-state card for signed-in users who have not saved any cycles yet. */
+const EmptyRecentCyclesCard: React.FC = () => (
+  <Card className="border-border/80 bg-card/95 shadow-sm">
+    <CardHeader className="space-y-2">
+      <CardTitle className="text-xl">Recent Cycles</CardTitle>
+      <CardDescription>Saved local packages will show up here once you start building a forecast cycle.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        Start on the current cycle card, then save locally whenever you want a package ready to reopen later.
+      </p>
+    </CardContent>
+  </Card>
+);
+
+/** Recent cycle list, shown as either a prominent section or a compact resume sidebar. */
+export const RecentCycles: React.FC<Props> = ({
+  savedCycles,
+  onLoad,
+  onOpenHistory,
+  variant = 'section',
+}) => {
+  if ((!savedCycles || savedCycles.length === 0) && variant === 'section') {
+    return null;
+  }
+
+  if ((!savedCycles || savedCycles.length === 0) && variant === 'compact') {
+    return <EmptyRecentCyclesCard />;
+  }
+
+  if (variant === 'compact') {
+    return (
+      <Card className="border-border/80 bg-card/95 shadow-sm">
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-xl">Recent Cycles</CardTitle>
+          <CardDescription>Jump back into a saved package without leaving the landing page.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {savedCycles.slice(0, 4).map((cycle) => (
+            <CompactCycleRow key={cycle.id} cycle={cycle} onLoad={onLoad} />
+          ))}
+
+          <Button variant="outline" className="w-full" onClick={onOpenHistory}>
+            View Full History
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-border/80 bg-card/95 shadow-sm">
+      <CardHeader className="space-y-2">
+        <CardTitle className="flex items-center gap-2 text-2xl">
+          <History className="h-5 w-5 text-primary" />
+          Recent Local Cycles
+        </CardTitle>
+        <CardDescription>
+          Saved packages stay easy to reopen, which makes it simpler to compare setups or continue older work.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {savedCycles.slice(0, 6).map((cycle) => (
+            <SectionCycleTile key={cycle.id} cycle={cycle} onLoad={onLoad} />
+          ))}
+        </div>
+
+        {savedCycles.length > 6 ? (
+          <Button variant="outline" className="w-full" onClick={onOpenHistory}>
+            View All {savedCycles.length} Cycles
+          </Button>
+        ) : null}
+      </CardContent>
     </Card>
   );
 };

--- a/src/pages/homeUtils.ts
+++ b/src/pages/homeUtils.ts
@@ -2,6 +2,12 @@ import type { ForecastCycle, OutlookDay, DayType } from '../types/outlooks';
 import type { SavedCycle } from '../store/forecastSlice';
 import { countForecastMetrics } from '../utils/forecastMetrics';
 
+/** Converts a YYYY-MM-DD cycle date into a stable UTC day index for day-to-day comparisons. */
+const getUtcDayIndex = (cycleDate: string): number => {
+  const [year, month, day] = cycleDate.split('-').map(Number);
+  return Math.floor(Date.UTC(year, month - 1, day) / 86400000);
+};
+
 /** Calculates a local streak of consecutive saved cycle dates, ending on the newest saved date. */
 const computeSavedCycleStreak = (savedCycles: SavedCycle[]): number => {
   if (savedCycles.length === 0) {
@@ -27,12 +33,6 @@ const computeSavedCycleStreak = (savedCycles: SavedCycle[]): number => {
   }
 
   return streak;
-};
-
-/** Converts a YYYY-MM-DD cycle date into a stable UTC day index for day-to-day comparisons. */
-const getUtcDayIndex = (cycleDate: string): number => {
-  const [year, month, day] = cycleDate.split('-').map(Number);
-  return Math.floor(Date.UTC(year, month - 1, day) / 86400000);
 };
 
 /** Aggregates outlook statistics from a forecast cycle for dashboard display. */

--- a/src/pages/homeUtils.ts
+++ b/src/pages/homeUtils.ts
@@ -1,8 +1,65 @@
 import type { Feature } from 'geojson';
 import type { ForecastCycle, OutlookDay, DayType } from '../types/outlooks';
+import type { SavedCycle } from '../store/forecastSlice';
+
+/** Counts how many forecast days inside a cycle actually contain outlook data. */
+const countForecastDays = (forecastCycle: ForecastCycle): number => {
+  let totalForecastDays = 0;
+
+  (Object.values(forecastCycle.days) as (OutlookDay | undefined)[]).forEach((dayData) => {
+    let dayHasData = false;
+
+    if (!dayData) {
+      return;
+    }
+
+    if (dayData.metadata?.lowProbabilityOutlooks && dayData.metadata.lowProbabilityOutlooks.length > 0) {
+      dayHasData = true;
+    }
+
+    (Object.values(dayData.data) as (Map<string, Feature[]> | undefined)[]).forEach((outlookMap) => {
+      if (outlookMap instanceof Map && outlookMap.size > 0) {
+        dayHasData = true;
+      }
+    });
+
+    if (dayHasData) {
+      totalForecastDays += 1;
+    }
+  });
+
+  return totalForecastDays;
+};
+
+/** Calculates a local streak of consecutive saved cycle dates, ending on the newest saved date. */
+const computeSavedCycleStreak = (savedCycles: SavedCycle[]): number => {
+  if (savedCycles.length === 0) {
+    return 0;
+  }
+
+  const uniqueDates = Array.from(new Set(savedCycles.map((cycle) => cycle.cycleDate))).sort(
+    (left, right) => new Date(right).getTime() - new Date(left).getTime()
+  );
+
+  let streak = 1;
+
+  for (let index = 1; index < uniqueDates.length; index += 1) {
+    const previous = new Date(uniqueDates[index - 1]);
+    const current = new Date(uniqueDates[index]);
+    const diffInDays = Math.round((previous.getTime() - current.getTime()) / 86400000);
+
+    if (diffInDays !== 1) {
+      break;
+    }
+
+    streak += 1;
+  }
+
+  return streak;
+};
 
 /** Aggregates outlook statistics from a forecast cycle for dashboard display. */
-export function computeHomeStats(forecastCycle: ForecastCycle, savedCyclesLength: number) {
+export function computeHomeStats(forecastCycle: ForecastCycle, savedCycles: SavedCycle[]) {
   const daysWithData: DayType[] = [];
   let totalOutlooks = 0;
   let totalFeatures = 0;
@@ -36,7 +93,13 @@ export function computeHomeStats(forecastCycle: ForecastCycle, savedCyclesLength
     daysWithData,
     totalOutlooks,
     totalFeatures,
-    savedCyclesCount: savedCyclesLength,
+    savedCyclesCount: savedCycles.length,
+    totalForecastsMade: savedCycles.reduce(
+      (runningTotal, cycle) => runningTotal + countForecastDays(cycle.forecastCycle),
+      countForecastDays(forecastCycle)
+    ),
+    totalCyclesMade: savedCycles.length,
+    forecastStreak: computeSavedCycleStreak(savedCycles),
   };
 }
 

--- a/src/pages/homeUtils.ts
+++ b/src/pages/homeUtils.ts
@@ -1,35 +1,6 @@
-import type { Feature } from 'geojson';
 import type { ForecastCycle, OutlookDay, DayType } from '../types/outlooks';
 import type { SavedCycle } from '../store/forecastSlice';
-
-/** Counts how many forecast days inside a cycle actually contain outlook data. */
-const countForecastDays = (forecastCycle: ForecastCycle): number => {
-  let totalForecastDays = 0;
-
-  (Object.values(forecastCycle.days) as (OutlookDay | undefined)[]).forEach((dayData) => {
-    let dayHasData = false;
-
-    if (!dayData) {
-      return;
-    }
-
-    if (dayData.metadata?.lowProbabilityOutlooks && dayData.metadata.lowProbabilityOutlooks.length > 0) {
-      dayHasData = true;
-    }
-
-    (Object.values(dayData.data) as (Map<string, Feature[]> | undefined)[]).forEach((outlookMap) => {
-      if (outlookMap instanceof Map && outlookMap.size > 0) {
-        dayHasData = true;
-      }
-    });
-
-    if (dayHasData) {
-      totalForecastDays += 1;
-    }
-  });
-
-  return totalForecastDays;
-};
+import { countForecastMetrics } from '../utils/forecastMetrics';
 
 /** Calculates a local streak of consecutive saved cycle dates, ending on the newest saved date. */
 const computeSavedCycleStreak = (savedCycles: SavedCycle[]): number => {
@@ -44,9 +15,9 @@ const computeSavedCycleStreak = (savedCycles: SavedCycle[]): number => {
   let streak = 1;
 
   for (let index = 1; index < uniqueDates.length; index += 1) {
-    const previous = new Date(uniqueDates[index - 1]);
-    const current = new Date(uniqueDates[index]);
-    const diffInDays = Math.round((previous.getTime() - current.getTime()) / 86400000);
+    const previousDayIndex = getUtcDayIndex(uniqueDates[index - 1]);
+    const currentDayIndex = getUtcDayIndex(uniqueDates[index]);
+    const diffInDays = previousDayIndex - currentDayIndex;
 
     if (diffInDays !== 1) {
       break;
@@ -58,8 +29,15 @@ const computeSavedCycleStreak = (savedCycles: SavedCycle[]): number => {
   return streak;
 };
 
+/** Converts a YYYY-MM-DD cycle date into a stable UTC day index for day-to-day comparisons. */
+const getUtcDayIndex = (cycleDate: string): number => {
+  const [year, month, day] = cycleDate.split('-').map(Number);
+  return Math.floor(Date.UTC(year, month - 1, day) / 86400000);
+};
+
 /** Aggregates outlook statistics from a forecast cycle for dashboard display. */
 export function computeHomeStats(forecastCycle: ForecastCycle, savedCycles: SavedCycle[]) {
+  const currentCycleMetrics = countForecastMetrics(forecastCycle);
   const daysWithData: DayType[] = [];
   let totalOutlooks = 0;
   let totalFeatures = 0;
@@ -95,8 +73,8 @@ export function computeHomeStats(forecastCycle: ForecastCycle, savedCycles: Save
     totalFeatures,
     savedCyclesCount: savedCycles.length,
     totalForecastsMade: savedCycles.reduce(
-      (runningTotal, cycle) => runningTotal + countForecastDays(cycle.forecastCycle),
-      countForecastDays(forecastCycle)
+      (runningTotal, cycle) => runningTotal + cycle.stats.forecastDays,
+      currentCycleMetrics.forecastDays
     ),
     totalCyclesMade: savedCycles.length,
     forecastStreak: computeSavedCycleStreak(savedCycles),

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -7,12 +7,10 @@ import { TextDecoder, TextEncoder } from 'util';
 
 const globalScope = globalThis as typeof globalThis & {
   __GFC_COMING_SOON__?: boolean;
-  __GFC_FIREBASE_CONFIG__?: {
-    apiKey?: string;
-    authDomain?: string;
-    projectId?: string;
-    appId?: string;
-  };
+  __GFC_FIREBASE_API_KEY__?: string;
+  __GFC_FIREBASE_AUTH_DOMAIN__?: string;
+  __GFC_FIREBASE_PROJECT_ID__?: string;
+  __GFC_FIREBASE_APP_ID__?: string;
   Headers?: typeof Headers;
   Request?: typeof Request;
   Response?: typeof Response;
@@ -30,14 +28,10 @@ if (typeof globalScope.__GFC_COMING_SOON__ === 'undefined') {
   globalScope.__GFC_COMING_SOON__ = false;
 }
 
-if (typeof globalScope.__GFC_FIREBASE_CONFIG__ === 'undefined') {
-  globalScope.__GFC_FIREBASE_CONFIG__ = {
-    apiKey: '',
-    authDomain: '',
-    projectId: '',
-    appId: '',
-  };
-}
+if (typeof globalScope.__GFC_FIREBASE_API_KEY__ === 'undefined') globalScope.__GFC_FIREBASE_API_KEY__ = '';
+if (typeof globalScope.__GFC_FIREBASE_AUTH_DOMAIN__ === 'undefined') globalScope.__GFC_FIREBASE_AUTH_DOMAIN__ = '';
+if (typeof globalScope.__GFC_FIREBASE_PROJECT_ID__ === 'undefined') globalScope.__GFC_FIREBASE_PROJECT_ID__ = '';
+if (typeof globalScope.__GFC_FIREBASE_APP_ID__ === 'undefined') globalScope.__GFC_FIREBASE_APP_ID__ = '';
 
 if (typeof globalScope.Headers === 'undefined') {
   globalScope.Headers =

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -3,6 +3,14 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { OutlookData, OutlookType, DrawingState, ForecastCycle, DayType, OutlookDay, DiscussionData, Probability } from '../types/outlooks';
 import type { Feature } from 'geojson';
 import { RootState } from './index'; // Need RootState for selectors
+import { cloneForecastCycle } from '../utils/fileUtils';
+import { countForecastMetrics } from '../utils/forecastMetrics';
+
+export interface SavedCycleStats {
+  forecastDays: number;
+  totalOutlooks: number;
+  totalFeatures: number;
+}
 
 export interface SavedCycle {
   id: string;
@@ -10,6 +18,7 @@ export interface SavedCycle {
   cycleDate: string;
   label?: string;
   forecastCycle: ForecastCycle;
+  stats: SavedCycleStats;
 }
 
 export interface ForecastState {
@@ -702,12 +711,14 @@ export const forecastSlice = createSlice({
 
     // Cycle History Management
     saveCurrentCycle: (state, action: PayloadAction<{ label?: string }>) => {
+      const forecastCycleSnapshot = cloneForecastCycle(state.forecastCycle);
       const savedCycle: SavedCycle = {
         id: `${Date.now()}-${Math.random()}`,
         timestamp: new Date().toISOString(),
         cycleDate: state.forecastCycle.cycleDate,
         label: action.payload.label,
-        forecastCycle: JSON.parse(JSON.stringify(state.forecastCycle))
+        forecastCycle: forecastCycleSnapshot,
+        stats: countForecastMetrics(forecastCycleSnapshot),
       };
       state.savedCycles.push(savedCycle);
       state.isSaved = true;
@@ -717,7 +728,7 @@ export const forecastSlice = createSlice({
       const cycleId = action.payload;
       const savedCycle = state.savedCycles.find(c => c.id === cycleId);
       if (savedCycle) {
-        state.forecastCycle = JSON.parse(JSON.stringify(savedCycle.forecastCycle));
+        state.forecastCycle = cloneForecastCycle(savedCycle.forecastCycle);
         clearHistory(state);
         state.isSaved = true;
       }

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -1,16 +1,70 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { loadCycleHistory } from '../store/forecastSlice';
-import type { SavedCycle } from '../store/forecastSlice';
+import type { SavedCycle, SavedCycleStats } from '../store/forecastSlice';
+import { deserializeForecast, serializeForecast } from './fileUtils';
+import { countForecastMetrics } from './forecastMetrics';
+import type { ForecastCycle, GFCForecastSaveData } from '../types/outlooks';
 
 const CYCLE_HISTORY_KEY = 'gfc-cycle-history';
+const STORAGE_MAP_VIEW = { center: [0, 0] as [number, number], zoom: 0 };
+
+interface PersistedSavedCycle {
+  id: string;
+  timestamp: string;
+  cycleDate: string;
+  label?: string;
+  forecastData: GFCForecastSaveData;
+  stats?: SavedCycleStats;
+}
+
+/** Converts an in-memory saved cycle into a JSON-safe storage shape that preserves map data. */
+const toPersistedSavedCycle = (cycle: SavedCycle): PersistedSavedCycle => ({
+  id: cycle.id,
+  timestamp: cycle.timestamp,
+  cycleDate: cycle.cycleDate,
+  label: cycle.label,
+  forecastData: serializeForecast(cycle.forecastCycle, STORAGE_MAP_VIEW),
+  stats: cycle.stats,
+});
+
+/** Restores one saved cycle from storage, rehydrating its forecast maps and filling stats when missing. */
+const fromPersistedSavedCycle = (cycle: PersistedSavedCycle): SavedCycle => {
+  const forecastCycle = deserializeForecast(cycle.forecastData);
+
+  return {
+    id: cycle.id,
+    timestamp: cycle.timestamp,
+    cycleDate: cycle.cycleDate,
+    label: cycle.label,
+    forecastCycle,
+    stats: cycle.stats ?? countForecastMetrics(forecastCycle),
+  };
+};
+
+/** Best-effort migration path for older saved-cycle entries that stored raw forecastCycle objects. */
+const fromLegacySavedCycle = (cycle: {
+  id: string;
+  timestamp: string;
+  cycleDate: string;
+  label?: string;
+  forecastCycle: ForecastCycle;
+  stats?: SavedCycleStats;
+}): SavedCycle => ({
+  id: cycle.id,
+  timestamp: cycle.timestamp,
+  cycleDate: cycle.cycleDate,
+  label: cycle.label,
+  forecastCycle: cycle.forecastCycle,
+  stats: cycle.stats ?? countForecastMetrics(cycle.forecastCycle),
+});
 
 /**
  * Save cycle history to localStorage
  */
 export const saveCycleHistoryToStorage = (cycles: SavedCycle[]): void => {
   try {
-    const serialized = JSON.stringify(cycles);
+    const serialized = JSON.stringify(cycles.map(toPersistedSavedCycle));
     localStorage.setItem(CYCLE_HISTORY_KEY, serialized);
   } catch {
     // Silently ignore localStorage write failures
@@ -26,7 +80,31 @@ export const loadCycleHistoryFromStorage = (): SavedCycle[] => {
     if (!serialized) return [];
     
     const parsed = JSON.parse(serialized);
-    return Array.isArray(parsed) ? parsed : [];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((cycle) => {
+        if (!cycle || typeof cycle !== 'object') {
+          return null;
+        }
+
+        try {
+          if ('forecastData' in cycle) {
+            return fromPersistedSavedCycle(cycle as PersistedSavedCycle);
+          }
+
+          if ('forecastCycle' in cycle) {
+            return fromLegacySavedCycle(cycle as SavedCycle);
+          }
+
+          return null;
+        } catch {
+          return null;
+        }
+      })
+      .filter((cycle): cycle is SavedCycle => cycle !== null);
   } catch {
     return [];
   }

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -155,6 +155,15 @@ export const deserializeForecast = (data: GFCForecastSaveData): ForecastCycle =>
   };
 };
 
+/** Creates a deep forecast-cycle clone while preserving Map-backed outlook data. */
+export const cloneForecastCycle = (forecastCycle: ForecastCycle): ForecastCycle =>
+  deserializeForecast(
+    serializeForecast(forecastCycle, {
+      center: [0, 0],
+      zoom: 0,
+    })
+  );
+
 /**
  * Validates that the input data conforms to the GFCForecastSaveData schema.
  */

--- a/src/utils/forecastMetrics.ts
+++ b/src/utils/forecastMetrics.ts
@@ -1,0 +1,49 @@
+import type { Feature } from 'geojson';
+import type { ForecastCycle, OutlookDay } from '../types/outlooks';
+
+export interface ForecastMetrics {
+  forecastDays: number;
+  totalOutlooks: number;
+  totalFeatures: number;
+}
+
+/** Counts the saved-day and outlook totals for a forecast cycle without relying on page-level helpers. */
+export const countForecastMetrics = (forecastCycle: ForecastCycle): ForecastMetrics => {
+  let forecastDays = 0;
+  let totalOutlooks = 0;
+  let totalFeatures = 0;
+
+  (Object.values(forecastCycle.days) as (OutlookDay | undefined)[]).forEach((dayData) => {
+    let dayHasData = false;
+
+    if (!dayData) {
+      return;
+    }
+
+    if (dayData.metadata?.lowProbabilityOutlooks && dayData.metadata.lowProbabilityOutlooks.length > 0) {
+      dayHasData = true;
+    }
+
+    (Object.values(dayData.data) as (Map<string, Feature[]> | undefined)[]).forEach((outlookMap) => {
+      if (!(outlookMap instanceof Map) || outlookMap.size === 0) {
+        return;
+      }
+
+      dayHasData = true;
+      totalOutlooks += outlookMap.size;
+      outlookMap.forEach((features) => {
+        totalFeatures += features.length;
+      });
+    });
+
+    if (dayHasData) {
+      forecastDays += 1;
+    }
+  });
+
+  return {
+    forecastDays,
+    totalOutlooks,
+    totalFeatures,
+  };
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,12 +1,10 @@
 /// <reference types="vite/client" />
 
 declare const __GFC_COMING_SOON__: boolean;
-declare const __GFC_FIREBASE_CONFIG__: {
-  apiKey: string;
-  authDomain: string;
-  projectId: string;
-  appId: string;
-};
+declare const __GFC_FIREBASE_API_KEY__: string;
+declare const __GFC_FIREBASE_AUTH_DOMAIN__: string;
+declare const __GFC_FIREBASE_PROJECT_ID__: string;
+declare const __GFC_FIREBASE_APP_ID__: string;
 
 interface ImportMetaEnv {
   readonly VITE_FIREBASE_API_KEY?: string;
@@ -21,12 +19,10 @@ interface ImportMeta {
 
 declare global {
   var __GFC_COMING_SOON__: boolean;
-  var __GFC_FIREBASE_CONFIG__: {
-    apiKey: string;
-    authDomain: string;
-    projectId: string;
-    appId: string;
-  };
+  var __GFC_FIREBASE_API_KEY__: string;
+  var __GFC_FIREBASE_AUTH_DOMAIN__: string;
+  var __GFC_FIREBASE_PROJECT_ID__: string;
+  var __GFC_FIREBASE_APP_ID__: string;
 }
 
 export {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,12 +16,7 @@ export default defineConfig(({ mode }) => {
     base,
     define: {
       __GFC_COMING_SOON__: JSON.stringify(env.VITE_COMING_SOON === 'true'),
-      __GFC_FIREBASE_CONFIG__: {
-        apiKey: JSON.stringify(firebaseConfig.apiKey),
-        authDomain: JSON.stringify(firebaseConfig.authDomain),
-        projectId: JSON.stringify(firebaseConfig.projectId),
-        appId: JSON.stringify(firebaseConfig.appId),
-      },
+      __GFC_FIREBASE_CONFIG__: firebaseConfig,
     },
     plugins: [react()],
     resolve: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,18 +5,15 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const base = env.PUBLIC_URL || '/';
-  const firebaseConfig = {
-    apiKey: env.VITE_FIREBASE_API_KEY ?? '',
-    authDomain: env.VITE_FIREBASE_AUTH_DOMAIN ?? '',
-    projectId: env.VITE_FIREBASE_PROJECT_ID ?? '',
-    appId: env.VITE_FIREBASE_APP_ID ?? '',
-  };
 
   return {
     base,
     define: {
       __GFC_COMING_SOON__: JSON.stringify(env.VITE_COMING_SOON === 'true'),
-      __GFC_FIREBASE_CONFIG__: firebaseConfig,
+      __GFC_FIREBASE_API_KEY__: JSON.stringify(env.VITE_FIREBASE_API_KEY ?? ''),
+      __GFC_FIREBASE_AUTH_DOMAIN__: JSON.stringify(env.VITE_FIREBASE_AUTH_DOMAIN ?? ''),
+      __GFC_FIREBASE_PROJECT_ID__: JSON.stringify(env.VITE_FIREBASE_PROJECT_ID ?? ''),
+      __GFC_FIREBASE_APP_ID__: JSON.stringify(env.VITE_FIREBASE_APP_ID ?? ''),
     },
     plugins: [react()],
     resolve: {


### PR DESCRIPTION
This pull request introduces a significant redesign of the home page and dashboard, focusing on a more workflow-oriented and user-aware experience. The changes include new layouts and components that adapt based on authentication status, improved onboarding for new or signed-out users, and a streamlined dashboard for signed-in users. Additionally, the codebase sees improved test coverage and code style refinements.

**Home page and dashboard redesign:**

* The `HomePage` component now renders different layouts and content depending on whether the user is signed in or not, using a new `variant` prop (`'signed_in'` or `'signed_out'`). This includes a workflow-first layout for signed-in users and onboarding panels for new users. (`[[1]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L119-R198)`, `[[2]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93R211-R237)`)
* The `Dashboard` component has been completely refactored. For signed-in users, it displays a compact workflow snapshot with streaks and totals. For signed-out users, it provides onboarding guidance and a sidebar with local stats. (`[src/pages/home/Dashboard.tsxL2-R146](diffhunk://#diff-59d56d528fd9a0f9dfb4138829a5efedbfabba11c9586aed4f89ab6babc1353cL2-R146)`)
* The `HomeHero` component now accepts a `variant` prop and additional props to display onboarding or resume-focused content, with new tests added for both user states. (`[[1]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L119-R198)`, `[[2]](diffhunk://#diff-a5bd8d91bc7711daf51dcd5ad3db59cf97b05c06dfd73aac4793d2c4c71daa7bR1-R32)`)

**Testing improvements:**

* New tests for `HomeHero` ensure that both onboarding and resume flows render the correct content based on the user's authentication status. (`[src/pages/home/HomeHero.test.tsxR1-R32](diffhunk://#diff-a5bd8d91bc7711daf51dcd5ad3db59cf97b05c06dfd73aac4793d2c4c71daa7bR1-R32)`)
* Additional tests for `AccountPage` verify the conditional rendering of password confirmation fields and the signed-in account view. (`[src/pages/AccountPage.test.tsxL33-R98](diffhunk://#diff-36b9a2b6006cbb02d8fd0d4f49883938293c310bcedce1e426860da88583ebc2L33-R98)`)

**Code and style refinements:**

* Improved code style and readability throughout `HomePage.tsx`, including consistent ordering of imports, clearer function structures, and more readable conditional logic. (`[[1]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L1-R14)`, `[[2]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L23-R76)`, `[[3]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L95-R135)`)
* Enhanced accessibility and layout in the AI development disclosure banner and confirmation modal. (`[[1]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L23-R76)`, `[[2]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93R211-R237)`)

**Testing utility updates:**

* The test utilities for `AccountPage` now import `fireEvent` to simulate user interactions. (`[src/pages/AccountPage.test.tsxL1-R1](diffhunk://#diff-36b9a2b6006cbb02d8fd0d4f49883938293c310bcedce1e426860da88583ebc2L1-R1)`)

These changes collectively provide a more intuitive, user-focused home page, better onboarding for new users, and a streamlined experience for returning users.

**References:**  
[[1]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L119-R198) [[2]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93R211-R237) [[3]](diffhunk://#diff-59d56d528fd9a0f9dfb4138829a5efedbfabba11c9586aed4f89ab6babc1353cL2-R146) [[4]](diffhunk://#diff-a5bd8d91bc7711daf51dcd5ad3db59cf97b05c06dfd73aac4793d2c4c71daa7bR1-R32) [[5]](diffhunk://#diff-36b9a2b6006cbb02d8fd0d4f49883938293c310bcedce1e426860da88583ebc2L33-R98) [[6]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L1-R14) [[7]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L23-R76) [[8]](diffhunk://#diff-bda7f631866d907345e59ae870d930d62793645d5292d32d60c255d3cab20e93L95-R135) [[9]](diffhunk://#diff-36b9a2b6006cbb02d8fd0d4f49883938293c310bcedce1e426860da88583ebc2L1-R1)