### PR TITLE
Implement Cloud Storage and Refine UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Cloud hosted forecasts:** Moved cloud forecast storage out of `userSettings` into a dedicated `cloudCycles` collection so forecast payloads have a long-term home separate from profile preferences.
+
 ### Fixed
 - **Billing route throttling:** Added explicit rate limiting to the Stripe billing checkout, portal, and webhook endpoints so authorization-bearing billing routes are consistently protected.
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "^4.21.2",
+        "express-rate-limit": "^8.3.1",
         "firebase-admin": "^13.6.0",
         "stripe": "^18.4.0"
       },
@@ -987,6 +988,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1665,6 +1684,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { EntitlementProvider } from './billing/EntitlementProvider';
 // New UI components
 import { AppLayout } from './components/Layout';
 import { HomePage, ForecastPage, DiscussionPage, VerificationPage, ComingSoonPage, AccountPage, PricingPage } from './pages';
+import CloudLibraryPage from './pages/CloudLibraryPage';
 import ToSModal, { hasAcceptedToS } from './components/ToS/ToSModal';
 import PrivacyPolicyModal, { hasAcceptedPrivacyPolicy } from './components/PrivacyPolicy/PrivacyPolicyModal';
 
@@ -131,6 +132,7 @@ const AppRoutes: React.FC<AppRoutesProps> = ({ showComingSoon }) => {
         <Route index element={<HomePage />} />
         <Route path="account" element={<AccountPage />} />
         <Route path="pricing" element={<PricingPage />} />
+        <Route path="cloud" element={<CloudLibraryPage />} />
         <Route path="forecast" element={<ForecastPage />} />
         <Route path="discussion" element={<DiscussionPage />} />
         <Route path="verification" element={<VerificationPage />} />

--- a/src/components/CloudCycleManager/CloudSaveLoadModals.css
+++ b/src/components/CloudCycleManager/CloudSaveLoadModals.css
@@ -1,0 +1,135 @@
+.cloud-save-dialog {
+  max-width: 36rem;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  border-radius: 1.5rem;
+  background: var(--bg-primary);
+  box-shadow: 0 26px 72px rgba(0, 0, 0, 0.3);
+}
+
+.cloud-save-dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+  padding: 1.5rem 1.5rem 1.35rem;
+  background: linear-gradient(180deg, var(--bg-secondary), var(--bg-primary) 28%);
+}
+
+.cloud-save-dialog-header {
+  gap: 0.7rem;
+  padding-right: 2rem;
+}
+
+.cloud-save-dialog-title {
+  font-size: 1.4rem;
+  line-height: 1.15;
+  color: var(--text-primary);
+}
+
+.cloud-save-dialog-description {
+  max-width: 32rem;
+  font-size: 0.96rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+.cloud-save-dialog-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.05rem;
+  border: 1px solid var(--border-color);
+  border-radius: 1.15rem;
+  background: var(--bg-primary);
+}
+
+.cloud-save-dialog-callout span {
+  display: block;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.cloud-save-dialog-callout strong {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.cloud-save-dialog-icon {
+  display: grid;
+  place-items: center;
+  width: 2.8rem;
+  height: 2.8rem;
+  border: 1px solid color-mix(in srgb, var(--button-bg) 30%, var(--border-color));
+  border-radius: 0.95rem;
+  background: color-mix(in srgb, var(--button-bg) 10%, var(--bg-primary));
+  color: var(--button-bg);
+  flex-shrink: 0;
+}
+
+.cloud-save-dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.cloud-save-dialog-field label {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.cloud-save-dialog-input {
+  height: 3.15rem;
+  border-radius: 1rem;
+  background: var(--bg-primary);
+  font-size: 1rem;
+}
+
+.cloud-save-dialog-error {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--error-text) 24%, transparent);
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--error-text) 10%, var(--bg-primary));
+}
+
+.cloud-save-dialog-error p {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--error-text);
+}
+
+.cloud-save-dialog-footer {
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 0.1rem;
+}
+
+.cloud-save-dialog-primary {
+  min-width: 10rem;
+  box-shadow: 0 12px 24px color-mix(in srgb, var(--button-bg) 24%, transparent);
+}
+
+@media (max-width: 640px) {
+  .cloud-save-dialog {
+    max-width: calc(100vw - 1.25rem);
+  }
+
+  .cloud-save-dialog-body {
+    padding: 1.15rem;
+  }
+
+  .cloud-save-dialog-callout {
+    align-items: flex-start;
+  }
+}

