### PR TITLE
[codex] Improve mobile forecast editor usability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,64 +1,107 @@
-## Local Workflow Preferences
+# AGENTS.md
 
-- Do not create a new branch unless the user explicitly asks for one.
-- Do not commit, push, or open a PR unless the user explicitly asks for it.
-- Run relevant tests/checks before suggesting a commit, but leave the actual commit to the user unless asked.
+## Operating Mode
 
-## Night Watch Skills
+This repo uses an agentic development workflow: inspect the codebase, make the smallest coherent change, verify it, and leave the workspace in a state a human can immediately continue from.
 
-The following Night Watch CLI commands are available. Use them when the user asks to manage PRDs, board issues, or trigger Night Watch operations.
+Agents should act like senior collaborators, not script runners. Prefer concrete progress over long proposals. When the user asks for an implementation, implement it. When the user reports a UI issue with screenshots, iterate directly against the actual behavior and verify the result.
 
-### Create a PRD (`/nw-create-prd`)
+## Core Principles
 
-Create a new PRD at `docs/prds/<name>.md`. Ask for feature title, assess complexity (1=Simple, 2=Medium, 3=Complex), split into phases with checkbox tasks, then write the file. Tell the user to run `night-watch run` to execute immediately.
+- Read the relevant code before changing it.
+- Follow existing patterns before introducing new abstractions.
+- Keep changes scoped to the requested behavior.
+- Preserve unrelated worktree changes.
+- Do not revert, reset, delete, or overwrite work you did not create unless explicitly asked.
+- Prefer clear, testable fixes over broad rewrites.
+- Make UI changes with the real user workflow in mind, not just the component in isolation.
+- Treat mobile and responsive behavior as first-class product behavior.
 
-### Add Issue to Board (`/nw-add-issue`)
+## Git Rules
 
-Add a GitHub issue to the Night Watch board:
+- Make code changes on a branch based on `beta` unless the user specifies another base or the workspace is already on a fresh task branch.
+- If the current branch is not suitable for the requested change, create a new branch from `beta` before editing.
+- Do not commit unless the user asks.
+- Do not push unless the user asks.
+- Do not open a pull request unless the user asks.
+- It is fine to inspect git status and diffs while working.
 
+## Implementation Workflow
+
+1. Inspect the relevant files and existing tests.
+2. Identify the smallest change that solves the reported problem.
+3. Edit the implementation.
+4. Add or update focused tests for the behavior.
+5. Run targeted verification.
+6. Run broader checks when the change touches shared behavior, build configuration, or user-facing flows.
+7. Summarize what changed and what was verified.
+
+If a test fails, fix the product code or the test based on the intended behavior. Do not weaken coverage just to make CI pass.
+
+New feature work should include reasonable test coverage for the behavior that is easily testable. Keep changed files above 80% coverage, preferably higher when the code is important or easy to exercise.
+
+## Frontend Expectations
+
+- Build the actual usable experience, not a placeholder or marketing surface.
+- Validate responsive layouts at realistic viewport sizes.
+- For forecast editor work, verify both portrait and landscape phone layouts.
+- Avoid horizontal page overflow.
+- Avoid controls that require both vertical and horizontal scrolling in the same toolbar surface.
+- Keep map workspace usable and visible on mobile.
+- Keep touch targets large enough for phone use.
+- Prefer CSS and existing component architecture before introducing mobile-only duplicates.
+- If screenshots show overlap, clipping, unreachable controls, or awkward placement, treat that as a product bug.
+
+## Forecast Editor Notes
+
+The forecast editor is the highest-priority workflow. The map should remain the primary workspace, with toolbar controls adapting around it.
+
+For mobile work, check:
+
+- Navbar does not overflow.
+- Map remains visible and usable.
+- Floating map controls do not collide with the toolbar, legend, credits, or warning badge.
+- Bottom toolbar tabs are reachable.
+- Draw, Days, Layers, and Tools controls remain accessible.
+- Legend/key can be hidden by default and opened intentionally.
+- Landscape phone layout uses the mobile interaction model when height is constrained.
+
+## Testing Guidance
+
+Use the narrowest useful verification first, then broaden as risk increases.
+
+Coverage matters. When adding features, update or add tests in the same change so behavior is protected and file coverage stays above 80%.
+
+Common focused unit test command:
+
+```powershell
+pnpm test -- --runTestsByPath <test-file-1> <test-file-2>
 ```
-night-watch board add-issue <issue-number>
-night-watch board add-issue <issue-number> --column "In Progress"
+
+Common build command:
+
+```powershell
+pnpm run build
 ```
 
-Available columns: Draft, Ready, In Progress, Review, Done.
+Common Playwright command:
 
-### Run Next PRD (`/nw-run`)
-
-Manually trigger Night Watch to execute the next PRD:
-
-```
-night-watch prd list         # see what's queued
-night-watch run              # execute next PRD
-night-watch run --prd <file> # run specific PRD
-night-watch logs --follow    # monitor progress
+```powershell
+pnpm exec playwright test e2e/smoke.spec.ts
 ```
 
-### Slice Roadmap (`/nw-slice`)
+When testing against an already-running local dev server:
 
-Break a high-level feature into multiple PRD files:
-
-```
-night-watch slice
-```
-
-Reads `docs/roadmap.md` and generates PRDs. Review and adjust output in `docs/prds/`.
-
-### Sync Board (`/nw-board-sync`)
-
-Sync the GitHub board with PRD/PR state:
-
-```
-night-watch board status
-night-watch board sync
+```powershell
+$env:PLAYWRIGHT_BASE_URL='http://127.0.0.1:3001'
+$env:PLAYWRIGHT_SKIP_WEBSERVER='1'
+pnpm exec playwright test e2e/smoke.spec.ts
 ```
 
-### Review PRs (`/nw-review`)
+## Communication
 
