### PR TITLE
[codex] Fix desktop key toggle

### DIFF
--- a/src/components/Map/Legend.css
+++ b/src/components/Map/Legend.css
@@ -14,6 +14,10 @@
   font-size: 0.9rem;
 }
 
+.map-legend.map-legend--desktop-hidden {
+  display: none;
+}
+
 .forecast-floating-panels-layout .map-legend {
   left: auto;
   right: 16px;

--- a/src/components/Map/Legend.test.tsx
+++ b/src/components/Map/Legend.test.tsx
@@ -71,6 +71,24 @@ describe('Legend', () => {
     expect(screen.getByRole('complementary', { name: /map legend/i })).toHaveClass('map-legend--mobile-open');
   });
 
+  it('marks the legend as hidden when the desktop key is toggled off', () => {
+    const store = createMockStore({
+      forecast: {
+        drawingState: { activeOutlookType: 'tornado' },
+        uiVariant: 'standard',
+      },
+      theme: { darkMode: false },
+    });
+
+    render(
+      <Provider store={store}>
+        <Legend activeOutlookType="tornado" desktopOpen={false} />
+      </Provider>
+    );
+
+    expect(screen.getByRole('complementary', { name: /map legend/i })).toHaveClass('map-legend--desktop-hidden');
+  });
+
   it.each([
     ['wind', /wind probabilities/i, /90%/i, /CIG3 \(Hatching\)/i],
     ['hail', /hail probabilities/i, /60%/i, /CIG2 \(Hatching\)/i],

--- a/src/components/Map/Legend.tsx
+++ b/src/components/Map/Legend.tsx
@@ -10,11 +10,16 @@ type LegendOutlookType = 'categorical' | 'tornado' | 'wind' | 'hail' | 'totalSev
 
 interface LegendProps {
   activeOutlookType?: LegendOutlookType;
+  desktopOpen?: boolean;
   mobileOpen?: boolean;
 }
 
 // Optimized: Memoized to prevent re-renders when parent re-renders
-const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOutlookTypeOverride, mobileOpen = false }) => {
+const Legend: React.FC<LegendProps> = React.memo(({
+  activeOutlookType: activeOutlookTypeOverride,
+  desktopOpen = true,
+  mobileOpen = false,
+}) => {
   // Optimized: Select only activeOutlookType to avoid re-rendering on other drawing state changes (like activeProbability)
   const storeActiveOutlookType = useSelector((state: RootState) => state.forecast.drawingState.activeOutlookType);
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
@@ -132,7 +137,11 @@ const Legend: React.FC<LegendProps> = React.memo(({ activeOutlookType: activeOut
   };
 
   return (
-    <div className={`map-legend ${mobileOpen ? 'map-legend--mobile-open' : ''}`} role="complementary" aria-label="Map Legend">
+    <div
+      className={`map-legend ${desktopOpen ? '' : 'map-legend--desktop-hidden'} ${mobileOpen ? 'map-legend--mobile-open' : ''}`}
+      role="complementary"
+      aria-label="Map Legend"
+    >
       {activeOutlookType === 'categorical' ? renderCategoricalLegend() : renderProbabilisticLegend()}
     </div>
   );

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -463,6 +463,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref
   const [interactionMode, setInteractionMode] = useState<'pan' | 'draw' | 'delete'>('pan');
   
   const [popupInfo, setPopupInfo] = useState<{ outlookType: string; probability: string; isSignificant: boolean } | null>(null);
+  const [showDesktopLegend, setShowDesktopLegend] = useState(true);
   const [showMobileLegend, setShowMobileLegend] = useState(false);
   const drawingState = useSelector((state: RootState) => state.forecast.drawingState);
   const currentMapView = useSelector((state: RootState) => state.forecast.currentMapView);
@@ -1263,11 +1264,11 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref
           </button>
           <button
             type="button"
-            className={`map-toolbar-button mode-key ${showMobileLegend ? 'active' : ''}`}
-            onClick={() => setShowMobileLegend((isVisible) => !isVisible)}
-            title={showMobileLegend ? 'Hide map key' : 'Show map key'}
-            aria-label={showMobileLegend ? 'Hide map key' : 'Show map key'}
-            aria-expanded={showMobileLegend}
+            className={`map-toolbar-button mode-key ${showDesktopLegend ? 'active' : ''}`}
+            onClick={() => setShowDesktopLegend((isVisible) => !isVisible)}
+            title={showDesktopLegend ? 'Hide map key' : 'Show map key'}
+            aria-label={showDesktopLegend ? 'Hide map key' : 'Show map key'}
+            aria-expanded={showDesktopLegend}
           >
             Key
           </button>
@@ -1278,7 +1279,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref
           {interactionMode === 'pan' && 'Pan mode: drag map to move, scroll to zoom. Click a polygon to see its details.'}
         </div>
       </div>
-      <Legend mobileOpen={showMobileLegend} />
+      <Legend desktopOpen={showDesktopLegend} mobileOpen={showMobileLegend} />
       <button
         type="button"
         className={`map-key-popout-button ${showMobileLegend ? 'active' : ''}`}


### PR DESCRIPTION
## Summary

Fixes the desktop forecast map Key button so it actually toggles the map legend. The desktop map toolbar already exposed a Key control, but clicking it only changed the mobile legend state. On desktop, the legend CSS remained visible because the desktop legend had no hidden state to respond to.

## Root Cause

`OpenLayersForecastMap` reused `showMobileLegend` for the desktop toolbar Key button. That state only mattered to the mobile popout behavior, where CSS hides the legend by default and shows it with `map-legend--mobile-open`. Desktop legend rendering ignored the state entirely, so the button could update its label/expanded state without changing legend visibility.

## Fix

This adds a separate `showDesktopLegend` state for the desktop toolbar Key button, keeps the mobile popout state independent, and teaches `Legend` to apply a desktop hidden class when `desktopOpen` is false. The default desktop behavior remains unchanged: the key starts visible. Mobile still starts hidden and opens intentionally through the mobile Key popout.

## Verification

- `pnpm test -- --runTestsByPath src/components/Map/Legend.test.tsx`
- `pnpm run build`