--- a/src/components/CloudCycleManager/CloudSaveLoadModals.tsx
+++ b/src/components/CloudCycleManager/CloudSaveLoadModals.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '../ui/button';
 import {
   Dialog,
@@ -17,9 +17,57 @@ interface CloudSaveModalProps {
   onOpenChange: (open: boolean) => void;
   onSave: (label: string) => Promise<boolean>;
   currentLabel?: string;
-  isLoading?: boolean;
   error?: string;
 }
+
+/** Header copy used by the cloud save modal. */
+const CloudSaveDialogHeader: React.FC = () => (
+  <DialogHeader className="cloud-save-dialog-header">
+    <DialogTitle className="cloud-save-dialog-title">Save to Cloud</DialogTitle>
+    <DialogDescription className="cloud-save-dialog-description">
+      Save the current forecast package to your hosted library so it is ready from any signed-in device.
+    </DialogDescription>
+  </DialogHeader>
+);
+
+/** Compact context callout showing the current cloud save label. */
+const CloudSaveDialogCallout: React.FC<{ currentLabel: string }> = ({ currentLabel }) => (
+  <div className="cloud-save-dialog-callout">
+    <div>
+      <span>Saving as</span>
+      <strong>{currentLabel || 'Untitled Forecast'}</strong>
+    </div>
+    <div className="cloud-save-dialog-icon">
+      <Cloud className="h-5 w-5" />
+    </div>
+  </div>
+);
+
+/** Error banner shown when the current cloud save attempt fails. */
+const CloudSaveDialogError: React.FC<{ error: string }> = ({ error }) => (
+  <div className="cloud-save-dialog-error">
+    <AlertCircle className="h-5 w-5 shrink-0 text-red-600" />
+    <p>{error}</p>
+  </div>
+);
+
+/** Footer actions for canceling or confirming the cloud save. */
+const CloudSaveDialogFooter: React.FC<{
+  isSaving: boolean;
+  canSave: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+}> = ({ isSaving, canSave, onCancel, onSave }) => (
+  <DialogFooter className="cloud-save-dialog-footer">
+    <Button type="button" variant="outline" onClick={onCancel} disabled={isSaving}>
+      Cancel
+    </Button>
+    <Button type="button" onClick={onSave} disabled={!canSave || isSaving} className="cloud-save-dialog-primary">
+      {isSaving ? <Loader className="mr-2 h-4 w-4 animate-spin" /> : null}
+      {isSaving ? 'Saving...' : 'Save to Cloud'}
+    </Button>
+  </DialogFooter>
+);
 
 /**
  * Modal for saving a forecast to the cloud
@@ -29,18 +77,22 @@ export const CloudSaveModal: React.FC<CloudSaveModalProps> = ({
   onOpenChange,
   onSave,
   currentLabel = '',
-  isLoading = false,
   error,
 }) => {
   const [label, setLabel] = useState(currentLabel);
   const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (open && !isSaving) {
       setLabel(currentLabel);
+      window.setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
     }
   }, [currentLabel, isSaving, open]);
 
+  /** Persists the trimmed cloud label and closes the modal on success. */
   const handleSave = async () => {
     if (!label.trim()) {
       return;
@@ -58,6 +110,7 @@ export const CloudSaveModal: React.FC<CloudSaveModalProps> = ({
     }
   };
 
+  /** Blocks closing while a save is in progress and resets stale label state on close. */
   const handleOpenChange = (newOpen: boolean) => {
     if (!isSaving) {
       onOpenChange(newOpen);
@@ -71,52 +124,29 @@ export const CloudSaveModal: React.FC<CloudSaveModalProps> = ({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="cloud-save-dialog">
         <div className="cloud-save-dialog-body">
-          <DialogHeader className="cloud-save-dialog-header">
-            <DialogTitle className="cloud-save-dialog-title">Save to Cloud</DialogTitle>
-            <DialogDescription className="cloud-save-dialog-description">
-              Save the current forecast package to your hosted library so it is ready from any signed-in device.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="cloud-save-dialog-callout">
-            <div>
-              <span>Saving as</span>
-              <strong>{currentLabel || 'Untitled Forecast'}</strong>
-            </div>
-            <div className="cloud-save-dialog-icon">
-              <Cloud className="h-5 w-5" />
-            </div>
-          </div>
-
-          {error && (
-            <div className="cloud-save-dialog-error">
-              <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-              <p>{error}</p>
-            </div>
-          )}
+          <CloudSaveDialogHeader />
+          <CloudSaveDialogCallout currentLabel={currentLabel} />
+          {error ? <CloudSaveDialogError error={error} /> : null}
 
           <div className="cloud-save-dialog-field">
             <label htmlFor="cloud-cycle-name">Cycle name</label>
             <Input
+              ref={inputRef}
               id="cloud-cycle-name"
               className="cloud-save-dialog-input"
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               placeholder="e.g., March 29 - Strong Pattern"
               disabled={isSaving}
-              autoFocus
             />
           </div>
 
-          <DialogFooter className="cloud-save-dialog-footer">
-            <Button type="button" variant="outline" onClick={() => handleOpenChange(false)} disabled={isSaving}>
-              Cancel
-            </Button>
-            <Button type="button" onClick={handleSave} disabled={!label.trim() || isSaving} className="cloud-save-dialog-primary">
-              {isSaving && <Loader className="w-4 h-4 mr-2 animate-spin" />}
-              {isSaving ? 'Saving...' : 'Save to Cloud'}
-            </Button>
-          </DialogFooter>
+          <CloudSaveDialogFooter
+            isSaving={isSaving}
+            canSave={Boolean(label.trim())}
+            onCancel={() => handleOpenChange(false)}
+            onSave={handleSave}
+          />
         </div>
       </DialogContent>
     </Dialog>
@@ -147,6 +177,7 @@ export const CloudLoadModal: React.FC<CloudLoadModalProps> = ({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isLoadingCycle, setIsLoadingCycle] = useState(false);
 
+  /** Loads the selected cycle and closes the modal when the request succeeds. */
   const handleLoad = async () => {
     if (!selectedId) return;
 

--- a/src/components/CloudCycleManager/CloudSaveLoadModals.tsx
+++ b/src/components/CloudCycleManager/CloudSaveLoadModals.tsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Input } from '../ui/input';
+import { AlertCircle, Cloud, Loader } from 'lucide-react';
+import './CloudSaveLoadModals.css';
+
+interface CloudSaveModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (label: string) => Promise<boolean>;
+  currentLabel?: string;
+  isLoading?: boolean;
+  error?: string;
+}
+
+/**
+ * Modal for saving a forecast to the cloud
+ */
+export const CloudSaveModal: React.FC<CloudSaveModalProps> = ({
+  open,
+  onOpenChange,
+  onSave,
+  currentLabel = '',
+  isLoading = false,
+  error,
+}) => {
+  const [label, setLabel] = useState(currentLabel);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (open && !isSaving) {
+      setLabel(currentLabel);
+    }
+  }, [currentLabel, isSaving, open]);
+
+  const handleSave = async () => {
+    if (!label.trim()) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const success = await onSave(label.trim());
+      if (success) {
+        onOpenChange(false);
+        setLabel('');
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!isSaving) {
+      onOpenChange(newOpen);
+      if (!newOpen) {
+        setLabel('');
+      }
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="cloud-save-dialog">
+        <div className="cloud-save-dialog-body">
+          <DialogHeader className="cloud-save-dialog-header">
+            <DialogTitle className="cloud-save-dialog-title">Save to Cloud</DialogTitle>
+            <DialogDescription className="cloud-save-dialog-description">
+              Save the current forecast package to your hosted library so it is ready from any signed-in device.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="cloud-save-dialog-callout">
+            <div>
+              <span>Saving as</span>
+              <strong>{currentLabel || 'Untitled Forecast'}</strong>
+            </div>
+            <div className="cloud-save-dialog-icon">
+              <Cloud className="h-5 w-5" />
+            </div>
+          </div>
+
+          {error && (
+            <div className="cloud-save-dialog-error">
+              <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+              <p>{error}</p>
+            </div>
+          )}
+
+          <div className="cloud-save-dialog-field">
+            <label htmlFor="cloud-cycle-name">Cycle name</label>
+            <Input
+              id="cloud-cycle-name"
+              className="cloud-save-dialog-input"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g., March 29 - Strong Pattern"
+              disabled={isSaving}
+              autoFocus
+            />
+          </div>
+
+          <DialogFooter className="cloud-save-dialog-footer">
+            <Button type="button" variant="outline" onClick={() => handleOpenChange(false)} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleSave} disabled={!label.trim() || isSaving} className="cloud-save-dialog-primary">
+              {isSaving && <Loader className="w-4 h-4 mr-2 animate-spin" />}
+              {isSaving ? 'Saving...' : 'Save to Cloud'}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+interface CloudLoadModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onLoad: (cycleId: string) => Promise<void>;
+  cycles: Array<{ id: string; label: string; updatedAt: string; cycleDate: string }>;
+  isLoading?: boolean;
+  error?: string;
+}
+
+/**
+ * Modal for loading a forecast from the cloud (deprecated - use CloudLibraryPage instead)
+ * Kept for potential inline preview applications
+ */
+export const CloudLoadModal: React.FC<CloudLoadModalProps> = ({
+  open,
+  onOpenChange,
+  onLoad,
+  cycles,
+  isLoading = false,
+  error,
+}) => {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [isLoadingCycle, setIsLoadingCycle] = useState(false);
+
+  const handleLoad = async () => {
+    if (!selectedId) return;
+
+    setIsLoadingCycle(true);
+    try {
+      await onLoad(selectedId);
+      onOpenChange(false);
+      setSelectedId(null);
+    } finally {
+      setIsLoadingCycle(false);
+    }
+  };
+
+  const selectedCycle = cycles.find((c) => c.id === selectedId);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Load from Cloud</DialogTitle>
+          <DialogDescription>
+            Select a forecast to load from your cloud library.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {error && (
+            <div className="flex gap-3 p-3 bg-red-50 border border-red-200 rounded-lg">
+              <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-red-800">{error}</p>
+            </div>
+          )}
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader className="w-6 h-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : cycles.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No cloud cycles saved yet
+            </p>
+          ) : (
+            <div className="space-y-2 max-h-80 overflow-y-auto">
+              {cycles.map((cycle) => (
+                <button
+                  key={cycle.id}
+                  onClick={() => setSelectedId(cycle.id)}
+                  className={`w-full text-left p-3 rounded-lg border-2 transition-colors ${
+                    selectedId === cycle.id
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border hover:border-primary/50'
+                  }`}
+                >
+                  <p className="font-medium">{cycle.label}</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {cycle.cycleDate} • {new Date(cycle.updatedAt).toLocaleDateString()}
+                  </p>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoadingCycle}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleLoad}
+            disabled={!selectedCycle || isLoadingCycle}
+          >
+            {isLoadingCycle && <Loader className="w-4 h-4 mr-2 animate-spin" />}
+            {isLoadingCycle ? 'Loading...' : 'Load'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/CloudCycleManager/CloudSaveLoadModals.tsx
+++ b/src/components/CloudCycleManager/CloudSaveLoadModals.tsx
@@ -20,6 +20,15 @@ interface CloudSaveModalProps {
   error?: string;
 }
 
+interface CloudSaveDialogState {
+  label: string;
+  isSaving: boolean;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  setLabel: React.Dispatch<React.SetStateAction<string>>;
+  handleSave: () => Promise<void>;
+  handleOpenChange: (open: boolean) => void;
+}
+
 /** Header copy used by the cloud save modal. */
 const CloudSaveDialogHeader: React.FC = () => (
   <DialogHeader className="cloud-save-dialog-header">
@@ -69,27 +78,26 @@ const CloudSaveDialogFooter: React.FC<{
   </DialogFooter>
 );
 
-/**
- * Modal for saving a forecast to the cloud
- */
-export const CloudSaveModal: React.FC<CloudSaveModalProps> = ({
-  open,
-  onOpenChange,
-  onSave,
-  currentLabel = '',
-  error,
-}) => {
+/** Creates the local state and event handlers used by the cloud save dialog. */
+const useCloudSaveDialogState = (
+  open: boolean,
+  currentLabel: string,
+  onOpenChange: (open: boolean) => void,
+  onSave: (label: string) => Promise<boolean>
+): CloudSaveDialogState => {
   const [label, setLabel] = useState(currentLabel);
   const [isSaving, setIsSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    if (open && !isSaving) {
-      setLabel(currentLabel);
-      window.setTimeout(() => {
-        inputRef.current?.focus();
-      }, 0);
+    if (!open || isSaving) {
+      return;
     }
+
+    setLabel(currentLabel);
+    window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
   }, [currentLabel, isSaving, open]);
 
   /** Persists the trimmed cloud label and closes the modal on success. */
@@ -112,13 +120,44 @@ export const CloudSaveModal: React.FC<CloudSaveModalProps> = ({
 
   /** Blocks closing while a save is in progress and resets stale label state on close. */
   const handleOpenChange = (newOpen: boolean) => {
-    if (!isSaving) {
-      onOpenChange(newOpen);
-      if (!newOpen) {
-        setLabel('');
-      }
+    if (isSaving) {
+      return;
+    }
+
+    onOpenChange(newOpen);
+    if (!newOpen) {
+      setLabel('');
     }
   };
+
+  return {
+    label,
+    isSaving,
+    inputRef,
+    setLabel,
+    handleSave,
+    handleOpenChange,
+  };
+};
+
+/**
+ * Modal for saving a forecast to the cloud
+ */
+export const CloudSaveModal: React.FC<CloudSaveModalProps> = ({
+  open,
+  onOpenChange,
+  onSave,
+  currentLabel = '',
+  error,
+}) => {
+  const {
+    label,
+    isSaving,
+    inputRef,
+    setLabel,
+    handleSave,
+    handleOpenChange,
+  } = useCloudSaveDialogState(open, currentLabel, onOpenChange, onSave);
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/src/components/CloudCycleManager/CloudSaveLoadModals.tsx
+++ b/src/components/CloudCycleManager/CloudSaveLoadModals.tsx
@@ -78,6 +78,44 @@ const CloudSaveDialogFooter: React.FC<{
   </DialogFooter>
 );
 
+/** Main content stack for the cloud save dialog. */
+const CloudSaveDialogBody: React.FC<{
+  currentLabel: string;
+  error?: string;
+  label: string;
+  isSaving: boolean;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  onLabelChange: (value: string) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}> = ({ currentLabel, error, label, isSaving, inputRef, onLabelChange, onCancel, onSave }) => (
+  <div className="cloud-save-dialog-body">
+    <CloudSaveDialogHeader />
+    <CloudSaveDialogCallout currentLabel={currentLabel} />
+    {error ? <CloudSaveDialogError error={error} /> : null}
+
+    <div className="cloud-save-dialog-field">
+      <label htmlFor="cloud-cycle-name">Cycle name</label>
+      <Input
+        ref={inputRef}
+        id="cloud-cycle-name"
+        className="cloud-save-dialog-input"
+        value={label}
+        onChange={(e) => onLabelChange(e.target.value)}
+        placeholder="e.g., March 29 - Strong Pattern"
+        disabled={isSaving}
+      />
+    </div>
+
+    <CloudSaveDialogFooter
+      isSaving={isSaving}
+      canSave={Boolean(label.trim())}
+      onCancel={onCancel}
+      onSave={onSave}
+    />
+  </div>
+);
+
 /** Creates the local state and event handlers used by the cloud save dialog. */
 const useCloudSaveDialogState = (
   open: boolean,
@@ -162,31 +200,16 @@ export const CloudSaveModal: React.FC<CloudSaveModalProps> = ({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="cloud-save-dialog">
-        <div className="cloud-save-dialog-body">
-          <CloudSaveDialogHeader />
-          <CloudSaveDialogCallout currentLabel={currentLabel} />
-          {error ? <CloudSaveDialogError error={error} /> : null}
-
-          <div className="cloud-save-dialog-field">
-            <label htmlFor="cloud-cycle-name">Cycle name</label>
-            <Input
-              ref={inputRef}
-              id="cloud-cycle-name"
-              className="cloud-save-dialog-input"
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              placeholder="e.g., March 29 - Strong Pattern"
-              disabled={isSaving}
-            />
-          </div>
-
-          <CloudSaveDialogFooter
-            isSaving={isSaving}
-            canSave={Boolean(label.trim())}
-            onCancel={() => handleOpenChange(false)}
-            onSave={handleSave}
-          />
-        </div>
+        <CloudSaveDialogBody
+          currentLabel={currentLabel}
+          error={error}
+          label={label}
+          isSaving={isSaving}
+          inputRef={inputRef}
+          onLabelChange={setLabel}
+          onCancel={() => handleOpenChange(false)}
+          onSave={handleSave}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/CloudCycleManager/CloudToolbarButton.css
+++ b/src/components/CloudCycleManager/CloudToolbarButton.css
@@ -1,0 +1,63 @@
+.cloud-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cloud-toolbar-action {
+  position: relative;
+  overflow: hidden;
+  border-width: 1px;
+  color: hsl(var(--foreground));
+  box-shadow:
+    inset 0 1px 0 hsl(var(--background) / 0.65),
+    0 10px 24px hsl(var(--foreground) / 0.08);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.cloud-toolbar-action:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 hsl(var(--background) / 0.7),
+    0 14px 28px hsl(var(--foreground) / 0.1);
+}
+
+.cloud-toolbar-action-save {
+  border-color: hsl(158 55% 66%);
+  background:
+    radial-gradient(circle at top left, hsl(160 78% 74% / 0.45), transparent 42%),
+    linear-gradient(180deg, hsl(154 53% 88%) 0%, hsl(154 55% 90%) 100%);
+  color: hsl(151 65% 24%);
+}
+
+.cloud-toolbar-action-library {
+  border-color: hsl(240 83% 78%);
+  background:
+    radial-gradient(circle at top left, hsl(244 100% 85% / 0.45), transparent 42%),
+    linear-gradient(180deg, hsl(243 88% 88%) 0%, hsl(240 84% 89%) 100%);
+  color: hsl(241 58% 31%);
+}
+
+.cloud-toolbar-action-save:hover {
+  background:
+    radial-gradient(circle at top left, hsl(160 82% 72% / 0.52), transparent 42%),
+    linear-gradient(180deg, hsl(154 58% 86%) 0%, hsl(154 60% 88%) 100%);
+}
+
+.cloud-toolbar-action-library:hover {
+  background:
+    radial-gradient(circle at top left, hsl(244 100% 84% / 0.52), transparent 42%),
+    linear-gradient(180deg, hsl(243 94% 87%) 0%, hsl(240 88% 88%) 100%);
+}
+
+.cloud-toolbar-action:disabled {
+  opacity: 0.72;
+  transform: none;
+  box-shadow:
+    inset 0 1px 0 hsl(var(--background) / 0.55),
+    0 8px 18px hsl(var(--foreground) / 0.06);
+}

--- a/src/components/CloudCycleManager/CloudToolbarButton.tsx
+++ b/src/components/CloudCycleManager/CloudToolbarButton.tsx
@@ -90,14 +90,17 @@ const useCloudToolbarState = ({
 /** Shared tooltip-wrapped toolbar button used by the cloud actions. */
 const CloudToolbarActionButton: React.FC<{
   tooltip: string;
+  ariaLabel: string;
   className: string;
   disabled?: boolean;
   onClick: () => void;
   children: React.ReactNode;
-}> = ({ tooltip, className, disabled = false, onClick, children }) => (
+}> = ({ tooltip, ariaLabel, className, disabled = false, onClick, children }) => (
   <Tooltip>
     <TooltipTrigger asChild>
       <Button
+        aria-label={ariaLabel}
+        title={ariaLabel}
         variant="outline"
         size="icon"
         onClick={onClick}
@@ -145,6 +148,7 @@ export const CloudToolbarButton: React.FC<CloudToolbarButtonProps> = ({
       <div className="cloud-toolbar-group">
         <CloudToolbarActionButton
           tooltip={tooltip}
+          ariaLabel="Save forecast to cloud"
           disabled={syncState === 'saving'}
           onClick={handleSaveClick}
           className="cloud-toolbar-action cloud-toolbar-action-save h-14 w-14 lg:h-16 lg:w-16"
@@ -154,6 +158,7 @@ export const CloudToolbarButton: React.FC<CloudToolbarButtonProps> = ({
 
         <CloudToolbarActionButton
           tooltip="Open the cloud library"
+          ariaLabel="Open cloud library"
           onClick={onOpenCloudLibrary}
           className="cloud-toolbar-action cloud-toolbar-action-library h-14 w-14 lg:h-16 lg:w-16"
         >

--- a/src/components/CloudCycleManager/CloudToolbarButton.tsx
+++ b/src/components/CloudCycleManager/CloudToolbarButton.tsx
@@ -17,6 +17,76 @@ interface CloudToolbarButtonProps {
   onOpenCloudLibrary: () => void;
 }
 
+/** Returns the cloud-save error shown when the user clicks save without write access. */
+const getCloudToolbarSaveError = (premiumActive: boolean, isExpiredPremium: boolean): string =>
+  premiumActive && isExpiredPremium
+    ? 'Your premium subscription has expired. Renew to save forecasts to the cloud.'
+    : 'Subscribe to premium to save forecasts to the cloud.';
+
+/** Returns the save-button tooltip for the current cloud save state. */
+const getCloudToolbarTooltip = (
+  canSave: boolean,
+  premiumActive: boolean,
+  isExpiredPremium: boolean,
+  currentCloudLabel?: string
+): string => {
+  if (!canSave) {
+    return premiumActive && isExpiredPremium
+      ? 'Premium expired. Cloud writes are read-only until you renew.'
+      : 'Subscribe to premium to save forecasts to the cloud';
+  }
+
+  return currentCloudLabel
+    ? `Save updates to "${currentCloudLabel}"`
+    : 'Save this forecast to your cloud library';
+};
+
+/** Returns the correct icon for the cloud save button based on the current sync state. */
+const renderCloudSaveIcon = (syncState: CloudSyncState) =>
+  syncState === 'saving'
+    ? <LoaderCircle className="h-6 w-6 animate-spin" />
+    : <Cloud className="h-6 w-6" />;
+
+/** Manages cloud save modal state and save errors for the toolbar button group. */
+const useCloudToolbarState = ({
+  canSave,
+  premiumActive,
+  isExpiredPremium,
+  onSaveToCloud,
+}: Pick<CloudToolbarButtonProps, 'canSave' | 'premiumActive' | 'isExpiredPremium' | 'onSaveToCloud'>) => {
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSaveClick = useCallback(() => {
+    setSaveModalOpen(true);
+    setError(canSave ? null : getCloudToolbarSaveError(premiumActive, isExpiredPremium));
+  }, [canSave, isExpiredPremium, premiumActive]);
+
+  const handleSaveToCloud = useCallback(
+    async (label: string) => {
+      try {
+        setError(null);
+        await onSaveToCloud(label);
+        setSaveModalOpen(false);
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to save to cloud';
+        setError(message);
+        return false;
+      }
+    },
+    [onSaveToCloud]
+  );
+
+  return {
+    saveModalOpen,
+    error,
+    handleSaveClick,
+    handleSaveToCloud,
+    setSaveModalOpen,
+  };
+};
+
 /** Shared tooltip-wrapped toolbar button used by the cloud actions. */
 const CloudToolbarActionButton: React.FC<{
   tooltip: string;
@@ -54,48 +124,21 @@ export const CloudToolbarButton: React.FC<CloudToolbarButtonProps> = ({
   currentCycleDate,
   onOpenCloudLibrary,
 }) => {
-  const [saveModalOpen, setSaveModalOpen] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    saveModalOpen,
+    error,
+    handleSaveClick,
+    handleSaveToCloud,
+    setSaveModalOpen,
+  } = useCloudToolbarState({
+    canSave,
+    premiumActive,
+    isExpiredPremium,
+    onSaveToCloud,
+  });
 
-  const handleSaveClick = useCallback(() => {
-    if (!canSave) {
-      setError(
-        premiumActive && isExpiredPremium
-          ? 'Your premium subscription has expired. Renew to save forecasts to the cloud.'
-          : 'Subscribe to premium to save forecasts to the cloud.'
-      );
-    }
-    setSaveModalOpen(true);
-    if (canSave) {
-      setError(null);
-    }
-  }, [canSave, premiumActive, isExpiredPremium]);
-
-  const handleSaveToCloud = useCallback(
-    async (label: string) => {
-      try {
-        setError(null);
-        await onSaveToCloud(label);
-        setSaveModalOpen(false);
-        return true;
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Failed to save to cloud';
-        setError(message);
-        return false;
-      }
-    },
-    [onSaveToCloud]
-  );
-
-  const tooltip = canSave
-    ? currentCloudLabel
-      ? `Save updates to "${currentCloudLabel}"`
-      : 'Save this forecast to your cloud library'
-    : premiumActive && isExpiredPremium
-      ? 'Premium expired. Cloud writes are read-only until you renew.'
-      : 'Subscribe to premium to save forecasts to the cloud';
-
-  const saveIcon = syncState === 'saving' ? <LoaderCircle className="h-6 w-6 animate-spin" /> : <Cloud className="h-6 w-6" />;
+  const tooltip = getCloudToolbarTooltip(canSave, premiumActive, isExpiredPremium, currentCloudLabel);
+  const saveIcon = renderCloudSaveIcon(syncState);
 
   return (
     <>

--- a/src/components/CloudCycleManager/CloudToolbarButton.tsx
+++ b/src/components/CloudCycleManager/CloudToolbarButton.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useCallback } from 'react';
+import { Cloud, FolderOpen, LoaderCircle } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import { CloudSaveModal } from './CloudSaveLoadModals';
+import type { CloudSyncState } from '../../types/cloudCycles';
+import './CloudToolbarButton.css';
+
+interface CloudToolbarButtonProps {
+  canSave: boolean;
+  premiumActive: boolean;
+  isExpiredPremium: boolean;
+  currentCycleDate: string;
+  currentCloudLabel?: string;
+  syncState?: CloudSyncState;
+  onSaveToCloud: (label: string) => Promise<void>;
+  onOpenCloudLibrary: () => void;
+}
+
+/**
+ * Toolbar button group for cloud save/load operations.
+ */
+export const CloudToolbarButton: React.FC<CloudToolbarButtonProps> = ({
+  canSave,
+  premiumActive,
+  isExpiredPremium,
+  currentCloudLabel,
+  syncState = 'idle',
+  onSaveToCloud,
+  currentCycleDate,
+  onOpenCloudLibrary,
+}) => {
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSaveClick = useCallback(() => {
+    if (!canSave) {
+      setError(
+        premiumActive && isExpiredPremium
+          ? 'Your premium subscription has expired. Renew to save forecasts to the cloud.'
+          : 'Subscribe to premium to save forecasts to the cloud.'
+      );
+    }
+    setSaveModalOpen(true);
+    if (canSave) {
+      setError(null);
+    }
+  }, [canSave, premiumActive, isExpiredPremium]);
+
+  const handleSaveToCloud = useCallback(
+    async (label: string) => {
+      try {
+        setError(null);
+        await onSaveToCloud(label);
+        setSaveModalOpen(false);
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to save to cloud';
+        setError(message);
+        return false;
+      }
+    },
+    [onSaveToCloud]
+  );
+
+  const tooltip = canSave
+    ? currentCloudLabel
+      ? `Save updates to "${currentCloudLabel}"`
+      : 'Save this forecast to your cloud library'
+    : premiumActive && isExpiredPremium
+      ? 'Premium expired. Cloud writes are read-only until you renew.'
+      : 'Subscribe to premium to save forecasts to the cloud';
+
+  const saveIcon = syncState === 'saving' ? <LoaderCircle className="h-6 w-6 animate-spin" /> : <Cloud className="h-6 w-6" />;
+
+  return (
+    <>
+      <div className="cloud-toolbar-group">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleSaveClick}
+              disabled={syncState === 'saving'}
+              className="cloud-toolbar-action cloud-toolbar-action-save h-14 w-14 lg:h-16 lg:w-16"
+            >
+              {saveIcon}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{tooltip}</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={onOpenCloudLibrary}
+              className="cloud-toolbar-action cloud-toolbar-action-library h-14 w-14 lg:h-16 lg:w-16"
+            >
+              <FolderOpen className="h-6 w-6" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Open the cloud library</TooltipContent>
+        </Tooltip>
+      </div>
+
+      <CloudSaveModal
+        open={saveModalOpen}
+        onOpenChange={setSaveModalOpen}
+        onSave={handleSaveToCloud}
+        currentLabel={currentCloudLabel || `${currentCycleDate} Forecast`}
+        error={error}
+      />
+    </>
+  );
+};

--- a/src/components/CloudCycleManager/CloudToolbarButton.tsx
+++ b/src/components/CloudCycleManager/CloudToolbarButton.tsx
@@ -17,6 +17,30 @@ interface CloudToolbarButtonProps {
   onOpenCloudLibrary: () => void;
 }
 
+/** Shared tooltip-wrapped toolbar button used by the cloud actions. */
+const CloudToolbarActionButton: React.FC<{
+  tooltip: string;
+  className: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}> = ({ tooltip, className, disabled = false, onClick, children }) => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={onClick}
+        disabled={disabled}
+        className={className}
+      >
+        {children}
+      </Button>
+    </TooltipTrigger>
+    <TooltipContent>{tooltip}</TooltipContent>
+  </Tooltip>
+);
+
 /**
  * Toolbar button group for cloud save/load operations.
  */
@@ -76,34 +100,22 @@ export const CloudToolbarButton: React.FC<CloudToolbarButtonProps> = ({
   return (
     <>
       <div className="cloud-toolbar-group">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={handleSaveClick}
-              disabled={syncState === 'saving'}
-              className="cloud-toolbar-action cloud-toolbar-action-save h-14 w-14 lg:h-16 lg:w-16"
-            >
-              {saveIcon}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{tooltip}</TooltipContent>
-        </Tooltip>
+        <CloudToolbarActionButton
+          tooltip={tooltip}
+          disabled={syncState === 'saving'}
+          onClick={handleSaveClick}
+          className="cloud-toolbar-action cloud-toolbar-action-save h-14 w-14 lg:h-16 lg:w-16"
+        >
+          {saveIcon}
+        </CloudToolbarActionButton>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={onOpenCloudLibrary}
-              className="cloud-toolbar-action cloud-toolbar-action-library h-14 w-14 lg:h-16 lg:w-16"
-            >
-              <FolderOpen className="h-6 w-6" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Open the cloud library</TooltipContent>
-        </Tooltip>
+        <CloudToolbarActionButton
+          tooltip="Open the cloud library"
+          onClick={onOpenCloudLibrary}
+          className="cloud-toolbar-action cloud-toolbar-action-library h-14 w-14 lg:h-16 lg:w-16"
+        >
+          <FolderOpen className="h-6 w-6" />
+        </CloudToolbarActionButton>
       </div>
 
       <CloudSaveModal

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -97,6 +97,7 @@ interface IntegratedToolbarProps {
   onLoad: (file: File) => void;
   mapRef: React.RefObject<ForecastMapHandle | null>;
   addToast: AddToastFn;
+  cloudTools: React.ReactNode;
 }
 
 /** Returns true if the given day in the forecast cycle has any outlook polygons drawn for any outlook type. */
@@ -196,6 +197,7 @@ const ToolbarTooltipButton: React.FC<{
 const ToolbarToolsSection: React.FC<{
   onSave: () => void;
   onLoadClick: () => void;
+  cloudTools: React.ReactNode;
   onInitiateExport: () => void;
   onPackageDownload: () => void;
   onOpenHistoryModal: () => void;
@@ -208,7 +210,7 @@ const ToolbarToolsSection: React.FC<{
   canRedo: boolean;
   isExporting: boolean;
   isPackageDownloading: boolean;
-}> = ({ onSave, onLoadClick, onInitiateExport, onPackageDownload, onOpenHistoryModal, onOpenCopyModal, onOpenResetConfirm, onUndo, onRedo, isSaved, canUndo, canRedo, isExporting, isPackageDownloading }) => (
+}> = ({ onSave, onLoadClick, cloudTools, onInitiateExport, onPackageDownload, onOpenHistoryModal, onOpenCopyModal, onOpenResetConfirm, onUndo, onRedo, isSaved, canUndo, canRedo, isExporting, isPackageDownloading }) => (
   <div className="flex flex-col gap-2 lg:gap-3 border-r border-border pr-2 lg:pr-4">
     <div className="flex items-center gap-2">
       <ToolbarTooltipButton
@@ -240,6 +242,9 @@ const ToolbarToolsSection: React.FC<{
         className="h-14 w-14 lg:h-16 lg:w-16 bg-blue-500/20 hover:bg-blue-500/30 border-blue-500/50 text-blue-700 dark:!bg-blue-500/20 dark:hover:!bg-blue-500/30 dark:border-blue-500/50 dark:text-blue-400"
         onClick={onLoadClick}
       />
+      {cloudTools}
+    </div>
+    <div className="flex items-center gap-2">
       <ToolbarTooltipButton
         icon={isExporting ? <span className="animate-spin h-5 w-5 border-2 border-current border-t-transparent rounded-full" /> : <ImageIcon className="h-6 w-6" />}
         tooltip={<p>{isExporting ? 'Exporting...' : 'Export Image'} <span className="text-muted-foreground">(⌃E)</span></p>}
@@ -247,8 +252,6 @@ const ToolbarToolsSection: React.FC<{
         onClick={onInitiateExport}
         disabled={isExporting}
       />
-    </div>
-    <div className="flex items-center gap-2">
       <ToolbarTooltipButton
         icon={<Archive className="h-6 w-6" />}
         tooltip={<p>Download Package <span className="text-muted-foreground">(JSON + Discussions)</span></p>}
@@ -651,6 +654,7 @@ const ToolbarModals: React.FC<{
 const IntegratedToolbarView: React.FC<IntegratedToolbarViewProps> = (props) => {
   const {
     onSave, onLoadClick, onInitiateExport, onPackageDownload,
+    cloudTools,
     onOpenHistoryModal, onOpenCopyModal, onOpenResetConfirm,
     onUndo, onRedo,
     onDateSave, onTempDateChange, onStartDateEdit,
@@ -677,7 +681,7 @@ const IntegratedToolbarView: React.FC<IntegratedToolbarViewProps> = (props) => {
         <div className="h-full overflow-x-auto overflow-y-hidden">
           <div className="flex items-center justify-center gap-2 lg:gap-3 px-2 sm:px-3 lg:px-4 h-full min-w-max">
             <ToolbarToolsSection
-              onSave={onSave} onLoadClick={onLoadClick} onInitiateExport={onInitiateExport}
+              onSave={onSave} onLoadClick={onLoadClick} cloudTools={cloudTools} onInitiateExport={onInitiateExport}
               onPackageDownload={onPackageDownload} onOpenHistoryModal={onOpenHistoryModal}
               onOpenCopyModal={onOpenCopyModal} onOpenResetConfirm={onOpenResetConfirm}
               onUndo={onUndo} onRedo={onRedo}
@@ -973,6 +977,7 @@ export const IntegratedToolbar: React.FC<IntegratedToolbarProps> = ({
   onLoad,
   mapRef,
   addToast,
+  cloudTools,
 }) => {
   const dispatch = useDispatch();
   const model = useToolbarDataModel(mapRef, addToast);
@@ -998,6 +1003,7 @@ export const IntegratedToolbar: React.FC<IntegratedToolbarProps> = ({
   return (
     <IntegratedToolbarView
       onSave={onSave}
+        cloudTools={cloudTools}
       onOpenHistoryModal={localUi.handleOpenHistoryModal}
       onOpenCopyModal={localUi.handleOpenCopyModal}
       onOpenResetConfirm={localUi.handleOpenResetConfirm}

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -97,7 +97,7 @@ interface IntegratedToolbarProps {
   onLoad: (file: File) => void;
   mapRef: React.RefObject<ForecastMapHandle | null>;
   addToast: AddToastFn;
-  cloudTools: React.ReactNode;
+  cloudTools?: React.ReactNode;
 }
 
 /** Returns true if the given day in the forecast cycle has any outlook polygons drawn for any outlook type. */
@@ -197,7 +197,7 @@ const ToolbarTooltipButton: React.FC<{
 const ToolbarToolsSection: React.FC<{
   onSave: () => void;
   onLoadClick: () => void;
-  cloudTools: React.ReactNode;
+  cloudTools?: React.ReactNode;
   onInitiateExport: () => void;
   onPackageDownload: () => void;
   onOpenHistoryModal: () => void;
@@ -242,7 +242,7 @@ const ToolbarToolsSection: React.FC<{
         className="h-14 w-14 lg:h-16 lg:w-16 bg-blue-500/20 hover:bg-blue-500/30 border-blue-500/50 text-blue-700 dark:!bg-blue-500/20 dark:hover:!bg-blue-500/30 dark:border-blue-500/50 dark:text-blue-400"
         onClick={onLoadClick}
       />
-      {cloudTools}
+      {cloudTools ?? null}
     </div>
     <div className="flex items-center gap-2">
       <ToolbarTooltipButton
@@ -977,7 +977,7 @@ export const IntegratedToolbar: React.FC<IntegratedToolbarProps> = ({
   onLoad,
   mapRef,
   addToast,
-  cloudTools,
+  cloudTools = null,
 }) => {
   const dispatch = useDispatch();
   const model = useToolbarDataModel(mapRef, addToast);
@@ -1003,7 +1003,7 @@ export const IntegratedToolbar: React.FC<IntegratedToolbarProps> = ({
   return (
     <IntegratedToolbarView
       onSave={onSave}
-        cloudTools={cloudTools}
+      cloudTools={cloudTools}
       onOpenHistoryModal={localUi.handleOpenHistoryModal}
       onOpenCopyModal={localUi.handleOpenCopyModal}
       onOpenResetConfirm={localUi.handleOpenResetConfirm}

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -348,7 +348,13 @@ function useCloudDeleteCycle({
     canWrite,
     setError,
     fallbackError: 'Failed to delete cloud cycle',
-    action: (cycleId) => deleteCloudCycle({ userId: userId!, cycleId }),
+    action: (cycleId) => {
+      if (!userId) {
+        return Promise.resolve({ success: false, error: 'Not signed in' });
+      }
+
+      return deleteCloudCycle({ userId, cycleId });
+    },
     onSuccess: (cycleId) => {
       clearDeletedCloudSelection({ currentCloudRef, setCurrentCloud, cycleId });
     },
@@ -368,7 +374,13 @@ function useCloudRenameCycle({
     canWrite,
     setError,
     fallbackError: 'Failed to rename cloud cycle',
-    action: (cycleId, newLabel) => renameCloudCycle({ userId: userId!, cycleId, newLabel }),
+    action: (cycleId, newLabel) => {
+      if (!userId) {
+        return Promise.resolve({ success: false, error: 'Not signed in' });
+      }
+
+      return renameCloudCycle({ userId, cycleId, newLabel });
+    },
     onSuccess: (cycleId, newLabel) => {
       syncRenamedCloudSelection({ currentCloudRef, setCurrentCloud, cycleId, newLabel });
     },

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -28,9 +28,12 @@ export interface UseCloudCyclesResult {
   updateSyncState: (state: CloudSyncState, error?: string) => void;
 }
 
-interface CloudOperationContext {
-  userId: string;
+interface CloudAccessContext {
+  userId?: string;
   canWrite: boolean;
+}
+
+interface CloudStateContext {
   cycles: CloudCycleMetadata[];
   currentCloudRef: MutableRefObject<CloudCycleContext | null>;
   setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>;
@@ -41,7 +44,7 @@ interface CloudOperationContext {
 }
 
 /** Returns the shared error message for cloud write actions when the user cannot save. */
-function getCloudWriteBlockedMessage(userId: string, canWrite: boolean): string {
+function getCloudWriteBlockedMessage({ userId, canWrite }: CloudAccessContext): string {
   if (!userId) {
     return 'Not signed in';
   }
@@ -49,15 +52,36 @@ function getCloudWriteBlockedMessage(userId: string, canWrite: boolean): string 
   return canWrite ? 'Action not allowed' : 'Premium subscription required to save cloud cycles';
 }
 
+/** Returns true when the requested sync state already matches the current cloud context. */
+function hasMatchingSyncState({
+  currentCloud,
+  state,
+  syncError,
+}: {
+  currentCloud: CloudCycleContext;
+  state: CloudSyncState;
+  syncError?: string;
+}): boolean {
+  return currentCloud.syncState === state && currentCloud.lastSyncError === syncError;
+}
+
 /** Updates the current cloud context when a sync state change actually changed something. */
-function applySyncStateUpdate(
-  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>,
-  state: CloudSyncState,
-  syncError?: string
-): void {
+function applySyncStateUpdate({
+  setCurrentCloud,
+  state,
+  syncError,
+}: {
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>;
+  state: CloudSyncState;
+  syncError?: string;
+}): void {
   setCurrentCloud((prev) => {
-    if (!prev || (prev.syncState === state && prev.lastSyncError === syncError)) {
-      return prev ?? null;
+    if (!prev) {
+      return null;
+    }
+
+    if (hasMatchingSyncState({ currentCloud: prev, state, syncError })) {
+      return prev;
     }
 
     return {
@@ -69,31 +93,48 @@ function applySyncStateUpdate(
 }
 
 /** Creates the current-cloud context stored for the active forecast session. */
-function createCurrentCloudContext(id: string, label: string, syncState: CloudSyncState): CloudCycleContext {
+function createCurrentCloudContext({
+  id,
+  label,
+  syncState,
+}: {
+  id: string;
+  label: string;
+  syncState: CloudSyncState;
+}): CloudCycleContext {
   return { id, label, syncState };
 }
 
 /** Updates the current cloud context when one cloud cycle is loaded. */
-function syncLoadedCloudSelection(
-  cycles: CloudCycleMetadata[],
-  cycleId: string,
-  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>
-): void {
+function syncLoadedCloudSelection({
+  cycles,
+  cycleId,
+  setCurrentCloud,
+}: {
+  cycles: CloudCycleMetadata[];
+  cycleId: string;
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>;
+}): void {
   const cycle = cycles.find((item) => item.id === cycleId);
   if (!cycle) {
     return;
   }
 
-  setCurrentCloud(createCurrentCloudContext(cycleId, cycle.label, 'saved'));
+  setCurrentCloud(createCurrentCloudContext({ id: cycleId, label: cycle.label, syncState: 'saved' }));
 }
 
 /** Updates the current cloud label after a successful rename when the renamed cycle is active. */
-function syncRenamedCloudSelection(
-  currentCloudRef: MutableRefObject<CloudCycleContext | null>,
-  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>,
-  cycleId: string,
-  newLabel: string
-): void {
+function syncRenamedCloudSelection({
+  currentCloudRef,
+  setCurrentCloud,
+  cycleId,
+  newLabel,
+}: {
+  currentCloudRef: MutableRefObject<CloudCycleContext | null>;
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>;
+  cycleId: string;
+  newLabel: string;
+}): void {
   if (currentCloudRef.current?.id !== cycleId || currentCloudRef.current.label === newLabel) {
     return;
   }
@@ -102,24 +143,34 @@ function syncRenamedCloudSelection(
 }
 
 /** Clears the current cloud selection after a delete when the deleted cycle was active. */
-function clearDeletedCloudSelection(
-  currentCloudRef: MutableRefObject<CloudCycleContext | null>,
-  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>,
-  cycleId: string
-): void {
+function clearDeletedCloudSelection({
+  currentCloudRef,
+  setCurrentCloud,
+  cycleId,
+}: {
+  currentCloudRef: MutableRefObject<CloudCycleContext | null>;
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>;
+  cycleId: string;
+}): void {
   if (currentCloudRef.current?.id === cycleId) {
     setCurrentCloud(null);
   }
 }
 
 /** Starts the realtime hosted-cycle subscription for the signed-in user. */
-function useCloudCycleSubscription(
-  userId: string | undefined,
-  setCycles: Dispatch<SetStateAction<CloudCycleMetadata[]>>,
-  setLoading: Dispatch<SetStateAction<boolean>>,
-  setError: Dispatch<SetStateAction<string | null>>,
-  unsubscribeRef: MutableRefObject<(() => void) | null>
-): void {
+function useCloudCycleSubscription({
+  userId,
+  setCycles,
+  setLoading,
+  setError,
+  unsubscribeRef,
+}: {
+  userId?: string;
+  setCycles: Dispatch<SetStateAction<CloudCycleMetadata[]>>;
+  setLoading: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  unsubscribeRef: MutableRefObject<(() => void) | null>;
+}): void {
   useEffect(() => {
     if (!userId) {
       setCycles([]);
@@ -148,19 +199,16 @@ function useCloudCycleSubscription(
   }, [userId, setCycles, setError, setLoading, unsubscribeRef]);
 }
 
-/** Creates the hosted cloud-cycle CRUD callbacks used by the forecast and library pages. */
-function useCloudCycleOperations({
+/** Returns the save callback for hosted cloud cycles. */
+function useCloudSaveCycle({
   userId,
   canWrite,
-  cycles,
   currentCloudRef,
   setCurrentCloud,
-  setCycles,
   setError,
-  setLoading,
   updateSyncState,
-}: CloudOperationContext) {
-  const saveCycle = useCallback(
+}: CloudAccessContext & Pick<CloudStateContext, 'currentCloudRef' | 'setCurrentCloud' | 'setError' | 'updateSyncState'>) {
+  return useCallback(
     async (
       label: string,
       cycleDate: string,
@@ -168,7 +216,7 @@ function useCloudCycleOperations({
       payload: GFCForecastSaveData
     ): Promise<boolean> => {
       if (!userId || !canWrite) {
-        setError(getCloudWriteBlockedMessage(userId, canWrite));
+        setError(getCloudWriteBlockedMessage({ userId, canWrite }));
         return false;
       }
 
@@ -193,15 +241,24 @@ function useCloudCycleOperations({
       }
 
       if (result.data) {
-        setCurrentCloud(createCurrentCloudContext(result.data, label, 'saved'));
+        setCurrentCloud(createCurrentCloudContext({ id: result.data, label, syncState: 'saved' }));
       }
       updateSyncState('saved');
       return true;
     },
     [canWrite, currentCloudRef, setCurrentCloud, setError, updateSyncState, userId]
   );
+}
 
-  const loadCycle = useCallback(
+/** Returns the load callback for hosted cloud cycles. */
+function useCloudLoadCycle({
+  userId,
+  cycles,
+  setCurrentCloud,
+  setError,
+  updateSyncState,
+}: Pick<CloudStateContext, 'cycles' | 'setCurrentCloud' | 'setError' | 'updateSyncState'> & Pick<CloudAccessContext, 'userId'>) {
+  return useCallback(
     async (cycleId: string): Promise<GFCForecastSaveData | null> => {
       if (!userId) {
         setError('Not signed in');
@@ -218,14 +275,23 @@ function useCloudCycleOperations({
         return null;
       }
 
-      syncLoadedCloudSelection(cycles, cycleId, setCurrentCloud);
+      syncLoadedCloudSelection({ cycles, cycleId, setCurrentCloud });
       updateSyncState('saved');
       return result.data.payload;
     },
     [cycles, setCurrentCloud, setError, updateSyncState, userId]
   );
+}
 
-  const deleteCycleAction = useCallback(
+/** Returns the delete callback for hosted cloud cycles. */
+function useCloudDeleteCycle({
+  userId,
+  canWrite,
+  currentCloudRef,
+  setCurrentCloud,
+  setError,
+}: Pick<CloudStateContext, 'currentCloudRef' | 'setCurrentCloud' | 'setError'> & CloudAccessContext) {
+  return useCallback(
     async (cycleId: string): Promise<boolean> => {
       if (!userId || !canWrite) {
         setError('Action not allowed');
@@ -239,13 +305,22 @@ function useCloudCycleOperations({
         return false;
       }
 
-      clearDeletedCloudSelection(currentCloudRef, setCurrentCloud, cycleId);
+      clearDeletedCloudSelection({ currentCloudRef, setCurrentCloud, cycleId });
       return true;
     },
     [canWrite, currentCloudRef, setCurrentCloud, setError, userId]
   );
+}
 
-  const renameCycleAction = useCallback(
+/** Returns the rename callback for hosted cloud cycles. */
+function useCloudRenameCycle({
+  userId,
+  canWrite,
+  currentCloudRef,
+  setCurrentCloud,
+  setError,
+}: Pick<CloudStateContext, 'currentCloudRef' | 'setCurrentCloud' | 'setError'> & CloudAccessContext) {
+  return useCallback(
     async (cycleId: string, newLabel: string): Promise<boolean> => {
       if (!userId || !canWrite) {
         setError('Action not allowed');
@@ -259,13 +334,21 @@ function useCloudCycleOperations({
         return false;
       }
 
-      syncRenamedCloudSelection(currentCloudRef, setCurrentCloud, cycleId, newLabel);
+      syncRenamedCloudSelection({ currentCloudRef, setCurrentCloud, cycleId, newLabel });
       return true;
     },
     [canWrite, currentCloudRef, setCurrentCloud, setError, userId]
   );
+}
 
-  const refreshCycles = useCallback(async (): Promise<void> => {
+/** Returns the explicit refresh callback for cloud-cycle metadata. */
+function useCloudRefreshCycles({
+  userId,
+  setCycles,
+  setError,
+  setLoading,
+}: Pick<CloudStateContext, 'setCycles' | 'setError' | 'setLoading'> & Pick<CloudAccessContext, 'userId'>) {
+  return useCallback(async (): Promise<void> => {
     if (!userId) {
       return;
     }
@@ -279,13 +362,84 @@ function useCloudCycleOperations({
     }
     setLoading(false);
   }, [setCycles, setError, setLoading, userId]);
+}
+
+/** Creates the hosted cloud-cycle CRUD callbacks used by the forecast and library pages. */
+function useCloudCycleOperations(context: CloudAccessContext & CloudStateContext) {
+  const saveCycle = useCloudSaveCycle(context);
+  const loadCycle = useCloudLoadCycle(context);
+  const deleteCycle = useCloudDeleteCycle(context);
+  const renameCycle = useCloudRenameCycle(context);
+  const refreshCycles = useCloudRefreshCycles(context);
 
   return {
     saveCycle,
     loadCycle,
-    deleteCycle: deleteCycleAction,
-    renameCycle: renameCycleAction,
+    deleteCycle,
+    renameCycle,
     refreshCycles,
+  };
+}
+
+/** Keeps the current-cloud ref in sync with state so callbacks can read the latest selection. */
+function useCurrentCloudRef(currentCloud: CloudCycleContext | null): MutableRefObject<CloudCycleContext | null> {
+  const currentCloudRef = useRef<CloudCycleContext | null>(null);
+
+  useEffect(() => {
+    currentCloudRef.current = currentCloud;
+  }, [currentCloud]);
+
+  return currentCloudRef;
+}
+
+/** Clears cloud-library state when the user signs out so stale data never leaks across sessions. */
+function useResetCloudStateOnSignOut({
+  userId,
+  setCycles,
+  setCurrentCloud,
+  setError,
+  currentCloudRef,
+}: {
+  userId?: string;
+  setCycles: Dispatch<SetStateAction<CloudCycleMetadata[]>>;
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  currentCloudRef: MutableRefObject<CloudCycleContext | null>;
+}) {
+  useEffect(() => {
+    if (userId) {
+      return;
+    }
+
+    setCycles([]);
+    setCurrentCloud(null);
+    setError(null);
+    currentCloudRef.current = null;
+  }, [currentCloudRef, setCurrentCloud, setCycles, setError, userId]);
+}
+
+/** Returns the mark/clear callbacks for the currently active cloud cycle. */
+function useCurrentCloudSelectionControls(
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>
+) {
+  const markAsCurrent = useCallback((cycleId: string, label: string) => {
+    setCurrentCloud((prev) => {
+      const nextValue = createCurrentCloudContext({ id: cycleId, label, syncState: 'idle' });
+      if (prev?.id === cycleId && prev.label === label && prev.syncState === 'idle' && !prev.lastSyncError) {
+        return prev;
+      }
+
+      return nextValue;
+    });
+  }, [setCurrentCloud]);
+
+  const clearCurrent = useCallback(() => {
+    setCurrentCloud(null);
+  }, [setCurrentCloud]);
+
+  return {
+    markAsCurrent,
+    clearCurrent,
   };
 }
 
@@ -301,32 +455,31 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
-  const currentCloudRef = useRef<CloudCycleContext | null>(null);
+  const currentCloudRef = useCurrentCloudRef(currentCloud);
   const canWrite = premiumActive;
 
-  useEffect(() => {
-    currentCloudRef.current = currentCloud;
-  }, [currentCloud]);
-
-  useEffect(() => {
-    if (user?.uid) {
-      return;
-    }
-
-    setCycles([]);
-    setCurrentCloud(null);
-    setError(null);
-    currentCloudRef.current = null;
-  }, [user?.uid]);
+  useResetCloudStateOnSignOut({
+    userId: user?.uid,
+    setCycles,
+    setCurrentCloud,
+    setError,
+    currentCloudRef,
+  });
 
   const updateSyncState = useCallback((state: CloudSyncState, syncError?: string) => {
-    applySyncStateUpdate(setCurrentCloud, state, syncError);
-  }, []);
+    applySyncStateUpdate({ setCurrentCloud, state, syncError });
+  }, [setCurrentCloud]);
 
-  useCloudCycleSubscription(user?.uid, setCycles, setLoading, setError, unsubscribeRef);
+  useCloudCycleSubscription({
+    userId: user?.uid,
+    setCycles,
+    setLoading,
+    setError,
+    unsubscribeRef,
+  });
 
   const operations = useCloudCycleOperations({
-    userId: user?.uid ?? '',
+    userId: user?.uid,
     canWrite,
     cycles,
     currentCloudRef,
@@ -337,20 +490,7 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
     updateSyncState,
   });
 
-  const markAsCurrent = useCallback((cycleId: string, label: string) => {
-    setCurrentCloud((prev) => {
-      const nextValue = createCurrentCloudContext(cycleId, label, 'idle');
-      if (prev?.id === cycleId && prev.label === label && prev.syncState === 'idle' && !prev.lastSyncError) {
-        return prev;
-      }
-
-      return nextValue;
-    });
-  }, []);
-
-  const clearCurrent = useCallback(() => {
-    setCurrentCloud(null);
-  }, []);
+  const { markAsCurrent, clearCurrent } = useCurrentCloudSelectionControls(setCurrentCloud);
 
   return {
     cycles,

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -89,7 +89,8 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
       }
     );
 
-    return () => {
+    // skipcq: JS-0045 React effects intentionally return cleanup callbacks.
+    return function cleanupCloudCycleSubscription() {
       unsubscribeRef.current?.();
     };
   }, [user?.uid]);

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -1,0 +1,254 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useAuth } from '../auth/AuthProvider';
+import { useEntitlement } from '../billing/EntitlementProvider';
+import { CloudCycleMetadata, CloudCycleContext, CloudSyncState } from '../types/cloudCycles';
+import {
+  saveCloudCycle,
+  loadCloudCycle,
+  deleteCloudCycle,
+  renameCloudCycle,
+  listCloudCycles,
+  subscribeToCloudCycles,
+} from '../lib/cloudCyclesService';
+import { GFCForecastSaveData } from '../types/outlooks';
+import { SavedCycleStats } from '../store/forecastSlice';
+
+export interface UseCloudCyclesResult {
+  cycles: CloudCycleMetadata[];
+  currentCloud: CloudCycleContext | null;
+  loading: boolean;
+  error: string | null;
+
+  // Operations
+  saveCycle: (label: string, cycleDate: string, stats: SavedCycleStats, payload: GFCForecastSaveData) => Promise<boolean>;
+  loadCycle: (cycleId: string) => Promise<GFCForecastSaveData | null>;
+  deleteCycle: (cycleId: string) => Promise<boolean>;
+  renameCycle: (cycleId: string, newLabel: string) => Promise<boolean>;
+  markAsCurrent: (cycleId: string, label: string) => void;
+  clearCurrent: () => void;
+  refreshCycles: () => Promise<void>;
+  updateSyncState: (state: CloudSyncState, error?: string) => void;
+}
+
+/**
+ * Hook for managing cloud-backed cycles
+ * Handles subscription, CRUD operations, and sync state
+ */
+export const useCloudCycles = (): UseCloudCyclesResult => {
+  const { user } = useAuth();
+  const { premiumActive } = useEntitlement();
+  const [cycles, setCycles] = useState<CloudCycleMetadata[]>([]);
+  const [currentCloud, setCurrentCloud] = useState<CloudCycleContext | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+  const currentCloudRef = useRef<CloudCycleContext | null>(null);
+
+  useEffect(() => {
+    currentCloudRef.current = currentCloud;
+  }, [currentCloud]);
+
+  // Check if user can write.
+  const canWrite = premiumActive;
+
+  const updateSyncState = useCallback((state: CloudSyncState, syncError?: string) => {
+    setCurrentCloud((prev) => {
+      if (!prev) return null;
+      if (prev.syncState === state && prev.lastSyncError === syncError) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        syncState: state,
+        lastSyncError: syncError,
+      };
+    });
+  }, []);
+
+  // Initialize subscription to cloud cycles
+  useEffect(() => {
+    if (!user?.uid) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+
+    // Set up real-time subscription
+    unsubscribeRef.current = subscribeToCloudCycles(
+      user.uid,
+      (cycles) => {
+        setCycles(cycles);
+        setLoading(false);
+      },
+      (err) => {
+        console.error('Cloud cycles subscribe error:', err);
+        setError(err.message);
+        setLoading(false);
+      }
+    );
+
+    return () => {
+      unsubscribeRef.current?.();
+    };
+  }, [user?.uid]);
+
+  const saveCycle = useCallback(
+    async (
+      label: string,
+      cycleDate: string,
+      stats: SavedCycleStats,
+      payload: GFCForecastSaveData
+    ): Promise<boolean> => {
+      if (!user?.uid || !premiumActive) {
+        setError('Premium subscription required to save cloud cycles');
+        return false;
+      }
+
+      setError(null);
+      if (currentCloudRef.current) {
+        updateSyncState('saving');
+      }
+
+      const result = await saveCloudCycle(user.uid, label, cycleDate, stats, payload, false, currentCloudRef.current?.id);
+
+      if (result.success) {
+        if (result.data) {
+          setCurrentCloud({ id: result.data, label, syncState: 'saved' });
+        }
+        updateSyncState('saved');
+        return true;
+      } else {
+        setError(result.error || 'Failed to save cloud cycle');
+        updateSyncState('error', result.error);
+        return false;
+      }
+    },
+    [user?.uid, premiumActive, updateSyncState]
+  );
+
+  const loadCycle = useCallback(
+    async (cycleId: string): Promise<GFCForecastSaveData | null> => {
+      if (!user?.uid) {
+        setError('Not signed in');
+        return null;
+      }
+
+      setError(null);
+      updateSyncState('loading');
+
+      const result = await loadCloudCycle(user.uid, cycleId);
+
+      if (result.success && result.data) {
+        // Mark as current
+        const cycle = cycles.find((c) => c.id === cycleId);
+        if (cycle) {
+          setCurrentCloud({ id: cycleId, label: cycle.label, syncState: 'saved' });
+        }
+        updateSyncState('saved');
+        return result.data.payload;
+      } else {
+        setError(result.error || 'Failed to load cloud cycle');
+        updateSyncState('error', result.error);
+        return null;
+      }
+    },
+    [user?.uid, cycles, updateSyncState]
+  );
+
+  const deleteCycle = useCallback(
+    async (cycleId: string): Promise<boolean> => {
+      if (!user?.uid || !canWrite) {
+        setError('Action not allowed');
+        return false;
+      }
+
+      setError(null);
+
+      const result = await deleteCloudCycle(user.uid, cycleId);
+
+      if (result.success) {
+        // If the deleted cycle was current, clear current
+        if (currentCloudRef.current?.id === cycleId) {
+          setCurrentCloud(null);
+        }
+        return true;
+      } else {
+        setError(result.error || 'Failed to delete cloud cycle');
+        return false;
+      }
+    },
+    [user?.uid, canWrite]
+  );
+
+  const renameCycle = useCallback(
+    async (cycleId: string, newLabel: string): Promise<boolean> => {
+      if (!user?.uid || !canWrite) {
+        setError('Action not allowed');
+        return false;
+      }
+
+      setError(null);
+
+      const result = await renameCloudCycle(user.uid, cycleId, newLabel);
+
+      if (result.success) {
+        // Update current if this is the current cycle
+        if (currentCloudRef.current?.id === cycleId && currentCloudRef.current.label !== newLabel) {
+          setCurrentCloud({ ...currentCloudRef.current, label: newLabel });
+        }
+        return true;
+      } else {
+        setError(result.error || 'Failed to rename cloud cycle');
+        return false;
+      }
+    },
+    [user?.uid, canWrite]
+  );
+
+  const refreshCycles = useCallback(async (): Promise<void> => {
+    if (!user?.uid) {
+      return;
+    }
+
+    setLoading(true);
+    const result = await listCloudCycles(user.uid);
+
+    if (result.success && result.data) {
+      setCycles(result.data);
+    } else {
+      setError(result.error || 'Failed to refresh cloud cycles');
+    }
+    setLoading(false);
+  }, [user?.uid]);
+
+  const markAsCurrent = useCallback((cycleId: string, label: string) => {
+    setCurrentCloud((prev) => {
+      if (prev?.id === cycleId && prev.label === label && prev.syncState === 'idle' && !prev.lastSyncError) {
+        return prev;
+      }
+
+      return { id: cycleId, label, syncState: 'idle' };
+    });
+  }, []);
+
+  const clearCurrent = useCallback(() => {
+    setCurrentCloud(null);
+  }, []);
+
+  return {
+    cycles,
+    currentCloud,
+    loading,
+    error,
+    saveCycle,
+    loadCycle,
+    deleteCycle,
+    renameCycle,
+    markAsCurrent,
+    clearCurrent,
+    refreshCycles,
+    updateSyncState,
+  };
+};

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 import { useAuth } from '../auth/AuthProvider';
 import { useEntitlement } from '../billing/EntitlementProvider';
 import { CloudCycleMetadata, CloudCycleContext, CloudSyncState } from '../types/cloudCycles';
@@ -18,8 +18,6 @@ export interface UseCloudCyclesResult {
   currentCloud: CloudCycleContext | null;
   loading: boolean;
   error: string | null;
-
-  // Operations
   saveCycle: (label: string, cycleDate: string, stats: SavedCycleStats, payload: GFCForecastSaveData) => Promise<boolean>;
   loadCycle: (cycleId: string) => Promise<GFCForecastSaveData | null>;
   deleteCycle: (cycleId: string) => Promise<boolean>;
@@ -28,6 +26,267 @@ export interface UseCloudCyclesResult {
   clearCurrent: () => void;
   refreshCycles: () => Promise<void>;
   updateSyncState: (state: CloudSyncState, error?: string) => void;
+}
+
+interface CloudOperationContext {
+  userId: string;
+  canWrite: boolean;
+  cycles: CloudCycleMetadata[];
+  currentCloudRef: MutableRefObject<CloudCycleContext | null>;
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>;
+  setCycles: Dispatch<SetStateAction<CloudCycleMetadata[]>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setLoading: Dispatch<SetStateAction<boolean>>;
+  updateSyncState: (state: CloudSyncState, error?: string) => void;
+}
+
+/** Returns the shared error message for cloud write actions when the user cannot save. */
+function getCloudWriteBlockedMessage(userId: string, canWrite: boolean): string {
+  if (!userId) {
+    return 'Not signed in';
+  }
+
+  return canWrite ? 'Action not allowed' : 'Premium subscription required to save cloud cycles';
+}
+
+/** Updates the current cloud context when a sync state change actually changed something. */
+function applySyncStateUpdate(
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>,
+  state: CloudSyncState,
+  syncError?: string
+): void {
+  setCurrentCloud((prev) => {
+    if (!prev || (prev.syncState === state && prev.lastSyncError === syncError)) {
+      return prev ?? null;
+    }
+
+    return {
+      ...prev,
+      syncState: state,
+      lastSyncError: syncError,
+    };
+  });
+}
+
+/** Creates the current-cloud context stored for the active forecast session. */
+function createCurrentCloudContext(id: string, label: string, syncState: CloudSyncState): CloudCycleContext {
+  return { id, label, syncState };
+}
+
+/** Updates the current cloud context when one cloud cycle is loaded. */
+function syncLoadedCloudSelection(
+  cycles: CloudCycleMetadata[],
+  cycleId: string,
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>
+): void {
+  const cycle = cycles.find((item) => item.id === cycleId);
+  if (!cycle) {
+    return;
+  }
+
+  setCurrentCloud(createCurrentCloudContext(cycleId, cycle.label, 'saved'));
+}
+
+/** Updates the current cloud label after a successful rename when the renamed cycle is active. */
+function syncRenamedCloudSelection(
+  currentCloudRef: MutableRefObject<CloudCycleContext | null>,
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>,
+  cycleId: string,
+  newLabel: string
+): void {
+  if (currentCloudRef.current?.id !== cycleId || currentCloudRef.current.label === newLabel) {
+    return;
+  }
+
+  setCurrentCloud({ ...currentCloudRef.current, label: newLabel });
+}
+
+/** Clears the current cloud selection after a delete when the deleted cycle was active. */
+function clearDeletedCloudSelection(
+  currentCloudRef: MutableRefObject<CloudCycleContext | null>,
+  setCurrentCloud: Dispatch<SetStateAction<CloudCycleContext | null>>,
+  cycleId: string
+): void {
+  if (currentCloudRef.current?.id === cycleId) {
+    setCurrentCloud(null);
+  }
+}
+
+/** Starts the realtime hosted-cycle subscription for the signed-in user. */
+function useCloudCycleSubscription(
+  userId: string | undefined,
+  setCycles: Dispatch<SetStateAction<CloudCycleMetadata[]>>,
+  setLoading: Dispatch<SetStateAction<boolean>>,
+  setError: Dispatch<SetStateAction<string | null>>,
+  unsubscribeRef: MutableRefObject<(() => void) | null>
+): void {
+  useEffect(() => {
+    if (!userId) {
+      setCycles([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    unsubscribeRef.current = subscribeToCloudCycles(
+      userId,
+      (nextCycles) => {
+        setCycles(nextCycles);
+        setLoading(false);
+      },
+      (nextError) => {
+        console.error('Cloud cycles subscribe error:', nextError);
+        setError(nextError.message);
+        setLoading(false);
+      }
+    );
+
+    // skipcq: JS-0045 React effects intentionally return cleanup callbacks.
+    return function cleanupCloudCycleSubscription() {
+      unsubscribeRef.current?.();
+    };
+  }, [userId, setCycles, setError, setLoading, unsubscribeRef]);
+}
+
+/** Creates the hosted cloud-cycle CRUD callbacks used by the forecast and library pages. */
+function useCloudCycleOperations({
+  userId,
+  canWrite,
+  cycles,
+  currentCloudRef,
+  setCurrentCloud,
+  setCycles,
+  setError,
+  setLoading,
+  updateSyncState,
+}: CloudOperationContext) {
+  const saveCycle = useCallback(
+    async (
+      label: string,
+      cycleDate: string,
+      stats: SavedCycleStats,
+      payload: GFCForecastSaveData
+    ): Promise<boolean> => {
+      if (!userId || !canWrite) {
+        setError(getCloudWriteBlockedMessage(userId, canWrite));
+        return false;
+      }
+
+      setError(null);
+      if (currentCloudRef.current) {
+        updateSyncState('saving');
+      }
+
+      const result = await saveCloudCycle({
+        userId,
+        label,
+        cycleDate,
+        stats,
+        payload,
+        existingId: currentCloudRef.current?.id,
+      });
+
+      if (!result.success) {
+        setError(result.error || 'Failed to save cloud cycle');
+        updateSyncState('error', result.error);
+        return false;
+      }
+
+      if (result.data) {
+        setCurrentCloud(createCurrentCloudContext(result.data, label, 'saved'));
+      }
+      updateSyncState('saved');
+      return true;
+    },
+    [canWrite, currentCloudRef, setCurrentCloud, setError, updateSyncState, userId]
+  );
+
+  const loadCycle = useCallback(
+    async (cycleId: string): Promise<GFCForecastSaveData | null> => {
+      if (!userId) {
+        setError('Not signed in');
+        return null;
+      }
+
+      setError(null);
+      updateSyncState('loading');
+
+      const result = await loadCloudCycle(userId, cycleId);
+      if (!result.success || !result.data) {
+        setError(result.error || 'Failed to load cloud cycle');
+        updateSyncState('error', result.error);
+        return null;
+      }
+
+      syncLoadedCloudSelection(cycles, cycleId, setCurrentCloud);
+      updateSyncState('saved');
+      return result.data.payload;
+    },
+    [cycles, setCurrentCloud, setError, updateSyncState, userId]
+  );
+
+  const deleteCycleAction = useCallback(
+    async (cycleId: string): Promise<boolean> => {
+      if (!userId || !canWrite) {
+        setError('Action not allowed');
+        return false;
+      }
+
+      setError(null);
+      const result = await deleteCloudCycle(userId, cycleId);
+      if (!result.success) {
+        setError(result.error || 'Failed to delete cloud cycle');
+        return false;
+      }
+
+      clearDeletedCloudSelection(currentCloudRef, setCurrentCloud, cycleId);
+      return true;
+    },
+    [canWrite, currentCloudRef, setCurrentCloud, setError, userId]
+  );
+
+  const renameCycleAction = useCallback(
+    async (cycleId: string, newLabel: string): Promise<boolean> => {
+      if (!userId || !canWrite) {
+        setError('Action not allowed');
+        return false;
+      }
+
+      setError(null);
+      const result = await renameCloudCycle(userId, cycleId, newLabel);
+      if (!result.success) {
+        setError(result.error || 'Failed to rename cloud cycle');
+        return false;
+      }
+
+      syncRenamedCloudSelection(currentCloudRef, setCurrentCloud, cycleId, newLabel);
+      return true;
+    },
+    [canWrite, currentCloudRef, setCurrentCloud, setError, userId]
+  );
+
+  const refreshCycles = useCallback(async (): Promise<void> => {
+    if (!userId) {
+      return;
+    }
+
+    setLoading(true);
+    const result = await listCloudCycles(userId);
+    if (result.success && result.data) {
+      setCycles(result.data);
+    } else {
+      setError(result.error || 'Failed to refresh cloud cycles');
+    }
+    setLoading(false);
+  }, [setCycles, setError, setLoading, userId]);
+
+  return {
+    saveCycle,
+    loadCycle,
+    deleteCycle: deleteCycleAction,
+    renameCycle: renameCycleAction,
+    refreshCycles,
+  };
 }
 
 /**
@@ -43,194 +302,38 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
   const [error, setError] = useState<string | null>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
   const currentCloudRef = useRef<CloudCycleContext | null>(null);
+  const canWrite = premiumActive;
 
   useEffect(() => {
     currentCloudRef.current = currentCloud;
   }, [currentCloud]);
 
-  // Check if user can write.
-  const canWrite = premiumActive;
-
   const updateSyncState = useCallback((state: CloudSyncState, syncError?: string) => {
-    setCurrentCloud((prev) => {
-      if (!prev) return null;
-      if (prev.syncState === state && prev.lastSyncError === syncError) {
-        return prev;
-      }
-
-      return {
-        ...prev,
-        syncState: state,
-        lastSyncError: syncError,
-      };
-    });
+    applySyncStateUpdate(setCurrentCloud, state, syncError);
   }, []);
 
-  // Initialize subscription to cloud cycles
-  useEffect(() => {
-    if (!user?.uid) {
-      setLoading(false);
-      return;
-    }
+  useCloudCycleSubscription(user?.uid, setCycles, setLoading, setError, unsubscribeRef);
 
-    setLoading(true);
-
-    // Set up real-time subscription
-    unsubscribeRef.current = subscribeToCloudCycles(
-      user.uid,
-      (cycles) => {
-        setCycles(cycles);
-        setLoading(false);
-      },
-      (err) => {
-        console.error('Cloud cycles subscribe error:', err);
-        setError(err.message);
-        setLoading(false);
-      }
-    );
-
-    // skipcq: JS-0045 React effects intentionally return cleanup callbacks.
-    return function cleanupCloudCycleSubscription() {
-      unsubscribeRef.current?.();
-    };
-  }, [user?.uid]);
-
-  const saveCycle = useCallback(
-    async (
-      label: string,
-      cycleDate: string,
-      stats: SavedCycleStats,
-      payload: GFCForecastSaveData
-    ): Promise<boolean> => {
-      if (!user?.uid || !premiumActive) {
-        setError('Premium subscription required to save cloud cycles');
-        return false;
-      }
-
-      setError(null);
-      if (currentCloudRef.current) {
-        updateSyncState('saving');
-      }
-
-      const result = await saveCloudCycle(user.uid, label, cycleDate, stats, payload, false, currentCloudRef.current?.id);
-
-      if (result.success) {
-        if (result.data) {
-          setCurrentCloud({ id: result.data, label, syncState: 'saved' });
-        }
-        updateSyncState('saved');
-        return true;
-      } else {
-        setError(result.error || 'Failed to save cloud cycle');
-        updateSyncState('error', result.error);
-        return false;
-      }
-    },
-    [user?.uid, premiumActive, updateSyncState]
-  );
-
-  const loadCycle = useCallback(
-    async (cycleId: string): Promise<GFCForecastSaveData | null> => {
-      if (!user?.uid) {
-        setError('Not signed in');
-        return null;
-      }
-
-      setError(null);
-      updateSyncState('loading');
-
-      const result = await loadCloudCycle(user.uid, cycleId);
-
-      if (result.success && result.data) {
-        // Mark as current
-        const cycle = cycles.find((c) => c.id === cycleId);
-        if (cycle) {
-          setCurrentCloud({ id: cycleId, label: cycle.label, syncState: 'saved' });
-        }
-        updateSyncState('saved');
-        return result.data.payload;
-      } else {
-        setError(result.error || 'Failed to load cloud cycle');
-        updateSyncState('error', result.error);
-        return null;
-      }
-    },
-    [user?.uid, cycles, updateSyncState]
-  );
-
-  const deleteCycle = useCallback(
-    async (cycleId: string): Promise<boolean> => {
-      if (!user?.uid || !canWrite) {
-        setError('Action not allowed');
-        return false;
-      }
-
-      setError(null);
-
-      const result = await deleteCloudCycle(user.uid, cycleId);
-
-      if (result.success) {
-        // If the deleted cycle was current, clear current
-        if (currentCloudRef.current?.id === cycleId) {
-          setCurrentCloud(null);
-        }
-        return true;
-      } else {
-        setError(result.error || 'Failed to delete cloud cycle');
-        return false;
-      }
-    },
-    [user?.uid, canWrite]
-  );
-
-  const renameCycle = useCallback(
-    async (cycleId: string, newLabel: string): Promise<boolean> => {
-      if (!user?.uid || !canWrite) {
-        setError('Action not allowed');
-        return false;
-      }
-
-      setError(null);
-
-      const result = await renameCloudCycle(user.uid, cycleId, newLabel);
-
-      if (result.success) {
-        // Update current if this is the current cycle
-        if (currentCloudRef.current?.id === cycleId && currentCloudRef.current.label !== newLabel) {
-          setCurrentCloud({ ...currentCloudRef.current, label: newLabel });
-        }
-        return true;
-      } else {
-        setError(result.error || 'Failed to rename cloud cycle');
-        return false;
-      }
-    },
-    [user?.uid, canWrite]
-  );
-
-  const refreshCycles = useCallback(async (): Promise<void> => {
-    if (!user?.uid) {
-      return;
-    }
-
-    setLoading(true);
-    const result = await listCloudCycles(user.uid);
-
-    if (result.success && result.data) {
-      setCycles(result.data);
-    } else {
-      setError(result.error || 'Failed to refresh cloud cycles');
-    }
-    setLoading(false);
-  }, [user?.uid]);
+  const operations = useCloudCycleOperations({
+    userId: user?.uid ?? '',
+    canWrite,
+    cycles,
+    currentCloudRef,
+    setCurrentCloud,
+    setCycles,
+    setError,
+    setLoading,
+    updateSyncState,
+  });
 
   const markAsCurrent = useCallback((cycleId: string, label: string) => {
     setCurrentCloud((prev) => {
+      const nextValue = createCurrentCloudContext(cycleId, label, 'idle');
       if (prev?.id === cycleId && prev.label === label && prev.syncState === 'idle' && !prev.lastSyncError) {
         return prev;
       }
 
-      return { id: cycleId, label, syncState: 'idle' };
+      return nextValue;
     });
   }, []);
 
@@ -243,13 +346,13 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
     currentCloud,
     loading,
     error,
-    saveCycle,
-    loadCycle,
-    deleteCycle,
-    renameCycle,
+    saveCycle: operations.saveCycle,
+    loadCycle: operations.loadCycle,
+    deleteCycle: operations.deleteCycle,
+    renameCycle: operations.renameCycle,
     markAsCurrent,
     clearCurrent,
-    refreshCycles,
+    refreshCycles: operations.refreshCycles,
     updateSyncState,
   };
 };

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 import { useAuth } from '../auth/AuthProvider';
 import { useEntitlement } from '../billing/EntitlementProvider';
-import { CloudCycleMetadata, CloudCycleContext, CloudSyncState } from '../types/cloudCycles';
+import { CloudCycleMetadata, CloudCycleContext, CloudOperationResult, CloudSyncState } from '../types/cloudCycles';
 import {
   saveCloudCycle,
   loadCloudCycle,
@@ -105,6 +105,22 @@ function createCurrentCloudContext({
   return { id, label, syncState };
 }
 
+/** Returns true when the requested cycle is already the active idle cloud selection. */
+function isMatchingIdleSelection({
+  currentCloud,
+  cycleId,
+  label,
+}: {
+  currentCloud: CloudCycleContext;
+  cycleId: string;
+  label: string;
+}): boolean {
+  return currentCloud.id === cycleId
+    && currentCloud.label === label
+    && currentCloud.syncState === 'idle'
+    && !currentCloud.lastSyncError;
+}
+
 /** Updates the current cloud context when one cloud cycle is loaded. */
 function syncLoadedCloudSelection({
   cycles,
@@ -179,24 +195,60 @@ function useCloudCycleSubscription({
     }
 
     setLoading(true);
-    unsubscribeRef.current = subscribeToCloudCycles(
+    unsubscribeRef.current = subscribeToCloudCycles({
       userId,
-      (nextCycles) => {
+      onUpdate: (nextCycles) => {
         setCycles(nextCycles);
         setLoading(false);
       },
-      (nextError) => {
+      onError: (nextError) => {
         console.error('Cloud cycles subscribe error:', nextError);
         setError(nextError.message);
         setLoading(false);
-      }
-    );
+      },
+    });
 
     // skipcq: JS-0045 React effects intentionally return cleanup callbacks.
     return function cleanupCloudCycleSubscription() {
       unsubscribeRef.current?.();
     };
   }, [userId, setCycles, setError, setLoading, unsubscribeRef]);
+}
+
+/** Shared mutation hook for guarded cloud-cycle write actions like rename and delete. */
+function useCloudCycleMutation<TArgs extends unknown[]>({
+  userId,
+  canWrite,
+  setError,
+  action,
+  onSuccess,
+  blockedMessage = 'Action not allowed',
+  fallbackError,
+}: CloudAccessContext & Pick<CloudStateContext, 'setError'> & {
+  action: (...args: TArgs) => Promise<CloudOperationResult>;
+  onSuccess?: (...args: TArgs) => void;
+  blockedMessage?: string;
+  fallbackError: string;
+}) {
+  return useCallback(
+    async (...args: TArgs): Promise<boolean> => {
+      if (!userId || !canWrite) {
+        setError(blockedMessage);
+        return false;
+      }
+
+      setError(null);
+      const result = await action(...args);
+      if (!result.success) {
+        setError(result.error || fallbackError);
+        return false;
+      }
+
+      onSuccess?.(...args);
+      return true;
+    },
+    [action, blockedMessage, canWrite, fallbackError, onSuccess, setError, userId]
+  );
 }
 
 /** Returns the save callback for hosted cloud cycles. */
@@ -268,7 +320,7 @@ function useCloudLoadCycle({
       setError(null);
       updateSyncState('loading');
 
-      const result = await loadCloudCycle(userId, cycleId);
+      const result = await loadCloudCycle({ userId, cycleId });
       if (!result.success || !result.data) {
         setError(result.error || 'Failed to load cloud cycle');
         updateSyncState('error', result.error);
@@ -291,25 +343,16 @@ function useCloudDeleteCycle({
   setCurrentCloud,
   setError,
 }: Pick<CloudStateContext, 'currentCloudRef' | 'setCurrentCloud' | 'setError'> & CloudAccessContext) {
-  return useCallback(
-    async (cycleId: string): Promise<boolean> => {
-      if (!userId || !canWrite) {
-        setError('Action not allowed');
-        return false;
-      }
-
-      setError(null);
-      const result = await deleteCloudCycle(userId, cycleId);
-      if (!result.success) {
-        setError(result.error || 'Failed to delete cloud cycle');
-        return false;
-      }
-
+  return useCloudCycleMutation<[string]>({
+    userId,
+    canWrite,
+    setError,
+    fallbackError: 'Failed to delete cloud cycle',
+    action: (cycleId) => deleteCloudCycle({ userId: userId!, cycleId }),
+    onSuccess: (cycleId) => {
       clearDeletedCloudSelection({ currentCloudRef, setCurrentCloud, cycleId });
-      return true;
     },
-    [canWrite, currentCloudRef, setCurrentCloud, setError, userId]
-  );
+  });
 }
 
 /** Returns the rename callback for hosted cloud cycles. */
@@ -320,25 +363,16 @@ function useCloudRenameCycle({
   setCurrentCloud,
   setError,
 }: Pick<CloudStateContext, 'currentCloudRef' | 'setCurrentCloud' | 'setError'> & CloudAccessContext) {
-  return useCallback(
-    async (cycleId: string, newLabel: string): Promise<boolean> => {
-      if (!userId || !canWrite) {
-        setError('Action not allowed');
-        return false;
-      }
-
-      setError(null);
-      const result = await renameCloudCycle(userId, cycleId, newLabel);
-      if (!result.success) {
-        setError(result.error || 'Failed to rename cloud cycle');
-        return false;
-      }
-
+  return useCloudCycleMutation<[string, string]>({
+    userId,
+    canWrite,
+    setError,
+    fallbackError: 'Failed to rename cloud cycle',
+    action: (cycleId, newLabel) => renameCloudCycle({ userId: userId!, cycleId, newLabel }),
+    onSuccess: (cycleId, newLabel) => {
       syncRenamedCloudSelection({ currentCloudRef, setCurrentCloud, cycleId, newLabel });
-      return true;
     },
-    [canWrite, currentCloudRef, setCurrentCloud, setError, userId]
-  );
+  });
 }
 
 /** Returns the explicit refresh callback for cloud-cycle metadata. */
@@ -354,7 +388,7 @@ function useCloudRefreshCycles({
     }
 
     setLoading(true);
-    const result = await listCloudCycles(userId);
+    const result = await listCloudCycles({ userId });
     if (result.success && result.data) {
       setCycles(result.data);
     } else {
@@ -425,7 +459,7 @@ function useCurrentCloudSelectionControls(
   const markAsCurrent = useCallback((cycleId: string, label: string) => {
     setCurrentCloud((prev) => {
       const nextValue = createCurrentCloudContext({ id: cycleId, label, syncState: 'idle' });
-      if (prev?.id === cycleId && prev.label === label && prev.syncState === 'idle' && !prev.lastSyncError) {
+      if (prev && isMatchingIdleSelection({ currentCloud: prev, cycleId, label })) {
         return prev;
       }
 

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -308,6 +308,17 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
     currentCloudRef.current = currentCloud;
   }, [currentCloud]);
 
+  useEffect(() => {
+    if (user?.uid) {
+      return;
+    }
+
+    setCycles([]);
+    setCurrentCloud(null);
+    setError(null);
+    currentCloudRef.current = null;
+  }, [user?.uid]);
+
   const updateSyncState = useCallback((state: CloudSyncState, syncError?: string) => {
     applySyncStateUpdate(setCurrentCloud, state, syncError);
   }, []);

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, type MutableRefObject } from 'react';
+import { useEffect, useRef, useCallback, useMemo, type MutableRefObject } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../store';
 import { serializeForecast } from '../utils/fileUtils';
@@ -93,7 +93,10 @@ export const useCloudSync = (
   const lastSyncStateRef = useRef<string | null>(null);
 
   const canSync = Boolean(currentCloud) && premiumActive;
-  const currentHash = buildCloudSyncHash(forecastCycle, mapView);
+  const currentHash = useMemo(
+    () => buildCloudSyncHash(forecastCycle, mapView),
+    [forecastCycle, mapView]
+  );
 
   const performSync = useCallback(async () => {
     await syncCurrentCloudCycle({

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, type MutableRefObject } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../store';
 import { serializeForecast } from '../utils/fileUtils';
@@ -7,6 +7,70 @@ import { useEntitlement } from '../billing/EntitlementProvider';
 import type { UseCloudCyclesResult } from './useCloudCycles';
 
 const SYNC_DEBOUNCE_MS = 5000; // 5 second debounce
+
+/** Clears a pending cloud-sync timer when one is currently scheduled. */
+const clearSyncTimeout = (syncTimeoutRef: MutableRefObject<ReturnType<typeof setTimeout> | null>) => {
+  if (!syncTimeoutRef.current) {
+    return;
+  }
+
+  clearTimeout(syncTimeoutRef.current);
+  syncTimeoutRef.current = null;
+};
+
+/** Builds the current sync hash for the forecast and map state. */
+const buildCloudSyncHash = (
+  forecastCycle: RootState['forecast']['forecastCycle'],
+  mapView: RootState['forecast']['currentMapView']
+) => JSON.stringify({ forecastCycle, mapView });
+
+/** Runs one hosted cloud save for the active cloud cycle and updates sync state around the request. */
+const syncCurrentCloudCycle = async ({
+  canSync,
+  currentCloud,
+  saveCycle,
+  updateSyncState,
+  forecastCycle,
+  mapView,
+  setLastSyncedHash,
+  currentHash,
+}: {
+  canSync: boolean;
+  currentCloud: Pick<UseCloudCyclesResult, 'currentCloud'>['currentCloud'];
+  saveCycle: Pick<UseCloudCyclesResult, 'saveCycle'>['saveCycle'];
+  updateSyncState: Pick<UseCloudCyclesResult, 'updateSyncState'>['updateSyncState'];
+  forecastCycle: RootState['forecast']['forecastCycle'];
+  mapView: RootState['forecast']['currentMapView'];
+  setLastSyncedHash: (hash: string) => void;
+  currentHash: string;
+}) => {
+  if (!canSync || !currentCloud) {
+    return;
+  }
+
+  try {
+    updateSyncState('saving');
+
+    const payload = serializeForecast(forecastCycle, mapView);
+    const stats = countForecastMetrics(forecastCycle);
+    const success = await saveCycle(currentCloud.label, forecastCycle.cycleDate, stats, payload);
+
+    if (!success) {
+      updateSyncState('error', 'Failed to sync to cloud');
+      return;
+    }
+
+    updateSyncState('saved');
+    setLastSyncedHash(currentHash);
+  } catch (error) {
+    console.error('Error syncing to cloud:', error);
+    updateSyncState('error', error instanceof Error ? error.message : 'Unknown error');
+  }
+};
+
+/** Returns true when the current forecast state has not changed since the last successful sync. */
+const isCurrentStateSynced = (lastSyncedHash: string | null, currentHash: string): boolean =>
+  lastSyncedHash === currentHash;
 
 /**
  * Hook for managing automatic sync of the current forecast to cloud
@@ -28,104 +92,57 @@ export const useCloudSync = (
   const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSyncStateRef = useRef<string | null>(null);
 
-  // Determine if we can write to cloud
   const canSync = Boolean(currentCloud) && premiumActive;
+  const currentHash = buildCloudSyncHash(forecastCycle, mapView);
 
-  // Check if forecast has changed since last sync
-  const getCurrentStateHash = useCallback(() => {
-    return JSON.stringify({ forecastCycle, mapView });
-  }, [forecastCycle, mapView]);
-
-  // Perform the sync
   const performSync = useCallback(async () => {
-    if (!canSync || !currentCloud) return;
+    await syncCurrentCloudCycle({
+      canSync,
+      currentCloud,
+      saveCycle,
+      updateSyncState,
+      forecastCycle,
+      mapView,
+      setLastSyncedHash: (hash) => {
+        lastSyncStateRef.current = hash;
+      },
+      currentHash,
+    });
+  }, [canSync, currentCloud, currentHash, forecastCycle, mapView, saveCycle, updateSyncState]);
 
-    try {
-      updateSyncState('saving');
-
-      const payload = serializeForecast(forecastCycle, mapView);
-      const stats = countForecastMetrics(forecastCycle);
-
-      const success = await saveCycle(
-        currentCloud.label,
-        forecastCycle.cycleDate,
-        stats,
-        payload,
-      );
-
-      if (success) {
-        updateSyncState('saved');
-        lastSyncStateRef.current = getCurrentStateHash();
-      } else {
-        updateSyncState('error', 'Failed to sync to cloud');
-      }
-    } catch (error) {
-      console.error('Error syncing to cloud:', error);
-      updateSyncState('error', error instanceof Error ? error.message : 'Unknown error');
-    }
-  }, [
-    canSync,
-    currentCloud,
-    saveCycle,
-    updateSyncState,
-    forecastCycle,
-    mapView,
-    getCurrentStateHash,
-  ]);
-
-  // Set up debounced sync trigger
   useEffect(() => {
     if (!canSync) {
-      // Clear any pending sync
-      if (syncTimeoutRef.current) {
-        clearTimeout(syncTimeoutRef.current);
-        syncTimeoutRef.current = null;
-      }
+      clearSyncTimeout(syncTimeoutRef);
       return;
     }
 
-    const currentHash = getCurrentStateHash();
-    
-    // Only sync if state has changed since last sync
-    if (currentHash === lastSyncStateRef.current) {
+    if (isCurrentStateSynced(lastSyncStateRef.current, currentHash)) {
       return;
     }
 
-    // Clear any pending sync timeout
-    if (syncTimeoutRef.current) {
-      clearTimeout(syncTimeoutRef.current);
-    }
-
-    // Debounce the sync
+    clearSyncTimeout(syncTimeoutRef);
     syncTimeoutRef.current = setTimeout(() => {
-      performSync();
+      performSync().catch(() => undefined);
       syncTimeoutRef.current = null;
     }, SYNC_DEBOUNCE_MS);
 
     // skipcq: JS-0045 React effects intentionally return cleanup callbacks.
     return function cleanupPendingCloudSync() {
-      if (syncTimeoutRef.current) {
-        clearTimeout(syncTimeoutRef.current);
-        syncTimeoutRef.current = null;
-      }
+      clearSyncTimeout(syncTimeoutRef);
     };
-  }, [canSync, forecastCycle, mapView, getCurrentStateHash, performSync]);
+  }, [canSync, currentHash, performSync]);
 
-  // Manual sync trigger (immediate, not debounced)
   const syncNow = useCallback(async () => {
-    if (syncTimeoutRef.current) {
-      clearTimeout(syncTimeoutRef.current);
-      syncTimeoutRef.current = null;
-    }
+    clearSyncTimeout(syncTimeoutRef);
     await performSync();
   }, [performSync]);
 
   const markCurrentStateSynced = useCallback(() => {
-    lastSyncStateRef.current = getCurrentStateHash();
-  }, [getCurrentStateHash]);
+    lastSyncStateRef.current = currentHash;
+  }, [currentHash]);
 
   return {
-    isSynced: lastSyncStateRef.current === getCurrentStateHash(),
+    isSynced: isCurrentStateSynced(lastSyncStateRef.current, currentHash),
     currentCloud,
     syncNow,
     markCurrentStateSynced,

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -102,7 +102,8 @@ export const useCloudSync = (
       syncTimeoutRef.current = null;
     }, SYNC_DEBOUNCE_MS);
 
-    return () => {
+    // skipcq: JS-0045 React effects intentionally return cleanup callbacks.
+    return function cleanupPendingCloudSync() {
       if (syncTimeoutRef.current) {
         clearTimeout(syncTimeoutRef.current);
         syncTimeoutRef.current = null;

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { RootState } from '../store';
+import { serializeForecast } from '../utils/fileUtils';
+import { countForecastMetrics } from '../utils/forecastMetrics';
+import { useEntitlement } from '../billing/EntitlementProvider';
+import type { UseCloudCyclesResult } from './useCloudCycles';
+
+const SYNC_DEBOUNCE_MS = 5000; // 5 second debounce
+
+/**
+ * Hook for managing automatic sync of the current forecast to cloud
+ * Only syncs if:
+ * 1. User has a current cloud cycle set
+ * 2. User has active premium (not expired)
+ * 3. Forecast has changes since last sync
+ */
+export const useCloudSync = (
+  cloud: Pick<UseCloudCyclesResult, 'currentCloud' | 'updateSyncState' | 'saveCycle'>
+) => {
+  const { premiumActive } = useEntitlement();
+  const currentCloud = cloud.currentCloud;
+  const saveCycle = cloud.saveCycle;
+  const updateSyncState = cloud.updateSyncState;
+  const forecastCycle = useSelector((state: RootState) => state.forecast.forecastCycle);
+  const mapView = useSelector((state: RootState) => state.forecast.currentMapView);
+  
+  const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSyncStateRef = useRef<string | null>(null);
+
+  // Determine if we can write to cloud
+  const canSync = Boolean(currentCloud) && premiumActive;
+
+  // Check if forecast has changed since last sync
+  const getCurrentStateHash = useCallback(() => {
+    return JSON.stringify({ forecastCycle, mapView });
+  }, [forecastCycle, mapView]);
+
+  // Perform the sync
+  const performSync = useCallback(async () => {
+    if (!canSync || !currentCloud) return;
+
+    try {
+      updateSyncState('saving');
+
+      const payload = serializeForecast(forecastCycle, mapView);
+      const stats = countForecastMetrics(forecastCycle);
+
+      const success = await saveCycle(
+        currentCloud.label,
+        forecastCycle.cycleDate,
+        stats,
+        payload,
+      );
+
+      if (success) {
+        updateSyncState('saved');
+        lastSyncStateRef.current = getCurrentStateHash();
+      } else {
+        updateSyncState('error', 'Failed to sync to cloud');
+      }
+    } catch (error) {
+      console.error('Error syncing to cloud:', error);
+      updateSyncState('error', error instanceof Error ? error.message : 'Unknown error');
+    }
+  }, [
+    canSync,
+    currentCloud,
+    saveCycle,
+    updateSyncState,
+    forecastCycle,
+    mapView,
+    getCurrentStateHash,
+  ]);
+
+  // Set up debounced sync trigger
+  useEffect(() => {
+    if (!canSync) {
+      // Clear any pending sync
+      if (syncTimeoutRef.current) {
+        clearTimeout(syncTimeoutRef.current);
+        syncTimeoutRef.current = null;
+      }
+      return;
+    }
+
+    const currentHash = getCurrentStateHash();
+    
+    // Only sync if state has changed since last sync
+    if (currentHash === lastSyncStateRef.current) {
+      return;
+    }
+
+    // Clear any pending sync timeout
+    if (syncTimeoutRef.current) {
+      clearTimeout(syncTimeoutRef.current);
+    }
+
+    // Debounce the sync
+    syncTimeoutRef.current = setTimeout(() => {
+      performSync();
+      syncTimeoutRef.current = null;
+    }, SYNC_DEBOUNCE_MS);
+
+    return () => {
+      if (syncTimeoutRef.current) {
+        clearTimeout(syncTimeoutRef.current);
+        syncTimeoutRef.current = null;
+      }
+    };
+  }, [canSync, forecastCycle, mapView, getCurrentStateHash, performSync]);
+
+  // Manual sync trigger (immediate, not debounced)
+  const syncNow = useCallback(async () => {
+    if (syncTimeoutRef.current) {
+      clearTimeout(syncTimeoutRef.current);
+      syncTimeoutRef.current = null;
+    }
+    await performSync();
+  }, [performSync]);
+
+  const markCurrentStateSynced = useCallback(() => {
+    lastSyncStateRef.current = getCurrentStateHash();
+  }, [getCurrentStateHash]);
+
+  return {
+    isSynced: lastSyncStateRef.current === getCurrentStateHash(),
+    currentCloud,
+    syncNow,
+    markCurrentStateSynced,
+  };
+};

--- a/src/lib/cloudCyclesService.ts
+++ b/src/lib/cloudCyclesService.ts
@@ -12,6 +12,38 @@ interface CloudCycleDocument extends CloudCycleMetadata {
   payloadJson: string;
 }
 
+interface NormalizeMetadataParams {
+  cycleId: string;
+  rawMetadata: Record<string, unknown> | undefined;
+  fallbackUserId: string;
+}
+
+interface NormalizeCloudCycleRecordParams {
+  cycleId: string;
+  rawRecord: unknown;
+  fallbackUserId: string;
+}
+
+interface ReadCloudCyclesFromQueryParams {
+  snapshot: { docs: Array<{ id: string; data: () => unknown }> };
+  fallbackUserId: string;
+}
+
+interface UserCycleLookupParams {
+  userId: string;
+  cycleId: string;
+}
+
+interface SaveCloudCycleParams {
+  userId: string;
+  label: string;
+  cycleDate: string;
+  stats: SavedCycleStats;
+  payload: GFCForecastSaveData;
+  isReadOnly?: boolean;
+  existingId?: string;
+}
+
 type LegacyCloudCyclesValue = string | Record<string, unknown> | undefined;
 
 type LegacyUserSettingsDocument = {
@@ -88,44 +120,51 @@ const getLegacyUserSettingsRef = (userId: string) => {
 const readTimestampString = (value: unknown, fallback = new Date(0).toISOString()): string =>
   typeof value === 'string' && value ? value : fallback;
 
+/** Reads a required non-empty string from a stored metadata field. */
+const readRequiredText = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim() ? value : null;
+
+/** Reads a stored number field, defaulting missing values to zero. */
+const readStoredCount = (value: unknown): number => (typeof value === 'number' ? value : 0);
+
 /** Normalizes stored cloud-cycle metadata into the current metadata contract. */
-const normalizeStoredMetadata = (
-  cycleId: string,
-  rawMetadata: Record<string, unknown> | undefined,
-  fallbackUserId: string
-): CloudCycleMetadata | null => {
+const normalizeStoredMetadata = ({
+  cycleId,
+  rawMetadata,
+  fallbackUserId,
+}: NormalizeMetadataParams): CloudCycleMetadata | null => {
   if (!rawMetadata) {
     return null;
   }
 
-  const label = typeof rawMetadata.label === 'string' && rawMetadata.label.trim() ? rawMetadata.label : null;
-  const cycleDate = typeof rawMetadata.cycleDate === 'string' && rawMetadata.cycleDate ? rawMetadata.cycleDate : null;
+  const label = readRequiredText(rawMetadata.label);
+  const cycleDate = readRequiredText(rawMetadata.cycleDate);
 
   if (!label || !cycleDate) {
     return null;
   }
 
   return {
-    id: typeof rawMetadata.id === 'string' && rawMetadata.id ? rawMetadata.id : cycleId,
-    userId: typeof rawMetadata.userId === 'string' && rawMetadata.userId ? rawMetadata.userId : fallbackUserId,
+    id: readRequiredText(rawMetadata.id) ?? cycleId,
+    userId: readRequiredText(rawMetadata.userId) ?? fallbackUserId,
     label,
     cycleDate,
     createdAt: readTimestampString(rawMetadata.createdAt),
     updatedAt: readTimestampString(rawMetadata.updatedAt, readTimestampString(rawMetadata.createdAt)),
-    forecastDays: typeof rawMetadata.forecastDays === 'number' ? rawMetadata.forecastDays : 0,
-    totalOutlooks: typeof rawMetadata.totalOutlooks === 'number' ? rawMetadata.totalOutlooks : 0,
-    totalFeatures: typeof rawMetadata.totalFeatures === 'number' ? rawMetadata.totalFeatures : 0,
+    forecastDays: readStoredCount(rawMetadata.forecastDays),
+    totalOutlooks: readStoredCount(rawMetadata.totalOutlooks),
+    totalFeatures: readStoredCount(rawMetadata.totalFeatures),
     isReadOnly: Boolean(rawMetadata.isReadOnly),
-    payloadHash: typeof rawMetadata.payloadHash === 'string' && rawMetadata.payloadHash ? rawMetadata.payloadHash : undefined,
+    payloadHash: readRequiredText(rawMetadata.payloadHash) ?? undefined,
   };
 };
 
 /** Normalizes one raw Firestore or legacy cloud-cycle record into the app's runtime shape. */
-const normalizeCloudCycleRecord = (
-  cycleId: string,
-  rawRecord: unknown,
-  fallbackUserId: string
-): CloudCycle | null => {
+const normalizeCloudCycleRecord = ({
+  cycleId,
+  rawRecord,
+  fallbackUserId,
+}: NormalizeCloudCycleRecordParams): CloudCycle | null => {
   if (!isPlainObject(rawRecord)) {
     return null;
   }
@@ -133,7 +172,7 @@ const normalizeCloudCycleRecord = (
   const metadataSource = isPlainObject(rawRecord.metadata) ? (rawRecord.metadata as Record<string, unknown>) : rawRecord;
   const payload = parseStoredPayload(rawRecord.payloadJson ?? rawRecord.payload);
 
-  const metadata = normalizeStoredMetadata(cycleId, metadataSource, fallbackUserId);
+  const metadata = normalizeStoredMetadata({ cycleId, rawMetadata: metadataSource, fallbackUserId });
   if (!metadata || !payload) {
     return null;
   }
@@ -158,9 +197,9 @@ const serializeCloudCycleDocument = (cycle: CloudCycle): CloudCycleDocument => {
 const toCloudCycleMetadata = ({ payload: _payload, ...cycleMetadata }: CloudCycle): CloudCycleMetadata => cycleMetadata;
 
 /** Converts a Firestore query snapshot into normalized cloud-cycle records. */
-const readCloudCyclesFromQuery = (snapshot: { docs: Array<{ id: string; data: () => unknown }> }, fallbackUserId: string): CloudCycle[] =>
+const readCloudCyclesFromQuery = ({ snapshot, fallbackUserId }: ReadCloudCyclesFromQueryParams): CloudCycle[] =>
   snapshot.docs
-    .map((cycleDoc) => normalizeCloudCycleRecord(cycleDoc.id, cycleDoc.data(), fallbackUserId))
+    .map((cycleDoc) => normalizeCloudCycleRecord({ cycleId: cycleDoc.id, rawRecord: cycleDoc.data(), fallbackUserId }))
     .filter((cycle): cycle is CloudCycle => Boolean(cycle));
 
 /** Reads older cloud-cycle data from the legacy user-settings document if present. */
@@ -192,7 +231,7 @@ const readLegacyCloudCycles = async (userId: string): Promise<CloudCycle[]> => {
     }
 
     return Object.entries(rawStore)
-      .map(([cycleId, rawRecord]) => normalizeCloudCycleRecord(cycleId, rawRecord, userId))
+      .map(([cycleId, rawRecord]) => normalizeCloudCycleRecord({ cycleId, rawRecord, fallbackUserId: userId }))
       .filter((cycle): cycle is CloudCycle => Boolean(cycle));
   } catch (error) {
     console.error('Error reading legacy cloud cycles:', error);
@@ -224,7 +263,7 @@ const migrateLegacyCloudCycles = async (userId: string, cycles: CloudCycle[]): P
 /** Reads all cloud cycles for a user, transparently migrating legacy records when needed. */
 const readCloudCyclesForUser = async (userId: string): Promise<CloudCycle[]> => {
   const snapshot = await getDocs(query(getCloudCyclesCollectionRef(), where('userId', '==', userId)));
-  const cycles = readCloudCyclesFromQuery(snapshot, userId);
+  const cycles = readCloudCyclesFromQuery({ snapshot, fallbackUserId: userId });
 
   if (cycles.length > 0) {
     return cycles.sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
@@ -239,10 +278,10 @@ const readCloudCyclesForUser = async (userId: string): Promise<CloudCycle[]> => 
 };
 
 /** Fetches one cloud cycle by id, including legacy fallback and migration support. */
-const fetchCloudCycleById = async (userId: string, cycleId: string): Promise<CloudCycle | null> => {
+const fetchCloudCycleById = async ({ userId, cycleId }: UserCycleLookupParams): Promise<CloudCycle | null> => {
   const docSnapshot = await getCloudCycleDocSnapshot(cycleId);
   if (docSnapshot.exists()) {
-    const cycle = normalizeCloudCycleRecord(docSnapshot.id, docSnapshot.data(), userId);
+    const cycle = normalizeCloudCycleRecord({ cycleId: docSnapshot.id, rawRecord: docSnapshot.data(), fallbackUserId: userId });
     if (cycle && cycle.userId === userId) {
       return cycle;
     }
@@ -258,13 +297,13 @@ const fetchCloudCycleById = async (userId: string, cycleId: string): Promise<Clo
 };
 
 /** Returns an existing cloud cycle only when it belongs to the current signed-in user. */
-const getOwnedCloudCycle = async (userId: string, cycleId: string): Promise<CloudCycle | null> => {
+const getOwnedCloudCycle = async ({ userId, cycleId }: UserCycleLookupParams): Promise<CloudCycle | null> => {
   const existingSnapshot = await getCloudCycleDocSnapshot(cycleId);
   if (!existingSnapshot.exists()) {
     return null;
   }
 
-  const existingCycle = normalizeCloudCycleRecord(cycleId, existingSnapshot.data(), userId);
+  const existingCycle = normalizeCloudCycleRecord({ cycleId, rawRecord: existingSnapshot.data(), fallbackUserId: userId });
   if (!existingCycle || existingCycle.userId !== userId) {
     return null;
   }
@@ -276,18 +315,13 @@ const getOwnedCloudCycle = async (userId: string, cycleId: string): Promise<Clou
  * Saves a new cloud cycle or updates an existing one
  */
 export const saveCloudCycle = async (
-  userId: string,
-  label: string,
-  cycleDate: string,
-  stats: SavedCycleStats,
-  payload: GFCForecastSaveData,
-  isReadOnly = false,
-  existingId?: string
+  params: SaveCloudCycleParams
 ): Promise<CloudOperationResult<string>> => {
   try {
+    const { userId, label, cycleDate, stats, payload, isReadOnly = false, existingId } = params;
     const cycleId = existingId || `${cycleDate}-${Date.now()}`;
     const now = new Date().toISOString();
-    const existingCycle = existingId ? await getOwnedCloudCycle(userId, existingId) : null;
+    const existingCycle = existingId ? await getOwnedCloudCycle({ userId, cycleId: existingId }) : null;
 
     if (existingId && !existingCycle) {
       return {
@@ -333,7 +367,7 @@ export const loadCloudCycle = async (
   cycleId: string
 ): Promise<CloudOperationResult<CloudCycle>> => {
   try {
-    const record = await fetchCloudCycleById(userId, cycleId);
+    const record = await fetchCloudCycleById({ userId, cycleId });
 
     if (!record) {
       return {
@@ -363,7 +397,7 @@ export const deleteCloudCycle = async (
   cycleId: string
 ): Promise<CloudOperationResult> => {
   try {
-    const existingCycle = await getOwnedCloudCycle(userId, cycleId);
+    const existingCycle = await getOwnedCloudCycle({ userId, cycleId });
     if (!existingCycle) {
       return { success: true };
     }
@@ -389,7 +423,7 @@ export const renameCloudCycle = async (
   newLabel: string
 ): Promise<CloudOperationResult> => {
   try {
-    const existing = await getOwnedCloudCycle(userId, cycleId);
+    const existing = await getOwnedCloudCycle({ userId, cycleId });
     if (!existing) {
       return {
         success: false,
@@ -450,7 +484,7 @@ export const subscribeToCloudCycles = (
     const unsubscribe = onSnapshot(
       cyclesQuery,
       async (querySnapshot) => {
-        const cycles = readCloudCyclesFromQuery(querySnapshot, userId);
+        const cycles = readCloudCyclesFromQuery({ snapshot: querySnapshot, fallbackUserId: userId });
 
         if (cycles.length > 0) {
           onUpdate(cycles.map(toCloudCycleMetadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));

--- a/src/lib/cloudCyclesService.ts
+++ b/src/lib/cloudCyclesService.ts
@@ -1,4 +1,5 @@
 import { collection, deleteField, deleteDoc, doc, getDoc, getDocs, onSnapshot, query, setDoc, where } from 'firebase/firestore';
+import { v4 as uuidv4 } from 'uuid';
 import { db } from './firebase';
 import { CloudCycleMetadata, CloudCycle, CloudOperationResult } from '../types/cloudCycles';
 import { GFCForecastSaveData } from '../types/outlooks';
@@ -65,7 +66,7 @@ const computePayloadHash = (payload: GFCForecastSaveData): string => {
   for (let i = 0; i < jsonStr.length; i++) {
     const char = jsonStr.charCodeAt(i);
     hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32-bit integer
+    hash |= 0; // Force the rolling hash back into a signed 32-bit integer.
   }
   return Math.abs(hash).toString(36).substring(0, 12);
 };
@@ -196,6 +197,14 @@ const serializeCloudCycleDocument = (cycle: CloudCycle): CloudCycleDocument => {
 /** Strips the saved payload from a cloud cycle so list views can work with metadata only. */
 const toCloudCycleMetadata = ({ payload: _payload, ...cycleMetadata }: CloudCycle): CloudCycleMetadata => cycleMetadata;
 
+/** Sorts cloud-cycle metadata from newest to oldest update time. */
+const sortCloudCycleMetadata = (cycles: CloudCycleMetadata[]): CloudCycleMetadata[] =>
+  [...cycles].sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
+
+/** Creates a collision-resistant id for new hosted cloud cycles. */
+const createCloudCycleId = (userId: string, cycleDate: string): string =>
+  `${userId}-${cycleDate}-${uuidv4()}`;
+
 /** Converts a Firestore query snapshot into normalized cloud-cycle records. */
 const readCloudCyclesFromQuery = ({ snapshot, fallbackUserId }: ReadCloudCyclesFromQueryParams): CloudCycle[] =>
   snapshot.docs
@@ -319,7 +328,7 @@ export const saveCloudCycle = async (
 ): Promise<CloudOperationResult<string>> => {
   try {
     const { userId, label, cycleDate, stats, payload, isReadOnly = false, existingId } = params;
-    const cycleId = existingId || `${cycleDate}-${Date.now()}`;
+    const cycleId = existingId || createCloudCycleId(userId, cycleDate);
     const now = new Date().toISOString();
     const existingCycle = existingId ? await getOwnedCloudCycle({ userId, cycleId: existingId }) : null;
 
@@ -480,25 +489,28 @@ export const subscribeToCloudCycles = (
 ): (() => void) => {
   try {
     const cyclesQuery = query(getCloudCyclesCollectionRef(), where('userId', '==', userId));
+    let isActive = true;
+
+    void readCloudCyclesForUser(userId)
+      .then((cycles) => {
+        if (!isActive) {
+          return;
+        }
+
+        onUpdate(sortCloudCycleMetadata(cycles.map(toCloudCycleMetadata)));
+      })
+      .catch((error) => {
+        console.error('Error bootstrapping cloud cycles:', error);
+        if (isActive) {
+          onError?.(error as Error);
+        }
+      });
 
     const unsubscribe = onSnapshot(
       cyclesQuery,
-      async (querySnapshot) => {
+      (querySnapshot) => {
         const cycles = readCloudCyclesFromQuery({ snapshot: querySnapshot, fallbackUserId: userId });
-
-        if (cycles.length > 0) {
-          onUpdate(cycles.map(toCloudCycleMetadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));
-          return;
-        }
-
-        const legacyCycles = await readLegacyCloudCycles(userId);
-        if (legacyCycles.length > 0) {
-          await migrateLegacyCloudCycles(userId, legacyCycles);
-          onUpdate(legacyCycles.map(toCloudCycleMetadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));
-          return;
-        }
-
-        onUpdate([]);
+        onUpdate(sortCloudCycleMetadata(cycles.map(toCloudCycleMetadata)));
       },
       (error) => {
         console.error('Error subscribing to cloud cycles:', error);
@@ -506,7 +518,10 @@ export const subscribeToCloudCycles = (
       }
     );
 
-    return unsubscribe;
+    return () => {
+      isActive = false;
+      unsubscribe();
+    };
   } catch (error) {
     console.error('Error setting up cloud cycles subscription:', error);
     if (onError && error instanceof Error) onError(error);

--- a/src/lib/cloudCyclesService.ts
+++ b/src/lib/cloudCyclesService.ts
@@ -225,6 +225,33 @@ const sortCloudCycleMetadata = (cycles: CloudCycleMetadata[]): CloudCycleMetadat
 const createCloudCycleId = (userId: string, cycleDate: string): string =>
   `${userId}-${cycleDate}-${uuidv4()}`;
 
+/** Performs the first metadata fetch for a cloud subscription before realtime updates attach. */
+const bootstrapCloudCycleSubscription = async ({
+  userId,
+  isActive,
+  onUpdate,
+  onError,
+}: {
+  userId: string;
+  isActive: () => boolean;
+  onUpdate: (cycles: CloudCycleMetadata[]) => void;
+  onError?: (error: Error) => void;
+}): Promise<void> => {
+  try {
+    const result = await listCloudCycles(userId);
+    if (!isActive()) {
+      return;
+    }
+
+    onUpdate(sortCloudCycleMetadata(result.success && result.data ? result.data : []));
+  } catch (error) {
+    console.error('Error bootstrapping cloud cycles:', error);
+    if (isActive()) {
+      onError?.(error as Error);
+    }
+  }
+};
+
 /** Converts a Firestore query snapshot into normalized cloud-cycle records, including payload validation. */
 const readCloudCyclesFromQuery = ({ snapshot, fallbackUserId }: ReadCloudCyclesFromQueryParams): CloudCycle[] =>
   snapshot.docs
@@ -526,20 +553,12 @@ export const subscribeToCloudCycles = (
     const cyclesQuery = query(getCloudCyclesCollectionRef(), where('userId', '==', userId));
     let isActive = true;
 
-    void listCloudCycles(userId)
-      .then((result) => {
-        if (!isActive) {
-          return;
-        }
-
-        onUpdate(sortCloudCycleMetadata(result.success && result.data ? result.data : []));
-      })
-      .catch((error) => {
-        console.error('Error bootstrapping cloud cycles:', error);
-        if (isActive) {
-          onError?.(error as Error);
-        }
-      });
+    bootstrapCloudCycleSubscription({
+      userId,
+      isActive: () => isActive,
+      onUpdate,
+      onError,
+    });
 
     const unsubscribe = onSnapshot(
       cyclesQuery,

--- a/src/lib/cloudCyclesService.ts
+++ b/src/lib/cloudCyclesService.ts
@@ -1,0 +1,468 @@
+import { collection, deleteField, deleteDoc, doc, getDoc, getDocs, onSnapshot, query, setDoc, where } from 'firebase/firestore';
+import { db } from './firebase';
+import { CloudCycleMetadata, CloudCycle, CloudOperationResult } from '../types/cloudCycles';
+import { GFCForecastSaveData } from '../types/outlooks';
+import { SavedCycleStats } from '../store/forecastSlice';
+import { validateForecastData } from '../utils/fileUtils';
+
+const LEGACY_USER_SETTINGS_COLLECTION = 'userSettings';
+const CLOUD_CYCLES_COLLECTION = 'cloudCycles';
+
+interface CloudCycleDocument extends CloudCycleMetadata {
+  payloadJson: string;
+}
+
+type LegacyCloudCyclesValue = string | Record<string, unknown> | undefined;
+
+type LegacyUserSettingsDocument = {
+  cloudCycles?: LegacyCloudCyclesValue;
+};
+
+/**
+ * Computes a simple hash of the cycle payload for change detection
+ * Uses a simple string hash rather than cryptographic hashing
+ */
+const computePayloadHash = (payload: GFCForecastSaveData): string => {
+  const jsonStr = JSON.stringify(payload);
+  let hash = 0;
+  for (let i = 0; i < jsonStr.length; i++) {
+    const char = jsonStr.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return Math.abs(hash).toString(36).substring(0, 12);
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const parseStoredPayload = (value: unknown): GFCForecastSaveData | null => {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return validateForecastData(parsed) ? (parsed as GFCForecastSaveData) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (validateForecastData(value)) {
+    return value as GFCForecastSaveData;
+  }
+
+  return null;
+};
+
+const getCloudCyclesCollectionRef = () => {
+  if (!db) {
+    throw new Error('Firestore is not initialized');
+  }
+
+  return collection(db, CLOUD_CYCLES_COLLECTION);
+};
+
+const getCloudCycleDocRef = (cycleId: string) => doc(getCloudCyclesCollectionRef(), cycleId);
+
+const getCloudCycleDocSnapshot = (cycleId: string) => getDoc(getCloudCycleDocRef(cycleId));
+
+const getLegacyUserSettingsRef = (userId: string) => {
+  if (!db) {
+    throw new Error('Firestore is not initialized');
+  }
+
+  return doc(db, LEGACY_USER_SETTINGS_COLLECTION, userId);
+};
+
+const readTimestampString = (value: unknown, fallback = new Date(0).toISOString()): string =>
+  typeof value === 'string' && value ? value : fallback;
+
+const normalizeStoredMetadata = (
+  cycleId: string,
+  rawMetadata: Record<string, unknown> | undefined,
+  fallbackUserId: string
+): CloudCycleMetadata | null => {
+  if (!rawMetadata) {
+    return null;
+  }
+
+  const label = typeof rawMetadata.label === 'string' && rawMetadata.label.trim() ? rawMetadata.label : null;
+  const cycleDate = typeof rawMetadata.cycleDate === 'string' && rawMetadata.cycleDate ? rawMetadata.cycleDate : null;
+
+  if (!label || !cycleDate) {
+    return null;
+  }
+
+  return {
+    id: typeof rawMetadata.id === 'string' && rawMetadata.id ? rawMetadata.id : cycleId,
+    userId: typeof rawMetadata.userId === 'string' && rawMetadata.userId ? rawMetadata.userId : fallbackUserId,
+    label,
+    cycleDate,
+    createdAt: readTimestampString(rawMetadata.createdAt),
+    updatedAt: readTimestampString(rawMetadata.updatedAt, readTimestampString(rawMetadata.createdAt)),
+    forecastDays: typeof rawMetadata.forecastDays === 'number' ? rawMetadata.forecastDays : 0,
+    totalOutlooks: typeof rawMetadata.totalOutlooks === 'number' ? rawMetadata.totalOutlooks : 0,
+    totalFeatures: typeof rawMetadata.totalFeatures === 'number' ? rawMetadata.totalFeatures : 0,
+    isReadOnly: Boolean(rawMetadata.isReadOnly),
+    payloadHash: typeof rawMetadata.payloadHash === 'string' && rawMetadata.payloadHash ? rawMetadata.payloadHash : undefined,
+  };
+};
+
+const normalizeCloudCycleRecord = (
+  cycleId: string,
+  rawRecord: unknown,
+  fallbackUserId: string
+): CloudCycle | null => {
+  if (!isPlainObject(rawRecord)) {
+    return null;
+  }
+
+  const metadataSource = isPlainObject(rawRecord.metadata) ? (rawRecord.metadata as Record<string, unknown>) : rawRecord;
+  const payload = parseStoredPayload(rawRecord.payloadJson ?? rawRecord.payload);
+
+  const metadata = normalizeStoredMetadata(cycleId, metadataSource, fallbackUserId);
+  if (!metadata || !payload) {
+    return null;
+  }
+
+  return {
+    ...metadata,
+    payload,
+  };
+};
+
+const serializeCloudCycleDocument = (cycle: CloudCycle): CloudCycleDocument => {
+  const { payload, ...metadata } = cycle;
+
+  return {
+    ...metadata,
+    payloadJson: JSON.stringify(payload),
+  };
+};
+
+const readCloudCyclesFromQuery = (snapshot: { docs: Array<{ id: string; data: () => unknown }> }, fallbackUserId: string): CloudCycle[] =>
+  snapshot.docs
+    .map((cycleDoc) => normalizeCloudCycleRecord(cycleDoc.id, cycleDoc.data(), fallbackUserId))
+    .filter((cycle): cycle is CloudCycle => Boolean(cycle));
+
+const readLegacyCloudCycles = async (userId: string): Promise<CloudCycle[]> => {
+  try {
+    const snapshot = await getDoc(getLegacyUserSettingsRef(userId));
+    const legacyData = snapshot.data() as LegacyUserSettingsDocument | undefined;
+    const rawValue = legacyData?.cloudCycles;
+
+    if (!rawValue) {
+      return [];
+    }
+
+    const rawStore = typeof rawValue === 'string'
+      ? (() => {
+          try {
+            const parsed = JSON.parse(rawValue) as unknown;
+            return isPlainObject(parsed) ? parsed : null;
+          } catch {
+            return null;
+          }
+        })()
+      : isPlainObject(rawValue)
+        ? rawValue
+        : null;
+
+    if (!rawStore) {
+      return [];
+    }
+
+    return Object.entries(rawStore)
+      .map(([cycleId, rawRecord]) => normalizeCloudCycleRecord(cycleId, rawRecord, userId))
+      .filter((cycle): cycle is CloudCycle => Boolean(cycle));
+  } catch (error) {
+    console.error('Error reading legacy cloud cycles:', error);
+    return [];
+  }
+};
+
+const migrateLegacyCloudCycles = async (userId: string, cycles: CloudCycle[]): Promise<void> => {
+  if (!cycles.length) {
+    return;
+  }
+
+  await Promise.all(
+    cycles.map(async (cycle) => {
+      await setDoc(getCloudCycleDocRef(cycle.id), serializeCloudCycleDocument(cycle));
+    })
+  );
+
+  await setDoc(
+    getLegacyUserSettingsRef(userId),
+    {
+      cloudCycles: deleteField(),
+    },
+    { merge: true }
+  );
+};
+
+const readCloudCyclesForUser = async (userId: string): Promise<CloudCycle[]> => {
+  const snapshot = await getDocs(query(getCloudCyclesCollectionRef(), where('userId', '==', userId)));
+  const cycles = readCloudCyclesFromQuery(snapshot, userId);
+
+  if (cycles.length > 0) {
+    return cycles.sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
+  }
+
+  const legacyCycles = await readLegacyCloudCycles(userId);
+  if (legacyCycles.length > 0) {
+    await migrateLegacyCloudCycles(userId, legacyCycles);
+  }
+
+  return legacyCycles.sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
+};
+
+const fetchCloudCycleById = async (userId: string, cycleId: string): Promise<CloudCycle | null> => {
+  const docSnapshot = await getCloudCycleDocSnapshot(cycleId);
+  if (docSnapshot.exists()) {
+    const cycle = normalizeCloudCycleRecord(docSnapshot.id, docSnapshot.data(), userId);
+    if (cycle && cycle.userId === userId) {
+      return cycle;
+    }
+  }
+
+  const legacyCycles = await readLegacyCloudCycles(userId);
+  const legacyMatch = legacyCycles.find((cycle) => cycle.id === cycleId) ?? null;
+  if (legacyMatch) {
+    await migrateLegacyCloudCycles(userId, legacyCycles);
+  }
+
+  return legacyMatch;
+};
+
+const getOwnedCloudCycle = async (userId: string, cycleId: string): Promise<CloudCycle | null> => {
+  const existingSnapshot = await getCloudCycleDocSnapshot(cycleId);
+  if (!existingSnapshot.exists()) {
+    return null;
+  }
+
+  const existingCycle = normalizeCloudCycleRecord(cycleId, existingSnapshot.data(), userId);
+  if (!existingCycle || existingCycle.userId !== userId) {
+    return null;
+  }
+
+  return existingCycle;
+};
+
+/**
+ * Saves a new cloud cycle or updates an existing one
+ */
+export const saveCloudCycle = async (
+  userId: string,
+  label: string,
+  cycleDate: string,
+  stats: SavedCycleStats,
+  payload: GFCForecastSaveData,
+  isReadOnly: boolean = false,
+  existingId?: string
+): Promise<CloudOperationResult<string>> => {
+  try {
+    const cycleId = existingId || `${cycleDate}-${Date.now()}`;
+    const now = new Date().toISOString();
+    const existingCycle = existingId ? await getOwnedCloudCycle(userId, existingId) : null;
+
+    if (existingId && !existingCycle) {
+      return {
+        success: false,
+        error: 'Cloud cycle not found',
+      };
+    }
+
+    const metadata: CloudCycleMetadata = {
+      id: cycleId,
+      userId,
+      label,
+      cycleDate,
+      createdAt: existingCycle?.createdAt ?? now,
+      updatedAt: now,
+      forecastDays: stats.forecastDays,
+      totalOutlooks: stats.totalOutlooks,
+      totalFeatures: stats.totalFeatures,
+      isReadOnly,
+      payloadHash: computePayloadHash(payload),
+    };
+
+    await setDoc(getCloudCycleDocRef(cycleId), {
+      ...metadata,
+      payloadJson: JSON.stringify(payload),
+    });
+
+    return { success: true, data: cycleId };
+  } catch (error) {
+    console.error('Error saving cloud cycle:', error);
+    return {
+      success: false,
+      error: `Failed to save cloud cycle: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+};
+
+/**
+ * Loads a specific cloud cycle
+ */
+export const loadCloudCycle = async (
+  userId: string,
+  cycleId: string
+): Promise<CloudOperationResult<CloudCycle>> => {
+  try {
+    const record = await fetchCloudCycleById(userId, cycleId);
+
+    if (!record) {
+      return {
+        success: false,
+        error: 'Cloud cycle not found',
+      };
+    }
+
+    return {
+      success: true,
+      data: record,
+    };
+  } catch (error) {
+    console.error('Error loading cloud cycle:', error);
+    return {
+      success: false,
+      error: `Failed to load cloud cycle: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+};
+
+/**
+ * Deletes a cloud cycle
+ */
+export const deleteCloudCycle = async (
+  userId: string,
+  cycleId: string
+): Promise<CloudOperationResult> => {
+  try {
+    const existingCycle = await getOwnedCloudCycle(userId, cycleId);
+    if (!existingCycle) {
+      return { success: true };
+    }
+
+    await deleteDoc(getCloudCycleDocRef(cycleId));
+
+    return { success: true };
+  } catch (error) {
+    console.error('Error deleting cloud cycle:', error);
+    return {
+      success: false,
+      error: `Failed to delete cloud cycle: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+};
+
+/**
+ * Renames a cloud cycle
+ */
+export const renameCloudCycle = async (
+  userId: string,
+  cycleId: string,
+  newLabel: string
+): Promise<CloudOperationResult> => {
+  try {
+    const existing = await getOwnedCloudCycle(userId, cycleId);
+    if (!existing) {
+      return {
+        success: false,
+        error: 'Cloud cycle not found',
+      };
+    }
+
+    const nextMetadata: CloudCycle = {
+      ...existing,
+      label: newLabel,
+      updatedAt: new Date().toISOString(),
+      payloadHash: computePayloadHash(existing.payload),
+    };
+
+    await setDoc(getCloudCycleDocRef(cycleId), serializeCloudCycleDocument(nextMetadata));
+
+    return { success: true };
+  } catch (error) {
+    console.error('Error renaming cloud cycle:', error);
+    return {
+      success: false,
+      error: `Failed to rename cloud cycle: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+};
+
+/**
+ * Lists all cloud cycles for a user (metadata only, not full payloads)
+ */
+export const listCloudCycles = async (
+  userId: string
+): Promise<CloudOperationResult<CloudCycleMetadata[]>> => {
+  try {
+    const cycles = await readCloudCyclesForUser(userId);
+    const metadata = cycles.map(({ payload, ...cycleMetadata }) => cycleMetadata);
+
+    return { success: true, data: metadata };
+  } catch (error) {
+    console.error('Error listing cloud cycles:', error);
+    return {
+      success: false,
+      error: `Failed to list cloud cycles: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+};
+
+/**
+ * Subscribes to cloud cycles list for real-time updates
+ */
+export const subscribeToCloudCycles = (
+  userId: string,
+  onUpdate: (cycles: CloudCycleMetadata[]) => void,
+  onError?: (error: Error) => void
+): (() => void) => {
+  try {
+    const cyclesQuery = query(getCloudCyclesCollectionRef(), where('userId', '==', userId));
+
+    const unsubscribe = onSnapshot(
+      cyclesQuery,
+      async (querySnapshot) => {
+        const cycles = readCloudCyclesFromQuery(querySnapshot, userId);
+
+        if (cycles.length > 0) {
+          onUpdate(cycles.map(({ payload, ...metadata }) => metadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));
+          return;
+        }
+
+        const legacyCycles = await readLegacyCloudCycles(userId);
+        if (legacyCycles.length > 0) {
+          await migrateLegacyCloudCycles(userId, legacyCycles);
+          onUpdate(legacyCycles.map(({ payload, ...metadata }) => metadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));
+          return;
+        }
+
+        onUpdate([]);
+      },
+      (error) => {
+        console.error('Error subscribing to cloud cycles:', error);
+        onError?.(error as Error);
+      }
+    );
+
+    return unsubscribe;
+  } catch (error) {
+    console.error('Error setting up cloud cycles subscription:', error);
+    if (onError && error instanceof Error) onError(error);
+    return () => {};
+  }
+};
+
+/**
+ * Checks if a local cycle differs from the remote version
+ */
+export const hasRemoteChanges = (
+  localPayload: GFCForecastSaveData,
+  remoteMetadata: CloudCycleMetadata
+): boolean => {
+  const localHash = computePayloadHash(localPayload);
+  return localHash !== remoteMetadata.payloadHash;
+};

--- a/src/lib/cloudCyclesService.ts
+++ b/src/lib/cloudCyclesService.ts
@@ -528,9 +528,9 @@ export const renameCloudCycle = async (
  * Lists all cloud cycles for a user as metadata-only objects.
  * Payload JSON is still stored in the same Firestore document today, so this avoids parse cost but not document transfer size.
  */
-export const listCloudCycles = async (
+export async function listCloudCycles(
   { userId }: ListCloudCyclesParams
-): Promise<CloudOperationResult<CloudCycleMetadata[]>> => {
+): Promise<CloudOperationResult<CloudCycleMetadata[]>> {
   try {
     const snapshot = await getDocs(query(getCloudCyclesCollectionRef(), where('userId', '==', userId)));
     const metadata = readCloudCycleMetadataFromQuery({ snapshot, fallbackUserId: userId });
@@ -549,7 +549,7 @@ export const listCloudCycles = async (
       error: `Failed to list cloud cycles: ${error instanceof Error ? error.message : 'Unknown error'}`,
     };
   }
-};
+}
 
 /**
  * Subscribes to cloud cycles list for real-time updates

--- a/src/lib/cloudCyclesService.ts
+++ b/src/lib/cloudCyclesService.ts
@@ -18,6 +18,11 @@ type LegacyUserSettingsDocument = {
   cloudCycles?: LegacyCloudCyclesValue;
 };
 
+/** Returns a stable no-op unsubscribe callback when the Firestore subscription cannot be created. */
+function noopUnsubscribe(): void {
+  return undefined;
+}
+
 /**
  * Computes a simple hash of the cycle payload for change detection
  * Uses a simple string hash rather than cryptographic hashing
@@ -33,9 +38,11 @@ const computePayloadHash = (payload: GFCForecastSaveData): string => {
   return Math.abs(hash).toString(36).substring(0, 12);
 };
 
+/** Returns true when the value is a plain object record rather than an array or primitive. */
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
 
+/** Reads a stored cloud payload from either a JSON string or already-parsed object value. */
 const parseStoredPayload = (value: unknown): GFCForecastSaveData | null => {
   if (typeof value === 'string') {
     try {
@@ -53,6 +60,7 @@ const parseStoredPayload = (value: unknown): GFCForecastSaveData | null => {
   return null;
 };
 
+/** Returns the shared Firestore collection reference for hosted cloud-cycle documents. */
 const getCloudCyclesCollectionRef = () => {
   if (!db) {
     throw new Error('Firestore is not initialized');
@@ -61,10 +69,13 @@ const getCloudCyclesCollectionRef = () => {
   return collection(db, CLOUD_CYCLES_COLLECTION);
 };
 
+/** Returns the Firestore document reference for a specific cloud cycle. */
 const getCloudCycleDocRef = (cycleId: string) => doc(getCloudCyclesCollectionRef(), cycleId);
 
+/** Reads the latest Firestore snapshot for one cloud cycle document. */
 const getCloudCycleDocSnapshot = (cycleId: string) => getDoc(getCloudCycleDocRef(cycleId));
 
+/** Returns the legacy user-settings document where pre-Phase 4 cloud cycles were stored. */
 const getLegacyUserSettingsRef = (userId: string) => {
   if (!db) {
     throw new Error('Firestore is not initialized');
@@ -73,9 +84,11 @@ const getLegacyUserSettingsRef = (userId: string) => {
   return doc(db, LEGACY_USER_SETTINGS_COLLECTION, userId);
 };
 
+/** Reads a timestamp-like string while falling back to a safe ISO date when missing. */
 const readTimestampString = (value: unknown, fallback = new Date(0).toISOString()): string =>
   typeof value === 'string' && value ? value : fallback;
 
+/** Normalizes stored cloud-cycle metadata into the current metadata contract. */
 const normalizeStoredMetadata = (
   cycleId: string,
   rawMetadata: Record<string, unknown> | undefined,
@@ -107,6 +120,7 @@ const normalizeStoredMetadata = (
   };
 };
 
+/** Normalizes one raw Firestore or legacy cloud-cycle record into the app's runtime shape. */
 const normalizeCloudCycleRecord = (
   cycleId: string,
   rawRecord: unknown,
@@ -130,6 +144,7 @@ const normalizeCloudCycleRecord = (
   };
 };
 
+/** Serializes a runtime cloud cycle back into the Firestore storage format. */
 const serializeCloudCycleDocument = (cycle: CloudCycle): CloudCycleDocument => {
   const { payload, ...metadata } = cycle;
 
@@ -139,11 +154,16 @@ const serializeCloudCycleDocument = (cycle: CloudCycle): CloudCycleDocument => {
   };
 };
 
+/** Strips the saved payload from a cloud cycle so list views can work with metadata only. */
+const toCloudCycleMetadata = ({ payload: _payload, ...cycleMetadata }: CloudCycle): CloudCycleMetadata => cycleMetadata;
+
+/** Converts a Firestore query snapshot into normalized cloud-cycle records. */
 const readCloudCyclesFromQuery = (snapshot: { docs: Array<{ id: string; data: () => unknown }> }, fallbackUserId: string): CloudCycle[] =>
   snapshot.docs
     .map((cycleDoc) => normalizeCloudCycleRecord(cycleDoc.id, cycleDoc.data(), fallbackUserId))
     .filter((cycle): cycle is CloudCycle => Boolean(cycle));
 
+/** Reads older cloud-cycle data from the legacy user-settings document if present. */
 const readLegacyCloudCycles = async (userId: string): Promise<CloudCycle[]> => {
   try {
     const snapshot = await getDoc(getLegacyUserSettingsRef(userId));
@@ -180,6 +200,7 @@ const readLegacyCloudCycles = async (userId: string): Promise<CloudCycle[]> => {
   }
 };
 
+/** Migrates legacy cloud cycles into the dedicated `cloudCycles` collection and clears the old field. */
 const migrateLegacyCloudCycles = async (userId: string, cycles: CloudCycle[]): Promise<void> => {
   if (!cycles.length) {
     return;
@@ -200,6 +221,7 @@ const migrateLegacyCloudCycles = async (userId: string, cycles: CloudCycle[]): P
   );
 };
 
+/** Reads all cloud cycles for a user, transparently migrating legacy records when needed. */
 const readCloudCyclesForUser = async (userId: string): Promise<CloudCycle[]> => {
   const snapshot = await getDocs(query(getCloudCyclesCollectionRef(), where('userId', '==', userId)));
   const cycles = readCloudCyclesFromQuery(snapshot, userId);
@@ -216,6 +238,7 @@ const readCloudCyclesForUser = async (userId: string): Promise<CloudCycle[]> => 
   return legacyCycles.sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
 };
 
+/** Fetches one cloud cycle by id, including legacy fallback and migration support. */
 const fetchCloudCycleById = async (userId: string, cycleId: string): Promise<CloudCycle | null> => {
   const docSnapshot = await getCloudCycleDocSnapshot(cycleId);
   if (docSnapshot.exists()) {
@@ -234,6 +257,7 @@ const fetchCloudCycleById = async (userId: string, cycleId: string): Promise<Clo
   return legacyMatch;
 };
 
+/** Returns an existing cloud cycle only when it belongs to the current signed-in user. */
 const getOwnedCloudCycle = async (userId: string, cycleId: string): Promise<CloudCycle | null> => {
   const existingSnapshot = await getCloudCycleDocSnapshot(cycleId);
   if (!existingSnapshot.exists()) {
@@ -257,7 +281,7 @@ export const saveCloudCycle = async (
   cycleDate: string,
   stats: SavedCycleStats,
   payload: GFCForecastSaveData,
-  isReadOnly: boolean = false,
+  isReadOnly = false,
   existingId?: string
 ): Promise<CloudOperationResult<string>> => {
   try {
@@ -400,7 +424,7 @@ export const listCloudCycles = async (
 ): Promise<CloudOperationResult<CloudCycleMetadata[]>> => {
   try {
     const cycles = await readCloudCyclesForUser(userId);
-    const metadata = cycles.map(({ payload, ...cycleMetadata }) => cycleMetadata);
+    const metadata = cycles.map(toCloudCycleMetadata);
 
     return { success: true, data: metadata };
   } catch (error) {
@@ -429,14 +453,14 @@ export const subscribeToCloudCycles = (
         const cycles = readCloudCyclesFromQuery(querySnapshot, userId);
 
         if (cycles.length > 0) {
-          onUpdate(cycles.map(({ payload, ...metadata }) => metadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));
+          onUpdate(cycles.map(toCloudCycleMetadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));
           return;
         }
 
         const legacyCycles = await readLegacyCloudCycles(userId);
         if (legacyCycles.length > 0) {
           await migrateLegacyCloudCycles(userId, legacyCycles);
-          onUpdate(legacyCycles.map(({ payload, ...metadata }) => metadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));
+          onUpdate(legacyCycles.map(toCloudCycleMetadata).sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()));
           return;
         }
 
@@ -452,7 +476,7 @@ export const subscribeToCloudCycles = (
   } catch (error) {
     console.error('Error setting up cloud cycles subscription:', error);
     if (onError && error instanceof Error) onError(error);
-    return () => {};
+    return noopUnsubscribe;
   }
 };
 

--- a/src/lib/cloudCyclesService.ts
+++ b/src/lib/cloudCyclesService.ts
@@ -41,6 +41,20 @@ interface UserCycleLookupParams {
   cycleId: string;
 }
 
+interface ListCloudCyclesParams {
+  userId: string;
+}
+
+interface RenameCloudCycleParams extends UserCycleLookupParams {
+  newLabel: string;
+}
+
+interface CloudCycleSubscriptionParams {
+  userId: string;
+  onUpdate: (cycles: CloudCycleMetadata[]) => void;
+  onError?: (error: Error) => void;
+}
+
 interface SaveCloudCycleParams {
   userId: string;
   label: string;
@@ -238,7 +252,7 @@ const bootstrapCloudCycleSubscription = async ({
   onError?: (error: Error) => void;
 }): Promise<void> => {
   try {
-    const result = await listCloudCycles(userId);
+    const result = await listCloudCycles({ userId });
     if (!isActive()) {
       return;
     }
@@ -427,11 +441,10 @@ export const saveCloudCycle = async (
  * Loads a specific cloud cycle
  */
 export const loadCloudCycle = async (
-  userId: string,
-  cycleId: string
+  params: UserCycleLookupParams
 ): Promise<CloudOperationResult<CloudCycle>> => {
   try {
-    const record = await fetchCloudCycleById({ userId, cycleId });
+    const record = await fetchCloudCycleById(params);
 
     if (!record) {
       return {
@@ -457,16 +470,15 @@ export const loadCloudCycle = async (
  * Deletes a cloud cycle
  */
 export const deleteCloudCycle = async (
-  userId: string,
-  cycleId: string
+  params: UserCycleLookupParams
 ): Promise<CloudOperationResult> => {
   try {
-    const existingCycle = await getOwnedCloudCycle({ userId, cycleId });
+    const existingCycle = await getOwnedCloudCycle(params);
     if (!existingCycle) {
       return { success: true };
     }
 
-    await deleteDoc(getCloudCycleDocRef(cycleId));
+    await deleteDoc(getCloudCycleDocRef(params.cycleId));
 
     return { success: true };
   } catch (error) {
@@ -482,12 +494,10 @@ export const deleteCloudCycle = async (
  * Renames a cloud cycle
  */
 export const renameCloudCycle = async (
-  userId: string,
-  cycleId: string,
-  newLabel: string
+  params: RenameCloudCycleParams
 ): Promise<CloudOperationResult> => {
   try {
-    const existing = await getOwnedCloudCycle({ userId, cycleId });
+    const existing = await getOwnedCloudCycle(params);
     if (!existing) {
       return {
         success: false,
@@ -497,12 +507,12 @@ export const renameCloudCycle = async (
 
     const nextMetadata: CloudCycle = {
       ...existing,
-      label: newLabel,
+      label: params.newLabel,
       updatedAt: new Date().toISOString(),
       payloadHash: computePayloadHash(existing.payload),
     };
 
-    await setDoc(getCloudCycleDocRef(cycleId), serializeCloudCycleDocument(nextMetadata));
+    await setDoc(getCloudCycleDocRef(params.cycleId), serializeCloudCycleDocument(nextMetadata));
 
     return { success: true };
   } catch (error) {
@@ -519,7 +529,7 @@ export const renameCloudCycle = async (
  * Payload JSON is still stored in the same Firestore document today, so this avoids parse cost but not document transfer size.
  */
 export const listCloudCycles = async (
-  userId: string
+  { userId }: ListCloudCyclesParams
 ): Promise<CloudOperationResult<CloudCycleMetadata[]>> => {
   try {
     const snapshot = await getDocs(query(getCloudCyclesCollectionRef(), where('userId', '==', userId)));
@@ -545,9 +555,7 @@ export const listCloudCycles = async (
  * Subscribes to cloud cycles list for real-time updates
  */
 export const subscribeToCloudCycles = (
-  userId: string,
-  onUpdate: (cycles: CloudCycleMetadata[]) => void,
-  onError?: (error: Error) => void
+  { userId, onUpdate, onError }: CloudCycleSubscriptionParams
 ): (() => void) => {
   try {
     const cyclesQuery = query(getCloudCyclesCollectionRef(), where('userId', '==', userId));

--- a/src/lib/cloudCyclesService.ts
+++ b/src/lib/cloudCyclesService.ts
@@ -25,6 +25,12 @@ interface NormalizeCloudCycleRecordParams {
   fallbackUserId: string;
 }
 
+interface NormalizeCloudCycleMetadataRecordParams {
+  cycleId: string;
+  rawRecord: unknown;
+  fallbackUserId: string;
+}
+
 interface ReadCloudCyclesFromQueryParams {
   snapshot: { docs: Array<{ id: string; data: () => unknown }> };
   fallbackUserId: string;
@@ -184,6 +190,20 @@ const normalizeCloudCycleRecord = ({
   };
 };
 
+/** Normalizes one raw Firestore cloud-cycle document into list-safe metadata without parsing the payload. */
+const normalizeCloudCycleMetadataRecord = ({
+  cycleId,
+  rawRecord,
+  fallbackUserId,
+}: NormalizeCloudCycleMetadataRecordParams): CloudCycleMetadata | null => {
+  if (!isPlainObject(rawRecord)) {
+    return null;
+  }
+
+  const metadataSource = isPlainObject(rawRecord.metadata) ? (rawRecord.metadata as Record<string, unknown>) : rawRecord;
+  return normalizeStoredMetadata({ cycleId, rawMetadata: metadataSource, fallbackUserId });
+};
+
 /** Serializes a runtime cloud cycle back into the Firestore storage format. */
 const serializeCloudCycleDocument = (cycle: CloudCycle): CloudCycleDocument => {
   const { payload, ...metadata } = cycle;
@@ -194,7 +214,7 @@ const serializeCloudCycleDocument = (cycle: CloudCycle): CloudCycleDocument => {
   };
 };
 
-/** Strips the saved payload from a cloud cycle so list views can work with metadata only. */
+/** Strips the saved payload from a cloud cycle so library APIs can expose metadata-only objects. */
 const toCloudCycleMetadata = ({ payload: _payload, ...cycleMetadata }: CloudCycle): CloudCycleMetadata => cycleMetadata;
 
 /** Sorts cloud-cycle metadata from newest to oldest update time. */
@@ -205,11 +225,19 @@ const sortCloudCycleMetadata = (cycles: CloudCycleMetadata[]): CloudCycleMetadat
 const createCloudCycleId = (userId: string, cycleDate: string): string =>
   `${userId}-${cycleDate}-${uuidv4()}`;
 
-/** Converts a Firestore query snapshot into normalized cloud-cycle records. */
+/** Converts a Firestore query snapshot into normalized cloud-cycle records, including payload validation. */
 const readCloudCyclesFromQuery = ({ snapshot, fallbackUserId }: ReadCloudCyclesFromQueryParams): CloudCycle[] =>
   snapshot.docs
     .map((cycleDoc) => normalizeCloudCycleRecord({ cycleId: cycleDoc.id, rawRecord: cycleDoc.data(), fallbackUserId }))
     .filter((cycle): cycle is CloudCycle => Boolean(cycle));
+
+/** Converts a Firestore query snapshot into normalized cloud-cycle metadata without parsing payload JSON. */
+const readCloudCycleMetadataFromQuery = ({ snapshot, fallbackUserId }: ReadCloudCyclesFromQueryParams): CloudCycleMetadata[] =>
+  snapshot.docs
+    .map((cycleDoc) =>
+      normalizeCloudCycleMetadataRecord({ cycleId: cycleDoc.id, rawRecord: cycleDoc.data(), fallbackUserId })
+    )
+    .filter((cycle): cycle is CloudCycleMetadata => Boolean(cycle));
 
 /** Reads older cloud-cycle data from the legacy user-settings document if present. */
 const readLegacyCloudCycles = async (userId: string): Promise<CloudCycle[]> => {
@@ -460,16 +488,23 @@ export const renameCloudCycle = async (
 };
 
 /**
- * Lists all cloud cycles for a user (metadata only, not full payloads)
+ * Lists all cloud cycles for a user as metadata-only objects.
+ * Payload JSON is still stored in the same Firestore document today, so this avoids parse cost but not document transfer size.
  */
 export const listCloudCycles = async (
   userId: string
 ): Promise<CloudOperationResult<CloudCycleMetadata[]>> => {
   try {
-    const cycles = await readCloudCyclesForUser(userId);
-    const metadata = cycles.map(toCloudCycleMetadata);
+    const snapshot = await getDocs(query(getCloudCyclesCollectionRef(), where('userId', '==', userId)));
+    const metadata = readCloudCycleMetadataFromQuery({ snapshot, fallbackUserId: userId });
 
-    return { success: true, data: metadata };
+    if (metadata.length > 0) {
+      return { success: true, data: sortCloudCycleMetadata(metadata) };
+    }
+
+    const cycles = await readCloudCyclesForUser(userId);
+
+    return { success: true, data: sortCloudCycleMetadata(cycles.map(toCloudCycleMetadata)) };
   } catch (error) {
     console.error('Error listing cloud cycles:', error);
     return {
@@ -491,13 +526,13 @@ export const subscribeToCloudCycles = (
     const cyclesQuery = query(getCloudCyclesCollectionRef(), where('userId', '==', userId));
     let isActive = true;
 
-    void readCloudCyclesForUser(userId)
-      .then((cycles) => {
+    void listCloudCycles(userId)
+      .then((result) => {
         if (!isActive) {
           return;
         }
 
-        onUpdate(sortCloudCycleMetadata(cycles.map(toCloudCycleMetadata)));
+        onUpdate(sortCloudCycleMetadata(result.success && result.data ? result.data : []));
       })
       .catch((error) => {
         console.error('Error bootstrapping cloud cycles:', error);
@@ -509,8 +544,8 @@ export const subscribeToCloudCycles = (
     const unsubscribe = onSnapshot(
       cyclesQuery,
       (querySnapshot) => {
-        const cycles = readCloudCyclesFromQuery({ snapshot: querySnapshot, fallbackUserId: userId });
-        onUpdate(sortCloudCycleMetadata(cycles.map(toCloudCycleMetadata)));
+        const metadata = readCloudCycleMetadataFromQuery({ snapshot: querySnapshot, fallbackUserId: userId });
+        onUpdate(sortCloudCycleMetadata(metadata));
       },
       (error) => {
         console.error('Error subscribing to cloud cycles:', error);

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -255,6 +255,44 @@ const SignedInActionRow: React.FC<{
   </div>
 );
 
+/** Cloud library access card for premium users. */
+const CloudLibraryCard: React.FC = () => {
+  const { premiumActive } = useEntitlement();
+
+  if (!premiumActive) {
+    return null; // Only show for premium users
+  }
+
+  return (
+    <Card>
+      <CardHeader className="account-section-header">
+        <div className="account-section-topline">
+          <div className="account-section-copy">
+            <CardTitle className="text-2xl flex items-center gap-2">
+              <Cloud className="h-6 w-6" />
+              Cloud Cycles
+            </CardTitle>
+            <CardDescription>
+              Access, save, and organize your forecasts in the cloud. Available on all your devices.
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="account-section-content">
+        <p className="text-sm text-muted-foreground mb-4">
+          Your premium subscription includes hosted access to all your saved forecast cycles. Save time by reusing previous patterns and maintain consistency across multiple devices.
+        </p>
+        <Button asChild>
+          <Link to="/cloud">
+            <Cloud className="mr-2 h-4 w-4" />
+            Open Cloud Library
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
 /** Billing summary card for Phase 3 subscription state and management. */
 const BillingCardHeader: React.FC<{
   premiumActive: boolean;
@@ -541,6 +579,7 @@ const SignedInAccountView: React.FC = () => {
         />
 
         <BillingCard />
+        <CloudLibraryCard />
       </div>
     </div>
   );

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -256,6 +256,38 @@ const SignedInActionRow: React.FC<{
 );
 
 /** Cloud library access card for premium users. */
+const CloudLibraryCardHeader: React.FC = () => (
+  <CardHeader className="account-section-header">
+    <div className="account-section-topline">
+      <div className="account-section-copy">
+        <CardTitle className="flex items-center gap-2 text-2xl">
+          <Cloud className="h-6 w-6" />
+          Cloud Cycles
+        </CardTitle>
+        <CardDescription>
+          Access, save, and organize your forecasts in the cloud. Available on all your devices.
+        </CardDescription>
+      </div>
+    </div>
+  </CardHeader>
+);
+
+/** Body copy and CTA for the premium cloud-library account card. */
+const CloudLibraryCardContent: React.FC = () => (
+  <CardContent className="account-section-content">
+    <p className="mb-4 text-sm text-muted-foreground">
+      Your premium subscription includes hosted access to all your saved forecast cycles. Save time by reusing previous patterns and maintain consistency across multiple devices.
+    </p>
+    <Button asChild>
+      <Link to="/cloud">
+        <Cloud className="mr-2 h-4 w-4" />
+        Open Cloud Library
+      </Link>
+    </Button>
+  </CardContent>
+);
+
+/** Cloud library access card for premium users. */
 const CloudLibraryCard: React.FC = () => {
   const { premiumActive } = useEntitlement();
 
@@ -265,30 +297,8 @@ const CloudLibraryCard: React.FC = () => {
 
   return (
     <Card>
-      <CardHeader className="account-section-header">
-        <div className="account-section-topline">
-          <div className="account-section-copy">
-            <CardTitle className="text-2xl flex items-center gap-2">
-              <Cloud className="h-6 w-6" />
-              Cloud Cycles
-            </CardTitle>
-            <CardDescription>
-              Access, save, and organize your forecasts in the cloud. Available on all your devices.
-            </CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="account-section-content">
-        <p className="text-sm text-muted-foreground mb-4">
-          Your premium subscription includes hosted access to all your saved forecast cycles. Save time by reusing previous patterns and maintain consistency across multiple devices.
-        </p>
-        <Button asChild>
-          <Link to="/cloud">
-            <Cloud className="mr-2 h-4 w-4" />
-            Open Cloud Library
-          </Link>
-        </Button>
-      </CardContent>
+      <CloudLibraryCardHeader />
+      <CloudLibraryCardContent />
     </Card>
   );
 };

--- a/src/pages/CloudLibraryPage.css
+++ b/src/pages/CloudLibraryPage.css
@@ -1,0 +1,391 @@
+.cloud-library-page {
+  min-height: 100%;
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary) 62%, var(--bg-primary));
+}
+
+.cloud-library-shell {
+  max-width: 84rem;
+  margin: 0 auto;
+  padding: 1.75rem 1.5rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.cloud-library-hero {
+  display: grid;
+  gap: 1.6rem;
+  align-items: start;
+  padding: 2rem;
+  border: 1px solid var(--border-color);
+  border-radius: 2rem;
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary) 58%, var(--bg-primary));
+  box-shadow: var(--shadow-lg);
+}
+
+.cloud-library-hero-copy,
+.cloud-library-hero-text,
+.cloud-library-hero-panel,
+.cloud-library-main,
+.cloud-library-side,
+.cloud-library-list-content,
+.cloud-library-support-content,
+.cloud-cycle-main,
+.cloud-cycle-header,
+.cloud-cycle-actions,
+.cloud-cycle-rename-row,
+.cloud-library-empty-state,
+.cloud-library-empty-copy,
+.cloud-library-quick-actions {
+  display: flex;
+  flex-direction: column;
+}
+
+.cloud-library-hero-copy {
+  gap: 1rem;
+}
+
+.cloud-library-pill {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--bg-primary);
+  color: var(--button-bg);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.cloud-library-hero-text {
+  gap: 0.75rem;
+}
+
+.cloud-library-hero-text h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 3.6vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+  font-weight: 800;
+  color: var(--text-primary);
+}
+
+.cloud-library-hero-text p {
+  margin: 0;
+  max-width: 58ch;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--text-secondary);
+}
+
+.cloud-library-hero-panel,
+.cloud-library-surface-card,
+.cloud-library-support-card,
+.cloud-library-notice-card {
+  border: 1px solid var(--border-color);
+  border-radius: 1.75rem;
+  background: var(--bg-primary);
+  box-shadow: var(--shadow-md);
+}
+
+.cloud-library-hero-panel {
+  gap: 1.25rem;
+  padding: 1.6rem;
+}
+
+.cloud-library-status-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cloud-library-stat-grid,
+.cloud-library-support-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.cloud-library-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.05rem;
+  border: 1px solid var(--border-color);
+  border-radius: 1.15rem;
+  background: var(--bg-secondary);
+}
+
+.cloud-library-stat span {
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.cloud-library-stat strong {
+  font-size: 1.05rem;
+  line-height: 1.45;
+  color: var(--text-primary);
+}
+
+.cloud-library-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.cloud-library-main,
+.cloud-library-side {
+  gap: 2rem;
+}
+
+.cloud-library-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 2.15rem 2.25rem 1.35rem;
+}
+
+.cloud-library-section-header h2,
+.cloud-library-section-header h3 {
+  margin: 0;
+}
+
+.cloud-library-section-header p,
+.cloud-library-support-copy,
+.cloud-library-side-note,
+.cloud-library-feedback p,
+.cloud-library-notice-content p,
+.cloud-cycle-meta,
+.cloud-library-empty-copy p {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.75;
+  color: var(--text-secondary);
+}
+
+.cloud-library-list-content,
+.cloud-library-support-content {
+  gap: 1.4rem;
+  padding: 0 2.25rem 2.25rem;
+}
+
+.cloud-library-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cloud-library-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cloud-cycle-card {
+  border-radius: 1.45rem;
+}
+
+.cloud-cycle-card-content {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  padding: 1.4rem;
+}
+
+.cloud-cycle-main,
+.cloud-cycle-header,
+.cloud-cycle-actions,
+.cloud-cycle-rename-row {
+  gap: 0.9rem;
+}
+
+.cloud-cycle-title-row,
+.cloud-cycle-meta,
+.cloud-cycle-stats,
+.cloud-cycle-inline-actions,
+.cloud-library-empty-actions,
+.cloud-library-support-actions,
+.cloud-library-feedback,
+.cloud-library-notice-content {
+  display: flex;
+}
+
+.cloud-cycle-title-row,
+.cloud-cycle-meta,
+.cloud-cycle-stats,
+.cloud-library-empty-actions,
+.cloud-library-support-actions {
+  flex-wrap: wrap;
+}
+
+.cloud-cycle-title-row,
+.cloud-cycle-meta {
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cloud-cycle-title-row h3 {
+  margin: 0;
+  font-size: 1.22rem;
+  line-height: 1.2;
+  color: var(--text-primary);
+}
+
+.cloud-cycle-stats {
+  gap: 0.75rem;
+}
+
+.cloud-cycle-stats .cloud-library-stat {
+  min-width: 8rem;
+  flex: 1 1 0;
+}
+
+.cloud-cycle-actions {
+  gap: 0.75rem;
+  min-width: 10rem;
+}
+
+.cloud-cycle-inline-actions {
+  gap: 0.7rem;
+}
+
+.cloud-library-empty-state {
+  gap: 1.15rem;
+  padding: 0.35rem 0 0.1rem;
+}
+
+.cloud-library-empty-icon {
+  display: grid;
+  place-items: center;
+  width: 4rem;
+  height: 4rem;
+  border: 1px solid var(--border-color);
+  border-radius: 1.25rem;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.cloud-library-empty-copy {
+  gap: 0.6rem;
+}
+
+.cloud-library-empty-copy h2 {
+  margin: 0;
+  font-size: 1.45rem;
+  line-height: 1.2;
+  color: var(--text-primary);
+}
+
+.cloud-library-empty-actions,
+.cloud-library-support-actions {
+  gap: 0.75rem;
+}
+
+.cloud-library-divider {
+  height: 1px;
+  background: var(--border-color);
+}
+
+.cloud-library-quick-actions {
+  gap: 0.75rem;
+}
+
+.cloud-library-support-title {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.cloud-library-support-copy {
+  font-size: 0.96rem;
+}
+
+.cloud-library-feedback,
+.cloud-library-notice-content {
+  gap: 0.85rem;
+  align-items: flex-start;
+  padding: 1.4rem;
+}
+
+.cloud-library-loading,
+.cloud-library-center-shell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cloud-library-loading {
+  padding: 3rem 0;
+  color: var(--text-secondary);
+}
+
+.cloud-library-center-shell {
+  min-height: 100%;
+  padding: 2rem;
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary) 62%, var(--bg-primary));
+}
+
+.cloud-library-auth-card {
+  width: 100%;
+  max-width: 32rem;
+}
+
+@media (min-width: 1024px) {
+  .cloud-library-hero {
+    grid-template-columns: minmax(0, 1.65fr) minmax(320px, 0.85fr);
+    align-items: stretch;
+  }
+
+  .cloud-library-layout {
+    grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.82fr);
+    align-items: start;
+  }
+}
+
+@media (max-width: 800px) {
+  .cloud-library-shell {
+    padding: 1.25rem 1rem 2rem;
+    gap: 1.5rem;
+  }
+
+  .cloud-library-hero {
+    padding: 1.45rem;
+    border-radius: 1.5rem;
+  }
+
+  .cloud-library-hero-text h1 {
+    font-size: 2.15rem;
+  }
+
+  .cloud-library-section-header {
+    padding: 1.75rem 1.5rem 1.15rem;
+  }
+
+  .cloud-library-list-content,
+  .cloud-library-support-content {
+    padding: 0 1.5rem 1.5rem;
+  }
+
+  .cloud-library-stat-grid,
+  .cloud-library-support-grid,
+  .cloud-cycle-card-content {
+    grid-template-columns: 1fr;
+  }
+
+  .cloud-cycle-actions {
+    min-width: 0;
+  }
+
+  .cloud-cycle-actions button,
+  .cloud-library-support-actions button,
+  .cloud-library-empty-actions button {
+    width: 100%;
+  }
+}

--- a/src/pages/CloudLibraryPage.css
+++ b/src/pages/CloudLibraryPage.css
@@ -210,6 +210,7 @@
 .cloud-cycle-meta,
 .cloud-cycle-stats,
 .cloud-cycle-inline-actions,
+.cloud-cycle-delete-prompt,
 .cloud-library-empty-actions,
 .cloud-library-support-actions,
 .cloud-library-feedback,
@@ -254,6 +255,21 @@
 
 .cloud-cycle-inline-actions {
   gap: 0.7rem;
+}
+
+.cloud-cycle-delete-prompt {
+  gap: 0.7rem;
+  padding: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--error-text) 18%, var(--border-color));
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--error-text) 6%, var(--bg-primary));
+}
+
+.cloud-cycle-delete-prompt p {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--text-primary);
 }
 
 .cloud-library-empty-state {

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -229,7 +229,7 @@ const CloudCycleDeletePrompt: React.FC<{
   onConfirm: () => void;
 }> = ({ cycleLabel, isBusy, onCancel, onConfirm }) => (
   <div className="cloud-cycle-delete-prompt">
-    <p>Delete "{cycleLabel}"? This action cannot be undone.</p>
+    <p>Delete &quot;{cycleLabel}&quot;? This action cannot be undone.</p>
     <div className="cloud-cycle-inline-actions">
       <Button variant="outline" size="sm" onClick={onCancel} disabled={isBusy}>
         Keep

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -1,0 +1,417 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AlertCircle, Cloud, CloudOff, Download, Edit2, FolderOpen, LoaderCircle, Lock, ShieldCheck, Trash2 } from 'lucide-react';
+import { Badge } from '../components/ui/badge';
+import { Button } from '../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Input } from '../components/ui/input';
+import { useAuth } from '../auth/AuthProvider';
+import { useEntitlement } from '../billing/EntitlementProvider';
+import { useCloudCycles } from '../hooks/useCloudCycles';
+import { CloudCycleMetadata } from '../types/cloudCycles';
+import './CloudLibraryPage.css';
+
+/** Formats cloud-cycle timestamps for the library surface. */
+const formatDate = (dateString: string): string =>
+  new Date(dateString).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+/** Small stat card used in the cloud-library summary row. */
+const CloudLibraryStat: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="cloud-library-stat">
+    <span>{label}</span>
+    <strong>{value}</strong>
+  </div>
+);
+
+/** Top hero shared by the signed-in cloud library states. */
+const CloudLibraryHero: React.FC<{
+  premiumActive: boolean;
+  cycleCount: number;
+  isExpiredPremium: boolean;
+}> = ({ premiumActive, cycleCount, isExpiredPremium }) => (
+  <section className="cloud-library-hero">
+    <div className="cloud-library-hero-copy">
+      <div className="cloud-library-pill">
+        <Cloud className="h-4 w-4" />
+        Cloud Library
+      </div>
+      <div className="cloud-library-hero-text">
+        <h1>Your saved cloud cycles.</h1>
+        <p>Load a hosted package back into the editor, rename it, or clean up old saves without digging through menus.</p>
+      </div>
+    </div>
+
+    <div className="cloud-library-hero-panel">
+      <div className="cloud-library-status-row">
+        <Badge variant={premiumActive ? 'success' : 'outline'}>
+          {premiumActive ? 'Premium active' : isExpiredPremium ? 'Premium expired' : 'Free plan'}
+        </Badge>
+        <Badge variant="secondary">{cycleCount} saved</Badge>
+      </div>
+      <div className="cloud-library-stat-grid">
+        <CloudLibraryStat label="Cloud cycles" value={`${cycleCount}`} />
+        <CloudLibraryStat label="Writes" value={premiumActive ? 'Enabled' : 'Read-only'} />
+      </div>
+    </div>
+  </section>
+);
+
+/** Compact notice shown when premium has lapsed but cloud reads stay available. */
+const ExpiredPremiumNotice: React.FC = () => (
+  <Card className="cloud-library-notice-card">
+    <CardContent className="cloud-library-notice-content">
+      <AlertCircle className="h-5 w-5 text-warning shrink-0 mt-0.5" />
+      <div>
+        <strong>Premium expired</strong>
+        <p>
+          Your library is still readable, but new saves, renames, and deletes are locked until premium is active again.
+        </p>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+/** Combined utility card for access details and next actions. */
+const CloudLibraryUtilityCard: React.FC<{
+  premiumActive: boolean;
+  isExpiredPremium: boolean;
+}> = ({ premiumActive, isExpiredPremium }) => (
+  <Card className="cloud-library-support-card">
+    <CardHeader className="cloud-library-section-header">
+      <div className="cloud-library-support-title">
+        <ShieldCheck className="h-5 w-5 text-primary" />
+        <CardTitle>Storage access</CardTitle>
+      </div>
+      <CardDescription>Hosted saves live here. The forecast editor, discussions, verification, and exports still stay local-first.</CardDescription>
+    </CardHeader>
+    <CardContent className="cloud-library-support-content">
+      <div className="cloud-library-support-grid">
+        <CloudLibraryStat label="Mode" value={premiumActive ? 'Full access' : isExpiredPremium ? 'Read-only' : 'Locked'} />
+        <CloudLibraryStat label="Library" value={premiumActive ? 'Writable' : 'Readable'} />
+      </div>
+      <p className="cloud-library-support-copy">
+        {premiumActive
+          ? 'Save new versions from the toolbar and they will show up here automatically.'
+          : isExpiredPremium
+            ? 'Your saved cycles are still available to open, but writes stay off until premium is active again.'
+            : 'Premium unlocks hosted saves. Until then, your forecast workflow stays local.'}
+      </p>
+      <div className="cloud-library-divider" />
+      <div className="cloud-library-support-actions">
+        <Button asChild variant="default">
+          <Link to="/forecast">Back to Forecast Editor</Link>
+        </Button>
+        <Button asChild variant={premiumActive ? 'outline' : 'default'}>
+          <Link to="/pricing">{premiumActive ? 'View Pricing' : 'Upgrade to Premium'}</Link>
+        </Button>
+        {isExpiredPremium ? (
+          <p className="cloud-library-side-note">Renew premium to turn cloud writes back on.</p>
+        ) : null}
+      </div>
+    </CardContent>
+  </Card>
+);
+
+/** Empty library state with cleaner product-facing calls to action. */
+const EmptyState: React.FC<{ premiumActive: boolean }> = ({ premiumActive }) => (
+  <div className="cloud-library-empty-state">
+    <div className="cloud-library-empty-icon">
+      <FolderOpen className="h-8 w-8" />
+    </div>
+    <div className="cloud-library-empty-copy">
+      <h2>No cloud cycles saved yet</h2>
+      <p>
+        {premiumActive
+          ? 'Use the cloud save button in the forecast toolbar and your current package will land here.'
+          : 'Hosted cloud saves are part of premium. You can still keep working locally and upgrade when you want syncing.'}
+      </p>
+    </div>
+    <div className="cloud-library-empty-actions">
+      <Button asChild variant="default">
+        <Link to="/forecast">Open Forecast Editor</Link>
+      </Button>
+      <Button asChild variant={premiumActive ? 'outline' : 'default'}>
+        <Link to="/pricing">{premiumActive ? 'View Pricing' : 'See Premium'}</Link>
+      </Button>
+    </div>
+  </div>
+);
+
+/** Renaming controls shown in-place for one cloud cycle row. */
+const CycleRenameRow: React.FC<{
+  newLabel: string;
+  isBusy: boolean;
+  onLabelChange: (value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}> = ({ newLabel, isBusy, onLabelChange, onSave, onCancel }) => (
+  <div className="cloud-cycle-rename-row">
+    <Input
+      value={newLabel}
+      onChange={(e) => onLabelChange(e.target.value)}
+      placeholder="Cycle name"
+      disabled={isBusy}
+    />
+    <div className="cloud-cycle-inline-actions">
+      <Button variant="outline" size="sm" onClick={onCancel} disabled={isBusy}>
+        Cancel
+      </Button>
+      <Button size="sm" onClick={onSave} disabled={isBusy}>
+        {isBusy ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : null}
+        Save
+      </Button>
+    </div>
+  </div>
+);
+
+interface CycleItemProps {
+  cycle: CloudCycleMetadata;
+  canWrite: boolean;
+  loading: boolean;
+  onLoad: (cycleId: string) => Promise<void>;
+  onDelete: (cycleId: string) => Promise<void>;
+  onRename: (cycleId: string, newLabel: string) => Promise<void>;
+}
+
+/** One cloud cycle row inside the library list. */
+const CycleItem: React.FC<CycleItemProps> = ({ cycle, canWrite, loading, onLoad, onDelete, onRename }) => {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [isSavingRename, setIsSavingRename] = useState(false);
+  const [newLabel, setNewLabel] = useState(cycle.label);
+
+  const handleDelete = async () => {
+    if (!window.confirm(`Delete "${cycle.label}"? This action cannot be undone.`)) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      await onDelete(cycle.id);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleRenameSave = async () => {
+    if (!newLabel.trim() || newLabel.trim() === cycle.label) {
+      setIsRenaming(false);
+      setNewLabel(cycle.label);
+      return;
+    }
+
+    setIsSavingRename(true);
+    try {
+      await onRename(cycle.id, newLabel.trim());
+    } finally {
+      setIsSavingRename(false);
+      setIsRenaming(false);
+    }
+  };
+
+  return (
+    <Card className="cloud-library-surface-card cloud-cycle-card">
+      <CardContent className="cloud-cycle-card-content">
+        <div className="cloud-cycle-main">
+          <div className="cloud-cycle-header">
+            <div className="cloud-cycle-title-row">
+              <h3>{cycle.label}</h3>
+              {cycle.isReadOnly ? (
+                <Badge variant="outline">
+                  <Lock className="mr-1 h-3.5 w-3.5" />
+                  Read-only
+                </Badge>
+              ) : null}
+            </div>
+            <div className="cloud-cycle-meta">
+              <span>Cycle {cycle.cycleDate}</span>
+              <span>Updated {formatDate(cycle.updatedAt)}</span>
+            </div>
+          </div>
+
+          {isRenaming ? (
+            <CycleRenameRow
+              newLabel={newLabel}
+              isBusy={loading || isSavingRename}
+              onLabelChange={setNewLabel}
+              onSave={handleRenameSave}
+              onCancel={() => {
+                setIsRenaming(false);
+                setNewLabel(cycle.label);
+              }}
+            />
+          ) : null}
+
+          <div className="cloud-cycle-stats">
+            <CloudLibraryStat label="Forecast days" value={`${cycle.forecastDays}`} />
+            <CloudLibraryStat label="Outlooks" value={`${cycle.totalOutlooks}`} />
+            <CloudLibraryStat label="Features" value={`${cycle.totalFeatures}`} />
+          </div>
+        </div>
+
+        <div className="cloud-cycle-actions">
+          <Button variant="outline" onClick={() => onLoad(cycle.id)} disabled={loading || isDeleting || isSavingRename}>
+            <Download className="mr-2 h-4 w-4" />
+            Load
+          </Button>
+
+          {canWrite && !cycle.isReadOnly ? (
+            <>
+              <Button variant="outline" onClick={() => setIsRenaming(true)} disabled={loading || isDeleting || isSavingRename || isRenaming}>
+                <Edit2 className="mr-2 h-4 w-4" />
+                Rename
+              </Button>
+              <Button variant="destructive" onClick={handleDelete} disabled={loading || isDeleting || isSavingRename}>
+                {isDeleting ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
+                Delete
+              </Button>
+            </>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+/** Sign-in gate shown when a user reaches the cloud page without auth. */
+const SignedOutGate: React.FC = () => (
+  <div className="cloud-library-center-shell">
+    <Card className="cloud-library-surface-card cloud-library-auth-card">
+      <CardHeader className="cloud-library-section-header">
+        <CardTitle>Sign in to use your cloud library</CardTitle>
+        <CardDescription>
+          Hosted cycle storage is tied to your account, so you need to sign in before opening cloud saves.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="cloud-library-support-actions">
+        <Button asChild>
+          <Link to="/account">Sign In</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+/** Production-facing page for loading and managing cloud-hosted cycles. */
+const CloudLibraryPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const { premiumActive, effectiveSource } = useEntitlement();
+  const { cycles, loading, error, loadCycle, deleteCycle, renameCycle, refreshCycles } = useCloudCycles();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const canWrite = premiumActive;
+  const isExpiredPremium = !premiumActive && effectiveSource === 'stripe';
+  const cycleCountLabel = useMemo(() => `${cycles.length} cloud cycle${cycles.length === 1 ? '' : 's'}`, [cycles.length]);
+
+  const handleLoadCycle = useCallback(async (cycleId: string) => {
+    setMessage(null);
+    const payload = await loadCycle(cycleId);
+    if (!payload) {
+      return;
+    }
+
+    const selectedCycle = cycles.find((cycle) => cycle.id === cycleId);
+    sessionStorage.setItem('cloudCyclePayload', JSON.stringify(payload));
+    sessionStorage.setItem(
+      'cloudCycleMeta',
+      JSON.stringify({
+        id: cycleId,
+        label: selectedCycle?.label ?? 'Cloud Forecast',
+      })
+    );
+    navigate('/forecast');
+  }, [cycles, loadCycle, navigate]);
+
+  const handleDeleteCycle = useCallback(async (cycleId: string) => {
+    setMessage(null);
+    const success = await deleteCycle(cycleId);
+    if (success) {
+      setMessage('Cloud cycle deleted.');
+    }
+  }, [deleteCycle]);
+
+  const handleRenameCycle = useCallback(async (cycleId: string, newLabel: string) => {
+    setMessage(null);
+    const success = await renameCycle(cycleId, newLabel);
+    if (success) {
+      await refreshCycles();
+      setMessage('Cloud cycle renamed.');
+    }
+  }, [refreshCycles, renameCycle]);
+
+  if (!user) {
+    return <SignedOutGate />;
+  }
+
+  return (
+    <div className="cloud-library-page">
+      <div className="cloud-library-shell">
+        <CloudLibraryHero premiumActive={premiumActive} cycleCount={cycles.length} isExpiredPremium={isExpiredPremium} />
+
+        {isExpiredPremium ? <ExpiredPremiumNotice /> : null}
+        {error || message ? (
+          <Card className="cloud-library-surface-card">
+            <CardContent className="cloud-library-feedback">
+              {error ? <CloudOff className="h-5 w-5 text-destructive shrink-0 mt-0.5" /> : <Cloud className="h-5 w-5 text-primary shrink-0 mt-0.5" />}
+              <p>{error ?? message}</p>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        <div className="cloud-library-layout">
+          <div className="cloud-library-main">
+            <Card className="cloud-library-surface-card">
+              <CardHeader className="cloud-library-section-header">
+                <CardTitle>Your cloud cycles</CardTitle>
+                <CardDescription>Open a saved package, rename it, or clear out older copies.</CardDescription>
+              </CardHeader>
+              <CardContent className="cloud-library-list-content">
+                {loading && cycles.length === 0 ? (
+                  <div className="cloud-library-loading">
+                    <LoaderCircle className="h-6 w-6 animate-spin" />
+                  </div>
+                ) : cycles.length === 0 ? (
+                  <EmptyState premiumActive={premiumActive} />
+                ) : (
+                  <>
+                    <div className="cloud-library-list-header">
+                      <strong>{cycleCountLabel}</strong>
+                      {!premiumActive ? <Badge variant="outline">Read-only</Badge> : null}
+                    </div>
+
+                    <div className="cloud-library-list">
+                      {cycles.map((cycle) => (
+                        <CycleItem
+                          key={cycle.id}
+                          cycle={cycle}
+                          canWrite={canWrite}
+                          loading={loading}
+                          onLoad={handleLoadCycle}
+                          onDelete={handleDeleteCycle}
+                          onRename={handleRenameCycle}
+                        />
+                      ))}
+                    </div>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="cloud-library-side">
+            <CloudLibraryUtilityCard premiumActive={premiumActive} isExpiredPremium={isExpiredPremium} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CloudLibraryPage;

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -175,6 +175,7 @@ const CycleRenameRow: React.FC<{
 }> = ({ newLabel, isBusy, onLabelChange, onSave, onCancel }) => (
   <div className="cloud-cycle-rename-row">
     <Input
+      aria-label="Rename cloud cycle"
       value={newLabel}
       onChange={(e) => onLabelChange(e.target.value)}
       placeholder="Cycle name"
@@ -564,6 +565,26 @@ const useCloudLibraryActions = ({
 }): CloudLibraryActions => {
   const [message, setMessage] = useState<string | null>(null);
 
+  const persistCloudCycleToSession = useCallback(
+    (cycleId: string, label: string, payload: unknown): boolean => {
+      try {
+        sessionStorage.setItem('cloudCyclePayload', JSON.stringify(payload));
+        sessionStorage.setItem(
+          'cloudCycleMeta',
+          JSON.stringify({
+            id: cycleId,
+            label,
+          })
+        );
+        return true;
+      } catch {
+        setMessage('Unable to hand this cloud cycle off to the editor right now. Please try again.');
+        return false;
+      }
+    },
+    []
+  );
+
   /** Loads one hosted cycle into the forecast editor and preserves its cloud metadata in session storage. */
   const handleLoadCycle = useCallback(async (cycleId: string) => {
     setMessage(null);
@@ -573,16 +594,12 @@ const useCloudLibraryActions = ({
     }
 
     const selectedCycle = cycles.find((cycle) => cycle.id === cycleId);
-    sessionStorage.setItem('cloudCyclePayload', JSON.stringify(payload));
-    sessionStorage.setItem(
-      'cloudCycleMeta',
-      JSON.stringify({
-        id: cycleId,
-        label: selectedCycle?.label ?? 'Cloud Forecast',
-      })
-    );
+    if (!persistCloudCycleToSession(cycleId, selectedCycle?.label ?? 'Cloud Forecast', payload)) {
+      return;
+    }
+
     navigate('/forecast');
-  }, [cycles, loadCycle, navigate]);
+  }, [cycles, loadCycle, navigate, persistCloudCycleToSession]);
 
   /** Deletes one hosted cloud cycle and surfaces a short success message on completion. */
   const handleDeleteCycle = useCallback(async (cycleId: string) => {

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -316,6 +316,14 @@ interface CycleItemProps {
   onRename: (cycleId: string, newLabel: string) => Promise<void>;
 }
 
+interface CloudLibraryActions {
+  message: string | null;
+  setMessage: React.Dispatch<React.SetStateAction<string | null>>;
+  handleLoadCycle: (cycleId: string) => Promise<void>;
+  handleDeleteCycle: (cycleId: string) => Promise<void>;
+  handleRenameCycle: (cycleId: string, newLabel: string) => Promise<void>;
+}
+
 /** One cloud cycle row inside the library list. */
 const CycleItem: React.FC<CycleItemProps> = ({ cycle, canWrite, loading, onLoad, onDelete, onRename }) => {
   const [isDeleting, setIsDeleting] = useState(false);
@@ -538,17 +546,23 @@ const CloudLibrarySignedInLayout: React.FC<{
   </div>
 );
 
-/** Production-facing page for loading and managing cloud-hosted cycles. */
-const CloudLibraryPage: React.FC = () => {
-  const navigate = useNavigate();
-  const { user } = useAuth();
-  const { premiumActive, effectiveSource } = useEntitlement();
-  const { cycles, loading, error, loadCycle, deleteCycle, renameCycle, refreshCycles } = useCloudCycles();
+/** Creates the cloud library actions used by the page and keeps transient feedback local. */
+const useCloudLibraryActions = ({
+  cycles,
+  loadCycle,
+  deleteCycle,
+  renameCycle,
+  refreshCycles,
+  navigate,
+}: {
+  cycles: CloudCycleMetadata[];
+  loadCycle: ReturnType<typeof useCloudCycles>['loadCycle'];
+  deleteCycle: ReturnType<typeof useCloudCycles>['deleteCycle'];
+  renameCycle: ReturnType<typeof useCloudCycles>['renameCycle'];
+  refreshCycles: ReturnType<typeof useCloudCycles>['refreshCycles'];
+  navigate: ReturnType<typeof useNavigate>;
+}): CloudLibraryActions => {
   const [message, setMessage] = useState<string | null>(null);
-
-  const canWrite = premiumActive;
-  const isExpiredPremium = !premiumActive && effectiveSource === 'stripe';
-  const cycleCountLabel = useMemo(() => `${cycles.length} cloud cycle${cycles.length === 1 ? '' : 's'}`, [cycles.length]);
 
   /** Loads one hosted cycle into the forecast editor and preserves its cloud metadata in session storage. */
   const handleLoadCycle = useCallback(async (cycleId: string) => {
@@ -588,6 +602,39 @@ const CloudLibraryPage: React.FC = () => {
       setMessage('Cloud cycle renamed.');
     }
   }, [refreshCycles, renameCycle]);
+
+  return {
+    message,
+    setMessage,
+    handleLoadCycle,
+    handleDeleteCycle,
+    handleRenameCycle,
+  };
+};
+
+/** Production-facing page for loading and managing cloud-hosted cycles. */
+const CloudLibraryPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const { premiumActive, effectiveSource } = useEntitlement();
+  const { cycles, loading, error, loadCycle, deleteCycle, renameCycle, refreshCycles } = useCloudCycles();
+  const {
+    message,
+    handleLoadCycle,
+    handleDeleteCycle,
+    handleRenameCycle,
+  } = useCloudLibraryActions({
+    cycles,
+    loadCycle,
+    deleteCycle,
+    renameCycle,
+    refreshCycles,
+    navigate,
+  });
+
+  const canWrite = premiumActive;
+  const isExpiredPremium = !premiumActive && effectiveSource === 'stripe';
+  const cycleCountLabel = useMemo(() => `${cycles.length} cloud cycle${cycles.length === 1 ? '' : 's'}`, [cycles.length]);
 
   if (!user) {
     return <SignedOutGate />;

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -77,43 +77,65 @@ const ExpiredPremiumNotice: React.FC = () => (
   </Card>
 );
 
+/** Header block used by the combined cloud-library utility card. */
+const CloudLibraryUtilityHeader: React.FC = () => (
+  <CardHeader className="cloud-library-section-header">
+    <div className="cloud-library-support-title">
+      <ShieldCheck className="h-5 w-5 text-primary" />
+      <CardTitle>Storage access</CardTitle>
+    </div>
+    <CardDescription>
+      Hosted saves live here. The forecast editor, discussions, verification, and exports still stay local-first.
+    </CardDescription>
+  </CardHeader>
+);
+
+/** Context-sensitive helper copy shown in the right-side utility card. */
+const getUtilityCardCopy = (premiumActive: boolean, isExpiredPremium: boolean): string => {
+  if (premiumActive) {
+    return 'Save new versions from the toolbar and they will show up here automatically.';
+  }
+
+  if (isExpiredPremium) {
+    return 'Your saved cycles are still available to open, but writes stay off until premium is active again.';
+  }
+
+  return 'Premium unlocks hosted saves. Until then, your forecast workflow stays local.';
+};
+
+/** Support actions rendered in the right-side cloud utility card. */
+const CloudLibraryUtilityActions: React.FC<{
+  premiumActive: boolean;
+  isExpiredPremium: boolean;
+}> = ({ premiumActive, isExpiredPremium }) => (
+  <div className="cloud-library-support-actions">
+    <Button asChild variant="default">
+      <Link to="/forecast">Back to Forecast Editor</Link>
+    </Button>
+    <Button asChild variant={premiumActive ? 'outline' : 'default'}>
+      <Link to="/pricing">{premiumActive ? 'View Pricing' : 'Upgrade to Premium'}</Link>
+    </Button>
+    {isExpiredPremium ? (
+      <p className="cloud-library-side-note">Renew premium to turn cloud writes back on.</p>
+    ) : null}
+  </div>
+);
+
 /** Combined utility card for access details and next actions. */
 const CloudLibraryUtilityCard: React.FC<{
   premiumActive: boolean;
   isExpiredPremium: boolean;
 }> = ({ premiumActive, isExpiredPremium }) => (
   <Card className="cloud-library-support-card">
-    <CardHeader className="cloud-library-section-header">
-      <div className="cloud-library-support-title">
-        <ShieldCheck className="h-5 w-5 text-primary" />
-        <CardTitle>Storage access</CardTitle>
-      </div>
-      <CardDescription>Hosted saves live here. The forecast editor, discussions, verification, and exports still stay local-first.</CardDescription>
-    </CardHeader>
+    <CloudLibraryUtilityHeader />
     <CardContent className="cloud-library-support-content">
       <div className="cloud-library-support-grid">
         <CloudLibraryStat label="Mode" value={premiumActive ? 'Full access' : isExpiredPremium ? 'Read-only' : 'Locked'} />
         <CloudLibraryStat label="Library" value={premiumActive ? 'Writable' : 'Readable'} />
       </div>
-      <p className="cloud-library-support-copy">
-        {premiumActive
-          ? 'Save new versions from the toolbar and they will show up here automatically.'
-          : isExpiredPremium
-            ? 'Your saved cycles are still available to open, but writes stay off until premium is active again.'
-            : 'Premium unlocks hosted saves. Until then, your forecast workflow stays local.'}
-      </p>
+      <p className="cloud-library-support-copy">{getUtilityCardCopy(premiumActive, isExpiredPremium)}</p>
       <div className="cloud-library-divider" />
-      <div className="cloud-library-support-actions">
-        <Button asChild variant="default">
-          <Link to="/forecast">Back to Forecast Editor</Link>
-        </Button>
-        <Button asChild variant={premiumActive ? 'outline' : 'default'}>
-          <Link to="/pricing">{premiumActive ? 'View Pricing' : 'Upgrade to Premium'}</Link>
-        </Button>
-        {isExpiredPremium ? (
-          <p className="cloud-library-side-note">Renew premium to turn cloud writes back on.</p>
-        ) : null}
-      </div>
+      <CloudLibraryUtilityActions premiumActive={premiumActive} isExpiredPremium={isExpiredPremium} />
     </CardContent>
   </Card>
 );
@@ -170,6 +192,121 @@ const CycleRenameRow: React.FC<{
   </div>
 );
 
+/** Header block for one saved cloud cycle row. */
+const CloudCycleHeader: React.FC<{ cycle: CloudCycleMetadata }> = ({ cycle }) => (
+  <div className="cloud-cycle-header">
+    <div className="cloud-cycle-title-row">
+      <h3>{cycle.label}</h3>
+      {cycle.isReadOnly ? (
+        <Badge variant="outline">
+          <Lock className="mr-1 h-3.5 w-3.5" />
+          Read-only
+        </Badge>
+      ) : null}
+    </div>
+    <div className="cloud-cycle-meta">
+      <span>Cycle {cycle.cycleDate}</span>
+      <span>Updated {formatDate(cycle.updatedAt)}</span>
+    </div>
+  </div>
+);
+
+/** Stats row summarizing forecast density for one saved cloud cycle. */
+const CloudCycleStats: React.FC<{ cycle: CloudCycleMetadata }> = ({ cycle }) => (
+  <div className="cloud-cycle-stats">
+    <CloudLibraryStat label="Forecast days" value={`${cycle.forecastDays}`} />
+    <CloudLibraryStat label="Outlooks" value={`${cycle.totalOutlooks}`} />
+    <CloudLibraryStat label="Features" value={`${cycle.totalFeatures}`} />
+  </div>
+);
+
+/** Inline delete confirmation shown instead of a blocking browser confirm dialog. */
+const CloudCycleDeletePrompt: React.FC<{
+  cycleLabel: string;
+  isBusy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}> = ({ cycleLabel, isBusy, onCancel, onConfirm }) => (
+  <div className="cloud-cycle-delete-prompt">
+    <p>Delete "{cycleLabel}"? This action cannot be undone.</p>
+    <div className="cloud-cycle-inline-actions">
+      <Button variant="outline" size="sm" onClick={onCancel} disabled={isBusy}>
+        Keep
+      </Button>
+      <Button variant="destructive" size="sm" onClick={onConfirm} disabled={isBusy}>
+        {isBusy ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
+        Delete
+      </Button>
+    </div>
+  </div>
+);
+
+/** Action block for loading, renaming, and deleting one cloud cycle. */
+const CloudCycleActions: React.FC<{
+  canWrite: boolean;
+  loading: boolean;
+  cycle: CloudCycleMetadata;
+  isDeleting: boolean;
+  isSavingRename: boolean;
+  isRenaming: boolean;
+  confirmingDelete: boolean;
+  onLoad: () => void;
+  onStartRename: () => void;
+  onRequestDelete: () => void;
+  onCancelDelete: () => void;
+  onConfirmDelete: () => void;
+}> = ({
+  canWrite,
+  loading,
+  cycle,
+  isDeleting,
+  isSavingRename,
+  isRenaming,
+  confirmingDelete,
+  onLoad,
+  onStartRename,
+  onRequestDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}) => (
+  <div className="cloud-cycle-actions">
+    <Button variant="outline" onClick={onLoad} disabled={loading || isDeleting || isSavingRename}>
+      <Download className="mr-2 h-4 w-4" />
+      Load
+    </Button>
+
+    {canWrite && !cycle.isReadOnly ? (
+      <>
+        <Button
+          variant="outline"
+          onClick={onStartRename}
+          disabled={loading || isDeleting || isSavingRename || isRenaming || confirmingDelete}
+        >
+          <Edit2 className="mr-2 h-4 w-4" />
+          Rename
+        </Button>
+        {confirmingDelete ? (
+          <CloudCycleDeletePrompt
+            cycleLabel={cycle.label}
+            isBusy={loading || isDeleting}
+            onCancel={onCancelDelete}
+            onConfirm={onConfirmDelete}
+          />
+        ) : (
+          <Button
+            variant="destructive"
+            onClick={onRequestDelete}
+            disabled={loading || isDeleting || isSavingRename || isRenaming}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Delete
+          </Button>
+        )}
+      </>
+    ) : null}
+  </div>
+);
+
 interface CycleItemProps {
   cycle: CloudCycleMetadata;
   canWrite: boolean;
@@ -184,21 +321,21 @@ const CycleItem: React.FC<CycleItemProps> = ({ cycle, canWrite, loading, onLoad,
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [isSavingRename, setIsSavingRename] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [newLabel, setNewLabel] = useState(cycle.label);
 
+  /** Deletes the selected cloud cycle after the inline confirmation has been accepted. */
   const handleDelete = async () => {
-    if (!window.confirm(`Delete "${cycle.label}"? This action cannot be undone.`)) {
-      return;
-    }
-
     setIsDeleting(true);
     try {
       await onDelete(cycle.id);
+      setConfirmingDelete(false);
     } finally {
       setIsDeleting(false);
     }
   };
 
+  /** Saves a renamed cloud-cycle label and exits inline editing when the request completes. */
   const handleRenameSave = async () => {
     if (!newLabel.trim() || newLabel.trim() === cycle.label) {
       setIsRenaming(false);
@@ -219,21 +356,7 @@ const CycleItem: React.FC<CycleItemProps> = ({ cycle, canWrite, loading, onLoad,
     <Card className="cloud-library-surface-card cloud-cycle-card">
       <CardContent className="cloud-cycle-card-content">
         <div className="cloud-cycle-main">
-          <div className="cloud-cycle-header">
-            <div className="cloud-cycle-title-row">
-              <h3>{cycle.label}</h3>
-              {cycle.isReadOnly ? (
-                <Badge variant="outline">
-                  <Lock className="mr-1 h-3.5 w-3.5" />
-                  Read-only
-                </Badge>
-              ) : null}
-            </div>
-            <div className="cloud-cycle-meta">
-              <span>Cycle {cycle.cycleDate}</span>
-              <span>Updated {formatDate(cycle.updatedAt)}</span>
-            </div>
-          </div>
+          <CloudCycleHeader cycle={cycle} />
 
           {isRenaming ? (
             <CycleRenameRow
@@ -244,57 +367,174 @@ const CycleItem: React.FC<CycleItemProps> = ({ cycle, canWrite, loading, onLoad,
               onCancel={() => {
                 setIsRenaming(false);
                 setNewLabel(cycle.label);
+                setConfirmingDelete(false);
               }}
             />
           ) : null}
 
-          <div className="cloud-cycle-stats">
-            <CloudLibraryStat label="Forecast days" value={`${cycle.forecastDays}`} />
-            <CloudLibraryStat label="Outlooks" value={`${cycle.totalOutlooks}`} />
-            <CloudLibraryStat label="Features" value={`${cycle.totalFeatures}`} />
-          </div>
+          <CloudCycleStats cycle={cycle} />
         </div>
 
-        <div className="cloud-cycle-actions">
-          <Button variant="outline" onClick={() => onLoad(cycle.id)} disabled={loading || isDeleting || isSavingRename}>
-            <Download className="mr-2 h-4 w-4" />
-            Load
-          </Button>
-
-          {canWrite && !cycle.isReadOnly ? (
-            <>
-              <Button variant="outline" onClick={() => setIsRenaming(true)} disabled={loading || isDeleting || isSavingRename || isRenaming}>
-                <Edit2 className="mr-2 h-4 w-4" />
-                Rename
-              </Button>
-              <Button variant="destructive" onClick={handleDelete} disabled={loading || isDeleting || isSavingRename}>
-                {isDeleting ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
-                Delete
-              </Button>
-            </>
-          ) : null}
-        </div>
+        <CloudCycleActions
+          canWrite={canWrite}
+          loading={loading}
+          cycle={cycle}
+          isDeleting={isDeleting}
+          isSavingRename={isSavingRename}
+          isRenaming={isRenaming}
+          confirmingDelete={confirmingDelete}
+          onLoad={() => onLoad(cycle.id)}
+          onStartRename={() => {
+            setIsRenaming(true);
+            setConfirmingDelete(false);
+          }}
+          onRequestDelete={() => setConfirmingDelete(true)}
+          onCancelDelete={() => setConfirmingDelete(false)}
+          onConfirmDelete={handleDelete}
+        />
       </CardContent>
     </Card>
   );
 };
 
+/** Centered sign-in card body for the signed-out cloud-library state. */
+const CloudLibraryAuthCard: React.FC = () => (
+  <Card className="cloud-library-surface-card cloud-library-auth-card">
+    <CardHeader className="cloud-library-section-header">
+      <CardTitle>Sign in to use your cloud library</CardTitle>
+      <CardDescription>
+        Hosted cycle storage is tied to your account, so you need to sign in before opening cloud saves.
+      </CardDescription>
+    </CardHeader>
+    <CardContent className="cloud-library-support-actions">
+      <Button asChild>
+        <Link to="/account">Sign In</Link>
+      </Button>
+    </CardContent>
+  </Card>
+);
+
 /** Sign-in gate shown when a user reaches the cloud page without auth. */
 const SignedOutGate: React.FC = () => (
   <div className="cloud-library-center-shell">
-    <Card className="cloud-library-surface-card cloud-library-auth-card">
-      <CardHeader className="cloud-library-section-header">
-        <CardTitle>Sign in to use your cloud library</CardTitle>
-        <CardDescription>
-          Hosted cycle storage is tied to your account, so you need to sign in before opening cloud saves.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="cloud-library-support-actions">
-        <Button asChild>
-          <Link to="/account">Sign In</Link>
-        </Button>
-      </CardContent>
-    </Card>
+    <CloudLibraryAuthCard />
+  </div>
+);
+
+/** Lightweight feedback banner used for transient cloud-library status or error messages. */
+const CloudLibraryFeedbackCard: React.FC<{
+  error: string | null;
+  message: string | null;
+}> = ({ error, message }) => (
+  <Card className="cloud-library-surface-card">
+    <CardContent className="cloud-library-feedback">
+      {error ? (
+        <CloudOff className="h-5 w-5 shrink-0 text-destructive" />
+      ) : (
+        <Cloud className="h-5 w-5 shrink-0 text-primary" />
+      )}
+      <p>{error ?? message}</p>
+    </CardContent>
+  </Card>
+);
+
+/** Main library card that owns the saved-cycle list, empty state, and loading state. */
+const CloudLibraryMainCard: React.FC<{
+  loading: boolean;
+  cycles: CloudCycleMetadata[];
+  premiumActive: boolean;
+  canWrite: boolean;
+  cycleCountLabel: string;
+  onLoadCycle: (cycleId: string) => Promise<void>;
+  onDeleteCycle: (cycleId: string) => Promise<void>;
+  onRenameCycle: (cycleId: string, newLabel: string) => Promise<void>;
+}> = ({
+  loading,
+  cycles,
+  premiumActive,
+  canWrite,
+  cycleCountLabel,
+  onLoadCycle,
+  onDeleteCycle,
+  onRenameCycle,
+}) => (
+  <Card className="cloud-library-surface-card">
+    <CardHeader className="cloud-library-section-header">
+      <CardTitle>Your cloud cycles</CardTitle>
+      <CardDescription>Open a saved package, rename it, or clear out older copies.</CardDescription>
+    </CardHeader>
+    <CardContent className="cloud-library-list-content">
+      {loading && cycles.length === 0 ? (
+        <div className="cloud-library-loading">
+          <LoaderCircle className="h-6 w-6 animate-spin" />
+        </div>
+      ) : cycles.length === 0 ? (
+        <EmptyState premiumActive={premiumActive} />
+      ) : (
+        <>
+          <div className="cloud-library-list-header">
+            <strong>{cycleCountLabel}</strong>
+            {!premiumActive ? <Badge variant="outline">Read-only</Badge> : null}
+          </div>
+
+          <div className="cloud-library-list">
+            {cycles.map((cycle) => (
+              <CycleItem
+                key={cycle.id}
+                cycle={cycle}
+                canWrite={canWrite}
+                loading={loading}
+                onLoad={onLoadCycle}
+                onDelete={onDeleteCycle}
+                onRename={onRenameCycle}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </CardContent>
+  </Card>
+);
+
+/** Signed-in library layout tying together the main list and the utility rail. */
+const CloudLibrarySignedInLayout: React.FC<{
+  premiumActive: boolean;
+  isExpiredPremium: boolean;
+  loading: boolean;
+  cycles: CloudCycleMetadata[];
+  canWrite: boolean;
+  cycleCountLabel: string;
+  onLoadCycle: (cycleId: string) => Promise<void>;
+  onDeleteCycle: (cycleId: string) => Promise<void>;
+  onRenameCycle: (cycleId: string, newLabel: string) => Promise<void>;
+}> = ({
+  premiumActive,
+  isExpiredPremium,
+  loading,
+  cycles,
+  canWrite,
+  cycleCountLabel,
+  onLoadCycle,
+  onDeleteCycle,
+  onRenameCycle,
+}) => (
+  <div className="cloud-library-layout">
+    <div className="cloud-library-main">
+      <CloudLibraryMainCard
+        loading={loading}
+        cycles={cycles}
+        premiumActive={premiumActive}
+        canWrite={canWrite}
+        cycleCountLabel={cycleCountLabel}
+        onLoadCycle={onLoadCycle}
+        onDeleteCycle={onDeleteCycle}
+        onRenameCycle={onRenameCycle}
+      />
+    </div>
+
+    <div className="cloud-library-side">
+      <CloudLibraryUtilityCard premiumActive={premiumActive} isExpiredPremium={isExpiredPremium} />
+    </div>
   </div>
 );
 
@@ -310,6 +550,7 @@ const CloudLibraryPage: React.FC = () => {
   const isExpiredPremium = !premiumActive && effectiveSource === 'stripe';
   const cycleCountLabel = useMemo(() => `${cycles.length} cloud cycle${cycles.length === 1 ? '' : 's'}`, [cycles.length]);
 
+  /** Loads one hosted cycle into the forecast editor and preserves its cloud metadata in session storage. */
   const handleLoadCycle = useCallback(async (cycleId: string) => {
     setMessage(null);
     const payload = await loadCycle(cycleId);
@@ -329,6 +570,7 @@ const CloudLibraryPage: React.FC = () => {
     navigate('/forecast');
   }, [cycles, loadCycle, navigate]);
 
+  /** Deletes one hosted cloud cycle and surfaces a short success message on completion. */
   const handleDeleteCycle = useCallback(async (cycleId: string) => {
     setMessage(null);
     const success = await deleteCycle(cycleId);
@@ -337,6 +579,7 @@ const CloudLibraryPage: React.FC = () => {
     }
   }, [deleteCycle]);
 
+  /** Persists a renamed label for one hosted cloud cycle and refreshes the list metadata. */
   const handleRenameCycle = useCallback(async (cycleId: string, newLabel: string) => {
     setMessage(null);
     const success = await renameCycle(cycleId, newLabel);
@@ -356,59 +599,19 @@ const CloudLibraryPage: React.FC = () => {
         <CloudLibraryHero premiumActive={premiumActive} cycleCount={cycles.length} isExpiredPremium={isExpiredPremium} />
 
         {isExpiredPremium ? <ExpiredPremiumNotice /> : null}
-        {error || message ? (
-          <Card className="cloud-library-surface-card">
-            <CardContent className="cloud-library-feedback">
-              {error ? <CloudOff className="h-5 w-5 text-destructive shrink-0 mt-0.5" /> : <Cloud className="h-5 w-5 text-primary shrink-0 mt-0.5" />}
-              <p>{error ?? message}</p>
-            </CardContent>
-          </Card>
-        ) : null}
+        {error || message ? <CloudLibraryFeedbackCard error={error} message={message} /> : null}
 
-        <div className="cloud-library-layout">
-          <div className="cloud-library-main">
-            <Card className="cloud-library-surface-card">
-              <CardHeader className="cloud-library-section-header">
-                <CardTitle>Your cloud cycles</CardTitle>
-                <CardDescription>Open a saved package, rename it, or clear out older copies.</CardDescription>
-              </CardHeader>
-              <CardContent className="cloud-library-list-content">
-                {loading && cycles.length === 0 ? (
-                  <div className="cloud-library-loading">
-                    <LoaderCircle className="h-6 w-6 animate-spin" />
-                  </div>
-                ) : cycles.length === 0 ? (
-                  <EmptyState premiumActive={premiumActive} />
-                ) : (
-                  <>
-                    <div className="cloud-library-list-header">
-                      <strong>{cycleCountLabel}</strong>
-                      {!premiumActive ? <Badge variant="outline">Read-only</Badge> : null}
-                    </div>
-
-                    <div className="cloud-library-list">
-                      {cycles.map((cycle) => (
-                        <CycleItem
-                          key={cycle.id}
-                          cycle={cycle}
-                          canWrite={canWrite}
-                          loading={loading}
-                          onLoad={handleLoadCycle}
-                          onDelete={handleDeleteCycle}
-                          onRename={handleRenameCycle}
-                        />
-                      ))}
-                    </div>
-                  </>
-                )}
-              </CardContent>
-            </Card>
-          </div>
-
-          <div className="cloud-library-side">
-            <CloudLibraryUtilityCard premiumActive={premiumActive} isExpiredPremium={isExpiredPremium} />
-          </div>
-        </div>
+        <CloudLibrarySignedInLayout
+          premiumActive={premiumActive}
+          isExpiredPremium={isExpiredPremium}
+          loading={loading}
+          cycles={cycles}
+          canWrite={canWrite}
+          cycleCountLabel={cycleCountLabel}
+          onLoadCycle={handleLoadCycle}
+          onDeleteCycle={handleDeleteCycle}
+          onRenameCycle={handleRenameCycle}
+        />
       </div>
     </div>
   );

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -242,6 +242,85 @@ const CloudCycleDeletePrompt: React.FC<{
   </div>
 );
 
+/** Delete action control that swaps between the confirm prompt and the destructive button. */
+const CloudCycleDeleteAction: React.FC<{
+  confirmingDelete: boolean;
+  cycleLabel: string;
+  isBusy: boolean;
+  onRequestDelete: () => void;
+  onCancelDelete: () => void;
+  onConfirmDelete: () => void;
+}> = ({
+  confirmingDelete,
+  cycleLabel,
+  isBusy,
+  onRequestDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}) => {
+  if (confirmingDelete) {
+    return (
+      <CloudCycleDeletePrompt
+        cycleLabel={cycleLabel}
+        isBusy={isBusy}
+        onCancel={onCancelDelete}
+        onConfirm={onConfirmDelete}
+      />
+    );
+  }
+
+  return (
+    <Button variant="destructive" onClick={onRequestDelete} disabled={isBusy}>
+      <Trash2 className="mr-2 h-4 w-4" />
+      Delete
+    </Button>
+  );
+};
+
+/** Rename and delete actions shown only when the current cloud cycle can be edited. */
+const CloudCycleWriteActions: React.FC<{
+  cycle: CloudCycleMetadata;
+  canWrite: boolean;
+  isBusy: boolean;
+  isRenaming: boolean;
+  confirmingDelete: boolean;
+  onStartRename: () => void;
+  onRequestDelete: () => void;
+  onCancelDelete: () => void;
+  onConfirmDelete: () => void;
+}> = ({
+  cycle,
+  canWrite,
+  isBusy,
+  isRenaming,
+  confirmingDelete,
+  onStartRename,
+  onRequestDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}) => {
+  if (!canWrite || cycle.isReadOnly) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button variant="outline" onClick={onStartRename} disabled={isBusy || isRenaming || confirmingDelete}>
+        <Edit2 className="mr-2 h-4 w-4" />
+        Rename
+      </Button>
+      <CloudCycleDeleteAction
+        confirmingDelete={confirmingDelete}
+        cycleLabel={cycle.label}
+        isBusy={isBusy}
+        onRequestDelete={onRequestDelete}
+        onCancelDelete={onCancelDelete}
+        onConfirmDelete={onConfirmDelete}
+      />
+    </>
+  );
+};
+
 /** Action block for loading, renaming, and deleting one cloud cycle. */
 const CloudCycleActions: React.FC<{
   canWrite: boolean;
@@ -275,36 +354,17 @@ const CloudCycleActions: React.FC<{
       <Download className="mr-2 h-4 w-4" />
       Load
     </Button>
-
-    {canWrite && !cycle.isReadOnly ? (
-      <>
-        <Button
-          variant="outline"
-          onClick={onStartRename}
-          disabled={loading || isDeleting || isSavingRename || isRenaming || confirmingDelete}
-        >
-          <Edit2 className="mr-2 h-4 w-4" />
-          Rename
-        </Button>
-        {confirmingDelete ? (
-          <CloudCycleDeletePrompt
-            cycleLabel={cycle.label}
-            isBusy={loading || isDeleting}
-            onCancel={onCancelDelete}
-            onConfirm={onConfirmDelete}
-          />
-        ) : (
-          <Button
-            variant="destructive"
-            onClick={onRequestDelete}
-            disabled={loading || isDeleting || isSavingRename || isRenaming}
-          >
-            <Trash2 className="mr-2 h-4 w-4" />
-            Delete
-          </Button>
-        )}
-      </>
-    ) : null}
+    <CloudCycleWriteActions
+      cycle={cycle}
+      canWrite={canWrite}
+      isBusy={loading || isDeleting || isSavingRename}
+      isRenaming={isRenaming}
+      confirmingDelete={confirmingDelete}
+      onStartRename={onStartRename}
+      onRequestDelete={onRequestDelete}
+      onCancelDelete={onCancelDelete}
+      onConfirmDelete={onConfirmDelete}
+    />
   </div>
 );
 

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -535,12 +535,17 @@ const clearStoredCloudSession = () => {
   sessionStorage.removeItem(CLOUD_CYCLE_META_KEY);
 };
 
+/** Returns true when stored cloud metadata includes the id and label needed to restore selection context. */
+const hasRestorableCloudSelection = (
+  cloudMeta: StoredCloudMeta | null
+): cloudMeta is Required<Pick<StoredCloudMeta, 'id' | 'label'>> => Boolean(cloudMeta?.id && cloudMeta.label);
+
 /** Notifies the forecast page about the cloud cycle that was just restored when metadata is complete. */
 const restoreCloudSelectionContext = (
   cloudMeta: StoredCloudMeta | null,
   onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
 ) => {
-  if (!cloudMeta?.id || !cloudMeta.label || !onCloudCycleLoaded) {
+  if (!onCloudCycleLoaded || !hasRestorableCloudSelection(cloudMeta)) {
     return;
   }
 

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -29,7 +29,7 @@ import useAutoCategorical from '../hooks/useAutoCategorical';
 import type { AddToastFn } from '../components/Layout';
 import { useAuth } from '../auth/AuthProvider';
 import { useEntitlement } from '../billing/EntitlementProvider';
-import { useCloudCycles } from '../hooks/useCloudCycles';
+import { useCloudCycles, type UseCloudCyclesResult } from '../hooks/useCloudCycles';
 import { useCloudSync } from '../hooks/useCloudSync';
 import { CloudToolbarButton } from '../components/CloudCycleManager/CloudToolbarButton';
 import { countForecastMetrics } from '../utils/forecastMetrics';
@@ -97,6 +97,11 @@ const buildMapView = (ref: React.RefObject<ForecastMapHandle | null>) => {
 interface LoadedForecastPayload {
   rawData: { mapView?: { center: [number, number]; zoom: number } };
   deserializedCycle: ReturnType<typeof deserializeForecast>;
+}
+
+interface StoredCloudMeta {
+  id?: string;
+  label?: string;
 }
 
 /** Reads and validates a forecast JSON file, returning the parsed payload or null on failure. */
@@ -480,6 +485,82 @@ const useFeatureFlagSync = (
   }, [dispatch, featureFlags]);
 };
 
+/** Reads and validates one stored forecast payload string from browser storage. */
+const parseStoredForecastPayload = (storedValue: string | null): unknown | null => {
+  if (!storedValue) {
+    return null;
+  }
+
+  const parsed = JSON.parse(storedValue) as unknown;
+  return validateForecastData(parsed) ? parsed : null;
+};
+
+/** Applies one stored forecast payload into Redux and restores the saved map view when present. */
+const restoreStoredForecastPayload = (
+  data: unknown,
+  dispatch: ShortcutDispatch
+) => {
+  const deserializedCycle = deserializeForecast(data);
+  dispatch(importForecastCycle(deserializedCycle));
+
+  const rawData = data as LoadedForecastPayload['rawData'];
+  if (rawData.mapView) {
+    dispatch(setMapView(rawData.mapView));
+  }
+};
+
+/** Reads the stored cloud-cycle metadata payload when it exists and is well-formed. */
+const parseStoredCloudMeta = (storedValue: string | null): StoredCloudMeta | null => {
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(storedValue) as StoredCloudMeta;
+  } catch {
+    return null;
+  }
+};
+
+/** Restores a cloud-loaded forecast from session storage when one is waiting to be opened. */
+const restoreCloudSession = (
+  dispatch: ShortcutDispatch,
+  addToast: AddToastFn,
+  onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
+): boolean => {
+  const cloudPayloadStr = sessionStorage.getItem('cloudCyclePayload');
+  const data = parseStoredForecastPayload(cloudPayloadStr);
+  if (!data) {
+    return false;
+  }
+
+  const cloudMeta = parseStoredCloudMeta(sessionStorage.getItem('cloudCycleMeta'));
+  sessionStorage.removeItem('cloudCyclePayload');
+  sessionStorage.removeItem('cloudCycleMeta');
+
+  restoreStoredForecastPayload(data, dispatch);
+  if (cloudMeta?.id && cloudMeta.label && onCloudCycleLoaded) {
+    onCloudCycleLoaded({ id: cloudMeta.id, label: cloudMeta.label });
+  }
+
+  addToast('Cloud forecast loaded successfully.', 'success');
+  return true;
+};
+
+/** Restores the last local auto-saved forecast when no cloud-loaded payload is pending. */
+const restoreLocalSession = (
+  dispatch: ShortcutDispatch,
+  addToast: AddToastFn
+): void => {
+  const data = parseStoredForecastPayload(localStorage.getItem('forecastData'));
+  if (!data) {
+    return;
+  }
+
+  restoreStoredForecastPayload(data, dispatch);
+  addToast('Session restored from auto-save.', 'success');
+};
+
 /** Attempts to restore the last auto-saved forecast session from localStorage on mount. */
 const useSessionRestore = (
   dispatch: ShortcutDispatch,
@@ -494,49 +575,11 @@ const useSessionRestore = (
 
   useEffect(() => {
     try {
-      // First, check if a cloud payload was loaded (takes priority)
-      const cloudPayloadStr = sessionStorage.getItem('cloudCyclePayload');
-      if (cloudPayloadStr) {
-        const cloudMetaStr = sessionStorage.getItem('cloudCycleMeta');
-        if (cloudMetaStr) {
-          sessionStorage.removeItem('cloudCycleMeta');
-        }
-        sessionStorage.removeItem('cloudCyclePayload');
-        const data = JSON.parse(cloudPayloadStr);
-        if (!validateForecastData(data)) return;
-
-        const deserializedCycle = deserializeForecast(data);
-        dispatch(importForecastCycle(deserializedCycle));
-        if (data.mapView) {
-          dispatch(setMapView(data.mapView));
-        }
-        if (cloudMetaStr && onCloudCycleLoadedRef.current) {
-          try {
-            const cloudMeta = JSON.parse(cloudMetaStr) as { id?: string; label?: string };
-            if (typeof cloudMeta.id === 'string' && typeof cloudMeta.label === 'string') {
-              onCloudCycleLoadedRef.current({ id: cloudMeta.id, label: cloudMeta.label });
-            }
-          } catch {
-            // If the cloud metadata is malformed, still load the cycle data.
-          }
-        }
-        addToast('Cloud forecast loaded successfully.', 'success');
+      if (restoreCloudSession(dispatch, addToast, onCloudCycleLoadedRef.current)) {
         return;
       }
 
-      // Fall back to local auto-save
-      const savedData = localStorage.getItem('forecastData');
-      if (!savedData) return;
-
-      const data = JSON.parse(savedData);
-      if (!validateForecastData(data)) return;
-
-      const deserializedCycle = deserializeForecast(data);
-      dispatch(importForecastCycle(deserializedCycle));
-      if (data.mapView) {
-        dispatch(setMapView(data.mapView));
-      }
-      addToast('Session restored from auto-save.', 'success');
+      restoreLocalSession(dispatch, addToast);
     } catch {
       // Silently skip auto-load errors to avoid disrupting initial render
     }
@@ -626,6 +669,86 @@ const useKeyboardShortcuts = ({
   }, [dispatch, addToast, drawingState, isSaved, canUndo, canRedo, handleSave, fileInputRef, mapRef, currentDay]);
 };
 
+/** Returns the cloud-cycle restore callback and cloud-save action used by the forecast toolbar. */
+const useCloudForecastActions = ({
+  addToast,
+  currentMapView,
+  forecastCycle,
+  markAsCurrent,
+  markCurrentStateSynced,
+  saveCycle,
+  userId,
+}: {
+  addToast: AddToastFn;
+  currentMapView: RootState['forecast']['currentMapView'];
+  forecastCycle: ReturnType<typeof selectForecastCycle>;
+  markAsCurrent: UseCloudCyclesResult['markAsCurrent'];
+  markCurrentStateSynced: () => void;
+  saveCycle: UseCloudCyclesResult['saveCycle'];
+  userId: string | undefined;
+}) => {
+  const handleCloudCycleLoaded = useCallback(
+    (cloudCycle: { id: string; label: string }) => {
+      markAsCurrent(cloudCycle.id, cloudCycle.label);
+      markCurrentStateSynced();
+    },
+    [markAsCurrent, markCurrentStateSynced]
+  );
+
+  const handleSaveToCloud = useCallback(
+    async (label: string) => {
+      if (!userId) {
+        throw new Error('Sign in to save forecasts to the cloud.');
+      }
+
+      const payload = serializeForecast(forecastCycle, currentMapView);
+      const stats = countForecastMetrics(forecastCycle);
+      const success = await saveCycle(label, forecastCycle.cycleDate, stats, payload);
+
+      if (!success) {
+        throw new Error('Unable to save this forecast to the cloud right now.');
+      }
+
+      markCurrentStateSynced();
+      addToast(`Saved "${label}" to the cloud.`, 'success');
+    },
+    [addToast, currentMapView, forecastCycle, markCurrentStateSynced, saveCycle, userId]
+  );
+
+  return {
+    handleCloudCycleLoaded,
+    handleSaveToCloud,
+  };
+};
+
+/** Creates the cloud toolbar node so the page body stays focused on layout. */
+const renderCloudToolbar = ({
+  premiumActive,
+  isExpiredPremium,
+  forecastCycle,
+  currentCloud,
+  onSaveToCloud,
+  onOpenCloudLibrary,
+}: {
+  premiumActive: boolean;
+  isExpiredPremium: boolean;
+  forecastCycle: ReturnType<typeof selectForecastCycle>;
+  currentCloud: UseCloudCyclesResult['currentCloud'];
+  onSaveToCloud: (label: string) => Promise<void>;
+  onOpenCloudLibrary: () => void;
+}) => (
+  <CloudToolbarButton
+    canSave={premiumActive}
+    premiumActive={premiumActive}
+    isExpiredPremium={isExpiredPremium}
+    currentCycleDate={forecastCycle.cycleDate}
+    currentCloudLabel={currentCloud?.label}
+    syncState={currentCloud?.syncState}
+    onSaveToCloud={onSaveToCloud}
+    onOpenCloudLibrary={onOpenCloudLibrary}
+  />
+);
+
 /** Root forecast page: mounts the full-screen map with the integrated toolbar and wires all hooks. */
 export const ForecastPage: React.FC = () => {
   const dispatch = useDispatch();
@@ -655,36 +778,18 @@ export const ForecastPage: React.FC = () => {
   useAutoSave();
   useCycleHistoryPersistence();
   useFeatureFlagSync(dispatch, featureFlags);
-  const handleCloudCycleLoaded = useCallback(
-    (cloudCycle: { id: string; label: string }) => {
-      markAsCurrent(cloudCycle.id, cloudCycle.label);
-      markCurrentStateSynced();
-    },
-    [markAsCurrent, markCurrentStateSynced]
-  );
+  const { handleCloudCycleLoaded, handleSaveToCloud } = useCloudForecastActions({
+    addToast,
+    currentMapView,
+    forecastCycle,
+    markAsCurrent,
+    markCurrentStateSynced,
+    saveCycle,
+    userId: user?.uid,
+  });
 
   useSessionRestore(dispatch, addToast, handleCloudCycleLoaded);
   useUnsavedChangesWarning(isSaved);
-
-  const handleSaveToCloud = useCallback(
-    async (label: string) => {
-      if (!user?.uid) {
-        throw new Error('Sign in to save forecasts to the cloud.');
-      }
-
-      const payload = serializeForecast(forecastCycle, currentMapView);
-      const stats = countForecastMetrics(forecastCycle);
-      const success = await saveCycle(label, forecastCycle.cycleDate, stats, payload);
-
-      if (!success) {
-        throw new Error('Unable to save this forecast to the cloud right now.');
-      }
-
-      markCurrentStateSynced();
-      addToast(`Saved "${label}" to the cloud.`, 'success');
-    },
-    [addToast, currentMapView, forecastCycle, markCurrentStateSynced, saveCycle, user?.uid]
-  );
 
   const { handleSave, handleLoad, handleShortcutFileInputChange } = useForecastFileActions(
     dispatch,
@@ -732,18 +837,14 @@ export const ForecastPage: React.FC = () => {
         onLoad={handleLoad}
         mapRef={mapRef}
         addToast={addToast}
-        cloudTools={(
-          <CloudToolbarButton
-            canSave={premiumActive}
-            premiumActive={premiumActive}
-            isExpiredPremium={isExpiredPremium}
-            currentCycleDate={forecastCycle.cycleDate}
-            currentCloudLabel={currentCloud?.label}
-            syncState={currentCloud?.syncState}
-            onSaveToCloud={handleSaveToCloud}
-            onOpenCloudLibrary={() => navigate('/cloud')}
-          />
-        )}
+        cloudTools={renderCloudToolbar({
+          premiumActive,
+          isExpiredPremium,
+          forecastCycle,
+          currentCloud,
+          onSaveToCloud: handleSaveToCloud,
+          onOpenCloudLibrary: () => navigate('/cloud'),
+        })}
       />
     </div>
   );

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import type { Dispatch, UnknownAction } from 'redux';
@@ -103,6 +103,9 @@ interface StoredCloudMeta {
   id?: string;
   label?: string;
 }
+
+const CLOUD_CYCLE_PAYLOAD_KEY = 'cloudCyclePayload';
+const CLOUD_CYCLE_META_KEY = 'cloudCycleMeta';
 
 /** Reads and validates a forecast JSON file, returning the parsed payload or null on failure. */
 const parseLoadedForecast = async (
@@ -522,27 +525,32 @@ const parseStoredCloudMeta = (storedValue: string | null): StoredCloudMeta | nul
   }
 };
 
+/** Clears the temporary session-storage keys used for handing a cloud cycle into the editor. */
+const clearStoredCloudSession = () => {
+  sessionStorage.removeItem(CLOUD_CYCLE_PAYLOAD_KEY);
+  sessionStorage.removeItem(CLOUD_CYCLE_META_KEY);
+};
+
 /** Restores a cloud-loaded forecast from session storage when one is waiting to be opened. */
 const restoreCloudSession = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
   onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
 ): boolean => {
-  const cloudPayloadStr = sessionStorage.getItem('cloudCyclePayload');
+  const cloudPayloadStr = sessionStorage.getItem(CLOUD_CYCLE_PAYLOAD_KEY);
   const data = parseStoredForecastPayload(cloudPayloadStr);
   if (!data) {
     return false;
   }
 
-  const cloudMeta = parseStoredCloudMeta(sessionStorage.getItem('cloudCycleMeta'));
-  sessionStorage.removeItem('cloudCyclePayload');
-  sessionStorage.removeItem('cloudCycleMeta');
+  const cloudMeta = parseStoredCloudMeta(sessionStorage.getItem(CLOUD_CYCLE_META_KEY));
 
   restoreStoredForecastPayload(data, dispatch);
   if (cloudMeta?.id && cloudMeta.label && onCloudCycleLoaded) {
     onCloudCycleLoaded({ id: cloudMeta.id, label: cloudMeta.label });
   }
 
+  clearStoredCloudSession();
   addToast('Cloud forecast loaded successfully.', 'success');
   return true;
 };

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useOutletContext } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 import type { Dispatch, UnknownAction } from 'redux';
 import ForecastMap, { ForecastMapHandle } from '../components/Map/ForecastMap';
 import { IntegratedToolbar } from '../components/IntegratedToolbar/IntegratedToolbar';
@@ -27,6 +27,13 @@ import { useAutoSave } from '../hooks/useAutoSave';
 import { useCycleHistoryPersistence } from '../utils/cycleHistoryPersistence';
 import useAutoCategorical from '../hooks/useAutoCategorical';
 import type { AddToastFn } from '../components/Layout';
+import { useAuth } from '../auth/AuthProvider';
+import { useEntitlement } from '../billing/EntitlementProvider';
+import { useCloudCycles } from '../hooks/useCloudCycles';
+import { useCloudSync } from '../hooks/useCloudSync';
+import { CloudToolbarButton } from '../components/CloudCycleManager/CloudToolbarButton';
+import { countForecastMetrics } from '../utils/forecastMetrics';
+import { serializeForecast } from '../utils/fileUtils';
 
 interface PageContext {
   addToast: AddToastFn;
@@ -477,10 +484,48 @@ const useFeatureFlagSync = (
 /** Attempts to restore the last auto-saved forecast session from localStorage on mount. */
 const useSessionRestore = (
   dispatch: ShortcutDispatch,
-  addToast: AddToastFn
+  addToast: AddToastFn,
+  onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
 ) => {
+  const onCloudCycleLoadedRef = useRef(onCloudCycleLoaded);
+
+  useEffect(() => {
+    onCloudCycleLoadedRef.current = onCloudCycleLoaded;
+  }, [onCloudCycleLoaded]);
+
   useEffect(() => {
     try {
+      // First, check if a cloud payload was loaded (takes priority)
+      const cloudPayloadStr = sessionStorage.getItem('cloudCyclePayload');
+      if (cloudPayloadStr) {
+        const cloudMetaStr = sessionStorage.getItem('cloudCycleMeta');
+        if (cloudMetaStr) {
+          sessionStorage.removeItem('cloudCycleMeta');
+        }
+        sessionStorage.removeItem('cloudCyclePayload');
+        const data = JSON.parse(cloudPayloadStr);
+        if (!validateForecastData(data)) return;
+
+        const deserializedCycle = deserializeForecast(data);
+        dispatch(importForecastCycle(deserializedCycle));
+        if (data.mapView) {
+          dispatch(setMapView(data.mapView));
+        }
+        if (cloudMetaStr && onCloudCycleLoadedRef.current) {
+          try {
+            const cloudMeta = JSON.parse(cloudMetaStr) as { id?: string; label?: string };
+            if (typeof cloudMeta.id === 'string' && typeof cloudMeta.label === 'string') {
+              onCloudCycleLoadedRef.current({ id: cloudMeta.id, label: cloudMeta.label });
+            }
+          } catch {
+            // If the cloud metadata is malformed, still load the cycle data.
+          }
+        }
+        addToast('Cloud forecast loaded successfully.', 'success');
+        return;
+      }
+
+      // Fall back to local auto-save
       const savedData = localStorage.getItem('forecastData');
       if (!savedData) return;
 
@@ -585,26 +630,62 @@ const useKeyboardShortcuts = ({
 /** Root forecast page: mounts the full-screen map with the integrated toolbar and wires all hooks. */
 export const ForecastPage: React.FC = () => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { addToast } = useOutletContext<PageContext>();
   const mapRef = useRef<ForecastMapHandle>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const featureFlags = useSelector((state: RootState) => state.featureFlags);
   const forecastCycle = useSelector(selectForecastCycle);
+  const currentMapView = useSelector((state: RootState) => state.forecast.currentMapView);
   const isSaved = useSelector((state: RootState) => state.forecast.isSaved);
   const canUndo = useSelector(selectCanUndo);
   const canRedo = useSelector(selectCanRedo);
   const emergencyMode = useSelector((state: RootState) => state.forecast.emergencyMode);
   const drawingState = useSelector((state: RootState) => state.forecast.drawingState);
+  const { user } = useAuth();
+  const { premiumActive, effectiveSource } = useEntitlement();
+  const cloudCycles = useCloudCycles();
+  const { currentCloud, saveCycle, markAsCurrent } = cloudCycles;
+  const cloudSync = useCloudSync(cloudCycles);
+  const { markCurrentStateSynced } = cloudSync;
+  const isExpiredPremium = !premiumActive && effectiveSource === 'stripe';
 
   // Hooks
   useAutoCategorical();
   useAutoSave();
   useCycleHistoryPersistence();
-
   useFeatureFlagSync(dispatch, featureFlags);
-  useSessionRestore(dispatch, addToast);
+  const handleCloudCycleLoaded = useCallback(
+    (cloudCycle: { id: string; label: string }) => {
+      markAsCurrent(cloudCycle.id, cloudCycle.label);
+      markCurrentStateSynced();
+    },
+    [markAsCurrent, markCurrentStateSynced]
+  );
+
+  useSessionRestore(dispatch, addToast, handleCloudCycleLoaded);
   useUnsavedChangesWarning(isSaved);
+
+  const handleSaveToCloud = useCallback(
+    async (label: string) => {
+      if (!user?.uid) {
+        throw new Error('Sign in to save forecasts to the cloud.');
+      }
+
+      const payload = serializeForecast(forecastCycle, currentMapView);
+      const stats = countForecastMetrics(forecastCycle);
+      const success = await saveCycle(label, forecastCycle.cycleDate, stats, payload);
+
+      if (!success) {
+        throw new Error('Unable to save this forecast to the cloud right now.');
+      }
+
+      markCurrentStateSynced();
+      addToast(`Saved "${label}" to the cloud.`, 'success');
+    },
+    [addToast, currentMapView, forecastCycle, markCurrentStateSynced, saveCycle, user?.uid]
+  );
 
   const { handleSave, handleLoad, handleShortcutFileInputChange } = useForecastFileActions(
     dispatch,
@@ -652,6 +733,18 @@ export const ForecastPage: React.FC = () => {
         onLoad={handleLoad}
         mapRef={mapRef}
         addToast={addToast}
+        cloudTools={(
+          <CloudToolbarButton
+            canSave={premiumActive}
+            premiumActive={premiumActive}
+            isExpiredPremium={isExpiredPremium}
+            currentCycleDate={forecastCycle.cycleDate}
+            currentCloudLabel={currentCloud?.label}
+            syncState={currentCloud?.syncState}
+            onSaveToCloud={handleSaveToCloud}
+            onOpenCloudLibrary={() => navigate('/cloud')}
+          />
+        )}
       />
     </div>
   );

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -494,8 +494,12 @@ const parseStoredForecastPayload = (storedValue: string | null): unknown | null 
     return null;
   }
 
-  const parsed = JSON.parse(storedValue) as unknown;
-  return validateForecastData(parsed) ? parsed : null;
+  try {
+    const parsed = JSON.parse(storedValue) as unknown;
+    return validateForecastData(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 };
 
 /** Applies one stored forecast payload into Redux and restores the saved map view when present. */

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -531,6 +531,18 @@ const clearStoredCloudSession = () => {
   sessionStorage.removeItem(CLOUD_CYCLE_META_KEY);
 };
 
+/** Notifies the forecast page about the cloud cycle that was just restored when metadata is complete. */
+const restoreCloudSelectionContext = (
+  cloudMeta: StoredCloudMeta | null,
+  onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
+) => {
+  if (!cloudMeta?.id || !cloudMeta.label || !onCloudCycleLoaded) {
+    return;
+  }
+
+  onCloudCycleLoaded({ id: cloudMeta.id, label: cloudMeta.label });
+};
+
 /** Restores a cloud-loaded forecast from session storage when one is waiting to be opened. */
 const restoreCloudSession = (
   dispatch: ShortcutDispatch,
@@ -546,10 +558,7 @@ const restoreCloudSession = (
   const cloudMeta = parseStoredCloudMeta(sessionStorage.getItem(CLOUD_CYCLE_META_KEY));
 
   restoreStoredForecastPayload(data, dispatch);
-  if (cloudMeta?.id && cloudMeta.label && onCloudCycleLoaded) {
-    onCloudCycleLoaded({ id: cloudMeta.id, label: cloudMeta.label });
-  }
-
+  restoreCloudSelectionContext(cloudMeta, onCloudCycleLoaded);
   clearStoredCloudSession();
   addToast('Cloud forecast loaded successfully.', 'success');
   return true;
@@ -569,6 +578,20 @@ const restoreLocalSession = (
   addToast('Session restored from auto-save.', 'success');
 };
 
+/** Restores a pending cloud session first, then falls back to the local auto-save snapshot. */
+const restoreAvailableSession = (
+  dispatch: ShortcutDispatch,
+  addToast: AddToastFn,
+  onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
+) => {
+  const restoredCloudSession = restoreCloudSession(dispatch, addToast, onCloudCycleLoaded);
+  if (restoredCloudSession) {
+    return;
+  }
+
+  restoreLocalSession(dispatch, addToast);
+};
+
 /** Attempts to restore the last auto-saved forecast session from localStorage on mount. */
 const useSessionRestore = (
   dispatch: ShortcutDispatch,
@@ -583,11 +606,7 @@ const useSessionRestore = (
 
   useEffect(() => {
     try {
-      if (restoreCloudSession(dispatch, addToast, onCloudCycleLoadedRef.current)) {
-        return;
-      }
-
-      restoreLocalSession(dispatch, addToast);
+      restoreAvailableSession(dispatch, addToast, onCloudCycleLoadedRef.current);
     } catch {
       // Silently skip auto-load errors to avoid disrupting initial render
     }
@@ -757,14 +776,20 @@ const renderCloudToolbar = ({
   />
 );
 
-/** Root forecast page: mounts the full-screen map with the integrated toolbar and wires all hooks. */
-export const ForecastPage: React.FC = () => {
-  const dispatch = useDispatch();
-  const navigate = useNavigate();
-  const { addToast } = useOutletContext<PageContext>();
-  const mapRef = useRef<ForecastMapHandle>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
+/** Composes the forecast page's cloud, file, and shortcut hooks into a single workspace model. */
+const useForecastPageWorkspace = ({
+  dispatch,
+  addToast,
+  navigate,
+  mapRef,
+  fileInputRef,
+}: {
+  dispatch: ShortcutDispatch;
+  addToast: AddToastFn;
+  navigate: ReturnType<typeof useNavigate>;
+  mapRef: React.RefObject<ForecastMapHandle | null>;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+}) => {
   const featureFlags = useSelector((state: RootState) => state.featureFlags);
   const forecastCycle = useSelector(selectForecastCycle);
   const currentMapView = useSelector((state: RootState) => state.forecast.currentMapView);
@@ -781,11 +806,11 @@ export const ForecastPage: React.FC = () => {
   const { markCurrentStateSynced } = cloudSync;
   const isExpiredPremium = !premiumActive && effectiveSource === 'stripe';
 
-  // Hooks
   useAutoCategorical();
   useAutoSave();
   useCycleHistoryPersistence();
   useFeatureFlagSync(dispatch, featureFlags);
+
   const { handleCloudCycleLoaded, handleSaveToCloud } = useCloudForecastActions({
     addToast,
     currentMapView,
@@ -819,6 +844,43 @@ export const ForecastPage: React.FC = () => {
     currentDay: forecastCycle.currentDay,
   });
 
+  return {
+    emergencyMode,
+    handleLoad,
+    handleSave,
+    handleShortcutFileInputChange,
+    cloudTools: renderCloudToolbar({
+      premiumActive,
+      isExpiredPremium,
+      forecastCycle,
+      currentCloud,
+      onSaveToCloud: handleSaveToCloud,
+      onOpenCloudLibrary: () => navigate('/cloud'),
+    }),
+  };
+};
+
+/** Root forecast page: mounts the full-screen map with the integrated toolbar and wires all hooks. */
+export const ForecastPage: React.FC = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { addToast } = useOutletContext<PageContext>();
+  const mapRef = useRef<ForecastMapHandle>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    emergencyMode,
+    handleLoad,
+    handleSave,
+    handleShortcutFileInputChange,
+    cloudTools,
+  } = useForecastPageWorkspace({
+    dispatch,
+    addToast,
+    navigate,
+    mapRef,
+    fileInputRef,
+  });
+
   if (emergencyMode) {
     return <EmergencyModeMessage />;
   }
@@ -845,14 +907,7 @@ export const ForecastPage: React.FC = () => {
         onLoad={handleLoad}
         mapRef={mapRef}
         addToast={addToast}
-        cloudTools={renderCloudToolbar({
-          premiumActive,
-          isExpiredPremium,
-          forecastCycle,
-          currentCloud,
-          onSaveToCloud: handleSaveToCloud,
-          onOpenCloudLibrary: () => navigate('/cloud'),
-        })}
+        cloudTools={cloudTools}
       />
     </div>
   );

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -21,7 +21,7 @@ import {
   undoLastEdit,
 } from '../store/forecastSlice';
 import { OutlookType, Probability, DayType } from '../types/outlooks';
-import { deserializeForecast, validateForecastData, exportForecastToJson } from '../utils/fileUtils';
+import { deserializeForecast, validateForecastData, exportForecastToJson, serializeForecast } from '../utils/fileUtils';
 import { isAnyOutlookEnabled, getFirstEnabledOutlookType } from '../utils/featureFlagsUtils';
 import { useAutoSave } from '../hooks/useAutoSave';
 import { useCycleHistoryPersistence } from '../utils/cycleHistoryPersistence';
@@ -33,7 +33,6 @@ import { useCloudCycles } from '../hooks/useCloudCycles';
 import { useCloudSync } from '../hooks/useCloudSync';
 import { CloudToolbarButton } from '../components/CloudCycleManager/CloudToolbarButton';
 import { countForecastMetrics } from '../utils/forecastMetrics';
-import { serializeForecast } from '../utils/fileUtils';
 
 interface PageContext {
   addToast: AddToastFn;

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect, useMemo } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import type { Dispatch, UnknownAction } from 'redux';

--- a/src/types/cloudCycles.ts
+++ b/src/types/cloudCycles.ts
@@ -2,7 +2,7 @@ import { GFCForecastSaveData } from './outlooks';
 
 /**
  * Cloud-backed cycle metadata stored in Firestore
- * Kept separate from the full payload for efficient listing
+ * Exposed separately in app code even though the current Firestore document also stores payloadJson.
  */
 export interface CloudCycleMetadata {
   id: string;

--- a/src/types/cloudCycles.ts
+++ b/src/types/cloudCycles.ts
@@ -1,0 +1,53 @@
+import { GFCForecastSaveData } from './outlooks';
+
+/**
+ * Cloud-backed cycle metadata stored in Firestore
+ * Kept separate from the full payload for efficient listing
+ */
+export interface CloudCycleMetadata {
+  id: string;
+  userId: string;
+  label: string;
+  cycleDate: string;
+  createdAt: string;
+  updatedAt: string;
+  forecastDays: number;
+  totalOutlooks: number;
+  totalFeatures: number;
+  /** Indicates whether the user can modify this cycle (false when premium has expired) */
+  isReadOnly: boolean;
+  /** Content hash to detect remote changes */
+  payloadHash?: string;
+}
+
+/**
+ * Full cloud cycle including both metadata and serialized payload
+ */
+export interface CloudCycle extends CloudCycleMetadata {
+  payload: GFCForecastSaveData;
+}
+
+/**
+ * Cloud sync state for UI display
+ */
+export type CloudSyncState = 'idle' | 'saving' | 'saved' | 'error' | 'offline' | 'newer-remote' | 'loading';
+
+/**
+ * Cloud cycle context for the currently opened cloud cycle
+ */
+export interface CloudCycleContext {
+  id: string;
+  label: string;
+  syncState: CloudSyncState;
+  lastSyncError?: string;
+  newerVersionAvailable?: boolean;
+}
+
+/**
+ * Response from cloud operations
+ */
+export interface CloudOperationResult<T = void> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}


### PR DESCRIPTION
This pull request introduces a major update to cloud forecast storage and the user interface for managing cloud-saved forecasts. The main improvement is the migration of cloud-hosted forecast data from user settings to a dedicated `cloudCycles` collection, providing a more robust and scalable foundation for cloud features. Additionally, several new UI components and toolbar integrations have been added to enhance the user experience with cloud save/load operations.

**Cloud Forecast Storage & Backend Changes:**

- Migrated cloud-hosted forecast storage out of `userSettings` and into a dedicated `cloudCycles` collection, ensuring forecast payloads have a persistent, separate home from user profile preferences.

**UI/UX Enhancements for Cloud Features:**

- Added new components for cloud save/load modals (`CloudSaveLoadModals.tsx` and `.css`) and a toolbar button group (`CloudToolbarButton.tsx` and `.css`) to enable saving forecasts to the cloud and accessing the cloud library from the main toolbar. [[1]](diffhunk://#diff-8f070171ca7d87ccc6753bdaee6590e8d69a7a10acf31911bdbe917c5ce0f337R1-R234) [[2]](diffhunk://#diff-35f6087e710bde278af10f6fd493f884f1a1137ff1897f82249d5d721e918d81R1-R135) [[3]](diffhunk://#diff-ed92a642a405d75725ffd7253f1866cf322205792b72b08e21e8ffd904027b3cR1-R118) [[4]](diffhunk://#diff-9219e4ba68909e4f662a6f5bc52a75681ea4d6e10adbfa05688af467486b73a8R1-R63)
- Integrated cloud tools into the main toolbar by updating `IntegratedToolbar` components to accept and render cloud-related UI elements. [[1]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R100) [[2]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R200) [[3]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888L211-R213) [[4]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R245-L251)

**Routing & Navigation:**

- Added a new route and page (`CloudLibraryPage`) to allow users to browse and load their cloud-saved forecasts. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R23) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R135)

**Dependency Updates:**

- Added the `express-rate-limit` and `ip-address` packages to the backend dependencies, supporting rate limiting for API endpoints. [[1]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R12) [[2]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R991-R1008) [[3]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R1688-R1696)