### PR TITLE
Update getFeatureStyle for fully opaque fills in released map

### DIFF
--- a/src/utils/mapStyleUtils.ts
+++ b/src/utils/mapStyleUtils.ts
@@ -99,8 +99,8 @@ export const computeZIndex = (outlookType: OutlookType, probability: string) => 
 /**
  * Create a `FeatureStyle` describing stroke/fill and z-index for a
  * specific outlook/probability combination. Handles special 'CIG'
- * pattern values, keeps categorical fills fully opaque, and preserves
- * the lighter probabilistic fill treatment used elsewhere in the app.
+ * pattern values and uses fully opaque fills for the released map
+ * treatment.
  *
  * @param outlookType - The outlook type (e.g. 'categorical')
  * @param probability - The probability string
@@ -135,7 +135,7 @@ export const getFeatureStyle = (
     weight: 2,
     opacity: 1,
     fillColor: color,
-    fillOpacity: outlookType === 'categorical' ? 1 : 0.3,
+    fillOpacity: 1,
     zIndex: computeZIndex(outlookType, probability)
   };
 };


### PR DESCRIPTION
This pull request updates the map styling logic to make all feature fills fully opaque, regardless of outlook type or probability. This change aligns the map's appearance with the released treatment, removing the previous distinction where probabilistic fills were lighter.

Map styling updates:

* Updated the `getFeatureStyle` function in `mapStyleUtils.ts` to always use a fill opacity of 1, instead of using a lighter fill for non-categorical outlooks.
* Revised documentation for `computeZIndex` to clarify that all fills are now fully opaque in the released map treatment.