-Run automated PR review:
-
-```
-night-watch review
-night-watch review --pr <number>
-night-watch logs --type review
-```
+- Keep updates short and concrete while working.
+- Tell the user what you changed and what passed.
+- Call out any verification that could not be run.
+- Mention unrelated dirty files only when they matter.
+- Do not bury the result under process narration.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -6,27 +6,122 @@ import { test, expect } from '@playwright/test';
  */
 
 test.describe('App smoke tests', () => {
+  const bypassLocalBeta = async (page: import('@playwright/test').Page) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('gfc-local-beta-bypass', 'true');
+    });
+  };
+
+  const acceptAgreementsIfPresent = async (page: import('@playwright/test').Page) => {
+    for (let i = 0; i < 2; i += 1) {
+      const agreementCheckbox = page.getByRole('checkbox', { name: /I have read and agree/i });
+      if (!(await agreementCheckbox.isVisible().catch(() => false))) break;
+
+      await agreementCheckbox.check();
+      await page.getByRole('button', { name: /Accept & Continue/i }).click();
+    }
+  };
+
   test('homepage loads with correct title', async ({ page }) => {
-    await page.goto('/');
+    await bypassLocalBeta(page);
+    await page.goto('/?localBetaBypass=true');
+    await acceptAgreementsIfPresent(page);
+
     await expect(page).toHaveTitle(/Graphical Forecast Creator/);
-    // Use level:1 to avoid strict-mode conflict with the welcome card h2
-    await expect(page.getByRole('heading', { level: 1, name: /Graphical Forecast Creator/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /Create forecasts/i })).toBeVisible();
   });
 
   test('navbar is visible on homepage', async ({ page }) => {
-    await page.goto('/');
-    // Version badge
-    await expect(page.getByText('v1.0.0')).toBeVisible();
+    await bypassLocalBeta(page);
+    await page.goto('/?localBetaBypass=true');
+    await acceptAgreementsIfPresent(page);
+
+    await expect(page.getByRole('navigation')).toBeVisible();
+    await expect(page.locator('.app-navbar__brandName--full')).toBeVisible();
   });
 
   test('forecast page loads without crashing', async ({ page }) => {
-    await page.goto('/forecast');
+    await page.goto('/forecast?localBetaBypass=true');
     // The OpenLayers map container renders with class .map-container
     await expect(page.locator('.map-container')).toBeVisible({ timeout: 10000 });
   });
 
