### PR TITLE
Integrate ol-mapbox-style and feature flag management

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.577.0",
     "ol": "^10.8.0",
+    "ol-mapbox-style": "^13.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       ol:
         specifier: ^10.8.0
         version: 10.8.0
+      ol-mapbox-style:
+        specifier: ^13.4.0
+        version: 13.4.0(ol@10.8.0)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1451,6 +1454,17 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@maplibre/maplibre-gl-style-spec@24.7.0':
+    resolution: {integrity: sha512-Ed7rcKYU5iELfablg9Mj+TVCsXsPBgdMyXPRAxb2v7oWg9YJnpQdZ5msDs1LESu/mtXy3Z48Vdppv2t/x5kAhw==}
+    hasBin: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3568,6 +3582,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -3725,6 +3742,9 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  mapbox-to-css-font@3.2.0:
+    resolution: {integrity: sha512-kvsEfzvLik34BiFj+S19bv5d70l9qSdkUzrq99dvZ9d5POaLyB4vJMQmq3BoJ5D6lFG1GYnMM7o7cm5Jh8YEEg==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -3747,6 +3767,9 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -3787,6 +3810,11 @@ packages:
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  ol-mapbox-style@13.4.0:
+    resolution: {integrity: sha512-nme+Ko+hBKpdWwPr3tBIvOxlO/qLCStVgsPL39SQtIoVNM+mFq2dkX6ty6jrGcgyXS/QvyAOImUEN8VWSViFXw==}
+    peerDependencies:
+      ol: '*'
 
   ol@10.8.0:
     resolution: {integrity: sha512-kLk7jIlJvKyhVMAjORTXKjzlM6YIByZ1H/d0DBx3oq8nSPCG6/gbLr5RxukzPgwbhnAqh+xHNCmrvmFKhVMvoQ==}
@@ -4132,6 +4160,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -4302,6 +4333,9 @@ packages:
 
   tinyqueue@2.0.3:
     resolution: {integrity: sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -6198,6 +6232,20 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@maplibre/maplibre-gl-style-spec@24.7.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -9241,6 +9289,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@2.2.3: {}
 
   jsonfile@6.2.0:
@@ -9365,6 +9415,8 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  mapbox-to-css-font@3.2.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -9381,6 +9433,8 @@ snapshots:
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.0.2
+
+  minimist@1.2.8: {}
 
   minipass@7.1.3: {}
 
@@ -9407,6 +9461,12 @@ snapshots:
       fflate: 0.8.2
 
   nwsapi@2.2.23: {}
+
+  ol-mapbox-style@13.4.0(ol@10.8.0):
+    dependencies:
+      '@maplibre/maplibre-gl-style-spec': 24.7.0
+      mapbox-to-css-font: 3.2.0
+      ol: 10.8.0
 
   ol@10.8.0:
     dependencies:
@@ -9767,6 +9827,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rw@1.3.3: {}
+
   safe-buffer@5.1.2: {}
 
   safer-buffer@2.1.2: {}
@@ -9919,6 +9981,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinyqueue@2.0.3: {}
+
+  tinyqueue@3.0.0: {}
 
   tldts-core@6.1.86: {}
 

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -6,6 +6,7 @@ import {
   CloudHail, 
   LayoutGrid,
   Layers,
+  SlidersHorizontal,
   Calendar,
   ChevronLeft,
   ChevronRight,
@@ -21,6 +22,13 @@ import {
   Redo2,
 } from 'lucide-react';
 import { Button } from '../ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
 import {
   Tooltip,
   TooltipContent,
@@ -52,6 +60,7 @@ import {
   redoLastEdit,
   undoLastEdit,
 } from '../../store/forecastSlice';
+import { setFeatureFlag } from '../../store/featureFlagsSlice';
 import { toggleGhostOutlook } from '../../store/overlaysSlice';
 import { ForecastMapHandle } from '../Map/ForecastMap';
 import CycleHistoryModal from '../CycleManager/CycleHistoryModal';
@@ -171,6 +180,9 @@ interface IntegratedToolbarViewProps {
   probabilityHandlers: Record<string, () => void>;
   currentColor: string;
   isLowProb: boolean;
+  showBetaLabs: boolean;
+  vectorBasemapEnabled: boolean;
+  onToggleVectorBasemap: (enabled: boolean) => void;
 }
 
 /** Toolbar actions panel: Save, Load, Export, Package download, Cycle History, Copy from Previous, and Reset buttons. */
@@ -277,6 +289,38 @@ const ToolbarToolsSection: React.FC<{
         className="h-14 w-14 lg:h-16 lg:w-16 bg-red-500/20 hover:bg-red-500/30 border-red-500/50 text-red-700 dark:!bg-red-500/20 dark:hover:!bg-red-500/30 dark:border-red-500/50 dark:text-red-400"
         onClick={onOpenResetConfirm}
       />
+    </div>
+  </div>
+);
+
+/** Quick beta-only experiment menu so testers can compare old and new forecast map rendering. */
+const BetaLabsSection: React.FC<{
+  vectorBasemapEnabled: boolean;
+  onToggleVectorBasemap: (enabled: boolean) => void;
+}> = ({ vectorBasemapEnabled, onToggleVectorBasemap }) => (
+  <div className="border-r border-border pr-2 lg:pr-4">
+    <div className="flex flex-col gap-3">
+      <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Beta Labs</label>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            className="h-14 lg:h-16 min-w-[128px] justify-start gap-2 border-sky-500/50 bg-sky-500/10 text-sky-700 hover:bg-sky-500/20 dark:!bg-sky-500/15 dark:hover:!bg-sky-500/25 dark:border-sky-500/50 dark:text-sky-300"
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+            <span>Labs</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-72">
+          <DropdownMenuLabel>Beta map experiments</DropdownMenuLabel>
+          <DropdownMenuCheckboxItem
+            checked={vectorBasemapEnabled}
+            onCheckedChange={(checked) => onToggleVectorBasemap(Boolean(checked))}
+          >
+            Vector basemap + opaque outlook fills
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   </div>
 );
@@ -671,6 +715,7 @@ const IntegratedToolbarView: React.FC<IntegratedToolbarViewProps> = (props) => {
     lowProbabilityOutlooks, visibleGhostOutlooks, outlookTypeHandlers, ghostOutlookHandlers,
     probabilities, probabilityHandlers,
     currentColor, isLowProb,
+    showBetaLabs, vectorBasemapEnabled, onToggleVectorBasemap,
   } = props;
 
   const ghostTypes = availableTypes.filter((type) => type !== activeOutlookType);
@@ -688,6 +733,12 @@ const IntegratedToolbarView: React.FC<IntegratedToolbarViewProps> = (props) => {
               isSaved={isSaved} canUndo={canUndo} canRedo={canRedo}
               isExporting={isExporting} isPackageDownloading={isPackageDownloading}
             />
+            {showBetaLabs ? (
+              <BetaLabsSection
+                vectorBasemapEnabled={vectorBasemapEnabled}
+                onToggleVectorBasemap={onToggleVectorBasemap}
+              />
+            ) : null}
             <ToolbarForecastDaySection
               isEditingDate={isEditingDate} tempDate={tempDate} cycleDate={cycleDate}
               currentDay={currentDay} days={days}
@@ -980,7 +1031,12 @@ export const IntegratedToolbar: React.FC<IntegratedToolbarProps> = ({
   cloudTools = null,
 }) => {
   const dispatch = useDispatch();
+  const vectorBasemapEnabled = useSelector((state: RootState) => state.featureFlags.vectorBasemapEnabled);
   const model = useToolbarDataModel(mapRef, addToast);
+  const showBetaLabs = __GFC_BETA_MODE__;
+  const handleToggleVectorBasemap = useCallback((enabled: boolean) => {
+    dispatch(setFeatureFlag({ feature: 'vectorBasemapEnabled', enabled }));
+  }, [dispatch]);
 
   const localUi = useToolbarLocalUi(model.cycleDate);
   const handlers = useToolbarActionHandlers({
@@ -1012,6 +1068,9 @@ export const IntegratedToolbar: React.FC<IntegratedToolbarProps> = ({
       onCancelReset={localUi.handleCancelReset}
       onTempDateChange={localUi.handleTempDateChange}
       onStartDateEdit={localUi.handleStartDateEdit}
+      showBetaLabs={showBetaLabs}
+      vectorBasemapEnabled={vectorBasemapEnabled}
+      onToggleVectorBasemap={handleToggleVectorBasemap}
       {...handlers}
       {...localUi}
       {...model}

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -293,6 +293,43 @@ const ToolbarToolsSection: React.FC<{
   </div>
 );
 
+/** Trigger button for the beta Labs dropdown; forwards Radix trigger props/ref to the underlying button. */
+const BetaLabsTriggerButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof Button>
+>(({ className, ...props }, ref) => (
+  <Button
+    ref={ref}
+    variant="outline"
+    className={cn(
+      'h-14 lg:h-16 min-w-[128px] justify-start gap-2 border-sky-500/50 bg-sky-500/10 text-sky-700 hover:bg-sky-500/20 dark:!bg-sky-500/15 dark:hover:!bg-sky-500/25 dark:border-sky-500/50 dark:text-sky-300',
+      className
+    )}
+    {...props}
+  >
+    <SlidersHorizontal className="h-4 w-4" />
+    <span>Labs</span>
+  </Button>
+));
+
+BetaLabsTriggerButton.displayName = 'BetaLabsTriggerButton';
+
+/** Beta-only Labs menu content for quickly comparing legacy and experimental map rendering. */
+const BetaLabsMenuContent: React.FC<{
+  vectorBasemapEnabled: boolean;
+  onToggleVectorBasemap: (enabled: boolean) => void;
+}> = ({ vectorBasemapEnabled, onToggleVectorBasemap }) => (
+  <DropdownMenuContent align="start" className="w-72">
+    <DropdownMenuLabel>Beta map experiments</DropdownMenuLabel>
+    <DropdownMenuCheckboxItem
+      checked={vectorBasemapEnabled}
+      onCheckedChange={(checked) => onToggleVectorBasemap(Boolean(checked))}
+    >
+      Vector basemap + opaque outlook fills
+    </DropdownMenuCheckboxItem>
+  </DropdownMenuContent>
+);
+
 /** Quick beta-only experiment menu so testers can compare old and new forecast map rendering. */
 const BetaLabsSection: React.FC<{
   vectorBasemapEnabled: boolean;
@@ -303,23 +340,12 @@ const BetaLabsSection: React.FC<{
       <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Beta Labs</label>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button
-            variant="outline"
-            className="h-14 lg:h-16 min-w-[128px] justify-start gap-2 border-sky-500/50 bg-sky-500/10 text-sky-700 hover:bg-sky-500/20 dark:!bg-sky-500/15 dark:hover:!bg-sky-500/25 dark:border-sky-500/50 dark:text-sky-300"
-          >
-            <SlidersHorizontal className="h-4 w-4" />
-            <span>Labs</span>
-          </Button>
+          <BetaLabsTriggerButton />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-72">
-          <DropdownMenuLabel>Beta map experiments</DropdownMenuLabel>
-          <DropdownMenuCheckboxItem
-            checked={vectorBasemapEnabled}
-            onCheckedChange={(checked) => onToggleVectorBasemap(Boolean(checked))}
-          >
-            Vector basemap + opaque outlook fills
-          </DropdownMenuCheckboxItem>
-        </DropdownMenuContent>
+        <BetaLabsMenuContent
+          vectorBasemapEnabled={vectorBasemapEnabled}
+          onToggleVectorBasemap={onToggleVectorBasemap}
+        />
       </DropdownMenu>
     </div>
   </div>

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -6,7 +6,6 @@ import {
   CloudHail, 
   LayoutGrid,
   Layers,
-  SlidersHorizontal,
   Calendar,
   ChevronLeft,
   ChevronRight,
@@ -22,13 +21,6 @@ import {
   Redo2,
 } from 'lucide-react';
 import { Button } from '../ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from '../ui/dropdown-menu';
 import {
   Tooltip,
   TooltipContent,
@@ -60,7 +52,6 @@ import {
   redoLastEdit,
   undoLastEdit,
 } from '../../store/forecastSlice';
-import { setFeatureFlag } from '../../store/featureFlagsSlice';
 import { toggleGhostOutlook } from '../../store/overlaysSlice';
 import { ForecastMapHandle } from '../Map/ForecastMap';
 import CycleHistoryModal from '../CycleManager/CycleHistoryModal';
@@ -180,9 +171,6 @@ interface IntegratedToolbarViewProps {
   probabilityHandlers: Record<string, () => void>;
   currentColor: string;
   isLowProb: boolean;
-  showBetaLabs: boolean;
-  vectorBasemapEnabled: boolean;
-  onToggleVectorBasemap: (enabled: boolean) => void;
 }
 
 /** Toolbar actions panel: Save, Load, Export, Package download, Cycle History, Copy from Previous, and Reset buttons. */
@@ -289,64 +277,6 @@ const ToolbarToolsSection: React.FC<{
         className="h-14 w-14 lg:h-16 lg:w-16 bg-red-500/20 hover:bg-red-500/30 border-red-500/50 text-red-700 dark:!bg-red-500/20 dark:hover:!bg-red-500/30 dark:border-red-500/50 dark:text-red-400"
         onClick={onOpenResetConfirm}
       />
-    </div>
-  </div>
-);
-
-/** Trigger button for the beta Labs dropdown; forwards Radix trigger props/ref to the underlying button. */
-const BetaLabsTriggerButton = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentPropsWithoutRef<typeof Button>
->(({ className, ...props }, ref) => (
-  <Button
-    ref={ref}
-    variant="outline"
-    className={cn(
-      'h-14 lg:h-16 min-w-[128px] justify-start gap-2 border-sky-500/50 bg-sky-500/10 text-sky-700 hover:bg-sky-500/20 dark:!bg-sky-500/15 dark:hover:!bg-sky-500/25 dark:border-sky-500/50 dark:text-sky-300',
-      className
-    )}
-    {...props}
-  >
-    <SlidersHorizontal className="h-4 w-4" />
-    <span>Labs</span>
-  </Button>
-));
-
-BetaLabsTriggerButton.displayName = 'BetaLabsTriggerButton';
-
-/** Beta-only Labs menu content for quickly comparing legacy and experimental map rendering. */
-const BetaLabsMenuContent: React.FC<{
-  vectorBasemapEnabled: boolean;
-  onToggleVectorBasemap: (enabled: boolean) => void;
-}> = ({ vectorBasemapEnabled, onToggleVectorBasemap }) => (
-  <DropdownMenuContent align="start" className="w-72">
-    <DropdownMenuLabel>Beta map experiments</DropdownMenuLabel>
-    <DropdownMenuCheckboxItem
-      checked={vectorBasemapEnabled}
-      onCheckedChange={(checked) => onToggleVectorBasemap(Boolean(checked))}
-    >
-      Vector basemap + opaque outlook fills
-    </DropdownMenuCheckboxItem>
-  </DropdownMenuContent>
-);
-
-/** Quick beta-only experiment menu so testers can compare old and new forecast map rendering. */
-const BetaLabsSection: React.FC<{
-  vectorBasemapEnabled: boolean;
-  onToggleVectorBasemap: (enabled: boolean) => void;
-}> = ({ vectorBasemapEnabled, onToggleVectorBasemap }) => (
-  <div className="border-r border-border pr-2 lg:pr-4">
-    <div className="flex flex-col gap-3">
-      <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Beta Labs</label>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <BetaLabsTriggerButton />
-        </DropdownMenuTrigger>
-        <BetaLabsMenuContent
-          vectorBasemapEnabled={vectorBasemapEnabled}
-          onToggleVectorBasemap={onToggleVectorBasemap}
-        />
-      </DropdownMenu>
     </div>
   </div>
 );
@@ -741,7 +671,6 @@ const IntegratedToolbarView: React.FC<IntegratedToolbarViewProps> = (props) => {
     lowProbabilityOutlooks, visibleGhostOutlooks, outlookTypeHandlers, ghostOutlookHandlers,
     probabilities, probabilityHandlers,
     currentColor, isLowProb,
-    showBetaLabs, vectorBasemapEnabled, onToggleVectorBasemap,
   } = props;
 
   const ghostTypes = availableTypes.filter((type) => type !== activeOutlookType);
@@ -759,12 +688,6 @@ const IntegratedToolbarView: React.FC<IntegratedToolbarViewProps> = (props) => {
               isSaved={isSaved} canUndo={canUndo} canRedo={canRedo}
               isExporting={isExporting} isPackageDownloading={isPackageDownloading}
             />
-            {showBetaLabs ? (
-              <BetaLabsSection
-                vectorBasemapEnabled={vectorBasemapEnabled}
-                onToggleVectorBasemap={onToggleVectorBasemap}
-              />
-            ) : null}
             <ToolbarForecastDaySection
               isEditingDate={isEditingDate} tempDate={tempDate} cycleDate={cycleDate}
               currentDay={currentDay} days={days}
@@ -1057,12 +980,7 @@ export const IntegratedToolbar: React.FC<IntegratedToolbarProps> = ({
   cloudTools = null,
 }) => {
   const dispatch = useDispatch();
-  const vectorBasemapEnabled = useSelector((state: RootState) => state.featureFlags.vectorBasemapEnabled);
   const model = useToolbarDataModel(mapRef, addToast);
-  const showBetaLabs = __GFC_BETA_MODE__;
-  const handleToggleVectorBasemap = useCallback((enabled: boolean) => {
-    dispatch(setFeatureFlag({ feature: 'vectorBasemapEnabled', enabled }));
-  }, [dispatch]);
 
   const localUi = useToolbarLocalUi(model.cycleDate);
   const handlers = useToolbarActionHandlers({
@@ -1094,9 +1012,6 @@ export const IntegratedToolbar: React.FC<IntegratedToolbarProps> = ({
       onCancelReset={localUi.handleCancelReset}
       onTempDateChange={localUi.handleTempDateChange}
       onStartDateEdit={localUi.handleStartDateEdit}
-      showBetaLabs={showBetaLabs}
-      vectorBasemapEnabled={vectorBasemapEnabled}
-      onToggleVectorBasemap={handleToggleVectorBasemap}
       {...handlers}
       {...localUi}
       {...model}

--- a/src/components/Layout/NavbarSections.tsx
+++ b/src/components/Layout/NavbarSections.tsx
@@ -17,7 +17,9 @@ import {
   CircleUserRound,
   MoreHorizontal,
   Crown,
+  SlidersHorizontal,
 } from 'lucide-react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Button } from '../ui/button';
 import {
   Tooltip,
@@ -26,6 +28,7 @@ import {
 } from '../ui/tooltip';
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -34,6 +37,8 @@ import {
 } from '../ui/dropdown-menu';
 import { cn } from '../../lib/utils';
 import { useAuth } from '../../auth/AuthProvider';
+import { RootState } from '../../store';
+import { setFeatureFlag } from '../../store/featureFlagsSlice';
 
 interface ExternalActionLink {
   href: string;
@@ -175,9 +180,18 @@ const MoreActionsMenu: React.FC<{
   onViewPrivacyPolicy?: () => void;
   onToggleDocumentation?: () => void;
 }> = ({ onViewTerms, onViewPrivacyPolicy, onToggleDocumentation }) => {
+  const dispatch = useDispatch();
+  const vectorBasemapEnabled = useSelector((state: RootState) => state.featureFlags.vectorBasemapEnabled);
+  const showBetaLabs = __GFC_BETA_MODE__;
+
   /** Opens a community/resource link from the navbar overflow menu in a new tab. */
   const openExternalLink = (href: string) => {
     window.open(href, '_blank', 'noopener,noreferrer');
+  };
+
+  /** Updates the shared beta-labs vector basemap override from the global overflow menu. */
+  const handleToggleVectorBasemap = (enabled: boolean) => {
+    dispatch(setFeatureFlag({ feature: 'vectorBasemapEnabled', enabled }));
   };
 
   return (
@@ -208,6 +222,19 @@ const MoreActionsMenu: React.FC<{
             Pricing
           </NavLink>
         </DropdownMenuItem>
+        {showBetaLabs ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Beta Labs</DropdownMenuLabel>
+            <DropdownMenuCheckboxItem
+              checked={vectorBasemapEnabled}
+              onCheckedChange={(checked) => handleToggleVectorBasemap(Boolean(checked))}
+            >
+              <SlidersHorizontal className="h-4 w-4" />
+              Vector basemap + opaque outlook fills
+            </DropdownMenuCheckboxItem>
+          </>
+        ) : null}
         <DropdownMenuSeparator />
         <DropdownMenuLabel>Community</DropdownMenuLabel>
         {externalLinks.map((link) => (

--- a/src/components/Map/Legend.tsx
+++ b/src/components/Map/Legend.tsx
@@ -17,6 +17,7 @@ const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOut
   // Optimized: Select only activeOutlookType to avoid re-rendering on other drawing state changes (like activeProbability)
   const storeActiveOutlookType = useSelector((state: RootState) => state.forecast.drawingState.activeOutlookType);
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
+  const vectorBasemapEnabled = useSelector((state: RootState) => state.featureFlags.vectorBasemapEnabled);
   const activeOutlookType = activeOutlookTypeOverride || storeActiveOutlookType;
 
   const renderCategoricalLegend = () => (
@@ -27,7 +28,7 @@ const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOut
           <div key={risk} className="legend-item" role="listitem">
             <div 
               className="legend-color" 
-              style={{ backgroundColor: colorMappings.categorical[risk], opacity: 0.5 }}
+              style={{ backgroundColor: colorMappings.categorical[risk], opacity: vectorBasemapEnabled ? 1 : 0.5 }}
               role="img"
               aria-label={`Color for ${getCategoricalRiskDisplayName(risk as CategoricalRiskLevel)}`}
             />

--- a/src/components/Map/Legend.tsx
+++ b/src/components/Map/Legend.tsx
@@ -20,6 +20,7 @@ const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOut
   const vectorBasemapEnabled = useSelector((state: RootState) => state.featureFlags.vectorBasemapEnabled);
   const activeOutlookType = activeOutlookTypeOverride || storeActiveOutlookType;
 
+  /** Renders the categorical legend swatches, matching the active map opacity mode. */
   const renderCategoricalLegend = () => (
     <>
       <h4 id="legend-title">Categorical Risk Levels</h4>
@@ -39,6 +40,7 @@ const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOut
     </>
   );
 
+  /** Renders probabilistic legend entries, including inline SVG hatch previews for CIG layers. */
   const renderProbabilisticLegend = () => {
     let probabilities: string[] = [];
     let colorMap: any;

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import 'ol/ol.css';
 import OLMap from 'ol/Map';
 import View from 'ol/View';
+import LayerGroup from 'ol/layer/Group';
 import TileLayer from 'ol/layer/Tile';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -25,9 +26,11 @@ import type { BaseMapStyle } from '../../store/overlaysSlice';
 import { getFeatureStyle, computeZIndex } from '../../utils/mapStyleUtils';
 import type { MapAdapterHandle } from '../../maps/contracts';
 import type { Feature as GeoJsonFeature, GeoJsonProperties, Polygon } from 'geojson';
+import { apply } from 'ol-mapbox-style';
 import Legend from './Legend';
 import StatusOverlay from './StatusOverlay';
 import UnofficialBadge from './UnofficialBadge';
+import { getOpenFreeMapStyleSet, isOpenFreeMapStyle } from '../../lib/openFreeMap';
 import './ForecastMap.css';
 
 type OutlookMapLike = Record<string, globalThis.Map<string, GeoJsonFeature[]>>;
@@ -88,6 +91,7 @@ interface HatchPatternInput {
 }
 
 const TOP_OUTLINE_LAYER_Z_INDEX = 1000;
+const TOP_VECTOR_REFERENCE_LAYER_Z_INDEX = 1050;
 const TOP_LABEL_LAYER_Z_INDEX = 1100;
 
 const DRAWABLE_OUTLOOK_TYPES = new Set<EditableOutlookType>([
@@ -516,6 +520,9 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
   const mapElementRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<OLMap | null>(null);
   const tileLayerRef = useRef<TileLayer<OSM | XYZ> | null>(null);
+  const vectorBaseGroupRef = useRef<LayerGroup | null>(null);
+  const vectorReferenceGroupRef = useRef<LayerGroup | null>(null);
+  const vectorStyleRequestRef = useRef(0);
   const worldSourceRef = useRef<VectorSource>(new VectorSource());
   const worldLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
   const lakesSourceRef = useRef<VectorSource>(new VectorSource());
@@ -576,6 +583,16 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
 
     const tileLayer = new TileLayer({ source: new OSM({ crossOrigin: 'anonymous' }) });
     tileLayerRef.current = tileLayer;
+    const vectorBaseGroup = new LayerGroup({
+      visible: false,
+      zIndex: 1,
+    });
+    vectorBaseGroupRef.current = vectorBaseGroup;
+    const vectorReferenceGroup = new LayerGroup({
+      visible: false,
+      zIndex: TOP_VECTOR_REFERENCE_LAYER_Z_INDEX,
+    });
+    vectorReferenceGroupRef.current = vectorReferenceGroup;
     // Blank base map layers: start hidden, only one (tile vs. world+lakes+land) will be visible at a time based on baseMapStyle.
     const worldLayer = new VectorLayer({
       source: worldSourceRef.current,
@@ -640,7 +657,19 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
     // without needing to re-add/remove layers or features, which can be expensive.
     const map = new OLMap({
       target: mapElementRef.current,
-      layers: [tileLayer, worldLayer, lakesLayer, landLayer, ghostLayer, catLayer, vectorLayer, landOutlineLayer, labelLayer],
+      layers: [
+        tileLayer,
+        vectorBaseGroup,
+        worldLayer,
+        lakesLayer,
+        landLayer,
+        ghostLayer,
+        catLayer,
+        vectorLayer,
+        landOutlineLayer,
+        vectorReferenceGroup,
+        labelLayer,
+      ],
       view: new View({
         center: fromLonLat([initialMapViewRef.current.center[1], initialMapViewRef.current.center[0]]),
         zoom: initialMapViewRef.current.zoom
@@ -814,6 +843,8 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
       }
       map.setTarget();
       mapRef.current = null;
+      vectorBaseGroupRef.current = null;
+      vectorReferenceGroupRef.current = null;
     };
   }, [dispatch]);
 
@@ -877,13 +908,15 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
   // Swap base tile source / blank land layer when style changes
   useEffect(() => {
     const tile = tileLayerRef.current;
+    const vectorBaseGroup = vectorBaseGroupRef.current;
+    const vectorReferenceGroup = vectorReferenceGroupRef.current;
     const world = worldLayerRef.current;
     const lakes = lakesLayerRef.current;
     const land = landLayerRef.current;
     const landOutline = landOutlineLayerRef.current;
     const labels = labelLayerRef.current;
     const el = mapElementRef.current;
-    if (!tile || !world || !lakes || !land || !landOutline || !labels || !el) return;
+    if (!tile || !vectorBaseGroup || !vectorReferenceGroup || !world || !lakes || !land || !landOutline || !labels || !el) return;
 
     /**
      * Ensure US states GeoJSON for the blank/base map is loaded into
@@ -907,7 +940,15 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
     // Keep state outlines available above outlook polygons in every map style.
     loadUsStatesBoundaries();
 
+    const hideVectorBasemapGroups = () => {
+      vectorBaseGroup.setVisible(false);
+      vectorReferenceGroup.setVisible(false);
+      vectorBaseGroup.getLayers().clear();
+      vectorReferenceGroup.getLayers().clear();
+    };
+
     if (baseMapStyle === 'blank') {
+      hideVectorBasemapGroups();
       tile.setVisible(false);
       world.setVisible(true);
       lakes.setVisible(true);
@@ -952,7 +993,55 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
       loaders.forEach((loader) => {
         ensureBlankLayerLoaded(loader).catch(() => { /* blank map layer fetch failed — non-fatal */ });
       });
+      return;
+    }
+
+    if (isOpenFreeMapStyle(baseMapStyle)) {
+      const requestId = vectorStyleRequestRef.current + 1;
+      vectorStyleRequestRef.current = requestId;
+
+      tile.setVisible(false);
+      world.setVisible(false);
+      lakes.setVisible(false);
+      land.setVisible(false);
+      landOutline.setVisible(true);
+      labels.setVisible(false);
+      el.style.backgroundColor = '';
+      vectorBaseGroup.setVisible(false);
+      vectorReferenceGroup.setVisible(false);
+      vectorBaseGroup.getLayers().clear();
+      vectorReferenceGroup.getLayers().clear();
+
+      getOpenFreeMapStyleSet(baseMapStyle)
+        .then(({ baseStyle, overlayStyle }) => Promise.all([
+          apply(vectorBaseGroup, baseStyle),
+          apply(vectorReferenceGroup, overlayStyle),
+        ]))
+        .then(() => {
+          if (vectorStyleRequestRef.current !== requestId) {
+            return;
+          }
+
+          vectorBaseGroup.setVisible(true);
+          vectorReferenceGroup.setVisible(true);
+        })
+        .catch(() => {
+          if (vectorStyleRequestRef.current !== requestId) {
+            return;
+          }
+
+          vectorBaseGroup.getLayers().clear();
+          vectorReferenceGroup.getLayers().clear();
+          tile.setSource(createTileSource(baseMapStyle));
+          tile.setVisible(true);
+          const labelSource = createLabelOverlaySource(baseMapStyle);
+          if (labelSource) {
+            labels.setSource(labelSource);
+            labels.setVisible(true);
+          }
+        });
     } else {
+      hideVectorBasemapGroups();
       tile.setVisible(true);
       world.setVisible(false);
       lakes.setVisible(false);

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -78,7 +78,6 @@ interface RgbaInput {
 
 interface FillOpacityInput {
   fillOpacity: unknown;
-  forCategoricalLayer: boolean;
 }
 
 interface StrokeWidthInput {
@@ -172,9 +171,8 @@ const createHatchPattern = ({ cigLevel }: HatchPatternInput): CanvasPattern | nu
   return ctx.createPattern(canvas, 'repeat');
 };
 
-/** Returns the fill opacity for a feature: always 1.0 for the categorical layer, otherwise the numeric opacity value or 0.25 as default. */
-const resolveFillOpacity = ({ fillOpacity, forCategoricalLayer }: FillOpacityInput): number => {
-  if (forCategoricalLayer) return 1.0;
+/** Returns the fill opacity for a feature or a sensible fallback when a style omitted it. */
+const resolveFillOpacity = ({ fillOpacity }: FillOpacityInput): number => {
   return typeof fillOpacity === 'number' ? fillOpacity : 0.25;
 };
 
@@ -283,14 +281,14 @@ const isDrawableOutlookType = ({ outlookType }: { outlookType: string }): boolea
 // Convert outlook type and probability to an OpenLayers style, including handling CIG hatching patterns
 const toOlStyle = (
   selection: OutlookSelection,
-  options: LayerStyleOptions = {}
+  options: LayerStyleOptions & { vectorBasemapEnabled?: boolean } = {}
 ) => {
   const { outlookType, probability } = selection;
-  const { isTopLayer = false, forCategoricalLayer = false } = options;
+  const { isTopLayer = false, vectorBasemapEnabled = false } = options;
 
-  const style = getFeatureStyle(outlookType as EditableOutlookType, probability);
+  const style = getFeatureStyle(outlookType as EditableOutlookType, probability, { vectorBasemapEnabled });
   const fillColor = String(style.fillColor || '#ffffff');
-  const fillOpacity = resolveFillOpacity({ fillOpacity: style.fillOpacity, forCategoricalLayer });
+  const fillOpacity = resolveFillOpacity({ fillOpacity: style.fillOpacity });
   const strokeOpacity = typeof style.opacity === 'number' ? style.opacity : 1;
   const strokeColor = String(style.color || '#000000');
   const zIndex = computeZIndex(outlookType as EditableOutlookType, probability);
@@ -311,8 +309,11 @@ const toOlStyle = (
 };
 
 /** Creates a faded style variant for non-active outlooks shown as ghost overlays. */
-const toGhostOlStyle = ({ outlookType, probability, isCategorical }: GhostSelection) => {
-  const style = getFeatureStyle(outlookType as EditableOutlookType, probability);
+const toGhostOlStyle = (
+  { outlookType, probability, isCategorical }: GhostSelection,
+  vectorBasemapEnabled: boolean
+) => {
+  const style = getFeatureStyle(outlookType as EditableOutlookType, probability, { vectorBasemapEnabled });
   const strokeColor = String(style.color || '#000000');
   const ghostFillOpacity = isCategorical ? 0.15 : 0.15;
   const isCig = probability.startsWith('CIG');
@@ -502,6 +503,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
   const currentMapView = useSelector((state: RootState) => state.forecast.currentMapView);
   const outlooks = useSelector(selectCurrentOutlooks) as OutlookMapLike;
   const baseMapStyle = useSelector((state: RootState) => state.overlays.baseMapStyle);
+  const vectorBasemapEnabled = useSelector((state: RootState) => state.featureFlags.vectorBasemapEnabled);
   const ghostOutlooks = useSelector((state: RootState) => state.overlays.ghostOutlooks);
   const initialMapViewRef = useRef(currentMapView);
   const currentMapViewRef = useRef(currentMapView);
@@ -624,13 +626,12 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
       style: BLANK_LAND_OUTLINE_STYLE,
     });
     landOutlineLayerRef.current = landOutlineLayer;
-    // Categorical layer: dedicated source with per-feature full-opacity fills.
-    // Layer-level opacity (0.5) makes the basemap visible while higher-risk
-    // polygons completely cover lower-risk ones (no color blending).
+    // Categorical layer: dedicated source so the app can switch between
+    // legacy semi-transparent fills and the beta vector/opaque treatment.
     const catLayer = new VectorLayer({
       source: catSourceRef.current,
       zIndex: 3,
-      opacity: 0.5,
+      opacity: 1,
     });
     catLayerRef.current = catLayer;
     const ghostLayer = new VectorLayer({
@@ -996,7 +997,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
       return;
     }
 
-    if (isOpenFreeMapStyle(baseMapStyle)) {
+    if (vectorBasemapEnabled && isOpenFreeMapStyle(baseMapStyle)) {
       const requestId = vectorStyleRequestRef.current + 1;
       vectorStyleRequestRef.current = requestId;
 
@@ -1057,7 +1058,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
         labels.setVisible(false);
       }
     }
-  }, [baseMapStyle]);
+  }, [baseMapStyle, vectorBasemapEnabled]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -1156,7 +1157,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
       const applyProps = (f: OLFeature<Geometry>) => {
         f.setStyle(toOlStyle(
           { outlookType, probability },
-          { isTopLayer, forCategoricalLayer: isCategorical }
+          { isTopLayer, forCategoricalLayer: isCategorical, vectorBasemapEnabled }
         ));
         f.set('featureId', feature.id as string);
         f.set('outlookType', outlookType);
@@ -1191,7 +1192,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
 
           /** Apply ghost styling/metadata and add the feature to the ghost source. */
           const applyGhostProps = (f: OLFeature<Geometry>) => {
-            f.setStyle(toGhostOlStyle({ outlookType, probability, isCategorical }));
+            f.setStyle(toGhostOlStyle({ outlookType, probability, isCategorical }, vectorBasemapEnabled));
             f.set('featureId', feature.id as string);
             f.set('outlookType', outlookType);
             f.set('probability', probability);
@@ -1208,7 +1209,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
         });
       });
     });
-  }, [serializedFeatures, outlooks, drawingState.activeOutlookType, ghostOutlooks]);
+  }, [serializedFeatures, outlooks, drawingState.activeOutlookType, ghostOutlooks, vectorBasemapEnabled]);
 
   // Handlers for toolbar buttons to switch interaction modes and toggle style picker.
   const handleSetModePan = () => {

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -68,7 +68,6 @@ interface FillBuildInput {
 
 interface LayerStyleOptions {
   isTopLayer?: boolean;
-  forCategoricalLayer?: boolean;
 }
 
 interface RgbaInput {
@@ -245,6 +244,15 @@ const applyBlankLayerStyle = (features: FeatureLike[], style: Style) => {
     if ('setStyle' in feature && typeof feature.setStyle === 'function') {
       feature.setStyle(style);
     }
+  });
+};
+
+/** Replaces all layers in the target group with the current layers from the source group. */
+const replaceLayerGroupLayers = (target: LayerGroup, source: LayerGroup) => {
+  const targetLayers = target.getLayers();
+  targetLayers.clear();
+  source.getLayers().getArray().forEach((layer) => {
+    targetLayers.push(layer);
   });
 };
 
@@ -941,6 +949,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
     // Keep state outlines available above outlook polygons in every map style.
     loadUsStatesBoundaries();
 
+    /** Clears the split OpenFreeMap base/reference groups so raster and blank modes stay isolated. */
     const hideVectorBasemapGroups = () => {
       vectorBaseGroup.setVisible(false);
       vectorReferenceGroup.setVisible(false);
@@ -1014,23 +1023,34 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
       vectorReferenceGroup.getLayers().clear();
 
       getOpenFreeMapStyleSet(baseMapStyle)
-        .then(({ baseStyle, overlayStyle }) => Promise.all([
-          apply(vectorBaseGroup, baseStyle),
-          apply(vectorReferenceGroup, overlayStyle),
-        ]))
-        .then(() => {
+        .then(({ baseStyle, overlayStyle }) => {
+          const nextBaseGroup = new LayerGroup();
+          const nextReferenceGroup = new LayerGroup();
+
+          return Promise.all([
+            apply(nextBaseGroup, baseStyle),
+            apply(nextReferenceGroup, overlayStyle),
+          ]).then(() => ({ nextBaseGroup, nextReferenceGroup }));
+        })
+        .then(({ nextBaseGroup, nextReferenceGroup }) => {
           if (vectorStyleRequestRef.current !== requestId) {
             return;
           }
 
+          replaceLayerGroupLayers(vectorBaseGroup, nextBaseGroup);
+          replaceLayerGroupLayers(vectorReferenceGroup, nextReferenceGroup);
           vectorBaseGroup.setVisible(true);
           vectorReferenceGroup.setVisible(true);
         })
-        .catch(() => {
+        .catch((error) => {
           if (vectorStyleRequestRef.current !== requestId) {
             return;
           }
 
+          console.warn('[forecast-map] falling back to raster basemap after vector load failure', {
+            baseMapStyle,
+            error,
+          });
           vectorBaseGroup.getLayers().clear();
           vectorReferenceGroup.getLayers().clear();
           tile.setSource(createTileSource(baseMapStyle));
@@ -1157,7 +1177,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap>>((_, ref) => {
       const applyProps = (f: OLFeature<Geometry>) => {
         f.setStyle(toOlStyle(
           { outlookType, probability },
-          { isTopLayer, forCategoricalLayer: isCategorical, vectorBasemapEnabled }
+          { isTopLayer, vectorBasemapEnabled }
         ));
         f.set('featureId', feature.id as string);
         f.set('outlookType', outlookType);

--- a/src/components/Map/OpenLayersVerificationMap.tsx
+++ b/src/components/Map/OpenLayersVerificationMap.tsx
@@ -57,6 +57,15 @@ const TOP_OUTLINE_LAYER_Z_INDEX = 1000;
 const TOP_VECTOR_REFERENCE_LAYER_Z_INDEX = 1050;
 const TOP_LABEL_LAYER_Z_INDEX = 1100;
 
+/** Replaces all layers in the target group with the current layers from the source group. */
+const replaceLayerGroupLayers = (target: LayerGroup, source: LayerGroup) => {
+  const targetLayers = target.getLayers();
+  targetLayers.clear();
+  source.getLayers().getArray().forEach((layer) => {
+    targetLayers.push(layer);
+  });
+};
+
 // Define specific colors for each report type
 const reportColors = {
   tornado: '#FF0000', // Red for tornado
@@ -588,6 +597,7 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
     // Keep state outlines above outlook polygons across base-map styles.
     loadStatesBoundaries();
 
+    /** Clears the split OpenFreeMap base/reference groups so non-vector styles can render normally. */
     const hideVectorBasemapGroups = () => {
       vectorBaseGroup.setVisible(false);
       vectorReferenceGroup.setVisible(false);
@@ -620,23 +630,34 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
       vectorReferenceGroup.getLayers().clear();
 
       getOpenFreeMapStyleSet(baseMapStyle)
-        .then(({ baseStyle, overlayStyle }) => Promise.all([
-          apply(vectorBaseGroup, baseStyle),
-          apply(vectorReferenceGroup, overlayStyle),
-        ]))
-        .then(() => {
+        .then(({ baseStyle, overlayStyle }) => {
+          const nextBaseGroup = new LayerGroup();
+          const nextReferenceGroup = new LayerGroup();
+
+          return Promise.all([
+            apply(nextBaseGroup, baseStyle),
+            apply(nextReferenceGroup, overlayStyle),
+          ]).then(() => ({ nextBaseGroup, nextReferenceGroup }));
+        })
+        .then(({ nextBaseGroup, nextReferenceGroup }) => {
           if (vectorStyleRequestRef.current !== requestId) {
             return;
           }
 
+          replaceLayerGroupLayers(vectorBaseGroup, nextBaseGroup);
+          replaceLayerGroupLayers(vectorReferenceGroup, nextReferenceGroup);
           vectorBaseGroup.setVisible(true);
           vectorReferenceGroup.setVisible(true);
         })
-        .catch(() => {
+        .catch((error) => {
           if (vectorStyleRequestRef.current !== requestId) {
             return;
           }
 
+          console.warn('[verification-map] falling back to raster basemap after vector load failure', {
+            baseMapStyle,
+            error,
+          });
           vectorBaseGroup.getLayers().clear();
           vectorReferenceGroup.getLayers().clear();
           tile.setSource(createVerifTileSource(baseMapStyle));

--- a/src/components/Map/OpenLayersVerificationMap.tsx
+++ b/src/components/Map/OpenLayersVerificationMap.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import 'ol/ol.css';
 import OLMap from 'ol/Map';
 import View from 'ol/View';
+import LayerGroup from 'ol/layer/Group';
 import TileLayer from 'ol/layer/Tile';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -21,8 +22,10 @@ import type { Feature as GeoJsonFeature } from 'geojson';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
 import { Circle, Fill as StyleFill, Stroke as StyleStroke, Style as OlStyle, Fill, Stroke, Style } from 'ol/style';
+import { apply } from 'ol-mapbox-style';
 import Legend from './Legend';
 import UnofficialBadge from './UnofficialBadge';
+import { getOpenFreeMapStyleSet, isOpenFreeMapStyle } from '../../lib/openFreeMap';
 import './ForecastMap.css';
 import { ReportType } from '../../types/stormReports';
 
@@ -51,6 +54,7 @@ interface StrokeDescriptor {
 }
 
 const TOP_OUTLINE_LAYER_Z_INDEX = 1000;
+const TOP_VECTOR_REFERENCE_LAYER_Z_INDEX = 1050;
 const TOP_LABEL_LAYER_Z_INDEX = 1100;
 
 // Define specific colors for each report type
@@ -405,6 +409,9 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
   const mapElementRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<OLMap | null>(null);
   const tileLayerRef = useRef<TileLayer<OSM | XYZ> | null>(null);
+  const vectorBaseGroupRef = useRef<LayerGroup | null>(null);
+  const vectorReferenceGroupRef = useRef<LayerGroup | null>(null);
+  const vectorStyleRequestRef = useRef(0);
   const landSourceRef = useRef<VectorSource>(new VectorSource());
   const landLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
   const landOutlineLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
@@ -452,6 +459,16 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
 
     const baseTileLayer = new TileLayer({ source: new OSM({ crossOrigin: 'anonymous' }) });
     tileLayerRef.current = baseTileLayer;
+    const vectorBaseGroup = new LayerGroup({
+      visible: false,
+      zIndex: 1,
+    });
+    vectorBaseGroupRef.current = vectorBaseGroup;
+    const vectorReferenceGroup = new LayerGroup({
+      visible: false,
+      zIndex: TOP_VECTOR_REFERENCE_LAYER_Z_INDEX,
+    });
+    vectorReferenceGroupRef.current = vectorReferenceGroup;
     // Land fill sits above the base tile layer for blank style.
     const landLayer = new VectorLayer({
       source: landSourceRef.current,
@@ -481,9 +498,11 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
       target: mapElementRef.current,
       layers: [
         baseTileLayer,
+        vectorBaseGroup,
         landLayer,
         outlookLayer,
         landOutlineLayer,
+        vectorReferenceGroup,
         new VectorLayer({
           source: stormReportsSourceRef.current,
           zIndex: 4,
@@ -502,6 +521,8 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
     return () => {
       map.setTarget();
       mapRef.current = null;
+      vectorBaseGroupRef.current = null;
+      vectorReferenceGroupRef.current = null;
     };
   }, []);
 
@@ -528,11 +549,13 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
   // Swap base tile source / blank land layer when style changes
   useEffect(() => {
     const tile = tileLayerRef.current;
+    const vectorBaseGroup = vectorBaseGroupRef.current;
+    const vectorReferenceGroup = vectorReferenceGroupRef.current;
     const land = landLayerRef.current;
     const landOutline = landOutlineLayerRef.current;
     const labels = labelLayerRef.current;
     const el = mapElementRef.current;
-    if (!tile || !land || !landOutline || !labels || !el) return;
+    if (!tile || !vectorBaseGroup || !vectorReferenceGroup || !land || !landOutline || !labels || !el) return;
 
     /**
      * Load US state boundary features into the `landSourceRef` if they
@@ -570,13 +593,67 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
     // Keep state outlines above outlook polygons across base-map styles.
     loadStatesBoundaries();
 
+    const hideVectorBasemapGroups = () => {
+      vectorBaseGroup.setVisible(false);
+      vectorReferenceGroup.setVisible(false);
+      vectorBaseGroup.getLayers().clear();
+      vectorReferenceGroup.getLayers().clear();
+    };
+
     if (baseMapStyle === 'blank') {
+      hideVectorBasemapGroups();
       tile.setVisible(false);
       land.setVisible(true);
       landOutline.setVisible(true);
       labels.setVisible(false);
       el.style.backgroundColor = '#b8d4e8';
+      return;
+    }
+
+    if (isOpenFreeMapStyle(baseMapStyle)) {
+      const requestId = vectorStyleRequestRef.current + 1;
+      vectorStyleRequestRef.current = requestId;
+
+      tile.setVisible(false);
+      land.setVisible(false);
+      landOutline.setVisible(true);
+      labels.setVisible(false);
+      el.style.backgroundColor = '';
+      vectorBaseGroup.setVisible(false);
+      vectorReferenceGroup.setVisible(false);
+      vectorBaseGroup.getLayers().clear();
+      vectorReferenceGroup.getLayers().clear();
+
+      getOpenFreeMapStyleSet(baseMapStyle)
+        .then(({ baseStyle, overlayStyle }) => Promise.all([
+          apply(vectorBaseGroup, baseStyle),
+          apply(vectorReferenceGroup, overlayStyle),
+        ]))
+        .then(() => {
+          if (vectorStyleRequestRef.current !== requestId) {
+            return;
+          }
+
+          vectorBaseGroup.setVisible(true);
+          vectorReferenceGroup.setVisible(true);
+        })
+        .catch(() => {
+          if (vectorStyleRequestRef.current !== requestId) {
+            return;
+          }
+
+          vectorBaseGroup.getLayers().clear();
+          vectorReferenceGroup.getLayers().clear();
+          tile.setSource(createVerifTileSource(baseMapStyle));
+          tile.setVisible(true);
+          const labelSource = createVerificationLabelOverlaySource(baseMapStyle);
+          if (labelSource) {
+            labels.setSource(labelSource);
+            labels.setVisible(true);
+          }
+        });
     } else {
+      hideVectorBasemapGroups();
       tile.setVisible(true);
       land.setVisible(false);
       landOutline.setVisible(true);

--- a/src/components/Map/OpenLayersVerificationMap.tsx
+++ b/src/components/Map/OpenLayersVerificationMap.tsx
@@ -224,10 +224,6 @@ const FALLBACK_STROKE_COLOR = '#000000';
 const TRANSPARENT_PATTERN_FILL = 'rgba(0,0,0,0)';
 const CIG_STROKE_COLOR = '#111111';
 const CIG_STROKE_WIDTH = 1.2;
-const OUTLOOK_FILL_OPACITY: Record<string, number> = {
-  [CATEGORICAL_OUTLOOK]: 1,
-};
-
 /** Returns true if the color string uses a CSS function notation like rgb(), rgba(), hsl(), or hsla(). */
 const isFunctionColorNotation = (color: string): boolean => {
   return FUNCTION_COLOR_NOTATION_REGEX.test(color);
@@ -238,13 +234,8 @@ const coerceNumber = (value: unknown, fallback: number): number => {
   return typeof value === 'number' ? value : fallback;
 };
 
-/** Resolves fill opacity: uses the per-type override from OUTLOOK_FILL_OPACITY if present, otherwise coerces the unknown value or defaults to 0.25. */
-const resolveFillOpacity = (outlookType: VerificationOutlookType, fillOpacity: unknown): number => {
-  const explicitTypeOpacity = OUTLOOK_FILL_OPACITY[outlookType];
-  if (typeof explicitTypeOpacity === 'number') {
-    return explicitTypeOpacity;
-  }
-
+/** Resolves fill opacity from the style payload, defaulting to 0.25 when missing. */
+const resolveFillOpacity = (_outlookType: VerificationOutlookType, fillOpacity: unknown): number => {
   return coerceNumber(fillOpacity, 0.25);
 };
 
@@ -326,8 +317,11 @@ const createStandardStroke = ({ color, opacity, width }: StrokeDescriptor): Stro
 };
 
 // Function to build OpenLayers style for a given feature based on its outlook type and probability,
-const buildStyle = ({ outlookType, probability }: OutlookStyleDescriptor) => {
-  const style = getFeatureStyle(outlookType as VerificationOutlookType, probability);
+const buildStyle = (
+  { outlookType, probability }: OutlookStyleDescriptor,
+  vectorBasemapEnabled: boolean
+) => {
+  const style = getFeatureStyle(outlookType as VerificationOutlookType, probability, { vectorBasemapEnabled });
   const fillColor = String(style.fillColor || FALLBACK_FILL_COLOR);
   const strokeColor = String(style.color || FALLBACK_STROKE_COLOR);
   const fillOpacity = resolveFillOpacity(outlookType, style.fillOpacity);
@@ -423,6 +417,7 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
   const initialMapViewRef = useRef(mapView);
   const outlooks = useSelector((state: RootState) => selectVerificationOutlooksForDay(state, selectedDay));
   const baseMapStyle = useSelector((state: RootState) => state.overlays.baseMapStyle);
+  const vectorBasemapEnabled = useSelector((state: RootState) => state.featureFlags.vectorBasemapEnabled);
   const { reports, visible: reportsVisible, filterByType } = useSelector(
     (state: RootState) => state.stormReports
   ); // Select storm reports state
@@ -610,7 +605,7 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
       return;
     }
 
-    if (isOpenFreeMapStyle(baseMapStyle)) {
+    if (vectorBasemapEnabled && isOpenFreeMapStyle(baseMapStyle)) {
       const requestId = vectorStyleRequestRef.current + 1;
       vectorStyleRequestRef.current = requestId;
 
@@ -667,7 +662,7 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
         labels.setVisible(false);
       }
     }
-  }, [baseMapStyle]);
+  }, [baseMapStyle, vectorBasemapEnabled]);
 
   useEffect(() => {
     const outlookLayer = outlookLayerRef.current;
@@ -675,10 +670,8 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
       return;
     }
 
-    // Match forecast map: categorical uses layer-level opacity so nested fills
-    // don't compound differently than forecast rendering.
-    outlookLayer.setOpacity(activeOutlookType === CATEGORICAL_OUTLOOK ? 0.5 : 1);
-  }, [activeOutlookType]);
+    outlookLayer.setOpacity(1);
+  }, [activeOutlookType, vectorBasemapEnabled]);
 
   useEffect(() => {
     const source = vectorSourceRef.current;
@@ -700,15 +693,15 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap>, OpenLayers
 
       if (Array.isArray(olFeature)) {
         olFeature.forEach((item) => {
-          item.setStyle(buildStyle({ outlookType: activeOutlookType, probability }));
+          item.setStyle(buildStyle({ outlookType: activeOutlookType, probability }, vectorBasemapEnabled));
           source.addFeature(item);
         });
       } else {
-        olFeature.setStyle(buildStyle({ outlookType: activeOutlookType, probability }));
+        olFeature.setStyle(buildStyle({ outlookType: activeOutlookType, probability }, vectorBasemapEnabled));
         source.addFeature(olFeature);
       }
     });
-  }, [activeFeatures, activeOutlookType]);
+  }, [activeFeatures, activeOutlookType, vectorBasemapEnabled]);
 
   useEffect(() => {
     const source = stormReportsSourceRef.current;

--- a/src/lib/openFreeMap.ts
+++ b/src/lib/openFreeMap.ts
@@ -1,0 +1,104 @@
+import type { BaseMapStyle } from '../store/overlaysSlice';
+
+interface OpenFreeMapLayer {
+  id: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
+interface OpenFreeMapStyle {
+  version: number;
+  sources: Record<string, unknown>;
+  layers: OpenFreeMapLayer[];
+  sprite?: string;
+  glyphs?: string;
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface OpenFreeMapStyleSet {
+  baseStyle: OpenFreeMapStyle;
+  overlayStyle: OpenFreeMapStyle;
+}
+
+const OPEN_FREE_MAP_STYLE_URLS: Partial<Record<BaseMapStyle, string>> = {
+  osm: 'https://tiles.openfreemap.org/styles/liberty',
+  'carto-light': 'https://tiles.openfreemap.org/styles/positron',
+};
+
+const OVERLAY_LINE_PREFIXES = [
+  'road_',
+  'bridge_',
+  'tunnel_',
+  'boundary_',
+  'aeroway_',
+];
+
+const OVERLAY_LINE_IDS = new Set([
+  'road_area_pattern',
+]);
+
+const styleSetCache = new Map<BaseMapStyle, Promise<OpenFreeMapStyleSet>>();
+
+/** True when the selected basemap style should render through OpenFreeMap vector tiles. */
+export const isOpenFreeMapStyle = (style: BaseMapStyle): boolean => style in OPEN_FREE_MAP_STYLE_URLS;
+
+/** Returns the hosted OpenFreeMap style URL for the requested basemap style. */
+const getOpenFreeMapStyleUrl = (style: BaseMapStyle): string => {
+  const styleUrl = OPEN_FREE_MAP_STYLE_URLS[style];
+  if (!styleUrl) {
+    throw new Error(`No OpenFreeMap style is configured for "${style}".`);
+  }
+
+  return styleUrl;
+};
+
+/** Deep-clones a style payload so the filtered variants can be mutated independently. */
+const cloneStyle = (style: OpenFreeMapStyle): OpenFreeMapStyle =>
+  JSON.parse(JSON.stringify(style)) as OpenFreeMapStyle;
+
+/** True when a style layer should render above the forecast polygons as a reference overlay. */
+const isOverlayLayer = (layer: OpenFreeMapLayer): boolean => {
+  if (layer.type === 'symbol') {
+    return true;
+  }
+
+  return OVERLAY_LINE_PREFIXES.some((prefix) => layer.id.startsWith(prefix)) || OVERLAY_LINE_IDS.has(layer.id);
+};
+
+/** Keeps only the requested layers while preserving the original style metadata and sources. */
+const createFilteredStyle = (style: OpenFreeMapStyle, predicate: (layer: OpenFreeMapLayer) => boolean): OpenFreeMapStyle => {
+  const clonedStyle = cloneStyle(style);
+  clonedStyle.layers = clonedStyle.layers.filter(predicate);
+  return clonedStyle;
+};
+
+/** Loads and splits one OpenFreeMap style into a base stack and a top reference overlay stack. */
+const loadOpenFreeMapStyleSet = async (style: BaseMapStyle): Promise<OpenFreeMapStyleSet> => {
+  const response = await fetch(getOpenFreeMapStyleUrl(style));
+  if (!response.ok) {
+    throw new Error(`Unable to load OpenFreeMap style for "${style}".`);
+  }
+
+  const fullStyle = await response.json() as OpenFreeMapStyle;
+  return {
+    baseStyle: createFilteredStyle(fullStyle, (layer) => !isOverlayLayer(layer)),
+    overlayStyle: createFilteredStyle(fullStyle, isOverlayLayer),
+  };
+};
+
+/** Returns the cached OpenFreeMap base/overlay styles for the requested basemap style. */
+export const getOpenFreeMapStyleSet = (style: BaseMapStyle): Promise<OpenFreeMapStyleSet> => {
+  if (!isOpenFreeMapStyle(style)) {
+    return Promise.reject(new Error(`"${style}" does not use OpenFreeMap vector tiles.`));
+  }
+
+  const cached = styleSetCache.get(style);
+  if (cached) {
+    return cached;
+  }
+
+  const next = loadOpenFreeMapStyleSet(style);
+  styleSetCache.set(style, next);
+  return next;
+};

--- a/src/lib/openFreeMap.ts
+++ b/src/lib/openFreeMap.ts
@@ -98,7 +98,10 @@ export const getOpenFreeMapStyleSet = (style: BaseMapStyle): Promise<OpenFreeMap
     return cached;
   }
 
-  const next = loadOpenFreeMapStyleSet(style);
+  const next = loadOpenFreeMapStyleSet(style).catch((error) => {
+    styleSetCache.delete(style);
+    throw error;
+  });
   styleSetCache.set(style, next);
   return next;
 };

--- a/src/lib/releaseFlags.ts
+++ b/src/lib/releaseFlags.ts
@@ -1,0 +1,8 @@
+export interface ReleaseFlags {
+  vectorBasemapEnabled: boolean;
+}
+
+/** Deployment-scoped feature flags. Beta can enable these before main does. */
+export const releaseFlags: ReleaseFlags = {
+  vectorBasemapEnabled: __GFC_FLAG_VECTOR_BASEMAP__,
+};

--- a/src/lib/releaseFlags.ts
+++ b/src/lib/releaseFlags.ts
@@ -2,7 +2,13 @@ export interface ReleaseFlags {
   vectorBasemapEnabled: boolean;
 }
 
+/** Safe accessor for build-time globals so tests and non-Vite tools can import this module. */
+const readBooleanFlag = (value: unknown, fallback = false): boolean =>
+  typeof value === 'boolean' ? value : fallback;
+
 /** Deployment-scoped feature flags. Beta can enable these before main does. */
 export const releaseFlags: ReleaseFlags = {
-  vectorBasemapEnabled: __GFC_FLAG_VECTOR_BASEMAP__,
+  vectorBasemapEnabled: readBooleanFlag(
+    typeof __GFC_FLAG_VECTOR_BASEMAP__ !== 'undefined' ? __GFC_FLAG_VECTOR_BASEMAP__ : undefined
+  ),
 };

--- a/src/store/featureFlagsSlice.ts
+++ b/src/store/featureFlagsSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { releaseFlags } from '../lib/releaseFlags';
 
 // Define the feature flags interface
 export interface FeatureFlags {
@@ -14,6 +15,7 @@ export interface FeatureFlags {
   // Other features
   saveLoadEnabled: boolean;
   significantThreatsEnabled: boolean;
+  vectorBasemapEnabled: boolean;
 }
 
 const initialState: FeatureFlags = {
@@ -24,6 +26,7 @@ const initialState: FeatureFlags = {
   categoricalOutlookEnabled: true,
   saveLoadEnabled: true,
   significantThreatsEnabled: true,
+  vectorBasemapEnabled: releaseFlags.vectorBasemapEnabled,
 };
 
 export const featureFlagsSlice = createSlice({

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -251,7 +251,9 @@ const renderOutlooksToMap = (mapInstance: L.Map, outlooks: OutlookData) => {
     const sortedEntries = sortProbabilities(entries);
     // Then we loop through the sorted probabilities and render the features with styles based on the outlook type and probability.
     sortedEntries.forEach(([probability, features]) => {
-      const styleOptions = getFeatureStyle(outlookType, probability);
+      const styleOptions = getFeatureStyle(outlookType, probability, {
+        vectorBasemapEnabled: store.getState().featureFlags.vectorBasemapEnabled,
+      });
       // We add each feature as a GeoJSON layer to the map with the appropriate style.
       // This ensures that the exported image will have the same outlook layers rendered as seen in the live map.
       features.forEach(feature => {

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -241,10 +241,13 @@ const sortProbabilities = (entries: [string, GeoJSON.Feature[]][]): [string, Geo
 const renderOutlooksToMap = (mapInstance: L.Map, outlooks: OutlookData) => {
   const vectorBasemapEnabled = store.getState().featureFlags.vectorBasemapEnabled;
   /** Returns export-time style options that match the currently selected map rendering mode. */
-  const getExportFeatureStyle = (outlookType: OutlookType, probability: string) =>
-    getFeatureStyle(outlookType, probability, {
-      vectorBasemapEnabled,
-    });
+  const getExportFeatureStyle = (outlookType: OutlookType, probability: string) => {
+    const style = getFeatureStyle(outlookType, probability);
+    return {
+      ...style,
+      fillOpacity: vectorBasemapEnabled ? 1 : (outlookType === 'categorical' ? 0.5 : 0.3),
+    };
+  };
 
   // We want to render in a specific order to ensure proper layering
   // (e.g. categorical at bottom, then tornado/wind/hail, then totalSevere, then day4-8 on top)

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -239,6 +239,13 @@ const sortProbabilities = (entries: [string, GeoJSON.Feature[]][]): [string, Geo
 
 // Helper: render outlooks onto a map instance
 const renderOutlooksToMap = (mapInstance: L.Map, outlooks: OutlookData) => {
+  const vectorBasemapEnabled = store.getState().featureFlags.vectorBasemapEnabled;
+  /** Returns export-time style options that match the currently selected map rendering mode. */
+  const getExportFeatureStyle = (outlookType: OutlookType, probability: string) =>
+    getFeatureStyle(outlookType, probability, {
+      vectorBasemapEnabled,
+    });
+
   // We want to render in a specific order to ensure proper layering
   // (e.g. categorical at bottom, then tornado/wind/hail, then totalSevere, then day4-8 on top)
   const outlookOrder: OutlookType[] = ['categorical', 'tornado', 'wind', 'hail', 'totalSevere', 'day4-8'];
@@ -251,9 +258,7 @@ const renderOutlooksToMap = (mapInstance: L.Map, outlooks: OutlookData) => {
     const sortedEntries = sortProbabilities(entries);
     // Then we loop through the sorted probabilities and render the features with styles based on the outlook type and probability.
     sortedEntries.forEach(([probability, features]) => {
-      const styleOptions = getFeatureStyle(outlookType, probability, {
-        vectorBasemapEnabled: store.getState().featureFlags.vectorBasemapEnabled,
-      });
+      const styleOptions = getExportFeatureStyle(outlookType, probability);
       // We add each feature as a GeoJSON layer to the map with the appropriate style.
       // This ensures that the exported image will have the same outlook layers rendered as seen in the live map.
       features.forEach(feature => {

--- a/src/utils/mapStyleUtils.ts
+++ b/src/utils/mapStyleUtils.ts
@@ -12,6 +12,10 @@ export type FeatureStyle = {
   fillOpacity?: number;
 };
 
+interface FeatureStyleOptions {
+  vectorBasemapEnabled?: boolean;
+}
+
 const RISK_ORDER: Record<string, number> = {
   TSTM: 0, MRGL: 1, SLGT: 2, ENH: 3, MDT: 4, HIGH: 5
 };
@@ -106,7 +110,13 @@ export const computeZIndex = (outlookType: OutlookType, probability: string) => 
  * @param probability - The probability string
  * @returns A `FeatureStyle` object used by rendering code
  */
-export const getFeatureStyle = (outlookType: OutlookType, probability: string): FeatureStyle => {
+export const getFeatureStyle = (
+  outlookType: OutlookType,
+  probability: string,
+  options: FeatureStyleOptions = {}
+): FeatureStyle => {
+  const { vectorBasemapEnabled = false } = options;
+
   if (probability.startsWith('CIG')) {
     const patternMap: Record<string, string> = {
       'CIG1': 'url(#pattern-cig1)',
@@ -127,12 +137,7 @@ export const getFeatureStyle = (outlookType: OutlookType, probability: string): 
   }
 
   const color = lookupColor(outlookType, probability);
-  // Categorical polygons are nested (MRGL contains SLGT contains ENH…).
-  // On the map, a dedicated categorical VectorLayer renders them at full
-  // fill opacity with layer-level 0.5 opacity, so higher-risk polygons
-  // completely cover lower-risk ones without color blending.
-  // This value is used as a fallback / for export utilities.
-  const fillOpacity = 1;
+  const fillOpacity = vectorBasemapEnabled ? 1 : (outlookType === 'categorical' ? 0.5 : 0.3);
   return {
     color: '#000000',
     weight: 2,

--- a/src/utils/mapStyleUtils.ts
+++ b/src/utils/mapStyleUtils.ts
@@ -132,7 +132,7 @@ export const getFeatureStyle = (outlookType: OutlookType, probability: string): 
   // fill opacity with layer-level 0.5 opacity, so higher-risk polygons
   // completely cover lower-risk ones without color blending.
   // This value is used as a fallback / for export utilities.
-  const fillOpacity = outlookType === 'categorical' ? 0.5 : 0.3;
+  const fillOpacity = 1;
   return {
     color: '#000000',
     weight: 2,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 declare const __GFC_COMING_SOON__: boolean;
 declare const __GFC_BETA_MODE__: boolean;
 declare const __GFC_BETA_INVITE_PATH__: string;
+declare const __GFC_FLAG_VECTOR_BASEMAP__: boolean;
 declare const __GFC_FIREBASE_API_KEY__: string;
 declare const __GFC_FIREBASE_AUTH_DOMAIN__: string;
 declare const __GFC_FIREBASE_PROJECT_ID__: string;
@@ -13,6 +14,7 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_AUTH_DOMAIN?: string;
   readonly VITE_FIREBASE_PROJECT_ID?: string;
   readonly VITE_FIREBASE_APP_ID?: string;
+  readonly VITE_FLAG_VECTOR_BASEMAP?: string;
 }
 
 interface ImportMeta {
@@ -23,6 +25,7 @@ declare global {
   var __GFC_COMING_SOON__: boolean;
   var __GFC_BETA_MODE__: boolean;
   var __GFC_BETA_INVITE_PATH__: string;
+  var __GFC_FLAG_VECTOR_BASEMAP__: boolean;
   var __GFC_FIREBASE_API_KEY__: string;
   var __GFC_FIREBASE_AUTH_DOMAIN__: string;
   var __GFC_FIREBASE_PROJECT_ID__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => {
       __GFC_COMING_SOON__: JSON.stringify(env.VITE_COMING_SOON === 'true'),
       __GFC_BETA_MODE__: JSON.stringify(env.VITE_BETA_MODE === 'true'),
       __GFC_BETA_INVITE_PATH__: JSON.stringify(env.VITE_BETA_INVITE_PATH ?? ''),
+      __GFC_FLAG_VECTOR_BASEMAP__: JSON.stringify(env.VITE_FLAG_VECTOR_BASEMAP === 'true'),
       __GFC_FIREBASE_API_KEY__: JSON.stringify(env.VITE_FIREBASE_API_KEY ?? ''),
       __GFC_FIREBASE_AUTH_DOMAIN__: JSON.stringify(env.VITE_FIREBASE_AUTH_DOMAIN ?? ''),
       __GFC_FIREBASE_PROJECT_ID__: JSON.stringify(env.VITE_FIREBASE_PROJECT_ID ?? ''),


### PR DESCRIPTION
This pull request adds support for a new "vector basemap" experimental feature, allowing users to toggle between the standard and vector-based map rendering in the forecast application. The implementation introduces the necessary UI controls, integrates the `ol-mapbox-style` library to enable Mapbox-style vector tiles in OpenLayers, and updates the legend and map rendering logic to accommodate the new feature. Additionally, several new dependencies are added to support this capability.

**Vector Basemap Feature Integration:**

* Added a "Beta Labs" section to the toolbar (`IntegratedToolbar.tsx`), allowing users (when in beta mode) to enable or disable the "vector basemap + opaque outlook fills" experiment. This section uses a new dropdown menu UI. [[1]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R183-R185) [[2]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R296-R327) [[3]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R718) [[4]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R736-R741) [[5]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R1034-R1039) [[6]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R1071-R1073)
* Connected the vector basemap toggle to Redux state via a new `vectorBasemapEnabled` feature flag. [[1]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R63) [[2]](diffhunk://#diff-efdf7eadae21b6a6e6a20115bd7806d030822136c94913bf6b7c793d4f714888R1034-R1039)

**Map and Legend Rendering Updates:**

* Updated the map component to use the `ol-mapbox-style` library (`apply` function) for rendering vector basemaps when the feature is enabled, and adjusted layer z-indexing for proper display. [[1]](diffhunk://#diff-944659924c88dffd361a985266ba104706e76f051b8c432a1f954115036d2ebdR6) [[2]](diffhunk://#diff-944659924c88dffd361a985266ba104706e76f051b8c432a1f954115036d2ebdR29-R33) [[3]](diffhunk://#diff-944659924c88dffd361a985266ba104706e76f051b8c432a1f954115036d2ebdR93)
* Modified the legend so that, when the vector basemap is enabled, outlook fill colors are rendered fully opaque instead of semi-transparent. [[1]](diffhunk://#diff-ae269176a0ddccc5ec4f8222fd2f7a2313c50937804f2a42bb7cece10eb94581R20) [[2]](diffhunk://#diff-ae269176a0ddccc5ec4f8222fd2f7a2313c50937804f2a42bb7cece10eb94581L30-R31)
* Simplified fill opacity logic to no longer require a special case for categorical layers, since the opacity is now controlled by the feature flag. [[1]](diffhunk://#diff-944659924c88dffd361a985266ba104706e76f051b8c432a1f954115036d2ebdL78) [[2]](diffhunk://#diff-944659924c88dffd361a985266ba104706e76f051b8c432a1f954115036d2ebdL171-R175)

**Dependency and Build System Changes:**

* Added `ol-mapbox-style` and its dependencies (such as `@maplibre/maplibre-gl-style-spec`, `mapbox-to-css-font`, etc.) to `package.json` and `pnpm-lock.yaml` to enable vector tile rendering. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R40) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR118-R120) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1458-R1468) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3585-R3587) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3745-R3747) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3771-R3773) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3814-R3818) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4163-R4165) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4337-R4339) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6236-R6249) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9292-R9293) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9418-R9419) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9437-R9438) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9465-R9470) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9830-R9831) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9985-R9986)

These changes lay the groundwork for further experimentation with vector-based maps and improved map rendering performance and appearance.