### PR TITLE
[codex] Add home concept dark mode

### DIFF
--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -49,8 +49,10 @@
   --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.5);
   --input-bg: #2d2d2d;
   --input-border: #404040;
-  --button-bg: #0d6efd;
-  --button-hover: #0b5ed7;
+  --button-bg: #2563eb;
+  --button-hover: #1d4ed8;
+  --button-dark-default-bg: #2f3744;
+  --button-dark-default-hover: #3a4555;
   --success-bg: #1a3328;
   --success-border: #2d5a3f;
   --success-text: #75b798;
@@ -124,13 +126,13 @@
 }
 
 /* Buttons */
-.dark-mode button:not(.outlook-type-btn):not(.mode-toggle-btn):not(.dark-mode-toggle-btn):not(.day-btn):not(.day-tab):not(.home-day-button):not(.home-cycle-button):not(.home-utility-button):not(.ui-button):not(.map-toolbar-button):not(.ol-zoom-in):not(.ol-zoom-out):not(.tabbed-integrated-toolbar__action-tile) {
-  background-color: var(--button-bg);
-  color: white;
+.dark-mode button:not(.outlook-type-btn):not(.mode-toggle-btn):not(.dark-mode-toggle-btn):not(.day-btn):not(.day-tab):not(.home-day-button):not(.home-cycle-button):not(.home-utility-button):not(.home-concept-action):not(.home-concept-top-primary):not(.home-concept-top-secondary):not(.home-concept-link):not(.ui-button):not(.map-toolbar-button):not(.ol-zoom-in):not(.ol-zoom-out):not(.tabbed-integrated-toolbar__action-tile) {
+  background-color: var(--button-dark-default-bg);
+  color: var(--text-primary);
 }
 
-.dark-mode button:not(.outlook-type-btn):not(.mode-toggle-btn):not(.dark-mode-toggle-btn):not(.day-btn):not(.day-tab):not(.home-day-button):not(.home-cycle-button):not(.home-utility-button):not(.ui-button):not(.map-toolbar-button):not(.ol-zoom-in):not(.ol-zoom-out):not(.tabbed-integrated-toolbar__action-tile):hover:not(:disabled) {
-  background-color: var(--button-hover);
+.dark-mode button:not(.outlook-type-btn):not(.mode-toggle-btn):not(.dark-mode-toggle-btn):not(.day-btn):not(.day-tab):not(.home-day-button):not(.home-cycle-button):not(.home-utility-button):not(.home-concept-action):not(.home-concept-top-primary):not(.home-concept-top-secondary):not(.home-concept-link):not(.ui-button):not(.map-toolbar-button):not(.ol-zoom-in):not(.ol-zoom-out):not(.tabbed-integrated-toolbar__action-tile):hover:not(:disabled) {
+  background-color: var(--button-dark-default-hover);
 }
 
 /* Toolbar Button Colors - Maintain variety in dark mode */

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -659,3 +659,807 @@
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
+
+.home-concept-page {
+  min-height: 100%;
+  background:
+    radial-gradient(circle at 18% 68%, color-mix(in srgb, var(--button-bg) 7%, transparent), transparent 28rem),
+    linear-gradient(180deg, var(--bg-primary), color-mix(in srgb, var(--bg-secondary) 45%, var(--bg-primary)));
+  color: var(--text-primary);
+}
+
+.home-concept-shell {
+  position: relative;
+  isolation: isolate;
+  width: 100%;
+  min-height: calc(100vh - 4.5rem);
+  overflow: hidden;
+}
+
+.home-concept-map-bg {
+  position: absolute;
+  inset: auto 0 0;
+  z-index: -1;
+  height: min(42vh, 26rem);
+  opacity: 0.42;
+  color: color-mix(in srgb, var(--button-bg) 18%, transparent);
+  background-image: radial-gradient(color-mix(in srgb, var(--button-bg) 12%, transparent) 0.8px, transparent 0.8px);
+  background-size: 8px 8px;
+  pointer-events: none;
+}
+
+.home-concept-map-bg svg {
+  width: 100%;
+  height: 100%;
+}
+
+.home-concept-map-bg path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.1;
+}
+
+.home-concept-shell-signed-in {
+  display: flex;
+  flex-direction: column;
+}
+
+.home-concept-cycle-bar {
+  display: grid;
+  gap: 1.4rem;
+  align-items: center;
+  padding: 2.25rem clamp(1.25rem, 3vw, 3rem);
+  border-bottom: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+}
+
+.home-concept-cycle-meta,
+.home-concept-cycle-actions,
+.home-concept-start-row,
+.home-concept-quick-notes,
+.home-concept-link {
+  display: flex;
+  align-items: center;
+}
+
+.home-concept-cycle-meta {
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.home-concept-cycle-meta p,
+.home-concept-glance h2,
+.home-concept-recent h2 {
+  margin: 0 0 0.4rem;
+  color: var(--button-bg);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.home-concept-cycle-meta h1 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  line-height: 1.2;
+  color: var(--text-primary);
+}
+
+.home-concept-icon-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 4.25rem;
+  height: 4.25rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
+  color: var(--button-bg);
+}
+
+.home-concept-unsaved {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #f18700;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.home-concept-unsaved::before {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.home-concept-cycle-actions {
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.home-concept-top-primary,
+.home-concept-top-secondary,
+.home-concept-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  font-weight: 700;
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.home-concept-top-primary,
+.home-concept-action-primary {
+  border: 1px solid var(--button-bg);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--button-bg) 86%, #7b61ff), var(--button-bg));
+  color: #fff;
+  box-shadow: 0 1.15rem 2rem color-mix(in srgb, var(--button-bg) 20%, transparent);
+}
+
+.home-concept-top-primary {
+  gap: 1.8rem;
+  min-height: 3.15rem;
+  padding: 0 1.55rem;
+}
+
+.home-concept-top-secondary {
+  gap: 0.65rem;
+  min-height: 3.15rem;
+  padding: 0 1.2rem;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.home-concept-top-primary:hover,
+.home-concept-top-secondary:hover,
+.home-concept-action:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.home-concept-signed-in-grid {
+  display: grid;
+  gap: clamp(2rem, 5vw, 5rem);
+  grid-template-columns: minmax(0, 1fr);
+  flex: 1;
+  padding: clamp(3rem, 8vw, 7rem) clamp(1.25rem, 8vw, 8rem) 4rem;
+}
+
+.home-concept-continue {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 34rem;
+}
+
+.home-concept-continue h2,
+.home-concept-landing-hero h1 {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0;
+  margin: 0;
+  color: var(--text-primary);
+  font-size: clamp(3rem, 6vw, 5rem);
+  font-weight: 850;
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+.home-concept-heading-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  white-space: nowrap;
+}
+
+.home-concept-continue h2 svg,
+.home-concept-landing-hero h1 svg {
+  flex: 0 0 auto;
+  color: var(--button-bg);
+}
+
+.home-concept-continue p,
+.home-concept-landing-hero > p {
+  margin: 1.4rem 0 0;
+  max-width: 35rem;
+  color: var(--text-secondary);
+  font-size: clamp(1.05rem, 1.4vw, 1.25rem);
+  line-height: 1.55;
+}
+
+.home-concept-continue-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+.home-concept-action {
+  justify-content: flex-start;
+  gap: 1rem;
+  width: 100%;
+  min-height: 4.25rem;
+  padding: 0 1.45rem;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--button-bg);
+  text-align: left;
+}
+
+.home-concept-action.home-concept-action-primary {
+  border-color: var(--button-bg);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--button-bg) 86%, #7b61ff), var(--button-bg));
+  color: #fff;
+  box-shadow: 0 1.15rem 2rem color-mix(in srgb, var(--button-bg) 20%, transparent);
+}
+
+.home-concept-action strong,
+.home-concept-action small {
+  display: block;
+}
+
+.home-concept-action small {
+  margin-top: 0.3rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.home-concept-action.home-concept-action-primary small,
+.home-concept-action.home-concept-action-primary svg {
+  color: #fff;
+}
+
+.home-concept-action-arrow {
+  margin-left: auto;
+}
+
+.home-concept-side-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  border-left: 1px solid var(--border-color);
+  padding-left: clamp(1.5rem, 4vw, 3rem);
+}
+
+.home-concept-glance dl {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  margin: 1.5rem 0 0;
+}
+
+.home-concept-glance div {
+  display: grid;
+  grid-template-columns: minmax(9rem, auto) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: center;
+}
+
+.home-concept-glance dt,
+.home-concept-glance dd {
+  margin: 0;
+}
+
+.home-concept-glance dt {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.home-concept-glance dd {
+  color: var(--text-secondary);
+  text-align: right;
+}
+
+.home-concept-recent {
+  border-top: 1px solid var(--border-color);
+  padding-top: 1.5rem;
+}
+
+.home-concept-timeline {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  margin-top: 1.35rem;
+}
+
+.home-concept-timeline::before {
+  content: "";
+  position: absolute;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  left: 0.5rem;
+  width: 1px;
+  background: var(--border-color);
+}
+
+.home-concept-cycle-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr) auto auto;
+  gap: 1rem;
+  align-items: center;
+  width: 100%;
+  padding: 0.65rem 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.home-concept-dot {
+  position: relative;
+  z-index: 1;
+  width: 0.9rem;
+  height: 0.9rem;
+  border: 2px solid var(--text-tertiary);
+  border-radius: 999px;
+  background: var(--bg-primary);
+}
+
+.home-concept-dot.is-active {
+  border-color: var(--button-bg);
+  box-shadow: inset 0 0 0 2px var(--bg-primary);
+  background: var(--button-bg);
+}
+
+.home-concept-cycle-copy strong,
+.home-concept-cycle-copy small {
+  display: block;
+}
+
+.home-concept-cycle-copy small {
+  margin-top: 0.28rem;
+  color: var(--text-secondary);
+}
+
+.home-concept-resume,
+.home-concept-link {
+  color: var(--button-bg);
+  font-weight: 700;
+}
+
+.home-concept-link {
+  gap: 0.65rem;
+  margin-top: 1.2rem;
+  border: 0;
+  background: transparent;
+  padding: 0.2rem 0;
+  border-radius: 0;
+}
+
+.home-concept-muted {
+  color: var(--text-secondary);
+}
+
+.home-concept-shell-signed-out {
+  padding: clamp(3rem, 8vw, 7rem) clamp(1.25rem, 7vw, 7rem) 4rem;
+}
+
+.home-concept-landing-grid {
+  display: grid;
+  gap: clamp(2rem, 5vw, 4rem);
+  max-width: 110rem;
+  margin: 0 auto;
+}
+
+.home-concept-landing-hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+}
+
+.home-concept-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  width: fit-content;
+  margin-top: 2rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
+  color: var(--button-bg);
+  font-weight: 700;
+}
+
+.home-concept-start-row {
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin-top: 2rem;
+}
+
+.home-concept-start-row .home-concept-action {
+  max-width: 22rem;
+  min-height: 5.4rem;
+  border-color: var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.home-concept-start-row .home-concept-action-primary {
+  color: #fff;
+}
+
+.home-concept-account-strip {
+  display: grid;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.home-concept-account-strip p,
+.home-concept-benefit p,
+.home-concept-feature p,
+.home-concept-account-card > p,
+.home-concept-privacy {
+  margin: 0.35rem 0 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.home-concept-quick-notes {
+  flex-wrap: wrap;
+  gap: 1.8rem;
+  margin-top: 2rem;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+}
+
+.home-concept-quick-notes span,
+.home-concept-privacy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.home-concept-quick-notes svg,
+.home-concept-privacy svg {
+  color: var(--button-bg);
+}
+
+.home-concept-tool-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  border-left: 1px solid var(--border-color);
+  padding-left: clamp(1.5rem, 4vw, 3rem);
+}
+
+.home-concept-feature-list,
+.home-concept-account-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.home-concept-feature-list h2,
+.home-concept-account-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--text-primary);
+}
+
+.home-concept-feature,
+.home-concept-benefit {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1.2rem;
+  align-items: center;
+}
+
+.home-concept-feature h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.home-concept-account-card {
+  gap: 1.3rem;
+  padding: 1.6rem;
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--button-bg) 5%, var(--bg-secondary));
+}
+
+.home-concept-benefit {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  padding-bottom: 1.3rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.home-concept-badge {
+  border-radius: 999px;
+  padding: 0.5rem 0.95rem;
+  background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
+  color: var(--button-bg);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.dark-mode .home-concept-page {
+  background:
+    radial-gradient(circle at 16% 62%, rgba(82, 106, 135, 0.12), transparent 30rem),
+    radial-gradient(circle at 82% 16%, rgba(255, 255, 255, 0.035), transparent 24rem),
+    linear-gradient(180deg, #111214 0%, #171717 12rem, #181818 100%);
+  color: #f3f1ec;
+  --home-concept-surface: #1f1f1f;
+  --home-concept-surface-raised: #252422;
+  --home-concept-border: rgba(246, 241, 229, 0.12);
+  --home-concept-muted: #cbc6ba;
+  --home-concept-soft-muted: #948e82;
+  --home-concept-accent: #7f95ad;
+  --home-concept-accent-strong: #9fb2c8;
+  --home-concept-action-bg: #242424;
+  --home-concept-action-hover: #2d333b;
+  --home-concept-primary-bg: #2b3440;
+  --home-concept-primary-hover: #354151;
+}
+
+.dark-mode .home-concept-cycle-bar {
+  border-bottom-color: var(--home-concept-border);
+  background: linear-gradient(180deg, #121212, #181818);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.dark-mode .home-concept-cycle-meta h1,
+.dark-mode .home-concept-continue h2,
+.dark-mode .home-concept-landing-hero h1,
+.dark-mode .home-concept-glance dt,
+.dark-mode .home-concept-feature-list h2,
+.dark-mode .home-concept-account-card h2,
+.dark-mode .home-concept-feature h3,
+.dark-mode .home-concept-cycle-row,
+.dark-mode .home-concept-benefit strong,
+.dark-mode .home-concept-account-strip strong {
+  color: #f7f4ed;
+}
+
+.dark-mode .home-concept-cycle-meta p,
+.dark-mode .home-concept-glance h2,
+.dark-mode .home-concept-recent h2,
+.dark-mode .home-concept-resume,
+.dark-mode .home-concept-link,
+.dark-mode .home-concept-quick-notes svg,
+.dark-mode .home-concept-privacy svg,
+.dark-mode .home-concept-continue h2 svg,
+.dark-mode .home-concept-landing-hero h1 svg {
+  color: var(--home-concept-accent-strong);
+}
+
+.dark-mode .home-concept-continue p,
+.dark-mode .home-concept-landing-hero > p,
+.dark-mode .home-concept-glance dd,
+.dark-mode .home-concept-muted,
+.dark-mode .home-concept-cycle-copy small,
+.dark-mode .home-concept-account-strip p,
+.dark-mode .home-concept-benefit p,
+.dark-mode .home-concept-feature p,
+.dark-mode .home-concept-account-card > p,
+.dark-mode .home-concept-privacy,
+.dark-mode .home-concept-quick-notes {
+  color: var(--home-concept-muted);
+}
+
+.dark-mode .home-concept-icon-chip {
+  background: rgba(82, 106, 135, 0.18);
+  color: var(--home-concept-accent-strong);
+  box-shadow: inset 0 0 0 1px rgba(159, 178, 200, 0.15);
+}
+
+.dark-mode .home-concept-top-primary,
+.dark-mode .home-concept-action.home-concept-action-primary {
+  border-color: rgba(159, 178, 200, 0.28);
+  background: linear-gradient(180deg, var(--home-concept-primary-hover), var(--home-concept-primary-bg));
+  color: #edf3f8;
+  box-shadow: 0 0.9rem 2rem rgba(0, 0, 0, 0.2);
+}
+
+.dark-mode .home-concept-top-primary:hover,
+.dark-mode .home-concept-action.home-concept-action-primary:hover {
+  border-color: rgba(159, 178, 200, 0.4);
+  background: linear-gradient(180deg, #3c4a5c, #303b49);
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.24);
+}
+
+.dark-mode .home-concept-top-secondary {
+  border-color: rgba(246, 241, 229, 0.12);
+  background: var(--home-concept-action-bg);
+  color: #eee9df;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.dark-mode .home-concept-top-secondary:hover {
+  border-color: rgba(159, 178, 200, 0.24);
+  background: var(--home-concept-action-hover);
+}
+
+.dark-mode .home-concept-action {
+  border-color: rgba(246, 241, 229, 0.12);
+  background: var(--home-concept-action-bg);
+  color: #eee9df;
+  box-shadow: none;
+}
+
+.dark-mode .home-concept-action:not(.home-concept-action-primary):hover {
+  border-color: rgba(159, 178, 200, 0.22);
+  background: var(--home-concept-action-hover);
+  box-shadow: none;
+}
+
+.dark-mode .home-concept-start-row .home-concept-action:not(.home-concept-action-primary),
+.dark-mode .home-concept-account-card {
+  border-color: var(--home-concept-border);
+  background: var(--home-concept-surface);
+  color: #f7f4ed;
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.16);
+}
+
+.dark-mode .home-concept-side-rail,
+.dark-mode .home-concept-tool-rail,
+.dark-mode .home-concept-recent,
+.dark-mode .home-concept-account-strip,
+.dark-mode .home-concept-benefit {
+  border-color: var(--home-concept-border);
+}
+
+.dark-mode .home-concept-timeline::before {
+  background: var(--home-concept-border);
+}
+
+.dark-mode .home-concept-dot {
+  border-color: var(--home-concept-soft-muted);
+  background: #191919;
+}
+
+.dark-mode .home-concept-dot.is-active {
+  border-color: var(--home-concept-accent-strong);
+  background: var(--home-concept-accent-strong);
+  box-shadow: inset 0 0 0 2px #191919;
+}
+
+.dark-mode .home-concept-cycle-row:hover {
+  color: #fff;
+}
+
+.dark-mode .home-concept-link {
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--home-concept-accent-strong);
+}
+
+.dark-mode .home-concept-link:hover,
+.dark-mode .home-concept-link:focus-visible {
+  color: #f4f8fc;
+  background: transparent;
+  box-shadow: inset 0 -2px 0 rgba(159, 178, 200, 0.48);
+}
+
+.dark-mode .home-concept-map-bg {
+  opacity: 0.2;
+  color: rgba(82, 106, 135, 0.16);
+  background-image: radial-gradient(rgba(82, 106, 135, 0.07) 0.8px, transparent 0.8px);
+}
+
+.dark-mode .home-concept-badge {
+  background: rgba(82, 106, 135, 0.18);
+  color: #b8c7d8;
+}
+
+.dark-mode .home-concept-page .home-concept-action:not(.home-concept-action-primary),
+.dark-mode .home-concept-page .home-concept-top-secondary {
+  border-color: rgba(246, 241, 229, 0.12);
+  background: #242424;
+  color: #eee9df;
+  box-shadow: none;
+}
+
+.dark-mode .home-concept-page .home-concept-action:not(.home-concept-action-primary) svg,
+.dark-mode .home-concept-page .home-concept-top-secondary svg {
+  color: #d8d1c3;
+}
+
+.dark-mode .home-concept-page .home-concept-action:not(.home-concept-action-primary):hover,
+.dark-mode .home-concept-page .home-concept-top-secondary:hover {
+  border-color: rgba(159, 178, 200, 0.22);
+  background: #2d333b;
+  box-shadow: none;
+}
+
+.dark-mode .home-concept-page .home-concept-link {
+  width: fit-content;
+  color: #9fb2c8;
+  background: transparent;
+  box-shadow: inset 0 -1px 0 rgba(159, 178, 200, 0.35);
+}
+
+body.dark-mode .home-concept-page button.home-concept-action:not(.home-concept-action-primary),
+body.dark-mode .home-concept-page button.home-concept-top-secondary {
+  border-color: rgba(246, 241, 229, 0.14) !important;
+  background: #242424 !important;
+  color: #eee9df !important;
+  box-shadow: none !important;
+}
+
+body.dark-mode .home-concept-page button.home-concept-action:not(.home-concept-action-primary) *,
+body.dark-mode .home-concept-page button.home-concept-top-secondary * {
+  color: #eee9df !important;
+}
+
+body.dark-mode .home-concept-page button.home-concept-action:not(.home-concept-action-primary):hover,
+body.dark-mode .home-concept-page button.home-concept-action:not(.home-concept-action-primary):focus-visible,
+body.dark-mode .home-concept-page button.home-concept-top-secondary:hover,
+body.dark-mode .home-concept-page button.home-concept-top-secondary:focus-visible {
+  border-color: rgba(159, 178, 200, 0.25) !important;
+  background: #2d333b !important;
+  color: #f4f8fc !important;
+  box-shadow: none !important;
+}
+
+body.dark-mode .home-concept-page button.home-concept-link {
+  width: fit-content !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: #9fb2c8 !important;
+  box-shadow: inset 0 -1px 0 rgba(159, 178, 200, 0.38) !important;
+}
+
+body.dark-mode .home-concept-page button.home-concept-link * {
+  color: #9fb2c8 !important;
+}
+
+@media (max-width: 767px) {
+  .home-concept-cycle-actions,
+  .home-concept-start-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .home-concept-top-primary,
+  .home-concept-top-secondary,
+  .home-concept-start-row .home-concept-action {
+    width: 100%;
+    max-width: none;
+  }
+
+  .home-concept-side-rail,
+  .home-concept-tool-rail {
+    border-left: 0;
+    padding-left: 0;
+  }
+
+  .home-concept-glance div {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .home-concept-glance dd {
+    text-align: left;
+  }
+}
+
+@media (min-width: 900px) {
+  .home-concept-cycle-bar {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .home-concept-signed-in-grid {
+    grid-template-columns: minmax(0, 1.6fr) minmax(22rem, 0.75fr);
+  }
+
+  .home-concept-landing-grid {
+    grid-template-columns: minmax(0, 1.45fr) minmax(22rem, 0.85fr);
+  }
+
+  .home-concept-account-strip {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import HomeHero, { HeroSummaryCard } from './home/HomeHero';
 import Dashboard from './home/Dashboard';
 import MainGrid from './home/MainGrid';
 import RecentCycles from './home/RecentCycles';
+import HomeConceptPage from './home/HomeConceptPage';
 import './HomePage.css';
 import useHomePageLogic from './home/useHomePageLogic';
 import AIDisclosure from './home/AIDisclosure';
@@ -155,7 +156,7 @@ const HomeSignedOutSection: React.FC<HomeSectionProps> = ({
 
 
 /** Main home page with auth-aware landing variants and a workflow-first forecast layout. */
-const HomePage: React.FC = () => {
+const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
   const {
     variant,
     stats,
@@ -179,7 +180,7 @@ const HomePage: React.FC = () => {
     savedCycles,
     forecastCycle,
     isSaved,
-  } = useHomePageLogic();
+  } = logic;
 
   return (
     <div className="h-full overflow-auto bg-gradient-to-br from-background via-background to-muted/20">
@@ -227,6 +228,64 @@ const HomePage: React.FC = () => {
 
       <input ref={fileInputRef} type="file" accept=".json" onChange={handleFileSelect} className="hidden" />
 
+      <CycleHistoryModal isOpen={showHistoryModal} onClose={handleCloseHistoryModal} />
+      <ConfirmationModal
+        isOpen={confirmNewCycle}
+        title="Start New Cycle"
+        message="You have unsaved changes. Start a new cycle anyway?"
+        onConfirm={handleConfirmNewCycle}
+        onCancel={handleCancelNewCycle}
+        confirmLabel="Start New Cycle"
+      />
+    </div>
+  );
+};
+
+const HomePage: React.FC = () => {
+  const logic = useHomePageLogic();
+  const {
+    variant,
+    formattedDate,
+    fileInputRef,
+    handleFileSelect,
+    handleNavigateForecast,
+    handleNavigateAccount,
+    openFilePicker,
+    showHistoryModal,
+    confirmNewCycle,
+    handleCloseHistoryModal,
+    handleLoadRecentCycleClick,
+    handleConfirmNewCycle,
+    handleCancelNewCycle,
+    handleNewCycle,
+    savedCycles,
+    forecastCycle,
+    isSaved,
+  } = logic;
+
+  const isClassicHome = typeof window !== 'undefined'
+    && new URLSearchParams(window.location.search).get('home') === 'classic';
+
+  if (isClassicHome) {
+    return <LegacyHomePage logic={logic} />;
+  }
+
+  return (
+    <div className="h-full overflow-auto bg-background">
+      <HomeConceptPage
+        variant={variant}
+        formattedDate={formattedDate}
+        savedCycles={savedCycles}
+        forecastCycle={forecastCycle}
+        isSaved={isSaved}
+        onResumeForecast={handleNavigateForecast}
+        onOpenHistory={logic.handleOpenHistoryModal}
+        onOpenFile={openFilePicker}
+        onNewCycle={handleNewCycle}
+        onLoadRecentCycle={handleLoadRecentCycleClick}
+        onNavigateAccount={handleNavigateAccount}
+      />
+      <input ref={fileInputRef} type="file" accept=".json" onChange={handleFileSelect} className="hidden" />
       <CycleHistoryModal isOpen={showHistoryModal} onClose={handleCloseHistoryModal} />
       <ConfirmationModal
         isOpen={confirmNewCycle}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -241,6 +241,7 @@ const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
   );
 };
 
+/** Home route that can render either the current concept or classic fallback. */
 const HomePage: React.FC = () => {
   const logic = useHomePageLogic();
   const {

--- a/src/pages/home/HomeConceptPage.tsx
+++ b/src/pages/home/HomeConceptPage.tsx
@@ -1,0 +1,350 @@
+import React from 'react';
+import {
+  ArrowRight,
+  BarChart3,
+  Calendar,
+  CheckCircle2,
+  Clock3,
+  Cloud,
+  Edit3,
+  FileText,
+  Folder,
+  History,
+  Lock,
+  Map,
+  MessageSquare,
+  MoreVertical,
+  PlayCircle,
+  PlusCircle,
+  ShieldCheck,
+  Sparkles,
+  Upload,
+  Zap,
+} from 'lucide-react';
+import type { SavedCycle } from '../../store/forecastSlice';
+import type { ForecastCycle } from '../../types/outlooks';
+
+type HomeConceptVariant = 'signed_in' | 'signed_out';
+
+interface HomeConceptPageProps {
+  variant: HomeConceptVariant;
+  formattedDate: string;
+  savedCycles: SavedCycle[];
+  forecastCycle: ForecastCycle;
+  isSaved: boolean;
+  onResumeForecast: () => void;
+  onOpenHistory: () => void;
+  onOpenFile: () => void;
+  onNewCycle: () => void;
+  onLoadRecentCycle: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onNavigateAccount: () => void;
+}
+
+const featureItems = [
+  {
+    icon: Map,
+    title: 'Interactive mapping',
+    body: 'Draw, edit, and refine with intuitive mapping tools.',
+  },
+  {
+    icon: MessageSquare,
+    title: 'Discuss & collaborate',
+    body: "Share your thoughts and get feedback when you're ready.",
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Verify with confidence',
+    body: 'Use built-in verification tools to improve accuracy and consistency.',
+  },
+];
+
+const accountBenefits = [
+  {
+    icon: Map,
+    title: 'Track your forecasts',
+    body: 'View your forecast history and statistics to measure your progress.',
+    badge: 'Free',
+  },
+  {
+    icon: Upload,
+    title: 'Sync across devices',
+    body: 'Keep your settings in sync and access your forecasts anywhere.',
+    badge: 'Premium',
+  },
+];
+
+const formatRecentTimestamp = (timestamp: string) => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return 'Saved recently';
+  }
+
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
+
+const getCyclePeriod = (timestamp: string) => {
+  const hour = new Date(timestamp).getHours();
+  if (Number.isNaN(hour)) {
+    return 'Cycle';
+  }
+  if (hour < 12) {
+    return 'Morning';
+  }
+  if (hour < 18) {
+    return 'Afternoon';
+  }
+  return 'Evening';
+};
+
+const ConceptBackground: React.FC = () => (
+  <div className="home-concept-map-bg" aria-hidden="true">
+    <svg viewBox="0 0 1100 420" preserveAspectRatio="none">
+      <path d="M0 300 C140 210 205 415 350 320 C490 226 605 380 760 292 C895 215 1005 282 1100 210" />
+      <path d="M0 335 C115 260 220 440 375 350 C525 262 610 398 790 324 C928 267 1015 325 1100 250" />
+      <path d="M0 255 C130 160 220 360 360 266 C500 172 590 320 750 248 C895 184 1000 238 1100 168" />
+      <path d="M0 390 C128 300 230 485 390 390 C545 306 660 438 820 362 C955 296 1040 360 1100 310" />
+    </svg>
+  </div>
+);
+
+const HeroActionButton: React.FC<{
+  icon: React.ElementType;
+  label: string;
+  sublabel?: string;
+  onClick: () => void;
+  primary?: boolean;
+}> = ({ icon: Icon, label, sublabel, onClick, primary }) => (
+  <button
+    type="button"
+    className={primary ? 'home-concept-action home-concept-action-primary' : 'home-concept-action'}
+    onClick={onClick}
+  >
+    <Icon className="h-5 w-5" />
+    <span>
+      <strong>{label}</strong>
+      {sublabel && <small>{sublabel}</small>}
+    </span>
+    <ArrowRight className="h-5 w-5 home-concept-action-arrow" />
+  </button>
+);
+
+const RecentTimeline: React.FC<{
+  cycles: SavedCycle[];
+  onLoad: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onOpenHistory: () => void;
+}> = ({ cycles, onLoad, onOpenHistory }) => {
+  const recentCycles = cycles.slice(0, 5);
+
+  return (
+    <section className="home-concept-recent" aria-labelledby="recent-cycles-title">
+      <h2 id="recent-cycles-title">Recent Cycles</h2>
+      {recentCycles.length > 0 ? (
+        <div className="home-concept-timeline">
+          {recentCycles.map((cycle, index) => (
+            <button
+              type="button"
+              className="home-concept-cycle-row"
+              key={cycle.id}
+              data-cycle-id={cycle.id}
+              onClick={onLoad}
+            >
+              <span className={index === 0 ? 'home-concept-dot is-active' : 'home-concept-dot'} />
+              <span className="home-concept-cycle-copy">
+                <strong>{cycle.cycleDate}</strong>
+                <small>{formatRecentTimestamp(cycle.timestamp)}</small>
+                <small>{getCyclePeriod(cycle.timestamp)}</small>
+              </span>
+              {index === 0 ? <span className="home-concept-resume">Resume</span> : null}
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="home-concept-muted">Saved cycles will appear here once you create or load a forecast.</p>
+      )}
+      <button type="button" className="home-concept-link" onClick={onOpenHistory}>
+        View full history
+        <ArrowRight className="h-4 w-4" />
+      </button>
+    </section>
+  );
+};
+
+const AtAGlance: React.FC<{
+  formattedDate: string;
+  savedCyclesCount: number;
+  hasSavedCycles: boolean;
+}> = ({ formattedDate, savedCyclesCount, hasSavedCycles }) => (
+  <section className="home-concept-glance" aria-labelledby="at-a-glance-title">
+    <h2 id="at-a-glance-title">At A Glance</h2>
+    <dl>
+      <div>
+        <dt><Clock3 className="h-5 w-5" />Today</dt>
+        <dd>{formattedDate}</dd>
+      </div>
+      <div>
+        <dt><History className="h-5 w-5" />Saved cycles</dt>
+        <dd>{savedCyclesCount}</dd>
+      </div>
+      <div>
+        <dt><FileText className="h-5 w-5" />Cycle status</dt>
+        <dd>{hasSavedCycles ? 'History available' : 'Ready to draw'}</dd>
+      </div>
+    </dl>
+  </section>
+);
+
+const SignedInConcept: React.FC<HomeConceptPageProps> = ({
+  formattedDate,
+  savedCycles,
+  isSaved,
+  onResumeForecast,
+  onOpenHistory,
+  onNewCycle,
+  onLoadRecentCycle,
+}) => (
+  <main className="home-concept-shell home-concept-shell-signed-in">
+    <ConceptBackground />
+    <section className="home-concept-cycle-bar" aria-label="Active cycle">
+      <div className="home-concept-cycle-meta">
+        <span className="home-concept-icon-chip"><Calendar className="h-5 w-5" /></span>
+        <div>
+          <p>Active cycle</p>
+          <h1>{formattedDate}</h1>
+        </div>
+        {!isSaved && <span className="home-concept-unsaved">Unsaved changes</span>}
+      </div>
+      <div className="home-concept-cycle-actions">
+        <button type="button" className="home-concept-top-primary" onClick={onResumeForecast}>
+          Resume Forecast
+          <ArrowRight className="h-5 w-5" />
+        </button>
+        <button type="button" className="home-concept-top-secondary" onClick={onOpenHistory}>
+          <Calendar className="h-5 w-5" />
+          Switch Day
+        </button>
+        <button type="button" className="home-concept-top-secondary" onClick={onOpenHistory}>
+          <MoreVertical className="h-5 w-5" />
+          More
+        </button>
+      </div>
+    </section>
+
+    <div className="home-concept-signed-in-grid">
+      <section className="home-concept-continue">
+        <h2>
+          <span>Continue your</span>
+          <span className="home-concept-heading-line">forecast <Zap className="h-10 w-10" /></span>
+        </h2>
+        <p>Pick up right where you left off. Continue editing, verify your work, and publish with confidence.</p>
+        <div className="home-concept-continue-actions">
+          <HeroActionButton icon={PlayCircle} label="Resume Forecast" onClick={onResumeForecast} primary />
+          <HeroActionButton icon={Folder} label="Open another saved cycle" onClick={onOpenHistory} />
+          <HeroActionButton icon={PlusCircle} label="Start a new forecast cycle" onClick={onNewCycle} />
+        </div>
+      </section>
+
+      <aside className="home-concept-side-rail">
+        <AtAGlance
+          formattedDate={formattedDate}
+          savedCyclesCount={savedCycles.length}
+          hasSavedCycles={savedCycles.length > 0}
+        />
+        <RecentTimeline cycles={savedCycles} onLoad={onLoadRecentCycle} onOpenHistory={onOpenHistory} />
+      </aside>
+    </div>
+  </main>
+);
+
+const SignedOutConcept: React.FC<HomeConceptPageProps> = ({
+  onResumeForecast,
+  onOpenFile,
+  onNavigateAccount,
+}) => (
+  <main className="home-concept-shell home-concept-shell-signed-out">
+    <ConceptBackground />
+    <div className="home-concept-landing-grid">
+      <section className="home-concept-landing-hero">
+        <h1>
+          <span>Create forecasts.</span>
+          <span className="home-concept-heading-line">Your way. <Zap className="h-12 w-12" /></span>
+        </h1>
+        <p>Draw, organize, and verify forecasts faster with intuitive mapping tools built for weather forecasters.</p>
+        <div className="home-concept-pill">
+          <Sparkles className="h-4 w-4" />
+          No account required - start forecasting right away.
+        </div>
+        <div className="home-concept-start-row">
+          <HeroActionButton icon={Edit3} label="Start a new forecast" sublabel="Jump right in" onClick={onResumeForecast} primary />
+          <HeroActionButton icon={Folder} label="Open a saved forecast" sublabel="From your device" onClick={onOpenFile} />
+        </div>
+        <div className="home-concept-account-strip">
+          <span className="home-concept-icon-chip"><Map className="h-6 w-6" /></span>
+          <div>
+            <strong>Create a free account to track your forecasts</strong>
+            <p>See your history, view statistics, and access your work anywhere.</p>
+          </div>
+          <button type="button" className="home-concept-link" onClick={onNavigateAccount}>
+            Create a free account
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="home-concept-quick-notes">
+          <span><CheckCircle2 className="h-4 w-4" />Always free to forecast</span>
+          <span><BarChart3 className="h-4 w-4" />Track your performance</span>
+          <span><Upload className="h-4 w-4" />Sync settings across devices</span>
+        </div>
+      </section>
+
+      <aside className="home-concept-tool-rail">
+        <section className="home-concept-feature-list">
+          <h2>Powerful tools for every step</h2>
+          {featureItems.map(({ icon: Icon, title, body }) => (
+            <div className="home-concept-feature" key={title}>
+              <span className="home-concept-icon-chip"><Icon className="h-8 w-8" /></span>
+              <div>
+                <h3>{title}</h3>
+                <p>{body}</p>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <section className="home-concept-account-card">
+          <h2>More with an account</h2>
+          {accountBenefits.map(({ icon: Icon, title, body, badge }) => (
+            <div className="home-concept-benefit" key={title}>
+              <span className="home-concept-icon-chip"><Icon className="h-6 w-6" /></span>
+              <div>
+                <strong>{title}</strong>
+                <p>{body}</p>
+              </div>
+              <span className="home-concept-badge">{badge}</span>
+            </div>
+          ))}
+          <p>Create an account to unlock these benefits.</p>
+          <button type="button" className="home-concept-link" onClick={onNavigateAccount}>
+            Create a free account
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        </section>
+
+        <p className="home-concept-privacy"><Lock className="h-4 w-4" />Your data is private. You're in control.</p>
+      </aside>
+    </div>
+  </main>
+);
+
+const HomeConceptPage: React.FC<HomeConceptPageProps> = (props) => (
+  <div className="home-concept-page">
+    {props.variant === 'signed_in' ? <SignedInConcept {...props} /> : <SignedOutConcept {...props} />}
+  </div>
+);
+
+export default HomeConceptPage;

--- a/src/pages/home/HomeConceptPage.tsx
+++ b/src/pages/home/HomeConceptPage.tsx
@@ -5,7 +5,6 @@ import {
   Calendar,
   CheckCircle2,
   Clock3,
-  Cloud,
   Edit3,
   FileText,
   Folder,
@@ -49,7 +48,7 @@ const featureItems = [
   {
     icon: MessageSquare,
     title: 'Discuss & collaborate',
-    body: "Share your thoughts and get feedback when you're ready.",
+    body: 'Share your thoughts and get feedback when you are ready.',
   },
   {
     icon: ShieldCheck,
@@ -73,6 +72,7 @@ const accountBenefits = [
   },
 ];
 
+/** Formats a saved cycle timestamp for the recent-cycle timeline. */
 const formatRecentTimestamp = (timestamp: string) => {
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) {
@@ -88,6 +88,7 @@ const formatRecentTimestamp = (timestamp: string) => {
   });
 };
 
+/** Returns a friendly time-of-day label for a saved cycle timestamp. */
 const getCyclePeriod = (timestamp: string) => {
   const hour = new Date(timestamp).getHours();
   if (Number.isNaN(hour)) {
@@ -102,6 +103,7 @@ const getCyclePeriod = (timestamp: string) => {
   return 'Evening';
 };
 
+/** Decorative contour-line background used by the home concept layout. */
 const ConceptBackground: React.FC = () => (
   <div className="home-concept-map-bg" aria-hidden="true">
     <svg viewBox="0 0 1100 420" preserveAspectRatio="none">
@@ -113,6 +115,7 @@ const ConceptBackground: React.FC = () => (
   </div>
 );
 
+/** Reusable large action button for the concept hero areas. */
 const HeroActionButton: React.FC<{
   icon: React.ElementType;
   label: string;
@@ -134,6 +137,30 @@ const HeroActionButton: React.FC<{
   </button>
 );
 
+/** Single saved-cycle row in the recent-cycle timeline. */
+const RecentCycleButton: React.FC<{
+  cycle: SavedCycle;
+  isActive: boolean;
+  onLoad: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}> = ({ cycle, isActive, onLoad }) => (
+  <button
+    type="button"
+    className="home-concept-cycle-row"
+    data-cycle-id={cycle.id}
+    onClick={onLoad}
+  >
+    <span className={isActive ? 'home-concept-dot is-active' : 'home-concept-dot'} />
+    <span className="home-concept-cycle-copy">
+      <strong>{cycle.cycleDate}</strong>
+      <small>{formatRecentTimestamp(cycle.timestamp)}</small>
+      <small>{getCyclePeriod(cycle.timestamp)}</small>
+    </span>
+    {isActive ? <span className="home-concept-resume">Resume</span> : null}
+    <ArrowRight className="h-4 w-4" />
+  </button>
+);
+
+/** Lists the most recent saved cycles and exposes the full history action. */
 const RecentTimeline: React.FC<{
   cycles: SavedCycle[];
   onLoad: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -147,22 +174,7 @@ const RecentTimeline: React.FC<{
       {recentCycles.length > 0 ? (
         <div className="home-concept-timeline">
           {recentCycles.map((cycle, index) => (
-            <button
-              type="button"
-              className="home-concept-cycle-row"
-              key={cycle.id}
-              data-cycle-id={cycle.id}
-              onClick={onLoad}
-            >
-              <span className={index === 0 ? 'home-concept-dot is-active' : 'home-concept-dot'} />
-              <span className="home-concept-cycle-copy">
-                <strong>{cycle.cycleDate}</strong>
-                <small>{formatRecentTimestamp(cycle.timestamp)}</small>
-                <small>{getCyclePeriod(cycle.timestamp)}</small>
-              </span>
-              {index === 0 ? <span className="home-concept-resume">Resume</span> : null}
-              <ArrowRight className="h-4 w-4" />
-            </button>
+            <RecentCycleButton cycle={cycle} isActive={index === 0} key={cycle.id} onLoad={onLoad} />
           ))}
         </div>
       ) : (
@@ -176,6 +188,7 @@ const RecentTimeline: React.FC<{
   );
 };
 
+/** Shows quick cycle facts for the signed-in concept sidebar. */
 const AtAGlance: React.FC<{
   formattedDate: string;
   savedCyclesCount: number;
@@ -200,6 +213,60 @@ const AtAGlance: React.FC<{
   </section>
 );
 
+/** Top active-cycle action bar for signed-in users. */
+const SignedInCycleBar: React.FC<{
+  formattedDate: string;
+  isSaved: boolean;
+  onResumeForecast: () => void;
+  onOpenHistory: () => void;
+}> = ({ formattedDate, isSaved, onResumeForecast, onOpenHistory }) => (
+  <section className="home-concept-cycle-bar" aria-label="Active cycle">
+    <div className="home-concept-cycle-meta">
+      <span className="home-concept-icon-chip"><Calendar className="h-5 w-5" /></span>
+      <div>
+        <p>Active cycle</p>
+        <h1>{formattedDate}</h1>
+      </div>
+      {!isSaved && <span className="home-concept-unsaved">Unsaved changes</span>}
+    </div>
+    <div className="home-concept-cycle-actions">
+      <button type="button" className="home-concept-top-primary" onClick={onResumeForecast}>
+        Resume Forecast
+        <ArrowRight className="h-5 w-5" />
+      </button>
+      <button type="button" className="home-concept-top-secondary" onClick={onOpenHistory}>
+        <Calendar className="h-5 w-5" />
+        Switch Day
+      </button>
+      <button type="button" className="home-concept-top-secondary" onClick={onOpenHistory}>
+        <MoreVertical className="h-5 w-5" />
+        More
+      </button>
+    </div>
+  </section>
+);
+
+/** Main signed-in hero panel with resume, history, and new-cycle actions. */
+const SignedInContinuePanel: React.FC<{
+  onResumeForecast: () => void;
+  onOpenHistory: () => void;
+  onNewCycle: () => void;
+}> = ({ onResumeForecast, onOpenHistory, onNewCycle }) => (
+  <section className="home-concept-continue">
+    <h2>
+      <span>Continue your</span>
+      <span className="home-concept-heading-line">forecast <Zap className="h-10 w-10" /></span>
+    </h2>
+    <p>Pick up right where you left off. Continue editing, verify your work, and publish with confidence.</p>
+    <div className="home-concept-continue-actions">
+      <HeroActionButton icon={PlayCircle} label="Resume Forecast" onClick={onResumeForecast} primary />
+      <HeroActionButton icon={Folder} label="Open another saved cycle" onClick={onOpenHistory} />
+      <HeroActionButton icon={PlusCircle} label="Start a new forecast cycle" onClick={onNewCycle} />
+    </div>
+  </section>
+);
+
+/** Signed-in concept home screen. */
 const SignedInConcept: React.FC<HomeConceptPageProps> = ({
   formattedDate,
   savedCycles,
@@ -211,45 +278,19 @@ const SignedInConcept: React.FC<HomeConceptPageProps> = ({
 }) => (
   <main className="home-concept-shell home-concept-shell-signed-in">
     <ConceptBackground />
-    <section className="home-concept-cycle-bar" aria-label="Active cycle">
-      <div className="home-concept-cycle-meta">
-        <span className="home-concept-icon-chip"><Calendar className="h-5 w-5" /></span>
-        <div>
-          <p>Active cycle</p>
-          <h1>{formattedDate}</h1>
-        </div>
-        {!isSaved && <span className="home-concept-unsaved">Unsaved changes</span>}
-      </div>
-      <div className="home-concept-cycle-actions">
-        <button type="button" className="home-concept-top-primary" onClick={onResumeForecast}>
-          Resume Forecast
-          <ArrowRight className="h-5 w-5" />
-        </button>
-        <button type="button" className="home-concept-top-secondary" onClick={onOpenHistory}>
-          <Calendar className="h-5 w-5" />
-          Switch Day
-        </button>
-        <button type="button" className="home-concept-top-secondary" onClick={onOpenHistory}>
-          <MoreVertical className="h-5 w-5" />
-          More
-        </button>
-      </div>
-    </section>
+    <SignedInCycleBar
+      formattedDate={formattedDate}
+      isSaved={isSaved}
+      onResumeForecast={onResumeForecast}
+      onOpenHistory={onOpenHistory}
+    />
 
     <div className="home-concept-signed-in-grid">
-      <section className="home-concept-continue">
-        <h2>
-          <span>Continue your</span>
-          <span className="home-concept-heading-line">forecast <Zap className="h-10 w-10" /></span>
-        </h2>
-        <p>Pick up right where you left off. Continue editing, verify your work, and publish with confidence.</p>
-        <div className="home-concept-continue-actions">
-          <HeroActionButton icon={PlayCircle} label="Resume Forecast" onClick={onResumeForecast} primary />
-          <HeroActionButton icon={Folder} label="Open another saved cycle" onClick={onOpenHistory} />
-          <HeroActionButton icon={PlusCircle} label="Start a new forecast cycle" onClick={onNewCycle} />
-        </div>
-      </section>
-
+      <SignedInContinuePanel
+        onResumeForecast={onResumeForecast}
+        onOpenHistory={onOpenHistory}
+        onNewCycle={onNewCycle}
+      />
       <aside className="home-concept-side-rail">
         <AtAGlance
           formattedDate={formattedDate}
@@ -262,6 +303,106 @@ const SignedInConcept: React.FC<HomeConceptPageProps> = ({
   </main>
 );
 
+/** Signed-out hero panel with start, load, and account entry points. */
+const SignedOutHero: React.FC<{
+  onResumeForecast: () => void;
+  onOpenFile: () => void;
+  onNavigateAccount: () => void;
+}> = ({ onResumeForecast, onOpenFile, onNavigateAccount }) => (
+  <section className="home-concept-landing-hero">
+    <h1>
+      <span>Create forecasts.</span>
+      <span className="home-concept-heading-line">Your way. <Zap className="h-12 w-12" /></span>
+    </h1>
+    <p>Draw, organize, and verify forecasts faster with intuitive mapping tools built for weather forecasters.</p>
+    <div className="home-concept-pill">
+      <Sparkles className="h-4 w-4" />
+      No account required - start forecasting right away.
+    </div>
+    <div className="home-concept-start-row">
+      <HeroActionButton icon={Edit3} label="Start a new forecast" sublabel="Jump right in" onClick={onResumeForecast} primary />
+      <HeroActionButton icon={Folder} label="Open a saved forecast" sublabel="From your device" onClick={onOpenFile} />
+    </div>
+    <div className="home-concept-account-strip">
+      <span className="home-concept-icon-chip"><Map className="h-6 w-6" /></span>
+      <div>
+        <strong>Create a free account to track your forecasts</strong>
+        <p>See your history, view statistics, and access your work anywhere.</p>
+      </div>
+      <button type="button" className="home-concept-link" onClick={onNavigateAccount}>
+        Create a free account
+        <ArrowRight className="h-4 w-4" />
+      </button>
+    </div>
+    <div className="home-concept-quick-notes">
+      <span><CheckCircle2 className="h-4 w-4" />Always free to forecast</span>
+      <span><BarChart3 className="h-4 w-4" />Track your performance</span>
+      <span><Upload className="h-4 w-4" />Sync settings across devices</span>
+    </div>
+  </section>
+);
+
+/** Single tool feature row in the signed-out rail. */
+const FeatureItem: React.FC<{
+  icon: React.ElementType;
+  title: string;
+  body: string;
+}> = ({ icon: Icon, title, body }) => (
+  <div className="home-concept-feature">
+    <span className="home-concept-icon-chip"><Icon className="h-8 w-8" /></span>
+    <div>
+      <h3>{title}</h3>
+      <p>{body}</p>
+    </div>
+  </div>
+);
+
+/** Single account benefit row in the signed-out rail. */
+const AccountBenefitItem: React.FC<{
+  icon: React.ElementType;
+  title: string;
+  body: string;
+  badge: string;
+}> = ({ icon: Icon, title, body, badge }) => (
+  <div className="home-concept-benefit">
+    <span className="home-concept-icon-chip"><Icon className="h-6 w-6" /></span>
+    <div>
+      <strong>{title}</strong>
+      <p>{body}</p>
+    </div>
+    <span className="home-concept-badge">{badge}</span>
+  </div>
+);
+
+/** Supporting signed-out feature and account benefit rail. */
+const SignedOutToolRail: React.FC<{
+  onNavigateAccount: () => void;
+}> = ({ onNavigateAccount }) => (
+  <aside className="home-concept-tool-rail">
+    <section className="home-concept-feature-list">
+      <h2>Powerful tools for every step</h2>
+      {featureItems.map(({ icon: Icon, title, body }) => (
+        <FeatureItem icon={Icon} title={title} body={body} key={title} />
+      ))}
+    </section>
+
+    <section className="home-concept-account-card">
+      <h2>More with an account</h2>
+      {accountBenefits.map(({ icon: Icon, title, body, badge }) => (
+        <AccountBenefitItem icon={Icon} title={title} body={body} badge={badge} key={title} />
+      ))}
+      <p>Create an account to unlock these benefits.</p>
+      <button type="button" className="home-concept-link" onClick={onNavigateAccount}>
+        Create a free account
+        <ArrowRight className="h-4 w-4" />
+      </button>
+    </section>
+
+    <p className="home-concept-privacy"><Lock className="h-4 w-4" />Your data is private. You&apos;re in control.</p>
+  </aside>
+);
+
+/** Signed-out concept home screen. */
 const SignedOutConcept: React.FC<HomeConceptPageProps> = ({
   onResumeForecast,
   onOpenFile,
@@ -270,77 +411,17 @@ const SignedOutConcept: React.FC<HomeConceptPageProps> = ({
   <main className="home-concept-shell home-concept-shell-signed-out">
     <ConceptBackground />
     <div className="home-concept-landing-grid">
-      <section className="home-concept-landing-hero">
-        <h1>
-          <span>Create forecasts.</span>
-          <span className="home-concept-heading-line">Your way. <Zap className="h-12 w-12" /></span>
-        </h1>
-        <p>Draw, organize, and verify forecasts faster with intuitive mapping tools built for weather forecasters.</p>
-        <div className="home-concept-pill">
-          <Sparkles className="h-4 w-4" />
-          No account required - start forecasting right away.
-        </div>
-        <div className="home-concept-start-row">
-          <HeroActionButton icon={Edit3} label="Start a new forecast" sublabel="Jump right in" onClick={onResumeForecast} primary />
-          <HeroActionButton icon={Folder} label="Open a saved forecast" sublabel="From your device" onClick={onOpenFile} />
-        </div>
-        <div className="home-concept-account-strip">
-          <span className="home-concept-icon-chip"><Map className="h-6 w-6" /></span>
-          <div>
-            <strong>Create a free account to track your forecasts</strong>
-            <p>See your history, view statistics, and access your work anywhere.</p>
-          </div>
-          <button type="button" className="home-concept-link" onClick={onNavigateAccount}>
-            Create a free account
-            <ArrowRight className="h-4 w-4" />
-          </button>
-        </div>
-        <div className="home-concept-quick-notes">
-          <span><CheckCircle2 className="h-4 w-4" />Always free to forecast</span>
-          <span><BarChart3 className="h-4 w-4" />Track your performance</span>
-          <span><Upload className="h-4 w-4" />Sync settings across devices</span>
-        </div>
-      </section>
-
-      <aside className="home-concept-tool-rail">
-        <section className="home-concept-feature-list">
-          <h2>Powerful tools for every step</h2>
-          {featureItems.map(({ icon: Icon, title, body }) => (
-            <div className="home-concept-feature" key={title}>
-              <span className="home-concept-icon-chip"><Icon className="h-8 w-8" /></span>
-              <div>
-                <h3>{title}</h3>
-                <p>{body}</p>
-              </div>
-            </div>
-          ))}
-        </section>
-
-        <section className="home-concept-account-card">
-          <h2>More with an account</h2>
-          {accountBenefits.map(({ icon: Icon, title, body, badge }) => (
-            <div className="home-concept-benefit" key={title}>
-              <span className="home-concept-icon-chip"><Icon className="h-6 w-6" /></span>
-              <div>
-                <strong>{title}</strong>
-                <p>{body}</p>
-              </div>
-              <span className="home-concept-badge">{badge}</span>
-            </div>
-          ))}
-          <p>Create an account to unlock these benefits.</p>
-          <button type="button" className="home-concept-link" onClick={onNavigateAccount}>
-            Create a free account
-            <ArrowRight className="h-4 w-4" />
-          </button>
-        </section>
-
-        <p className="home-concept-privacy"><Lock className="h-4 w-4" />Your data is private. You're in control.</p>
-      </aside>
+      <SignedOutHero
+        onResumeForecast={onResumeForecast}
+        onOpenFile={onOpenFile}
+        onNavigateAccount={onNavigateAccount}
+      />
+      <SignedOutToolRail onNavigateAccount={onNavigateAccount} />
     </div>
   </main>
 );
 
+/** Switches between the signed-in and signed-out home concept variants. */
 const HomeConceptPage: React.FC<HomeConceptPageProps> = (props) => (
   <div className="home-concept-page">
     {props.variant === 'signed_in' ? <SignedInConcept {...props} /> : <SignedOutConcept {...props} />}

--- a/src/pages/home/HomePage.test.tsx
+++ b/src/pages/home/HomePage.test.tsx
@@ -37,9 +37,10 @@ const baseForecastCycle = {
 describe('HomePage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    window.history.pushState({}, '', '/');
   });
 
-  test('renders the signed-out landing view', () => {
+  test('renders the signed-out concept view', () => {
     const handlers = {
       handleNavigateForecast: jest.fn(),
       handleNavigateDiscussion: jest.fn(),
@@ -74,31 +75,29 @@ describe('HomePage', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText(/Build outlook packages without fighting the tooling/i)).toBeInTheDocument();
-    expect(screen.getByText(/GFC keeps drawing, cycle management, discussions, and verification in one place/i)).toBeInTheDocument();
-    expect(screen.getByText(/Still Local-First/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/days with outlooks/i).length).toBeGreaterThan(0);
-    expect(screen.queryByText(/Recent Cycles/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Create forecasts/i)).toBeInTheDocument();
+    expect(screen.getByText(/No account required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Powerful tools for every step/i)).toBeInTheDocument();
+    expect(screen.getByText(/More with an account/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Start Forecast/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Start a new forecast/i }));
     expect(handlers.handleNavigateForecast).toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: /Write Discussion/i }));
-    expect(handlers.handleNavigateDiscussion).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /Open a saved forecast/i }));
+    expect(handlers.openFilePicker).toHaveBeenCalled();
 
-    expect(screen.getByRole('button', { name: /Start New Cycle/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Load From File/i })).toBeInTheDocument();
-    expect(screen.getByText(/AI Development Disclosure/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /GitHub Issues/i })).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('button', { name: /Create a free account/i })[0]);
+    expect(handlers.handleNavigateAccount).toHaveBeenCalled();
   });
 
-  test('renders the signed-in workspace and wires core actions', () => {
+  test('renders the signed-in concept workspace and wires core actions', () => {
     const quickStart = jest.fn();
     const loadRecent = jest.fn();
     const openHistory = jest.fn();
     const openFilePicker = jest.fn();
     const save = jest.fn();
     const loadFile = jest.fn();
+    const navigateForecast = jest.fn();
 
     mockUseHomePageLogic.mockReturnValue({
       variant: 'signed_in',
@@ -151,7 +150,7 @@ describe('HomePage', () => {
       ],
       forecastCycle: baseForecastCycle,
       isSaved: true,
-      handleNavigateForecast: jest.fn(),
+      handleNavigateForecast: navigateForecast,
       handleNavigateDiscussion: jest.fn(),
       handleNavigateAccount: jest.fn(),
       handleOpenHistoryModal: openHistory,
@@ -171,22 +170,20 @@ describe('HomePage', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText(/Current Forecast Cycle/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Continue your forecast/i })).toBeInTheDocument();
+    expect(screen.getByText(/At A Glance/i)).toBeInTheDocument();
     expect(screen.getByText(/Recent Cycles/i)).toBeInTheDocument();
     expect(screen.getByText(/Cycle history modal open/i)).toBeInTheDocument();
     expect(screen.getByText(/Confirm start new cycle modal open/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /View Full History/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /View full history/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Day 4/i }));
-    expect(quickStart).toHaveBeenCalled();
+    fireEvent.click(screen.getAllByRole('button', { name: /Resume Forecast/i })[0]);
+    expect(navigateForecast).toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: /Cycle 1/i }));
+    fireEvent.click(screen.getByRole('button', { name: /2026-03-25/i }));
     expect(loadRecent).toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: /Save Cycle File/i }));
-    expect(save).toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole('button', { name: /Open Cycle History/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Switch Day/i }));
     expect(openHistory).toHaveBeenCalled();
 
     const fileInput = container.querySelector('input[type="file"]');
@@ -199,5 +196,48 @@ describe('HomePage', () => {
       });
     }
     expect(loadFile).toHaveBeenCalled();
+    expect(quickStart).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+    expect(openFilePicker).not.toHaveBeenCalled();
+  });
+
+  test('keeps the classic home page available with a query switch', () => {
+    window.history.pushState({}, '', '/?home=classic');
+    const handlers = {
+      handleNavigateForecast: jest.fn(),
+      handleNavigateDiscussion: jest.fn(),
+      handleNavigateAccount: jest.fn(),
+      handleOpenHistoryModal: jest.fn(),
+      handleQuickStartClick: jest.fn(),
+      handleNewCycle: jest.fn(),
+      handleSave: jest.fn(),
+      openFilePicker: jest.fn(),
+      handleLoadRecentCycleClick: jest.fn(),
+      handleConfirmNewCycle: jest.fn(),
+      handleCancelNewCycle: jest.fn(),
+      handleFileSelect: jest.fn(),
+    };
+
+    mockUseHomePageLogic.mockReturnValue({
+      variant: 'signed_out',
+      stats: baseStats,
+      formattedDate: 'Friday, March 27, 2026',
+      fileInputRef: { current: null },
+      showHistoryModal: false,
+      confirmNewCycle: false,
+      savedCycles: [],
+      forecastCycle: baseForecastCycle,
+      isSaved: false,
+      ...handlers,
+    });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Build outlook packages without fighting the tooling/i)).toBeInTheDocument();
+    expect(screen.getByText(/AI Development Disclosure/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Adds the new home concept UI while keeping the classic home page available with ?home=classic.
- Reworks dark-mode home styling with muted slate/steel accents instead of bright blue or yellow-heavy buttons.
- Fixes the global dark-mode plain button default so unstyled dark buttons no longer become bright blue by default.

## Validation

- npm test -- --watchAll=false --runInBand --runTestsByPath src/pages/home/HomePage.test.tsx
- npm run build