+  test('forecast editor is usable at mobile width', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await bypassLocalBeta(page);
+    await page.goto('/forecast?localBetaBypass=true');
+    await acceptAgreementsIfPresent(page);
+
+    await expect(page.locator('.map-container')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.tabbed-integrated-toolbar')).toBeVisible();
+    await expect(page.getByRole('complementary', { name: /map legend/i })).not.toBeVisible();
+    await page.getByRole('button', { name: /show map key/i }).click();
+    await expect(page.getByRole('complementary', { name: /map legend/i })).toBeVisible();
+
+    const documentOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(documentOverflow).toBeLessThanOrEqual(1);
+
+    for (const tabName of ['Draw', 'Days', 'Layers', 'Tools']) {
+      await page.getByRole('tab', { name: tabName }).click();
+      await expect(page.getByRole('tab', { name: tabName })).toHaveAttribute('aria-selected', 'true');
+    }
+
+    await page.getByRole('tab', { name: 'Draw' }).click();
+    await expect(page.getByRole('button', { name: /wind/i }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /15%/i }).first()).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Days' }).click();
+    await expect(page.getByRole('button', { name: '2' })).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Tools' }).click();
+    await expect(page.getByRole('button', { name: /Save/i }).first()).toBeVisible();
+
+    const mobileToolbarRow = page.locator('.tabbed-integrated-toolbar__row');
+    await mobileToolbarRow.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth;
+    });
+    await expect(page.getByRole('button', { name: /Reset All/i }).first()).toBeVisible();
+  });
+
+  test('forecast editor uses mobile controls in landscape phone view', async ({ page }) => {
+    await page.setViewportSize({ width: 932, height: 430 });
+    await bypassLocalBeta(page);
+    await page.goto('/forecast?localBetaBypass=true');
+    await acceptAgreementsIfPresent(page);
+
+    await expect(page.locator('.map-container')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.tabbed-integrated-toolbar__status-bar')).not.toBeVisible();
+    await expect(page.locator('.map-toolbar-help-surface')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: /show map key/i })).toBeVisible();
+
+    await page.getByRole('button', { name: /show map key/i }).click();
+    await expect(page.getByRole('complementary', { name: /map legend/i })).toBeVisible();
+
+    const legendBox = await page.getByRole('complementary', { name: /map legend/i }).boundingBox();
+    const toolbarBox = await page.locator('.tabbed-integrated-toolbar').boundingBox();
+    expect(legendBox).not.toBeNull();
+    expect(toolbarBox).not.toBeNull();
+    expect(legendBox!.y + legendBox!.height).toBeLessThanOrEqual(toolbarBox!.y + 1);
+
+    await page.getByRole('tab', { name: 'Tools' }).click();
+    await expect(page.getByRole('button', { name: /Undo/i }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /History/i }).first()).toBeVisible();
+
+    const landscapeToolbarRow = page.locator('.tabbed-integrated-toolbar__row');
+    await landscapeToolbarRow.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth;
+    });
+    await expect(page.getByRole('button', { name: /Reset All/i }).first()).toBeVisible();
+
+    const documentOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(documentOverflow).toBeLessThanOrEqual(1);
+  });
+
   test('verification page loads without crashing', async ({ page }) => {
-    await page.goto('/verification');
+    await bypassLocalBeta(page);
+    await page.goto('/verification?localBetaBypass=true');
+    await acceptAgreementsIfPresent(page);
+
     await expect(page.getByRole('heading', { name: /Verification/i })).toBeVisible({ timeout: 10000 });
   });
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -99,9 +99,10 @@ test.describe('App smoke tests', () => {
 
     const legendBox = await page.getByRole('complementary', { name: /map legend/i }).boundingBox();
     const toolbarBox = await page.locator('.tabbed-integrated-toolbar').boundingBox();
-    expect(legendBox).not.toBeNull();
-    expect(toolbarBox).not.toBeNull();
-    expect(legendBox!.y + legendBox!.height).toBeLessThanOrEqual(toolbarBox!.y + 1);
+    if (!legendBox || !toolbarBox) {
+      throw new Error('Expected the mobile key popout and toolbar to have measurable bounds.');
+    }
+    expect(legendBox.y + legendBox.height).toBeLessThanOrEqual(toolbarBox.y + 1);
 
     await page.getByRole('tab', { name: 'Tools' }).click();
     await expect(page.getByRole('button', { name: /Undo/i }).first()).toBeVisible();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphical-forecast-creator",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0-beta.3",
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const skipWebServer = process.env.PLAYWRIGHT_SKIP_WEBSERVER === '1';
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -8,7 +11,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -18,9 +21,9 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
+  webServer: skipWebServer ? undefined : {
     command: 'npm start',
-    url: 'http://localhost:3000',
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },

--- a/src/components/ForecastWorkspace/ForecastWorkspaceLayouts.tsx
+++ b/src/components/ForecastWorkspace/ForecastWorkspaceLayouts.tsx
@@ -12,8 +12,8 @@ export interface ForecastWorkspaceLayoutProps {
 /** ForecastTabbedToolbarLayout renders the Forecast map and the tabbed integrated toolbar. */
 export const ForecastTabbedToolbarLayout: React.FC<ForecastWorkspaceLayoutProps> = ({ controller, mapRef }) => (
   <TooltipProvider>
-    <div className="flex h-full min-h-0 flex-col bg-gradient-to-b from-background via-background to-muted/10">
-      <div className="relative min-h-0 flex-1">
+    <div className="forecast-workspace-layout flex h-full min-h-0 flex-col bg-gradient-to-b from-background via-background to-muted/10">
+      <div className="forecast-workspace-layout__map relative min-h-0 flex-1">
         <ForecastMap ref={mapRef} />
       </div>
       <TabbedIntegratedToolbar controller={controller} />

--- a/src/components/IntegratedToolbar/IntegratedToolbar.css
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.css
@@ -14,6 +14,22 @@
   transition: background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease, color 160ms ease;
 }
 
+.tabbed-integrated-toolbar__row {
+  scrollbar-width: thin;
+  overscroll-behavior-x: contain;
+}
+
+.tabbed-integrated-toolbar__row::-webkit-scrollbar,
+.tabbed-integrated-toolbar__tabs-list::-webkit-scrollbar {
+  height: 6px;
+}
+
+.tabbed-integrated-toolbar__row::-webkit-scrollbar-thumb,
+.tabbed-integrated-toolbar__tabs-list::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.45);
+  border-radius: 999px;
+}
+
 .dark-mode .tabbed-integrated-toolbar {
   background: #111215 !important;
   border-top-color: rgba(255, 255, 255, 0.08) !important;
@@ -209,4 +225,528 @@
 .dark-mode .tabbed-integrated-toolbar__action-tile--danger .tabbed-integrated-toolbar__action-icon {
   background: rgba(248, 113, 113, 0.12) !important;
   color: #fecaca !important;
+}
+
+@media (max-width: 640px), (max-height: 500px) and (orientation: landscape) {
+  .forecast-page-shell,
+  .forecast-workspace-layout {
+    min-height: 0;
+    width: 100%;
+    max-width: 100vw;
+    overflow: hidden;
+  }
+
+  .forecast-workspace-layout__map {
+    min-height: 320px;
+  }
+
+  .tabbed-integrated-toolbar {
+    height: 188px !important;
+    max-height: 38dvh;
+    min-height: 178px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    box-shadow: 0 -14px 34px -28px rgba(15, 23, 42, 0.65);
+    padding-bottom: env(safe-area-inset-bottom, 0);
+  }
+
+  .tabbed-integrated-toolbar__header {
+    padding: 6px 10px 0 !important;
+  }
+
+  .tabbed-integrated-toolbar__header > div {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__tabs-list {
+    display: flex;
+    width: 100%;
+    max-width: 100%;
+    gap: 4px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 1px;
+    scrollbar-width: none;
+  }
+
+  .tabbed-integrated-toolbar__tabs-list::-webkit-scrollbar {
+    display: none;
+  }
+
+  .tabbed-integrated-toolbar__trigger {
+    min-width: 82px;
+    flex: 1 0 82px;
+    justify-content: center;
+    padding: 7px 8px !important;
+    font-size: 12px !important;
+    border-radius: 14px !important;
+  }
+
+  .tabbed-integrated-toolbar__status-bar {
+    display: none !important;
+  }
+
+  .tabbed-integrated-toolbar__status-pill {
+    flex: 0 0 auto;
+  }
+
+  .tabbed-integrated-toolbar__tray {
+    padding: 6px 10px calc(8px + env(safe-area-inset-bottom, 0px)) !important;
+    overflow: hidden !important;
+  }
+
+  .tabbed-integrated-toolbar__row {
+    height: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 4px;
+    scrollbar-width: thin;
+  }
+
+  .tabbed-integrated-toolbar__row > div {
+    align-items: stretch;
+    gap: 10px;
+    min-width: max-content;
+    width: max-content;
+  }
+
+  .tabbed-integrated-toolbar__section {
+    width: auto !important;
+    min-width: 0 !important;
+    max-width: calc(100vw - 20px);
+    flex: 0 0 auto;
+    align-items: stretch;
+    gap: 0;
+    padding-right: 10px;
+  }
+
+  .tabbed-integrated-toolbar__section > div:first-child {
+    display: none;
+  }
+
+  .tabbed-integrated-toolbar__section-label {
+    font-size: 9px !important;
+    letter-spacing: 0.12em !important;
+  }
+
+  .tabbed-integrated-toolbar__section-hint {
+    display: none;
+  }
+
+  .tabbed-integrated-toolbar__section-content {
+    align-items: center;
+  }
+
+  .tabbed-integrated-toolbar__section--type {
+    flex: 0 0 146px;
+  }
+
+  .tabbed-integrated-toolbar__section--probability {
+    flex: 0 0 414px;
+    padding-right: 0;
+  }
+
+  .tabbed-integrated-toolbar__section--selection {
+    flex: 0 0 276px;
+    border-left: 1px solid var(--border);
+    padding-left: 12px;
+  }
+
+  .tabbed-integrated-toolbar__section--date {
+    flex: 0 0 224px;
+  }
+
+  .tabbed-integrated-toolbar__section--days {
+    flex: 0 0 260px;
+    padding-right: 0;
+  }
+
+  .tabbed-integrated-toolbar__section--day-status,
+  .tabbed-integrated-toolbar__section--layer-status {
+    display: none;
+  }
+
+  .tabbed-integrated-toolbar__section--cloud-context {
+    flex: 0 0 260px;
+    padding-right: 0;
+  }
+
+  .tabbed-integrated-toolbar__section--ghost-layers {
+    flex: 0 0 318px;
+  }
+
+  .tabbed-integrated-toolbar__section--base-map {
+    flex: 0 0 220px;
+    padding-right: 0;
+  }
+
+  .tabbed-integrated-toolbar__section--workspace-actions {
+    flex: 0 0 412px;
+    padding-right: 0;
+  }
+
+  .tabbed-integrated-toolbar__type-button,
+  .tabbed-integrated-toolbar__day-button,
+  .tabbed-integrated-toolbar__map-button,
+  .tabbed-integrated-toolbar__ghost-action,
+  .tabbed-integrated-toolbar__ghost-layer-button,
+  .tabbed-integrated-toolbar__action-tile,
+  .tabbed-integrated-toolbar__selection-toggle,
+  .tabbed-integrated-toolbar__primary-action,
+  .tabbed-integrated-toolbar__input {
+    min-height: 40px;
+  }
+
+  .tabbed-integrated-toolbar__section--type .tabbed-integrated-toolbar__section-content > div {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .tabbed-integrated-toolbar__type-button {
+    min-width: 0;
+    width: 100%;
+    padding-inline: 7px;
+  }
+
+  .tabbed-integrated-toolbar__section--probability .tabbed-integrated-toolbar__section-content > div {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 78px;
+    grid-template-rows: repeat(2, 36px);
+    width: max-content;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__probability-button {
+    min-width: 0;
+    width: 100%;
+    height: 36px;
+    min-height: 36px;
+    padding-inline: 6px;
+    border-radius: 11px !important;
+  }
+
+  .tabbed-integrated-toolbar__section--date .tabbed-integrated-toolbar__section-content > div {
+    width: 100%;
+    gap: 8px;
+  }
+
+  .tabbed-integrated-toolbar__day-button {
+    min-width: 0;
+    width: 100%;
+    height: 38px;
+    min-height: 38px;
+    padding-inline: 8px;
+  }
+
+  .tabbed-integrated-toolbar__section--days .tabbed-integrated-toolbar__section-content > div {
+    width: 100%;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__section--days .tabbed-integrated-toolbar__ghost-action {
+    display: flex;
+    width: 34px !important;
+    min-width: 34px;
+    height: 38px;
+    min-height: 38px;
+  }
+
+  .tabbed-integrated-toolbar__section--days .tabbed-integrated-toolbar__section-content > div > div {
+    flex: 1 1 auto;
+  }
+
+  .tabbed-integrated-toolbar__section--days .tabbed-integrated-toolbar__section-content > div > div > div {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    min-width: 0;
+    width: 100%;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__selection-strip {
+    max-width: 100%;
+    gap: 6px;
+    width: 100%;
+  }
+
+  .tabbed-integrated-toolbar__selection-swatch {
+    min-width: 136px;
+    max-width: 150px;
+    padding-inline: 10px;
+  }
+
+  .tabbed-integrated-toolbar__selection-toggle {
+    padding-inline: 10px;
+  }
+
+  .tabbed-integrated-toolbar__date-card {
+    flex: 1 1 auto;
+    min-width: 132px;
+    max-width: none;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    padding-block: 6px;
+  }
+
+  .tabbed-integrated-toolbar__date-card p {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tabbed-integrated-toolbar__input {
+    width: 148px !important;
+  }
+
+  .tabbed-integrated-toolbar__empty-state {
+    padding: 14px 16px !important;
+    min-width: 220px;
+  }
+
+  .tabbed-integrated-toolbar__action-group {
+    display: contents !important;
+    border-right: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .tabbed-integrated-toolbar__section--workspace-actions .tabbed-integrated-toolbar__section-content > div {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__action-tile {
+    min-width: 0;
+    width: 100%;
+    height: 38px;
+    min-height: 38px;
+    gap: 6px !important;
+    padding-inline: 8px !important;
+  }
+
+  .tabbed-integrated-toolbar__action-tile span:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tabbed-integrated-toolbar__section--ghost-layers .tabbed-integrated-toolbar__section-content > div {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 150px;
+    grid-template-rows: repeat(2, 40px);
+    width: max-content;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__ghost-layer-button {
+    min-width: 0;
+    width: 100%;
+    height: 40px;
+    gap: 6px !important;
+    padding-inline: 8px;
+  }
+
+  .tabbed-integrated-toolbar__ghost-layer-button > div:first-child {
+    width: 14px;
+    height: 14px;
+  }
+
+  .tabbed-integrated-toolbar__ghost-layer-button > div:last-child {
+    min-width: 0;
+    gap: 4px;
+  }
+
+  .tabbed-integrated-toolbar__ghost-layer-button span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tabbed-integrated-toolbar__section--base-map .tabbed-integrated-toolbar__section-content > div {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 86px;
+    grid-template-rows: repeat(2, 38px);
+    width: max-content;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__map-button {
+    width: 100%;
+    height: 38px;
+    min-height: 38px;
+    padding-inline: 8px;
+  }
+}
+
+@media (max-width: 380px) {
+  .tabbed-integrated-toolbar {
+    height: 190px !important;
+  }
+
+  .tabbed-integrated-toolbar__trigger {
+    min-width: 74px;
+    flex-basis: 74px;
+    gap: 5px !important;
+  }
+
+  .tabbed-integrated-toolbar__trigger svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .tabbed-integrated-toolbar__type-button {
+    min-width: 60px;
+  }
+
+  .tabbed-integrated-toolbar__probability-button {
+    min-width: 0;
+    font-size: 12px !important;
+  }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+  .forecast-workspace-layout__map {
+    min-height: 0;
+  }
+
+  .tabbed-integrated-toolbar {
+    height: 112px !important;
+    min-height: 112px;
+    max-height: 112px;
+  }
+
+  .tabbed-integrated-toolbar__header {
+    padding: 5px 10px 0 !important;
+  }
+
+  .tabbed-integrated-toolbar__tabs-list {
+    flex: 0 0 auto;
+  }
+
+  .tabbed-integrated-toolbar__trigger {
+    min-width: 120px;
+    flex: 1 0 120px;
+    height: 34px;
+    padding: 5px 8px !important;
+  }
+
+  .tabbed-integrated-toolbar__tray {
+    padding: 5px 10px 6px !important;
+  }
+
+  .tabbed-integrated-toolbar__row {
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .tabbed-integrated-toolbar__row > div {
+    align-items: center;
+  }
+
+  .tabbed-integrated-toolbar__type-button,
+  .tabbed-integrated-toolbar__probability-button,
+  .tabbed-integrated-toolbar__day-button,
+  .tabbed-integrated-toolbar__map-button,
+  .tabbed-integrated-toolbar__ghost-action,
+  .tabbed-integrated-toolbar__ghost-layer-button,
+  .tabbed-integrated-toolbar__action-tile,
+  .tabbed-integrated-toolbar__selection-toggle,
+  .tabbed-integrated-toolbar__primary-action,
+  .tabbed-integrated-toolbar__input {
+    height: 32px;
+    min-height: 32px;
+  }
+
+  .tabbed-integrated-toolbar__section--type {
+    flex-basis: 284px;
+  }
+
+  .tabbed-integrated-toolbar__section--type .tabbed-integrated-toolbar__section-content > div {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__type-button {
+    min-width: 64px;
+    width: 64px;
+  }
+
+  .tabbed-integrated-toolbar__section--probability {
+    flex-basis: 704px;
+  }
+
+  .tabbed-integrated-toolbar__section--probability .tabbed-integrated-toolbar__section-content > div {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__probability-button {
+    width: 64px;
+    min-width: 64px;
+  }
+
+  .tabbed-integrated-toolbar__section--selection {
+    flex-basis: 248px;
+  }
+
+  .tabbed-integrated-toolbar__section--days {
+    flex-basis: 482px;
+  }
+
+  .tabbed-integrated-toolbar__section--days .tabbed-integrated-toolbar__section-content > div > div > div,
+  .tabbed-integrated-toolbar__section--base-map .tabbed-integrated-toolbar__section-content > div,
+  .tabbed-integrated-toolbar__section--ghost-layers .tabbed-integrated-toolbar__section-content > div,
+  .tabbed-integrated-toolbar__section--workspace-actions .tabbed-integrated-toolbar__section-content > div {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 6px;
+  }
+
+  .tabbed-integrated-toolbar__day-button {
+    width: 42px;
+    min-width: 42px;
+  }
+
+  .tabbed-integrated-toolbar__section--ghost-layers {
+    flex-basis: 466px;
+  }
+
+  .tabbed-integrated-toolbar__ghost-layer-button {
+    min-width: 148px;
+  }
+
+  .tabbed-integrated-toolbar__section--base-map {
+    flex-basis: 350px;
+  }
+
+  .tabbed-integrated-toolbar__map-button {
+    min-width: 82px;
+  }
+
+  .tabbed-integrated-toolbar__section--workspace-actions {
+    flex-basis: 914px;
+  }
+
+  .tabbed-integrated-toolbar__action-tile {
+    width: 96px;
+    min-width: 96px;
+    flex: 0 0 96px;
+  }
+
+  .tabbed-integrated-toolbar__section--workspace-actions .tabbed-integrated-toolbar__section-content > div {
+    width: max-content;
+  }
 }

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -446,8 +446,9 @@ const TabbedToolbarStripSection: React.FC<{
   label: string;
   hint?: string;
   className?: string;
+  contentClassName?: string;
   children: React.ReactNode;
-}> = ({ label, hint, className, children }) => (
+}> = ({ label, hint, className, contentClassName, children }) => (
   <section className={cn('tabbed-integrated-toolbar__section flex h-full shrink-0 items-center gap-2 border-r border-border/70 pr-2 last:border-r-0 last:pr-0', className)}>
     <div className="flex w-[74px] shrink-0 flex-col justify-center">
       <span className="tabbed-integrated-toolbar__section-label text-[10px] font-semibold uppercase tracking-[0.22em] text-primary/80 leading-tight">{label}</span>
@@ -457,7 +458,7 @@ const TabbedToolbarStripSection: React.FC<{
         </span>
       ) : null}
     </div>
-    <div className="flex min-h-0 min-w-0 flex-1 items-center">{children}</div>
+    <div className={cn('tabbed-integrated-toolbar__section-content flex min-h-0 min-w-0 flex-1 items-center', contentClassName)}>{children}</div>
   </section>
 );
 
@@ -551,7 +552,7 @@ const TabbedToolbarStatPill: React.FC<{ label: string; value: string }> = ({ lab
 /** Draw tab containing outlook type and probability controls. */
 const TabbedToolbarDrawTab: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
   <TabbedToolbarTabRow>
-    <TabbedToolbarStripSection label="Outlook Type" hint="T / W / H / C" className="w-[316px]">
+    <TabbedToolbarStripSection label="Outlook Type" hint="T / W / H / C" className="tabbed-integrated-toolbar__section--type w-[316px]">
       <div className="flex flex-wrap items-center gap-1.5">
         {controller.availableTypes.map((type) => (
           <TabbedToolbarTypeButton key={type} controller={controller} type={type} />
@@ -562,7 +563,7 @@ const TabbedToolbarDrawTab: React.FC<{ controller: ForecastWorkspaceController }
     <TabbedToolbarStripSection
       label={controller.activeOutlookType === 'categorical' ? 'Risk Scale' : 'Probability Scale'}
       hint="Arrow Keys"
-      className="min-w-[500px] flex-1"
+      className="tabbed-integrated-toolbar__section--probability min-w-[500px] flex-1"
     >
       <div className="flex flex-wrap items-center gap-1.5">
         {controller.probabilities.map((probability) => (
@@ -575,7 +576,7 @@ const TabbedToolbarDrawTab: React.FC<{ controller: ForecastWorkspaceController }
       </div>
     </TabbedToolbarStripSection>
 
-    <TabbedToolbarStripSection label="Current Selection" className="w-[334px]">
+    <TabbedToolbarStripSection label="Current Selection" className="tabbed-integrated-toolbar__section--selection w-[334px]">
       <TabbedToolbarSelectionStrip controller={controller} showShortcuts={false} />
     </TabbedToolbarStripSection>
   </TabbedToolbarTabRow>
@@ -619,14 +620,14 @@ const CycleDateControl: React.FC<{ controller: ForecastWorkspaceController }> = 
 
 /** Cycle date strip wrapper used in the Days tab. */
 const CycleDateStrip: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
-  <TabbedToolbarStripSection label="Cycle Date" className="w-[300px]">
+  <TabbedToolbarStripSection label="Cycle Date" className="tabbed-integrated-toolbar__section--date w-[300px]">
     <CycleDateControl controller={controller} />
   </TabbedToolbarStripSection>
 );
 
 /** Forecast days strip with prev/next and day buttons. */
 const ForecastDaysStrip: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
-  <TabbedToolbarStripSection label="Forecast Days" hint="1-8" className="min-w-[680px] flex-1">
+  <TabbedToolbarStripSection label="Forecast Days" hint="1-8" className="tabbed-integrated-toolbar__section--days min-w-[680px] flex-1">
     <div className="flex items-center gap-2">
       <Button size="icon" variant="outline" className="tabbed-integrated-toolbar__ghost-action h-10 w-10 shrink-0 rounded-xl" onClick={controller.onPrevDay} disabled={controller.currentDay === 1}>
         <ChevronLeft className="h-4 w-4" />
@@ -668,7 +669,7 @@ const ForecastDaysStrip: React.FC<{ controller: ForecastWorkspaceController }> =
 const DayStatusStrip: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => {
   const daysWithData = FORECAST_DAYS.filter((day) => hasDayOutlookData(controller.days, day)).length;
   return (
-    <TabbedToolbarStripSection label="Day Status" className="w-[280px]">
+    <TabbedToolbarStripSection label="Day Status" className="tabbed-integrated-toolbar__section--day-status w-[280px]">
       <div className="flex flex-wrap items-center gap-2">
         <TabbedToolbarStatPill label="Current" value={`Day ${controller.currentDay}`} />
         <TabbedToolbarStatPill label="Data" value={`${daysWithData}/8`} />
@@ -692,7 +693,7 @@ const TabbedToolbarDaysTab: React.FC<{ controller: ForecastWorkspaceController }
 /** Layers tab exposing ghost layers and base map options. */
 const TabbedToolbarLayersTab: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
   <TabbedToolbarTabRow>
-    <TabbedToolbarStripSection label="Ghost Layers" hint={`Day ${controller.currentDay}`} className="min-w-[560px] flex-1">
+    <TabbedToolbarStripSection label="Ghost Layers" hint={`Day ${controller.currentDay}`} className="tabbed-integrated-toolbar__section--ghost-layers min-w-[560px] flex-1">
       {controller.ghostTypes.length > 0 ? (
         <div className="flex flex-wrap items-center gap-2">
           {controller.ghostTypes.map((type) => {
@@ -745,7 +746,7 @@ const TabbedToolbarLayersTab: React.FC<{ controller: ForecastWorkspaceController
       )}
     </TabbedToolbarStripSection>
 
-    <TabbedToolbarStripSection label="Base Map" className="w-[330px]">
+    <TabbedToolbarStripSection label="Base Map" className="tabbed-integrated-toolbar__section--base-map w-[330px]">
       <div className="flex flex-wrap items-center gap-2">
         {FORECAST_BASE_MAP_OPTIONS.map((option) => {
           const isActive = controller.baseMapStyle === option.value;
@@ -770,7 +771,7 @@ const TabbedToolbarLayersTab: React.FC<{ controller: ForecastWorkspaceController
       </div>
     </TabbedToolbarStripSection>
 
-    <TabbedToolbarStripSection label="Layer Status" className="w-[250px]">
+    <TabbedToolbarStripSection label="Layer Status" className="tabbed-integrated-toolbar__section--layer-status w-[250px]">
       <div className="flex flex-wrap items-center gap-2">
         <TabbedToolbarStatPill label="Visible" value={`${controller.visibleGhostOutlooks.length}`} />
         <TabbedToolbarStatPill label="Editing" value={outlookLabels[controller.activeOutlookType]} />
@@ -920,7 +921,7 @@ const TabbedToolbarToolsTab: React.FC<{ controller: ForecastWorkspaceController 
 
   return (
     <TabbedToolbarTabRow>
-      <TabbedToolbarStripSection label="Workspace Actions" className="min-w-[760px] flex-1">
+      <TabbedToolbarStripSection label="Workspace Actions" className="tabbed-integrated-toolbar__section--workspace-actions min-w-[760px] flex-1">
         <div className="flex flex-wrap items-center gap-3">
           <div className="tabbed-integrated-toolbar__action-group flex flex-wrap items-center gap-2 border-r border-border/70 pr-3">
             {historyItems.map((item) => (
@@ -940,7 +941,7 @@ const TabbedToolbarToolsTab: React.FC<{ controller: ForecastWorkspaceController 
         </div>
       </TabbedToolbarStripSection>
 
-      <TabbedToolbarStripSection label="Cloud & Context" className="w-[260px]">
+      <TabbedToolbarStripSection label="Cloud & Context" className="tabbed-integrated-toolbar__section--cloud-context w-[260px]">
         <div className="flex flex-wrap items-center gap-2">
           <TabbedToolbarStatPill label="State" value={controller.isSaved ? 'Saved' : 'Unsaved'} />
           {controller.cloudTools ?? (

--- a/src/components/Layout/Navbar.css
+++ b/src/components/Layout/Navbar.css
@@ -321,3 +321,110 @@
     display: none;
   }
 }
+
+@media (max-height: 500px) and (orientation: landscape) {
+  .app-navbar__inner {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 8px;
+    height: 56px;
+    padding: 0 12px;
+  }
+
+  .app-navbar__brandName--full {
+    display: none;
+  }
+
+  .app-navbar__brandName--short {
+    display: block;
+  }
+
+  .app-navbar__statusMeta,
+  .app-navbar__tabLabel,
+  .app-navbar__accountLabel {
+    display: none;
+  }
+
+  .app-navbar__tab {
+    height: 40px;
+    padding: 0 10px;
+  }
+
+  .app-navbar__actionButton--account {
+    width: 40px !important;
+    padding: 0 !important;
+  }
+
+  .app-navbar__utilityCluster {
+    gap: 4px;
+  }
+}
+
+@media (max-width: 460px) {
+  .app-navbar__inner {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 6px;
+    padding: 0 8px;
+  }
+
+  .app-navbar__brand {
+    gap: 6px;
+  }
+
+  .app-navbar__brandMark {
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+  }
+
+  .app-navbar__center {
+    justify-self: stretch;
+    overflow: hidden;
+  }
+
+  .app-navbar__tabs {
+    width: 100%;
+    justify-content: center;
+    gap: 0;
+    padding-left: 0;
+  }
+
+  .app-navbar__tab {
+    height: 40px;
+    min-width: 34px;
+    padding: 0 8px;
+  }
+
+  .app-navbar__utilityCluster {
+    gap: 2px;
+  }
+
+  .app-navbar__actionButton,
+  .app-navbar__iconButton {
+    width: 36px !important;
+    height: 40px !important;
+  }
+}
+
+@media (max-width: 380px) {
+  .app-navbar__inner {
+    gap: 4px;
+    padding: 0 6px;
+  }
+
+  .app-navbar__brandMark {
+    display: none;
+  }
+
+  .app-navbar__brandName--short {
+    font-size: 14px;
+  }
+
+  .app-navbar__tab {
+    min-width: 32px;
+    padding: 0 6px;
+  }
+
+  .app-navbar__actionButton--account {
+    display: none !important;
+  }
+}

--- a/src/components/Map/ForecastMap.css
+++ b/src/components/Map/ForecastMap.css
@@ -260,6 +260,10 @@
   background-color: #047857;
 }
 
+.map-key-popout-button {
+  display: none;
+}
+
 .dark-mode .map-toolbar-button {
   color: #f8fafc;
 }
@@ -324,14 +328,79 @@
   background-color: rgba(255, 255, 255, 0.1) !important;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 640px), (max-height: 500px) and (orientation: landscape) {
   .map-toolbar-bottom-right {
-    bottom: 52px;
-    right: 12px;
+    top: 12px;
+    bottom: auto;
+    right: 8px;
+    max-width: calc(100vw - 16px);
   }
 
   .map-toolbar-help-surface {
-    max-width: 240px;
+    display: none;
+  }
+
+  .map-toolbar-surface {
+    gap: 2px;
+    padding: 3px;
+    border-radius: 12px;
+  }
+
+  .map-toolbar-button {
+    min-width: 44px;
+    min-height: 36px;
+    padding: 8px 8px;
+    border-radius: 9px;
+    font-size: 0.74rem;
+  }
+
+  .map-toolbar-button.mode-key {
+    display: none;
+  }
+
+  .map-key-popout-button {
+    position: absolute;
+    left: 12px;
+    top: 132px;
+    bottom: auto;
+    z-index: 1201;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 36px;
+    padding: 8px 12px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.92);
+    color: #f8fafc;
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.22);
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .map-key-popout-button.active {
+    background: rgba(37, 99, 235, 0.94);
+    border-color: rgba(191, 219, 254, 0.5);
+  }
+
+  .map-container .ol-zoom {
+    top: 10px;
+    left: 10px;
+  }
+}
+
+@media (max-width: 380px) {
+  .map-toolbar-bottom-right {
+    top: 10px;
+  }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+  .map-key-popout-button {
+    top: 106px;
+    left: 12px;
+    bottom: auto;
   }
 }
 

--- a/src/components/Map/Legend.css
+++ b/src/components/Map/Legend.css
@@ -23,9 +23,53 @@
   overflow: auto;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 640px), (max-height: 500px) and (orientation: landscape) {
+  .map-legend,
   .forecast-floating-panels-layout .map-legend {
     display: none;
+  }
+
+  .map-legend.map-legend--mobile-open {
+    display: block;
+    left: 12px;
+    right: auto;
+    top: 176px;
+    bottom: auto;
+    z-index: 1200;
+    max-width: min(210px, calc(100vw - 24px));
+    max-height: min(42dvh, 300px);
+    overflow: auto;
+    padding: 10px;
+    font-size: 0.82rem;
+  }
+
+  .map-legend.map-legend--mobile-open h4 {
+    font-size: 0.88rem;
+    margin-bottom: 7px;
+  }
+
+  .map-legend.map-legend--mobile-open .legend-items {
+    gap: 3px;
+  }
+
+  .map-legend.map-legend--mobile-open .legend-color,
+  .map-legend.map-legend--mobile-open svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .map-legend.map-legend--mobile-open .legend-item span {
+    font-size: 0.78rem;
+  }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+  .map-legend.map-legend--mobile-open {
+    top: 106px;
+    left: 86px;
+    bottom: auto;
+    max-width: min(240px, calc(100vw - 110px));
+    max-height: calc(100dvh - var(--app-header-height, 64px) - 218px);
   }
 }
 

--- a/src/components/Map/Legend.test.tsx
+++ b/src/components/Map/Legend.test.tsx
@@ -52,4 +52,67 @@ describe('Legend', () => {
     
     expect(screen.getByText(/tornado/i)).toBeInTheDocument();
   });
+
+  it('marks the legend as open for the mobile popout state', () => {
+    const store = createMockStore({
+      forecast: {
+        drawingState: { activeOutlookType: 'tornado' },
+        uiVariant: 'standard',
+      },
+      theme: { darkMode: false },
+    });
+
+    render(
+      <Provider store={store}>
+        <Legend activeOutlookType="tornado" mobileOpen />
+      </Provider>
+    );
+
+    expect(screen.getByRole('complementary', { name: /map legend/i })).toHaveClass('map-legend--mobile-open');
+  });
+
+  it.each([
+    ['wind', /wind probabilities/i, /90%/i, /CIG3 \(Hatching\)/i],
+    ['hail', /hail probabilities/i, /60%/i, /CIG2 \(Hatching\)/i],
+    ['totalSevere', /totalsevere probabilities/i, /45%/i, /CIG1 \(Hatching\)/i],
+    ['day4-8', /day4-8 probabilities/i, /15%/i, /30%/i],
+  ] as const)('renders %s probability entries', (activeOutlookType, title, firstEntry, secondEntry) => {
+    const store = createMockStore({
+      forecast: {
+        drawingState: { activeOutlookType },
+        uiVariant: 'standard',
+      },
+      theme: { darkMode: false },
+    });
+
+    render(
+      <Provider store={store}>
+        <Legend activeOutlookType={activeOutlookType} />
+      </Provider>
+    );
+
+    expect(screen.getByText(title)).toBeInTheDocument();
+    expect(screen.getByText(firstEntry)).toBeInTheDocument();
+    expect(screen.getByText(secondEntry)).toBeInTheDocument();
+  });
+
+  it('uses dark-mode styling for hatch swatches', () => {
+    const store = createMockStore({
+      forecast: {
+        drawingState: { activeOutlookType: 'tornado' },
+        uiVariant: 'standard',
+      },
+      theme: { darkMode: true },
+    });
+
+    render(
+      <Provider store={store}>
+        <Legend activeOutlookType="tornado" />
+      </Provider>
+    );
+
+    expect(screen.getByRole('img', { name: /Legend for CIG1/i })).toHaveStyle({
+      border: '1px solid rgba(255,255,255,0.55)',
+    });
+  });
 });

--- a/src/components/Map/Legend.tsx
+++ b/src/components/Map/Legend.tsx
@@ -10,10 +10,11 @@ type LegendOutlookType = 'categorical' | 'tornado' | 'wind' | 'hail' | 'totalSev
 
 interface LegendProps {
   activeOutlookType?: LegendOutlookType;
+  mobileOpen?: boolean;
 }
 
 // Optimized: Memoized to prevent re-renders when parent re-renders
-const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOutlookTypeOverride }) => {
+const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOutlookTypeOverride, mobileOpen = false }) => {
   // Optimized: Select only activeOutlookType to avoid re-rendering on other drawing state changes (like activeProbability)
   const storeActiveOutlookType = useSelector((state: RootState) => state.forecast.drawingState.activeOutlookType);
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
@@ -131,7 +132,7 @@ const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOut
   };
 
   return (
-    <div className="map-legend" role="complementary" aria-label="Map Legend">
+    <div className={`map-legend ${mobileOpen ? 'map-legend--mobile-open' : ''}`} role="complementary" aria-label="Map Legend">
       {activeOutlookType === 'categorical' ? renderCategoricalLegend() : renderProbabilisticLegend()}
     </div>
   );

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -463,6 +463,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref
   const [interactionMode, setInteractionMode] = useState<'pan' | 'draw' | 'delete'>('pan');
   
   const [popupInfo, setPopupInfo] = useState<{ outlookType: string; probability: string; isSignificant: boolean } | null>(null);
+  const [showMobileLegend, setShowMobileLegend] = useState(false);
   const drawingState = useSelector((state: RootState) => state.forecast.drawingState);
   const currentMapView = useSelector((state: RootState) => state.forecast.currentMapView);
   const outlooks = useSelector(selectCurrentOutlooks) as OutlookMapLike;
@@ -1260,6 +1261,16 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref
           >
             Delete
           </button>
+          <button
+            type="button"
+            className={`map-toolbar-button mode-key ${showMobileLegend ? 'active' : ''}`}
+            onClick={() => setShowMobileLegend((isVisible) => !isVisible)}
+            title={showMobileLegend ? 'Hide map key' : 'Show map key'}
+            aria-label={showMobileLegend ? 'Hide map key' : 'Show map key'}
+            aria-expanded={showMobileLegend}
+          >
+            Key
+          </button>
         </div>
         <div className="map-toolbar-help-surface">
           {interactionMode === 'draw' && 'Draw mode: click to place points, double-click to finish polygon.'}
@@ -1267,7 +1278,18 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref
           {interactionMode === 'pan' && 'Pan mode: drag map to move, scroll to zoom. Click a polygon to see its details.'}
         </div>
       </div>
-      <Legend />
+      <Legend mobileOpen={showMobileLegend} />
+      <button
+        type="button"
+        className={`map-key-popout-button ${showMobileLegend ? 'active' : ''}`}
+        onClick={() => setShowMobileLegend((isVisible) => !isVisible)}
+        title={showMobileLegend ? 'Hide map key' : 'Show map key'}
+        aria-label={showMobileLegend ? 'Hide map key' : 'Show map key'}
+        aria-expanded={showMobileLegend}
+      >
+        <span aria-hidden="true">{showMobileLegend ? '▾' : '▴'}</span>
+        Key
+      </button>
       <StatusOverlay />
       <UnofficialBadge />
     </div>

--- a/src/components/Map/UnofficialBadge.css
+++ b/src/components/Map/UnofficialBadge.css
@@ -33,3 +33,9 @@
   background: #f59e0b;
   flex-shrink: 0;
 }
+
+@media (max-width: 640px), (max-height: 500px) and (orientation: landscape) {
+  .unofficial-badge {
+    bottom: 18px;
+  }
+}

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -1258,8 +1258,8 @@ export const ForecastPage: React.FC = () => {
 
   return (
     <div
-      className="w-full overflow-hidden"
-      style={{ height: 'calc(100dvh - var(--app-header-height, 64px))' }}
+      className="forecast-page-shell w-full overflow-hidden"
+      style={{ height: 'calc(100dvh - var(--app-header-height, 64px))', maxHeight: 'calc(100dvh - var(--app-header-height, 64px))' }}
     >
       {renderForecastWorkspaceLayout(forecastUiVariant, {
         mapRef,

--- a/src/pages/home/HomePage.test.tsx
+++ b/src/pages/home/HomePage.test.tsx
@@ -240,4 +240,88 @@ describe('HomePage', () => {
     expect(screen.getByText(/Build outlook packages without fighting the tooling/i)).toBeInTheDocument();
     expect(screen.getByText(/AI Development Disclosure/i)).toBeInTheDocument();
   });
+
+  test('renders the classic signed-in workspace and wires its actions', () => {
+    window.history.pushState({}, '', '/?home=classic');
+    const handlers = {
+      handleNavigateForecast: jest.fn(),
+      handleNavigateDiscussion: jest.fn(),
+      handleNavigateAccount: jest.fn(),
+      handleOpenHistoryModal: jest.fn(),
+      handleQuickStartClick: jest.fn(),
+      handleNewCycle: jest.fn(),
+      handleSave: jest.fn(),
+      openFilePicker: jest.fn(),
+      handleLoadRecentCycleClick: jest.fn(),
+      handleConfirmNewCycle: jest.fn(),
+      handleCancelNewCycle: jest.fn(),
+      handleFileSelect: jest.fn(),
+      handleCloseHistoryModal: jest.fn(),
+    };
+
+    mockUseHomePageLogic.mockReturnValue({
+      variant: 'signed_in',
+      stats: baseStats,
+      formattedDate: 'Friday, March 27, 2026',
+      fileInputRef: { current: null },
+      showHistoryModal: true,
+      confirmNewCycle: true,
+      savedCycles: [
+        {
+          id: 'cycle-1',
+          timestamp: '2026-03-25T12:00:00Z',
+          cycleDate: '2026-03-25',
+          label: 'Cycle 1',
+          forecastCycle: baseForecastCycle,
+          stats: { forecastDays: 1, totalOutlooks: 1, totalFeatures: 1 },
+        },
+      ],
+      forecastCycle: baseForecastCycle,
+      isSaved: false,
+      ...handlers,
+    });
+
+    const { container } = render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Cycle history modal open/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirm start new cycle modal open/i)).toBeInTheDocument();
+    expect(screen.getByText(/AI Development Disclosure/i)).toBeInTheDocument();
+    expect(screen.getByText(/Recent Cycles/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue Forecast/i }));
+    expect(handlers.handleNavigateForecast).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Write Discussion/i }));
+    expect(handlers.handleNavigateDiscussion).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Saved Cycles/i }));
+    expect(handlers.handleOpenHistoryModal).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Start New Cycle/i }));
+    expect(handlers.handleNewCycle).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Save Cycle File/i }));
+    expect(handlers.handleSave).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Load From File/i }));
+    expect(handlers.openFilePicker).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Cycle 1/i }));
+    expect(handlers.handleLoadRecentCycleClick).toHaveBeenCalled();
+
+    const fileInput = container.querySelector('input[type="file"]');
+    expect(fileInput).toBeInTheDocument();
+    if (fileInput) {
+      fireEvent.change(fileInput, {
+        target: {
+          files: [new File(['{}'], 'classic-forecast.json', { type: 'application/json' })],
+        },
+      });
+    }
+    expect(handlers.handleFileSelect).toHaveBeenCalled();
+  });
 });

--- a/src/utils/featureFlagsUtils.test.ts
+++ b/src/utils/featureFlagsUtils.test.ts
@@ -17,16 +17,26 @@ describe('featureFlagsUtils', () => {
 
   test('getFirstEnabledOutlookType returns first enabled or categorical fallback', () => {
     expect(getFirstEnabledOutlookType({ ...base, tornadoOutlookEnabled: true })).toBe('tornado');
+    expect(getFirstEnabledOutlookType({ ...base, windOutlookEnabled: true })).toBe('wind');
+    expect(getFirstEnabledOutlookType({ ...base, hailOutlookEnabled: true })).toBe('hail');
+    expect(getFirstEnabledOutlookType({ ...base, categoricalOutlookEnabled: true })).toBe('categorical');
     expect(getFirstEnabledOutlookType(base)).toBe('categorical');
   });
 
   test('isAnyOutlookEnabled', () => {
+    expect(isAnyOutlookEnabled({ ...base, tornadoOutlookEnabled: true })).toBe(true);
+    expect(isAnyOutlookEnabled({ ...base, windOutlookEnabled: true })).toBe(true);
+    expect(isAnyOutlookEnabled({ ...base, hailOutlookEnabled: true })).toBe(true);
     expect(isAnyOutlookEnabled({ ...base, categoricalOutlookEnabled: true })).toBe(true);
     expect(isAnyOutlookEnabled(base)).toBe(false);
   });
 
   test('isOutlookTypeEnabled', () => {
+    expect(isOutlookTypeEnabled({ ...base, tornadoOutlookEnabled: true }, 'tornado')).toBe(true);
     expect(isOutlookTypeEnabled({ ...base, windOutlookEnabled: true }, 'wind')).toBe(true);
+    expect(isOutlookTypeEnabled({ ...base, hailOutlookEnabled: true }, 'hail')).toBe(true);
+    expect(isOutlookTypeEnabled({ ...base, categoricalOutlookEnabled: true }, 'categorical')).toBe(true);
     expect(isOutlookTypeEnabled(base, 'hail')).toBe(false);
+    expect(isOutlookTypeEnabled(base, 'totalSevere')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a mobile-first forecast editor layout with a compact bottom toolbar and landscape phone handling.
- Adds a hidden-by-default map key popout and adjusts floating map controls, credits, and unofficial badge spacing.
- Refreshes agent workflow guidance and adds behavior-focused mobile, legend, home, and feature flag test coverage.

## Verification

- pnpm test -- --coverage --watch=false --runInBand
- pnpm run build
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:3001 PLAYWRIGHT_SKIP_WEBSERVER=1 playwright test e2e/smoke.spec.ts

## Coverage

Final Jest coverage: statements 93.26%, branches 80.03%, functions 84.08%, lines 93.26%.