### PR TITLE
[Port] chore(deps): bump @turf/helpers from 7.3.4 to 7.3.5 to beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
     "@turf/difference": "^7.3.4",
-    "@turf/helpers": "^7.3.4",
+    "@turf/helpers": "^7.3.5",
     "@turf/turf": "^7.3.4",
     "@types/jest": "^30.0.0",
     "@types/leaflet": "^1.9.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^7.3.4
         version: 7.3.4
       '@turf/helpers':
-        specifier: ^7.3.4
-        version: 7.3.4
+        specifier: ^7.3.5
+        version: 7.3.5
       '@turf/turf':
         specifier: ^7.3.4
         version: 7.3.4
@@ -2283,6 +2283,9 @@ packages:
 
   '@turf/helpers@7.3.4':
     resolution: {integrity: sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==}
+
+  '@turf/helpers@7.3.5':
+    resolution: {integrity: sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==}
 
   '@turf/hex-grid@7.3.4':
     resolution: {integrity: sha512-TDCgBykFdsrP3IOOfToiiLpYkbUb3eEEhM9riIqWht0ubKUY61LN7qVs9bxZD83hG6XaDB6uY7SWkxK1zIEopQ==}
@@ -7188,6 +7191,11 @@ snapshots:
       tslib: 2.8.1
 
   '@turf/helpers@7.3.4':
+    dependencies:
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/helpers@7.3.5':
     dependencies:
       '@types/geojson': 7946.0.16
       tslib: 2.8.1


### PR DESCRIPTION
Automated port of the original commits from PR #246 into beta after merge into main.