### PR TITLE
fix: recover OpenLayers map when container is zero-sized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## v1.5.1
+
+### Fixed
+- Fixed an issue where maps wouldn't render on Chromebooks
+- Updated package version to v1.5.1
+- Removed old beta selector from account screen
+
+## v1.5.0
 
 ### Changed
 - **Forecast Page nitpicks:** Fixed UI alignment on the forecast Draw tab (spacing for sections/menus and Current Selection breathing room), ensured the tab bar touches its bottom tray properly, expanded the Cycle Date fields horizontally on the Days tab, improved Ghost Layers labels placement, eliminated duplicated basemap dropdowns favoring the toolbar, standardized tools buttons on the right side to match the new Integrated Toolbar format, and gave map control buttons neutral hover colors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphical-forecast-creator",
-  "version": "1.5.0-beta.3",
+  "version": "1.5.1",
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -787,9 +787,10 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
         }
       };
       // Double requestAnimationFrame calls back to back for layout stabilization
+      let raf2: number | null = null;
       const raf1 = window.requestAnimationFrame(() => {
         updateSizeSafely();
-        requestAnimationFrame(updateSizeSafely);
+        raf2 = requestAnimationFrame(updateSizeSafely);
       });
       let resizeObserver: ResizeObserver | null = null;
       if (typeof ResizeObserver !== "undefined" && targetEl) {
@@ -934,6 +935,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
 
       return () => {
         window.cancelAnimationFrame(raf1);
+        if (raf2 !== null) window.cancelAnimationFrame(raf2);
         if (resizeObserver) {
           resizeObserver.disconnect();
         }

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -1,40 +1,66 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import 'ol/ol.css';
-import OLMap from 'ol/Map';
-import View from 'ol/View';
-import LayerGroup from 'ol/layer/Group';
-import TileLayer from 'ol/layer/Tile';
-import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
-import OSM from 'ol/source/OSM';
-import XYZ from 'ol/source/XYZ';
-import GeoJSON from 'ol/format/GeoJSON';
-import { Draw, Modify, Select, Snap } from 'ol/interaction';
-import { Fill, Stroke, Style } from 'ol/style';
-import { fromLonLat, toLonLat } from 'ol/proj';
-import Overlay from 'ol/Overlay';
-import type { FeatureLike } from 'ol/Feature';
-import type OLFeature from 'ol/Feature';
-import type Geometry from 'ol/geom/Geometry';
-import { click } from 'ol/events/condition';
-import { v4 as uuidv4 } from 'uuid';
-import { RootState } from '../../store';
-import { addFeature, removeFeature, selectCurrentOutlooks, setMapView, updateFeature } from '../../store/forecastSlice';
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useDispatch, useSelector } from "react-redux";
+import "ol/ol.css";
+import OLMap from "ol/Map";
+import View from "ol/View";
+import LayerGroup from "ol/layer/Group";
+import TileLayer from "ol/layer/Tile";
+import VectorLayer from "ol/layer/Vector";
+import VectorSource from "ol/source/Vector";
+import OSM from "ol/source/OSM";
+import XYZ from "ol/source/XYZ";
+import GeoJSON from "ol/format/GeoJSON";
+import { Draw, Modify, Select, Snap } from "ol/interaction";
+import { Fill, Stroke, Style } from "ol/style";
+import { fromLonLat, toLonLat } from "ol/proj";
+import Overlay from "ol/Overlay";
+import type { FeatureLike } from "ol/Feature";
+import type OLFeature from "ol/Feature";
+import type Geometry from "ol/geom/Geometry";
+import { click } from "ol/events/condition";
+import { v4 as uuidv4 } from "uuid";
+import { RootState } from "../../store";
+import {
+  addFeature,
+  removeFeature,
+  selectCurrentOutlooks,
+  setMapView,
+  updateFeature,
+} from "../../store/forecastSlice";
 
-import type { BaseMapStyle } from '../../store/overlaysSlice';
-import { getFeatureStyle, computeZIndex } from '../../utils/mapStyleUtils';
-import type { MapAdapterHandle } from '../../maps/contracts';
-import type { Feature as GeoJsonFeature, GeoJsonProperties, Polygon } from 'geojson';
-import { apply } from 'ol-mapbox-style';
-import Legend from './Legend';
-import StatusOverlay from './StatusOverlay';
-import UnofficialBadge from './UnofficialBadge';
-import { getOpenFreeMapStyleSet, isOpenFreeMapStyle } from '../../lib/openFreeMap';
-import './ForecastMap.css';
+import type { BaseMapStyle } from "../../store/overlaysSlice";
+import { getFeatureStyle, computeZIndex } from "../../utils/mapStyleUtils";
+import type { MapAdapterHandle } from "../../maps/contracts";
+import type {
+  Feature as GeoJsonFeature,
+  GeoJsonProperties,
+  Polygon,
+} from "geojson";
+import { apply } from "ol-mapbox-style";
+import Legend from "./Legend";
+import StatusOverlay from "./StatusOverlay";
+import UnofficialBadge from "./UnofficialBadge";
+import {
+  getOpenFreeMapStyleSet,
+  isOpenFreeMapStyle,
+} from "../../lib/openFreeMap";
+import "./ForecastMap.css";
 
 type OutlookMapLike = Record<string, globalThis.Map<string, GeoJsonFeature[]>>;
-type EditableOutlookType = 'categorical' | 'tornado' | 'wind' | 'hail' | 'totalSevere' | 'day4-8';
+type EditableOutlookType =
+  | "categorical"
+  | "tornado"
+  | "wind"
+  | "hail"
+  | "totalSevere"
+  | "day4-8";
 
 interface FeatureIdentity {
   featureId: string;
@@ -94,12 +120,12 @@ const TOP_LABEL_LAYER_Z_INDEX = 1100;
 const GHOST_REFERENCE_LAYER_Z_INDEX = TOP_OUTLINE_LAYER_Z_INDEX - 25;
 
 const DRAWABLE_OUTLOOK_TYPES = new Set<EditableOutlookType>([
-  'categorical',
-  'tornado',
-  'wind',
-  'hail',
-  'totalSevere',
-  'day4-8',
+  "categorical",
+  "tornado",
+  "wind",
+  "hail",
+  "totalSevere",
+  "day4-8",
 ]);
 
 // Helper to convert hex/rgb/hsl color strings to rgba with specified alpha
@@ -108,18 +134,22 @@ export const toRgbaColor = ({ color, alpha }: RgbaInput): string => {
     return `rgba(255, 255, 255, ${alpha})`;
   }
 
-  if (color.startsWith('rgba(') || color.startsWith('hsla(')) {
+  if (color.startsWith("rgba(") || color.startsWith("hsla(")) {
     return color;
   }
 
-  if (color.startsWith('rgb(') || color.startsWith('hsl(')) {
+  if (color.startsWith("rgb(") || color.startsWith("hsl(")) {
     return color;
   }
 
-  const hex = color.replace('#', '');
-  const normalized = hex.length === 3
-    ? hex.split('').map((char) => `${char}${char}`).join('')
-    : hex;
+  const hex = color.replace("#", "");
+  const normalized =
+    hex.length === 3
+      ? hex
+          .split("")
+          .map((char) => `${char}${char}`)
+          .join("")
+      : hex;
 
   if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
     return color;
@@ -132,19 +162,21 @@ export const toRgbaColor = ({ color, alpha }: RgbaInput): string => {
 };
 
 // Create canvas pattern for CIG hatching
-export const createHatchPattern = ({ cigLevel }: HatchPatternInput): CanvasPattern | null => {
-  const canvas = document.createElement('canvas');
+export const createHatchPattern = ({
+  cigLevel,
+}: HatchPatternInput): CanvasPattern | null => {
+  const canvas = document.createElement("canvas");
   const size = 10;
   canvas.width = size;
   canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  
+  const ctx = canvas.getContext("2d");
+
   if (!ctx) return null;
-  
-  ctx.strokeStyle = '#000000';
+
+  ctx.strokeStyle = "#000000";
   ctx.lineWidth = 1;
-  
-  if (cigLevel === 'CIG1') {
+
+  if (cigLevel === "CIG1") {
     // Broken diagonal lines
     ctx.beginPath();
     ctx.moveTo(0, 0);
@@ -152,13 +184,13 @@ export const createHatchPattern = ({ cigLevel }: HatchPatternInput): CanvasPatte
     ctx.moveTo(5, 5);
     ctx.lineTo(10, 10);
     ctx.stroke();
-  } else if (cigLevel === 'CIG2') {
+  } else if (cigLevel === "CIG2") {
     // Solid diagonal
     ctx.beginPath();
     ctx.moveTo(0, 0);
     ctx.lineTo(size, size);
     ctx.stroke();
-  } else if (cigLevel === 'CIG3') {
+  } else if (cigLevel === "CIG3") {
     // Crosshatch
     ctx.beginPath();
     ctx.moveTo(0, 0);
@@ -167,19 +199,27 @@ export const createHatchPattern = ({ cigLevel }: HatchPatternInput): CanvasPatte
     ctx.lineTo(size, 0);
     ctx.stroke();
   }
-  
-  return ctx.createPattern(canvas, 'repeat');
+
+  return ctx.createPattern(canvas, "repeat");
 };
 
 /** Returns the fill opacity for a feature or a sensible fallback when a style omitted it. */
-export const resolveFillOpacity = ({ fillOpacity }: FillOpacityInput): number => {
-  return typeof fillOpacity === 'number' ? fillOpacity : 0.25;
+export const resolveFillOpacity = ({
+  fillOpacity,
+}: FillOpacityInput): number => {
+  return typeof fillOpacity === "number" ? fillOpacity : 0.25;
 };
 
 /** Builds an OL Fill for a given probability: solid rgba fill for standard outlooks, or a CIG hatching CanvasPattern for CIG levels. */
-export const createOutlookFill = ({ probability, fillColor, fillOpacity }: FillBuildInput): Fill => {
-  if (!probability.startsWith('CIG')) {
-    return new Fill({ color: toRgbaColor({ color: fillColor, alpha: fillOpacity }) });
+export const createOutlookFill = ({
+  probability,
+  fillColor,
+  fillOpacity,
+}: FillBuildInput): Fill => {
+  if (!probability.startsWith("CIG")) {
+    return new Fill({
+      color: toRgbaColor({ color: fillColor, alpha: fillOpacity }),
+    });
   }
 
   const pattern = createHatchPattern({ cigLevel: probability });
@@ -187,20 +227,25 @@ export const createOutlookFill = ({ probability, fillColor, fillOpacity }: FillB
     return new Fill({ color: pattern as CanvasPattern });
   }
 
-  return new Fill({ color: 'rgba(0, 0, 0, 0)' });
+  return new Fill({ color: "rgba(0, 0, 0, 0)" });
 };
 
 /** Returns the stroke width: 3px for the top (selected) layer, the numeric weight value otherwise, or 2 as default. */
-export const resolveStrokeWidth = ({ weight, isTopLayer }: StrokeWidthInput): number => {
+export const resolveStrokeWidth = ({
+  weight,
+  isTopLayer,
+}: StrokeWidthInput): number => {
   if (isTopLayer) return 3;
-  return typeof weight === 'number' ? weight : 2;
+  return typeof weight === "number" ? weight : 2;
 };
 
 /** Extracts the featureId, outlookType, and probability properties from an OL feature, returning null if any are missing. */
-export const getFeatureIdentity = (feature: FeatureLike): FeatureIdentity | null => {
-  const featureId = feature.get('featureId') as string | undefined;
-  const outlookType = feature.get('outlookType') as string | undefined;
-  const probability = feature.get('probability') as string | undefined;
+export const getFeatureIdentity = (
+  feature: FeatureLike,
+): FeatureIdentity | null => {
+  const featureId = feature.get("featureId") as string | undefined;
+  const outlookType = feature.get("outlookType") as string | undefined;
+  const probability = feature.get("probability") as string | undefined;
 
   if (!featureId) return null;
   if (!outlookType) return null;
@@ -213,7 +258,7 @@ export const getFeatureIdentity = (feature: FeatureLike): FeatureIdentity | null
 export const toUpdatedGeoJsonFeature = (
   feature: FeatureLike,
   format: GeoJSON,
-  includeDerivedFrom: boolean
+  includeDerivedFrom: boolean,
 ): GeoJsonFeature | null => {
   const identity = getFeatureIdentity(feature);
   if (!identity) return null;
@@ -222,39 +267,47 @@ export const toUpdatedGeoJsonFeature = (
   if (!geometry) return null;
 
   const geoJsonGeometry = format.writeGeometryObject(geometry as Geometry, {
-    dataProjection: 'EPSG:4326',
-    featureProjection: 'EPSG:3857'
+    dataProjection: "EPSG:4326",
+    featureProjection: "EPSG:3857",
   });
 
   return {
-    type: 'Feature',
+    type: "Feature",
     id: identity.featureId,
     geometry: geoJsonGeometry as Polygon,
     properties: {
       outlookType: identity.outlookType,
       probability: identity.probability,
-      isSignificant: Boolean(feature.get('isSignificant')),
-      ...(includeDerivedFrom ? { derivedFrom: feature.get('derivedFrom') } : {})
-    }
+      isSignificant: Boolean(feature.get("isSignificant")),
+      ...(includeDerivedFrom
+        ? { derivedFrom: feature.get("derivedFrom") }
+        : {}),
+    },
   };
 };
 
 /** Iterates over a FeatureLike array and calls setStyle on each, guarding against RenderFeature instances that lack the method. */
 export const applyBlankLayerStyle = (features: FeatureLike[], style: Style) => {
   features.forEach((feature) => {
-    if ('setStyle' in feature && typeof feature.setStyle === 'function') {
+    if ("setStyle" in feature && typeof feature.setStyle === "function") {
       feature.setStyle(style);
     }
   });
 };
 
 /** Replaces all layers in the target group with the current layers from the source group. */
-export const replaceLayerGroupLayers = (target: LayerGroup, source: LayerGroup) => {
+export const replaceLayerGroupLayers = (
+  target: LayerGroup,
+  source: LayerGroup,
+) => {
   const targetLayers = target.getLayers();
   targetLayers.clear();
-  source.getLayers().getArray().forEach((layer) => {
-    targetLayers.push(layer);
-  });
+  source
+    .getLayers()
+    .getArray()
+    .forEach((layer) => {
+      targetLayers.push(layer);
+    });
 };
 
 /** Loads GeoJSON features into a blank-basemap VectorSource if not already populated, using an in-memory cache to avoid repeated network requests. */
@@ -264,7 +317,7 @@ export const ensureBlankLayerLoaded = async (config: BlankLayerConfig) => {
   let geoJson = config.getCache();
   if (!geoJson) {
     const response = await fetch(config.url);
-    geoJson = await response.json() as object;
+    geoJson = (await response.json()) as object;
     config.setCache(geoJson);
   }
 
@@ -272,8 +325,8 @@ export const ensureBlankLayerLoaded = async (config: BlankLayerConfig) => {
 
   const format = new GeoJSON();
   const features = format.readFeatures(geoJson, {
-    dataProjection: 'EPSG:4326',
-    featureProjection: 'EPSG:3857',
+    dataProjection: "EPSG:4326",
+    featureProjection: "EPSG:3857",
   });
 
   if (config.style) {
@@ -283,23 +336,30 @@ export const ensureBlankLayerLoaded = async (config: BlankLayerConfig) => {
 };
 
 /** Returns true if the given outlook type string is one of the user-editable types defined in DRAWABLE_OUTLOOK_TYPES. */
-export const isDrawableOutlookType = ({ outlookType }: { outlookType: string }): boolean => {
+export const isDrawableOutlookType = ({
+  outlookType,
+}: {
+  outlookType: string;
+}): boolean => {
   return DRAWABLE_OUTLOOK_TYPES.has(outlookType as EditableOutlookType);
 };
 
 // Convert outlook type and probability to an OpenLayers style, including handling CIG hatching patterns
 export const toOlStyle = (
   selection: OutlookSelection,
-  options: LayerStyleOptions = {}
+  options: LayerStyleOptions = {},
 ) => {
   const { outlookType, probability } = selection;
   const { isTopLayer = false } = options;
 
-  const style = getFeatureStyle(outlookType as EditableOutlookType, probability);
-  const fillColor = String(style.fillColor || '#ffffff');
+  const style = getFeatureStyle(
+    outlookType as EditableOutlookType,
+    probability,
+  );
+  const fillColor = String(style.fillColor || "#ffffff");
   const fillOpacity = resolveFillOpacity({ fillOpacity: style.fillOpacity });
-  const strokeOpacity = typeof style.opacity === 'number' ? style.opacity : 1;
-  const strokeColor = String(style.color || '#000000');
+  const strokeOpacity = typeof style.opacity === "number" ? style.opacity : 1;
+  const strokeColor = String(style.color || "#000000");
   const zIndex = computeZIndex(outlookType as EditableOutlookType, probability);
   const fill = createOutlookFill({ probability, fillColor, fillOpacity });
   const strokeWidth = resolveStrokeWidth({ weight: style.weight, isTopLayer });
@@ -311,37 +371,46 @@ export const toOlStyle = (
     fill,
     stroke: new Stroke({
       color: toRgbaColor({ color: strokeColor, alpha: strokeOpacity }),
-      width: strokeWidth
+      width: strokeWidth,
     }),
-    zIndex
+    zIndex,
   });
 };
 
 /** Creates a faded style variant for non-active outlooks shown as ghost overlays. */
-export const toGhostOlStyle = (
-  { outlookType, probability, isCategorical }: GhostSelection
-) => {
-  const style = getFeatureStyle(outlookType as EditableOutlookType, probability);
-  const strokeColor = String(style.color || '#000000');
+export const toGhostOlStyle = ({
+  outlookType,
+  probability,
+  isCategorical,
+}: GhostSelection) => {
+  const style = getFeatureStyle(
+    outlookType as EditableOutlookType,
+    probability,
+  );
+  const strokeColor = String(style.color || "#000000");
   const ghostFillOpacity = isCategorical ? 0.08 : 0.03;
-  const isCig = probability.startsWith('CIG');
+  const isCig = probability.startsWith("CIG");
 
   const fill = isCig
-    ? new Fill({ color: 'rgba(0,0,0,0)' })
+    ? new Fill({ color: "rgba(0,0,0,0)" })
     : createOutlookFill({
         probability,
-        fillColor: String(style.fillColor || '#ffffff'),
+        fillColor: String(style.fillColor || "#ffffff"),
         fillOpacity: ghostFillOpacity,
       });
 
   return new Style({
     fill,
     stroke: new Stroke({
-      color: toRgbaColor({ color: strokeColor, alpha: isCategorical ? 0.96 : 0.9 }),
+      color: toRgbaColor({
+        color: strokeColor,
+        alpha: isCategorical ? 0.96 : 0.9,
+      }),
       width: isCategorical ? 3 : 2.5,
       lineDash: isCig ? [4, 4] : [12, 7],
     }),
-    zIndex: computeZIndex(outlookType as EditableOutlookType, probability) + 500,
+    zIndex:
+      computeZIndex(outlookType as EditableOutlookType, probability) + 500,
   });
 };
 
@@ -352,57 +421,59 @@ let cachedLakesGeoJSON: object | null = null;
 
 // Gray style for world landmass (Canada, Mexico, etc.)
 const BLANK_WORLD_STYLE = new Style({
-  fill: new Fill({ color: '#808080' }),
-  stroke: new Stroke({ color: '#555555', width: 0.5 }),
+  fill: new Fill({ color: "#808080" }),
+  stroke: new Stroke({ color: "#555555", width: 0.5 }),
 });
 
 // Blue style for lakes (Great Lakes, etc.) — renders above world, below US states
 const BLANK_LAKE_STYLE = new Style({
-  fill: new Fill({ color: '#7BA0C8' }),
-  stroke: new Stroke({ color: '#5585b5', width: 0.5 }),
+  fill: new Fill({ color: "#7BA0C8" }),
+  stroke: new Stroke({ color: "#5585b5", width: 0.5 }),
 });
 
 // Cream fill for US land.
 const BLANK_LAND_FILL_STYLE = new Style({
-  fill: new Fill({ color: '#f2ede2' }),
+  fill: new Fill({ color: "#f2ede2" }),
 });
 
 // Outline-only style for US state borders rendered above outlook polygons.
 const BLANK_LAND_OUTLINE_STYLE = new Style({
-  fill: new Fill({ color: 'rgba(0, 0, 0, 0)' }),
-  stroke: new Stroke({ color: '#333333', width: 1 }),
+  fill: new Fill({ color: "rgba(0, 0, 0, 0)" }),
+  stroke: new Stroke({ color: "#333333", width: 1 }),
 });
 
 // Creates a labels/places overlay source so cities and boundaries stay readable above polygons.
-export const createLabelOverlaySource = (style: Exclude<BaseMapStyle, 'blank'>): XYZ | null => {
+export const createLabelOverlaySource = (
+  style: Exclude<BaseMapStyle, "blank">,
+): XYZ | null => {
   switch (style) {
-    case 'osm':
+    case "osm":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; OpenStreetMap &copy; CARTO',
+        url: "https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png",
+        attributions: "&copy; OpenStreetMap &copy; CARTO",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'carto-light':
+    case "carto-light":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; OpenStreetMap &copy; CARTO',
+        url: "https://{a-d}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png",
+        attributions: "&copy; OpenStreetMap &copy; CARTO",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'carto-dark':
+    case "carto-dark":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; OpenStreetMap &copy; CARTO',
+        url: "https://{a-d}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}{r}.png",
+        attributions: "&copy; OpenStreetMap &copy; CARTO",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'esri-satellite':
+    case "esri-satellite":
       return new XYZ({
-        url: 'https://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
-        attributions: 'Tiles &copy; Esri',
+        url: "https://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}",
+        attributions: "Tiles &copy; Esri",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
     default:
       return null;
@@ -410,917 +481,1030 @@ export const createLabelOverlaySource = (style: Exclude<BaseMapStyle, 'blank'>):
 };
 
 // Helper to create tile source based on selected base map style
-export const createTileSource = (style: Exclude<BaseMapStyle, 'blank'>): OSM | XYZ => {
+export const createTileSource = (
+  style: Exclude<BaseMapStyle, "blank">,
+): OSM | XYZ => {
   switch (style) {
-    case 'osm':
+    case "osm":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        url: "https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}{r}.png",
+        attributions:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'carto-light':
+    case "carto-light":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        url: "https://{a-d}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png",
+        attributions:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'carto-dark':
+    case "carto-dark":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        url: "https://{a-d}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png",
+        attributions:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'esri-satellite':
+    case "esri-satellite":
       return new XYZ({
-        url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-        attributions: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP',
+        url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        attributions:
+          "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
     default:
-      return new OSM({ crossOrigin: 'anonymous' });
+      return new OSM({ crossOrigin: "anonymous" });
   }
 };
 
-
-
 /** Sentinel value used to clear an Overlay's position, causing it to be hidden from the map. */
-const OVERLAY_HIDDEN_POSITION: Parameters<Overlay['setPosition']>[0] = undefined;
+const OVERLAY_HIDDEN_POSITION: Parameters<Overlay["setPosition"]>[0] =
+  undefined;
 
 /** Hides an OpenLayers Overlay by clearing its map position. */
 export const hideOverlay = (overlay: Overlay): void => {
   overlay.setPosition(OVERLAY_HIDDEN_POSITION);
 };
 
-
-
 // Main map component using OpenLayers, implementing the MapAdapterHandle interface for integration with the rest of the app.
-const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref) => {
-  const dispatch = useDispatch();
-  const [interactionMode, setInteractionMode] = useState<'pan' | 'draw' | 'delete'>('pan');
-  
-  const [popupInfo, setPopupInfo] = useState<{ outlookType: string; probability: string; isSignificant: boolean } | null>(null);
-  const [showDesktopLegend, setShowDesktopLegend] = useState(true);
-  const [showMobileLegend, setShowMobileLegend] = useState(false);
-  const drawingState = useSelector((state: RootState) => state.forecast.drawingState);
-  const currentMapView = useSelector((state: RootState) => state.forecast.currentMapView);
-  const outlooks = useSelector(selectCurrentOutlooks) as OutlookMapLike;
-  const baseMapStyle = useSelector((state: RootState) => state.overlays.baseMapStyle);
-  const ghostOutlooks = useSelector((state: RootState) => state.overlays.ghostOutlooks);
-  const initialMapViewRef = useRef(currentMapView);
-  const currentMapViewRef = useRef(currentMapView);
-  const popupRef = useRef<HTMLDivElement>(null);
-  const overlayRef = useRef<Overlay | null>(null);
-  const interactionModeRef = useRef(interactionMode);
+const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
+  (_, ref) => {
+    const dispatch = useDispatch();
+    const [interactionMode, setInteractionMode] = useState<
+      "pan" | "draw" | "delete"
+    >("pan");
 
-  useEffect(() => {
-    interactionModeRef.current = interactionMode;
-  }, [interactionMode]);
+    const [popupInfo, setPopupInfo] = useState<{
+      outlookType: string;
+      probability: string;
+      isSignificant: boolean;
+    } | null>(null);
+    const [showDesktopLegend, setShowDesktopLegend] = useState(true);
+    const [showMobileLegend, setShowMobileLegend] = useState(false);
+    const drawingState = useSelector(
+      (state: RootState) => state.forecast.drawingState,
+    );
+    const currentMapView = useSelector(
+      (state: RootState) => state.forecast.currentMapView,
+    );
+    const outlooks = useSelector(selectCurrentOutlooks) as OutlookMapLike;
+    const baseMapStyle = useSelector(
+      (state: RootState) => state.overlays.baseMapStyle,
+    );
+    const ghostOutlooks = useSelector(
+      (state: RootState) => state.overlays.ghostOutlooks,
+    );
+    const initialMapViewRef = useRef(currentMapView);
+    const currentMapViewRef = useRef(currentMapView);
+    const popupRef = useRef<HTMLDivElement>(null);
+    const overlayRef = useRef<Overlay | null>(null);
+    const interactionModeRef = useRef(interactionMode);
 
-  useEffect(() => {
-    currentMapViewRef.current = currentMapView;
-  }, [currentMapView]);
+    useEffect(() => {
+      interactionModeRef.current = interactionMode;
+    }, [interactionMode]);
 
-  const mapElementRef = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<OLMap | null>(null);
-  const tileLayerRef = useRef<TileLayer<OSM | XYZ> | null>(null);
-  const vectorBaseGroupRef = useRef<LayerGroup | null>(null);
-  const vectorReferenceGroupRef = useRef<LayerGroup | null>(null);
-  const vectorStyleRequestRef = useRef(0);
-  const worldSourceRef = useRef<VectorSource>(new VectorSource());
-  const worldLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
-  const lakesSourceRef = useRef<VectorSource>(new VectorSource());
-  const lakesLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
-  const landSourceRef = useRef<VectorSource>(new VectorSource());
-  const landLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
-  const landOutlineLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
-  const labelLayerRef = useRef<TileLayer<XYZ> | null>(null);
-  const vectorSourceRef = useRef<VectorSource>(new VectorSource());
-  const catSourceRef = useRef<VectorSource>(new VectorSource());
-  const ghostSourceRef = useRef<VectorSource>(new VectorSource());
-  const catLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
-  const ghostLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
-  const vectorLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
-  const drawRef = useRef<Draw | null>(null);
-  const modifyRef = useRef<Modify | null>(null);
-  const catModifyRef = useRef<Modify | null>(null);
-  const snapRef = useRef<Snap | null>(null);
-  const catSnapRef = useRef<Snap | null>(null);
-  const ghostSnapRef = useRef<Snap | null>(null);
-  const selectRef = useRef<Select | null>(null);
-  const isApplyingExternalViewRef = useRef(false);
+    useEffect(() => {
+      currentMapViewRef.current = currentMapView;
+    }, [currentMapView]);
 
-  // Serialize features from the Redux store into a flat array for rendering on the map.
-  const serializedFeatures = useMemo(() => {
-    const items: Array<{ outlookType: string; probability: string; feature: GeoJsonFeature }> = [];
-    Object.entries(outlooks).forEach(([outlookType, probs]) => {
-      if (outlookType !== drawingState.activeOutlookType) {
-        return;
-      }
+    const mapElementRef = useRef<HTMLDivElement>(null);
+    const mapRef = useRef<OLMap | null>(null);
+    const tileLayerRef = useRef<TileLayer<OSM | XYZ> | null>(null);
+    const vectorBaseGroupRef = useRef<LayerGroup | null>(null);
+    const vectorReferenceGroupRef = useRef<LayerGroup | null>(null);
+    const vectorStyleRequestRef = useRef(0);
+    const worldSourceRef = useRef<VectorSource>(new VectorSource());
+    const worldLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+    const lakesSourceRef = useRef<VectorSource>(new VectorSource());
+    const lakesLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+    const landSourceRef = useRef<VectorSource>(new VectorSource());
+    const landLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+    const landOutlineLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+    const labelLayerRef = useRef<TileLayer<XYZ> | null>(null);
+    const vectorSourceRef = useRef<VectorSource>(new VectorSource());
+    const catSourceRef = useRef<VectorSource>(new VectorSource());
+    const ghostSourceRef = useRef<VectorSource>(new VectorSource());
+    const catLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+    const ghostLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+    const vectorLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+    const drawRef = useRef<Draw | null>(null);
+    const modifyRef = useRef<Modify | null>(null);
+    const catModifyRef = useRef<Modify | null>(null);
+    const snapRef = useRef<Snap | null>(null);
+    const catSnapRef = useRef<Snap | null>(null);
+    const ghostSnapRef = useRef<Snap | null>(null);
+    const selectRef = useRef<Select | null>(null);
+    const isApplyingExternalViewRef = useRef(false);
 
-      if (!(probs instanceof Map)) return;
-      probs.forEach((features: GeoJsonFeature[], probability: string) => {
-        features.forEach((feature: GeoJsonFeature) => {
-          items.push({ outlookType, probability, feature });
+    // Serialize features from the Redux store into a flat array for rendering on the map.
+    const serializedFeatures = useMemo(() => {
+      const items: Array<{
+        outlookType: string;
+        probability: string;
+        feature: GeoJsonFeature;
+      }> = [];
+      Object.entries(outlooks).forEach(([outlookType, probs]) => {
+        if (outlookType !== drawingState.activeOutlookType) {
+          return;
+        }
+
+        if (!(probs instanceof Map)) return;
+        probs.forEach((features: GeoJsonFeature[], probability: string) => {
+          features.forEach((feature: GeoJsonFeature) => {
+            items.push({ outlookType, probability, feature });
+          });
         });
       });
-    });
-    return items;
-  }, [outlooks, drawingState.activeOutlookType]);
+      return items;
+    }, [outlooks, drawingState.activeOutlookType]);
 
-  useImperativeHandle(ref, () => ({
-    getMap: () => mapRef.current,
-    getEngine: () => 'openlayers',
-    getView: () => {
-      if (!mapRef.current) {
-        return { center: [39.8283, -98.5795] as [number, number], zoom: 4 };
-      }
-      const view = mapRef.current.getView();
-      const center = view.getCenter();
-      const zoom = view.getZoom() || 4;
-      const lonLat = center ? (toLonLat(center) as [number, number]) : ([-98.5795, 39.8283] as [number, number]);
-      return { center: [lonLat[1], lonLat[0]], zoom };
-    }
-  }), []);
-
-  useEffect(() => {
-    if (!mapElementRef.current || mapRef.current) return undefined;
-
-    const tileLayer = new TileLayer({ source: new OSM({ crossOrigin: 'anonymous' }) });
-    tileLayerRef.current = tileLayer;
-    const vectorBaseGroup = new LayerGroup({
-      visible: false,
-      zIndex: 1,
-    });
-    vectorBaseGroupRef.current = vectorBaseGroup;
-    const vectorReferenceGroup = new LayerGroup({
-      visible: false,
-      zIndex: TOP_VECTOR_REFERENCE_LAYER_Z_INDEX,
-    });
-    vectorReferenceGroupRef.current = vectorReferenceGroup;
-    // Blank base map layers: start hidden, only one (tile vs. world+lakes+land) will be visible at a time based on baseMapStyle.
-    const worldLayer = new VectorLayer({
-      source: worldSourceRef.current,
-      visible: false,
-      zIndex: 1,
-    });
-    worldLayerRef.current = worldLayer;
-    // Lakes layer sits above world layer to provide better definition of coastlines and inland water bodies,
-    // especially when using blank basemap style.
-    const lakesLayer = new VectorLayer({
-      source: lakesSourceRef.current,
-      visible: false,
-      zIndex: 1.5,
-    });
-    lakesLayerRef.current = lakesLayer;
-    // Land fill sits above world and lakes, below outlook polygons.
-    const landLayer = new VectorLayer({
-      source: landSourceRef.current,
-      visible: false,
-      zIndex: 2,
-      style: BLANK_LAND_FILL_STYLE,
-    });
-    landLayerRef.current = landLayer;
-    // Land outlines sit above outlook polygons so borders remain visible.
-    const landOutlineLayer = new VectorLayer({
-      source: landSourceRef.current,
-      visible: false,
-      zIndex: TOP_OUTLINE_LAYER_Z_INDEX,
-      style: BLANK_LAND_OUTLINE_STYLE,
-    });
-    landOutlineLayerRef.current = landOutlineLayer;
-    // Categorical features stay in a dedicated source so their edit flow
-    // remains separate from probabilistic outlook layers.
-    const catLayer = new VectorLayer({
-      source: catSourceRef.current,
-      zIndex: 3,
-      opacity: 1,
-    });
-    catLayerRef.current = catLayer;
-    const ghostLayer = new VectorLayer({
-      source: ghostSourceRef.current,
-      zIndex: GHOST_REFERENCE_LAYER_Z_INDEX,
-    });
-    ghostLayerRef.current = ghostLayer;
-    // Probabilistic/other features layer: separate source, normal per-feature opacity
-    const vectorLayer = new VectorLayer({
-      source: vectorSourceRef.current,
-      zIndex: 4,
-    });
-    vectorLayerRef.current = vectorLayer;
-    // Place labels/cities above outlook polygons.
-    const labelLayer = new TileLayer({
-      source: createLabelOverlaySource('osm') ?? undefined,
-      visible: true,
-      zIndex: TOP_LABEL_LAYER_Z_INDEX,
-    });
-    labelLayerRef.current = labelLayer;
-
-    // Initialize the map with all layers, but only the tile layer visible by default.
-    // The blank basemap layers will be toggled on if the user selects the blank style.
-    // This allows us to keep all layers in place and just switch visibility/styles
-    // without needing to re-add/remove layers or features, which can be expensive.
-    const map = new OLMap({
-      target: mapElementRef.current,
-      layers: [
-        tileLayer,
-        vectorBaseGroup,
-        worldLayer,
-        lakesLayer,
-        landLayer,
-        ghostLayer,
-        catLayer,
-        vectorLayer,
-        landOutlineLayer,
-        vectorReferenceGroup,
-        labelLayer,
-      ],
-      view: new View({
-        center: fromLonLat([initialMapViewRef.current.center[1], initialMapViewRef.current.center[0]]),
-        zoom: initialMapViewRef.current.zoom
-      })
-    });
-
-    map.on('moveend', () => {
-      if (isApplyingExternalViewRef.current) {
-        return;
-      }
-
-      const view = map.getView();
-      const center = view.getCenter();
-      if (!center) return;
-      const [lon, lat] = toLonLat(center);
-      const nextCenter: [number, number] = [lat, lon];
-      const nextZoom = view.getZoom() || 4;
-      const [stateLat, stateLon] = currentMapViewRef.current.center;
-      const stateZoom = currentMapViewRef.current.zoom;
-
-      const centerChanged = Math.abs(stateLat - nextCenter[0]) > 0.000001 || Math.abs(stateLon - nextCenter[1]) > 0.000001;
-      const zoomChanged = Math.abs(stateZoom - nextZoom) > 0.000001;
-
-      if (centerChanged || zoomChanged) {
-        dispatch(setMapView({ center: nextCenter, zoom: nextZoom }));
-      }
-    });
-
-    mapRef.current = map;
-
-    // Some browsers/devices (notably some Chromebooks) can mount the map into a container
-    // that temporarily measures 0x0 due to flex/layout timing. OpenLayers logs a warning
-    // and may not render until updateSize() is called after layout stabilizes.
-    const targetEl = mapElementRef.current;
-    const updateSizeSafely = () => {
-      try {
-        map.updateSize();
-      } catch {
-        // Non-fatal: map may be disposing.
-      }
-    };
-    const raf1 = window.requestAnimationFrame(updateSizeSafely);
-    const raf2 = window.requestAnimationFrame(updateSizeSafely);
-    let resizeObserver: ResizeObserver | null = null;
-    if (typeof ResizeObserver !== 'undefined' && targetEl) {
-      resizeObserver = new ResizeObserver(() => updateSizeSafely());
-      resizeObserver.observe(targetEl);
-    }
-
-    // Create popup overlay
-    if (popupRef.current) {
-      const overlay = new Overlay({
-        element: popupRef.current,
-        autoPan: {
-          animation: {
-            duration: 250,
-          },
+    useImperativeHandle(
+      ref,
+      () => ({
+        getMap: () => mapRef.current,
+        getEngine: () => "openlayers",
+        getView: () => {
+          if (!mapRef.current) {
+            return { center: [39.8283, -98.5795] as [number, number], zoom: 4 };
+          }
+          const view = mapRef.current.getView();
+          const center = view.getCenter();
+          const zoom = view.getZoom() || 4;
+          const lonLat = center
+            ? (toLonLat(center) as [number, number])
+            : ([-98.5795, 39.8283] as [number, number]);
+          return { center: [lonLat[1], lonLat[0]], zoom };
         },
-      });
-      map.addOverlay(overlay);
-      overlayRef.current = overlay;
-    }
+      }),
+      [],
+    );
 
-    // Add click handler for pan mode
-    map.on('click', (evt) => {
-      if (interactionModeRef.current !== 'pan') {
-        return;
+    useEffect(() => {
+      if (!mapElementRef.current || mapRef.current) return undefined;
+
+      const tileLayer = new TileLayer({
+        source: new OSM({ crossOrigin: "anonymous" }),
+      });
+      tileLayerRef.current = tileLayer;
+      const vectorBaseGroup = new LayerGroup({
+        visible: false,
+        zIndex: 1,
+      });
+      vectorBaseGroupRef.current = vectorBaseGroup;
+      const vectorReferenceGroup = new LayerGroup({
+        visible: false,
+        zIndex: TOP_VECTOR_REFERENCE_LAYER_Z_INDEX,
+      });
+      vectorReferenceGroupRef.current = vectorReferenceGroup;
+      // Blank base map layers: start hidden, only one (tile vs. world+lakes+land) will be visible at a time based on baseMapStyle.
+      const worldLayer = new VectorLayer({
+        source: worldSourceRef.current,
+        visible: false,
+        zIndex: 1,
+      });
+      worldLayerRef.current = worldLayer;
+      // Lakes layer sits above world layer to provide better definition of coastlines and inland water bodies,
+      // especially when using blank basemap style.
+      const lakesLayer = new VectorLayer({
+        source: lakesSourceRef.current,
+        visible: false,
+        zIndex: 1.5,
+      });
+      lakesLayerRef.current = lakesLayer;
+      // Land fill sits above world and lakes, below outlook polygons.
+      const landLayer = new VectorLayer({
+        source: landSourceRef.current,
+        visible: false,
+        zIndex: 2,
+        style: BLANK_LAND_FILL_STYLE,
+      });
+      landLayerRef.current = landLayer;
+      // Land outlines sit above outlook polygons so borders remain visible.
+      const landOutlineLayer = new VectorLayer({
+        source: landSourceRef.current,
+        visible: false,
+        zIndex: TOP_OUTLINE_LAYER_Z_INDEX,
+        style: BLANK_LAND_OUTLINE_STYLE,
+      });
+      landOutlineLayerRef.current = landOutlineLayer;
+      // Categorical features stay in a dedicated source so their edit flow
+      // remains separate from probabilistic outlook layers.
+      const catLayer = new VectorLayer({
+        source: catSourceRef.current,
+        zIndex: 3,
+        opacity: 1,
+      });
+      catLayerRef.current = catLayer;
+      const ghostLayer = new VectorLayer({
+        source: ghostSourceRef.current,
+        zIndex: GHOST_REFERENCE_LAYER_Z_INDEX,
+      });
+      ghostLayerRef.current = ghostLayer;
+      // Probabilistic/other features layer: separate source, normal per-feature opacity
+      const vectorLayer = new VectorLayer({
+        source: vectorSourceRef.current,
+        zIndex: 4,
+      });
+      vectorLayerRef.current = vectorLayer;
+      // Place labels/cities above outlook polygons.
+      const labelLayer = new TileLayer({
+        source: createLabelOverlaySource("osm") ?? undefined,
+        visible: true,
+        zIndex: TOP_LABEL_LAYER_Z_INDEX,
+      });
+      labelLayerRef.current = labelLayer;
+
+      // Initialize the map with all layers, but only the tile layer visible by default.
+      // The blank basemap layers will be toggled on if the user selects the blank style.
+      // This allows us to keep all layers in place and just switch visibility/styles
+      // without needing to re-add/remove layers or features, which can be expensive.
+      const map = new OLMap({
+        target: mapElementRef.current,
+        layers: [
+          tileLayer,
+          vectorBaseGroup,
+          worldLayer,
+          lakesLayer,
+          landLayer,
+          ghostLayer,
+          catLayer,
+          vectorLayer,
+          landOutlineLayer,
+          vectorReferenceGroup,
+          labelLayer,
+        ],
+        view: new View({
+          center: fromLonLat([
+            initialMapViewRef.current.center[1],
+            initialMapViewRef.current.center[0],
+          ]),
+          zoom: initialMapViewRef.current.zoom,
+        }),
+      });
+
+      map.on("moveend", () => {
+        if (isApplyingExternalViewRef.current) {
+          return;
+        }
+
+        const view = map.getView();
+        const center = view.getCenter();
+        if (!center) return;
+        const [lon, lat] = toLonLat(center);
+        const nextCenter: [number, number] = [lat, lon];
+        const nextZoom = view.getZoom() || 4;
+        const [stateLat, stateLon] = currentMapViewRef.current.center;
+        const stateZoom = currentMapViewRef.current.zoom;
+
+        const centerChanged =
+          Math.abs(stateLat - nextCenter[0]) > 0.000001 ||
+          Math.abs(stateLon - nextCenter[1]) > 0.000001;
+        const zoomChanged = Math.abs(stateZoom - nextZoom) > 0.000001;
+
+        if (centerChanged || zoomChanged) {
+          dispatch(setMapView({ center: nextCenter, zoom: nextZoom }));
+        }
+      });
+
+      mapRef.current = map;
+
+      // Some browsers/devices (notably some Chromebooks) can mount the map into a container
+      // that temporarily measures 0x0 due to flex/layout timing. OpenLayers logs a warning
+      // and may not render until updateSize() is called after layout stabilizes.
+      const targetEl = mapElementRef.current;
+      // Safely update the map size when flex/layout timing occurs incorrectly
+      const updateSizeSafely = () => {
+        try {
+          map.updateSize();
+        } catch {
+          // Non-fatal: map may be disposing.
+        }
+      };
+      // Double requestAnimationFrame calls back to back for layout stabilization
+      const raf1 = window.requestAnimationFrame(() => {
+        updateSizeSafely();
+        requestAnimationFrame(updateSizeSafely);
+      });
+      let resizeObserver: ResizeObserver | null = null;
+      if (typeof ResizeObserver !== "undefined" && targetEl) {
+        resizeObserver = new ResizeObserver(() => updateSizeSafely());
+        resizeObserver.observe(targetEl);
       }
 
-      // Use forEachFeatureAtPixel to get the topmost feature at the clicked pixel,
-      // which accounts for z-index and layer visibility.
-      const feature = map.forEachFeatureAtPixel(
-        evt.pixel,
-        (f) => f,
-        {
-          layerFilter: (layer) => layer === vectorLayerRef.current || layer === catLayerRef.current,
-        }
-      );
-      if (feature && overlayRef.current) {
-        const outlookType = feature.get('outlookType') as string;
-        const probability = feature.get('probability') as string;
-        const isSignificant = feature.get('isSignificant') as boolean;
-        
-        setPopupInfo({ outlookType, probability, isSignificant });
-        overlayRef.current.setPosition(evt.coordinate);
-      } else if (overlayRef.current) {
-        hideOverlay(overlayRef.current);
-        setPopupInfo(null);
+      // Create popup overlay
+      if (popupRef.current) {
+        const overlay = new Overlay({
+          element: popupRef.current,
+          autoPan: {
+            animation: {
+              duration: 250,
+            },
+          },
+        });
+        map.addOverlay(overlay);
+        overlayRef.current = overlay;
       }
-    });
 
-    const modify = new Modify({ source: vectorSourceRef.current });
+      // Add click handler for pan mode
+      map.on("click", (evt) => {
+        if (interactionModeRef.current !== "pan") {
+          return;
+        }
 
-    modify.on('modifyend', (event) => {
-      const format = new GeoJSON();
-      event.features.forEach((feature) => {
-        const updatedFeature = toUpdatedGeoJsonFeature(feature, format, false);
-        if (updatedFeature) {
-          dispatch(updateFeature({ feature: updatedFeature }));
+        // Use forEachFeatureAtPixel to get the topmost feature at the clicked pixel,
+        // which accounts for z-index and layer visibility.
+        const feature = map.forEachFeatureAtPixel(evt.pixel, (f) => f, {
+          layerFilter: (layer) =>
+            layer === vectorLayerRef.current || layer === catLayerRef.current,
+        });
+        if (feature && overlayRef.current) {
+          const outlookType = feature.get("outlookType") as string;
+          const probability = feature.get("probability") as string;
+          const isSignificant = feature.get("isSignificant") as boolean;
+
+          setPopupInfo({ outlookType, probability, isSignificant });
+          overlayRef.current.setPosition(evt.coordinate);
+        } else if (overlayRef.current) {
+          hideOverlay(overlayRef.current);
+          setPopupInfo(null);
         }
       });
-    });
-    map.addInteraction(modify);
-    modifyRef.current = modify;
 
-    // Separate modify interaction for categorical layer to handle its unique properties
-    // and to prevent accidental edits of auto-generated categorical features.
-    const catModify = new Modify({ source: catSourceRef.current });
-    catModify.on('modifyend', (event) => {
-      const format = new GeoJSON();
-      event.features.forEach((feature) => {
-        const derivedFrom = feature.get('derivedFrom') as string | undefined;
-        if (derivedFrom !== 'auto-generated') {
-          const updatedFeature = toUpdatedGeoJsonFeature(feature, format, true);
+      const modify = new Modify({ source: vectorSourceRef.current });
+
+      modify.on("modifyend", (event) => {
+        const format = new GeoJSON();
+        event.features.forEach((feature) => {
+          const updatedFeature = toUpdatedGeoJsonFeature(
+            feature,
+            format,
+            false,
+          );
           if (updatedFeature) {
             dispatch(updateFeature({ feature: updatedFeature }));
           }
-        }
+        });
       });
-    });
-    map.addInteraction(catModify);
-    catModifyRef.current = catModify;
+      map.addInteraction(modify);
+      modifyRef.current = modify;
 
-    const snap = new Snap({ source: vectorSourceRef.current });
-    map.addInteraction(snap);
-    snapRef.current = snap;
+      // Separate modify interaction for categorical layer to handle its unique properties
+      // and to prevent accidental edits of auto-generated categorical features.
+      const catModify = new Modify({ source: catSourceRef.current });
+      catModify.on("modifyend", (event) => {
+        const format = new GeoJSON();
+        event.features.forEach((feature) => {
+          const derivedFrom = feature.get("derivedFrom") as string | undefined;
+          if (derivedFrom !== "auto-generated") {
+            const updatedFeature = toUpdatedGeoJsonFeature(
+              feature,
+              format,
+              true,
+            );
+            if (updatedFeature) {
+              dispatch(updateFeature({ feature: updatedFeature }));
+            }
+          }
+        });
+      });
+      map.addInteraction(catModify);
+      catModifyRef.current = catModify;
 
-    const catSnap = new Snap({ source: catSourceRef.current });
-    map.addInteraction(catSnap);
-    catSnapRef.current = catSnap;
+      const snap = new Snap({ source: vectorSourceRef.current });
+      map.addInteraction(snap);
+      snapRef.current = snap;
 
-    const ghostSnap = new Snap({ source: ghostSourceRef.current });
-    map.addInteraction(ghostSnap);
-    ghostSnapRef.current = ghostSnap;
+      const catSnap = new Snap({ source: catSourceRef.current });
+      map.addInteraction(catSnap);
+      catSnapRef.current = catSnap;
 
-    // Limit delete picking to editable outlook layers so top overlays (state outlines/labels)
-    // do not intercept clicks and prevent polygon deletion.
-    const select = new Select({ condition: click, layers: [vectorLayer, catLayer] });
-    select.setActive(false);
-    select.on('select', (event) => {
-      const selected = event.selected[0];
-      if (!selected) {
-        return;
-      }
+      const ghostSnap = new Snap({ source: ghostSourceRef.current });
+      map.addInteraction(ghostSnap);
+      ghostSnapRef.current = ghostSnap;
 
-      const outlookType = selected.get('outlookType') as string | undefined;
-      const derivedFrom = selected.get('derivedFrom') as string | undefined;
+      // Limit delete picking to editable outlook layers so top overlays (state outlines/labels)
+      // do not intercept clicks and prevent polygon deletion.
+      const select = new Select({
+        condition: click,
+        layers: [vectorLayer, catLayer],
+      });
+      select.setActive(false);
+      select.on("select", (event) => {
+        const selected = event.selected[0];
+        if (!selected) {
+          return;
+        }
 
-      // Auto-generated categorical polygons are derived from probabilistic outlooks.
-      // Keep them read-only here; users should edit tornado/wind/hail/totalSevere
-      // (or draw/delete TSTM manually) and let auto-categorical regenerate.
-      if (outlookType === 'categorical' && derivedFrom === 'auto-generated') {
+        const outlookType = selected.get("outlookType") as string | undefined;
+        const derivedFrom = selected.get("derivedFrom") as string | undefined;
+
+        // Auto-generated categorical polygons are derived from probabilistic outlooks.
+        // Keep them read-only here; users should edit tornado/wind/hail/totalSevere
+        // (or draw/delete TSTM manually) and let auto-categorical regenerate.
+        if (outlookType === "categorical" && derivedFrom === "auto-generated") {
+          select.getFeatures().clear();
+          return;
+        }
+
+        const identity = getFeatureIdentity(selected);
+        if (!identity) {
+          select.getFeatures().clear();
+          return;
+        }
+
+        dispatch(
+          removeFeature({
+            outlookType: identity.outlookType as EditableOutlookType,
+            probability: identity.probability,
+            featureId: identity.featureId,
+          }),
+        );
+
         select.getFeatures().clear();
         return;
-      }
+      });
+      map.addInteraction(select);
+      selectRef.current = select;
 
-      const identity = getFeatureIdentity(selected);
-      if (!identity) {
-        select.getFeatures().clear();
+      return () => {
+        window.cancelAnimationFrame(raf1);
+        if (resizeObserver) {
+          resizeObserver.disconnect();
+        }
+        if (drawRef.current) {
+          map.removeInteraction(drawRef.current);
+        }
+        if (modifyRef.current) {
+          map.removeInteraction(modifyRef.current);
+        }
+        if (catModifyRef.current) {
+          map.removeInteraction(catModifyRef.current);
+        }
+        if (snapRef.current) {
+          map.removeInteraction(snapRef.current);
+        }
+        if (catSnapRef.current) {
+          map.removeInteraction(catSnapRef.current);
+        }
+        if (ghostSnapRef.current) {
+          map.removeInteraction(ghostSnapRef.current);
+        }
+        if (selectRef.current) {
+          map.removeInteraction(selectRef.current);
+        }
+        map.setTarget();
+        mapRef.current = null;
+        vectorBaseGroupRef.current = null;
+        vectorReferenceGroupRef.current = null;
+        vectorLayerRef.current = null;
+      };
+    }, [dispatch]);
+
+    useEffect(() => {
+      if (!selectRef.current) {
         return;
       }
 
-      dispatch(removeFeature({
-        outlookType: identity.outlookType as EditableOutlookType,
-        probability: identity.probability,
-        featureId: identity.featureId
-      }));
+      selectRef.current.setActive(interactionMode === "delete");
+      if (interactionMode !== "delete") {
+        selectRef.current.getFeatures().clear();
+      }
 
-      select.getFeatures().clear();
-      return;
-    });
-    map.addInteraction(select);
-    selectRef.current = select;
+      // Hide popup when not in pan mode
+      if (interactionMode !== "pan") {
+        if (overlayRef.current) {
+          hideOverlay(overlayRef.current);
+        }
+        setPopupInfo(null);
+      }
+    }, [interactionMode]);
 
-    return () => {
-      window.cancelAnimationFrame(raf1);
-      window.cancelAnimationFrame(raf2);
-      if (resizeObserver) {
-        resizeObserver.disconnect();
-      }
-      if (drawRef.current) {
-        map.removeInteraction(drawRef.current);
-      }
-      if (modifyRef.current) {
-        map.removeInteraction(modifyRef.current);
-      }
-      if (catModifyRef.current) {
-        map.removeInteraction(catModifyRef.current);
-      }
+    useEffect(() => {
+      // Keep snapping enabled outside delete mode for draw/modify workflows.
+      const enableSnap = interactionMode !== "delete";
       if (snapRef.current) {
-        map.removeInteraction(snapRef.current);
+        snapRef.current.setActive(enableSnap);
       }
       if (catSnapRef.current) {
-        map.removeInteraction(catSnapRef.current);
+        catSnapRef.current.setActive(enableSnap);
       }
       if (ghostSnapRef.current) {
-        map.removeInteraction(ghostSnapRef.current);
+        ghostSnapRef.current.setActive(enableSnap);
       }
-      if (selectRef.current) {
-        map.removeInteraction(selectRef.current);
+    }, [interactionMode]);
+
+    useEffect(() => {
+      const map = mapRef.current;
+      if (!map) return;
+
+      const view = map.getView();
+      const targetCenter = fromLonLat([
+        currentMapView.center[1],
+        currentMapView.center[0],
+      ]);
+      const currentCenter = view.getCenter();
+      const currentZoom = view.getZoom() || 4;
+
+      const centerChanged =
+        !currentCenter ||
+        Math.abs(currentCenter[0] - targetCenter[0]) > 0.01 ||
+        Math.abs(currentCenter[1] - targetCenter[1]) > 0.01;
+      const zoomChanged =
+        Math.abs(currentZoom - currentMapView.zoom) > 0.000001;
+
+      if (!centerChanged && !zoomChanged) {
+        return;
       }
-      map.setTarget();
-      mapRef.current = null;
-      vectorBaseGroupRef.current = null;
-      vectorReferenceGroupRef.current = null;
-      vectorLayerRef.current = null;
-    };
-  }, [dispatch]);
 
-  useEffect(() => {
-    if (!selectRef.current) {
-      return;
-    }
+      isApplyingExternalViewRef.current = true;
+      view.setCenter(targetCenter);
+      view.setZoom(currentMapView.zoom);
+      setTimeout(() => {
+        isApplyingExternalViewRef.current = false;
+      }, 0);
+    }, [currentMapView.center, currentMapView.zoom]);
 
-    selectRef.current.setActive(interactionMode === 'delete');
-    if (interactionMode !== 'delete') {
-      selectRef.current.getFeatures().clear();
-    }
+    // Swap base tile source / blank land layer when style changes
+    useEffect(() => {
+      const tile = tileLayerRef.current;
+      const vectorBaseGroup = vectorBaseGroupRef.current;
+      const vectorReferenceGroup = vectorReferenceGroupRef.current;
+      const world = worldLayerRef.current;
+      const lakes = lakesLayerRef.current;
+      const land = landLayerRef.current;
+      const landOutline = landOutlineLayerRef.current;
+      const labels = labelLayerRef.current;
+      const el = mapElementRef.current;
+      if (
+        !tile ||
+        !vectorBaseGroup ||
+        !vectorReferenceGroup ||
+        !world ||
+        !lakes ||
+        !land ||
+        !landOutline ||
+        !labels ||
+        !el
+      )
+        return;
 
-    // Hide popup when not in pan mode
-    if (interactionMode !== 'pan') {
-      if (overlayRef.current) {
-        hideOverlay(overlayRef.current);
-      }
-      setPopupInfo(null);
-    }
-  }, [interactionMode]);
-
-  useEffect(() => {
-    // Keep snapping enabled outside delete mode for draw/modify workflows.
-    const enableSnap = interactionMode !== 'delete';
-    if (snapRef.current) {
-      snapRef.current.setActive(enableSnap);
-    }
-    if (catSnapRef.current) {
-      catSnapRef.current.setActive(enableSnap);
-    }
-    if (ghostSnapRef.current) {
-      ghostSnapRef.current.setActive(enableSnap);
-    }
-  }, [interactionMode]);
-
-  useEffect(() => {
-    const map = mapRef.current;
-    if (!map) return;
-
-    const view = map.getView();
-    const targetCenter = fromLonLat([currentMapView.center[1], currentMapView.center[0]]);
-    const currentCenter = view.getCenter();
-    const currentZoom = view.getZoom() || 4;
-
-    const centerChanged = !currentCenter || Math.abs(currentCenter[0] - targetCenter[0]) > 0.01 || Math.abs(currentCenter[1] - targetCenter[1]) > 0.01;
-    const zoomChanged = Math.abs(currentZoom - currentMapView.zoom) > 0.000001;
-
-    if (!centerChanged && !zoomChanged) {
-      return;
-    }
-
-    isApplyingExternalViewRef.current = true;
-    view.setCenter(targetCenter);
-    view.setZoom(currentMapView.zoom);
-    setTimeout(() => {
-      isApplyingExternalViewRef.current = false;
-    }, 0);
-  }, [currentMapView.center, currentMapView.zoom]);
-
-  // Swap base tile source / blank land layer when style changes
-  useEffect(() => {
-    const tile = tileLayerRef.current;
-    const vectorBaseGroup = vectorBaseGroupRef.current;
-    const vectorReferenceGroup = vectorReferenceGroupRef.current;
-    const world = worldLayerRef.current;
-    const lakes = lakesLayerRef.current;
-    const land = landLayerRef.current;
-    const landOutline = landOutlineLayerRef.current;
-    const labels = labelLayerRef.current;
-    const el = mapElementRef.current;
-    if (!tile || !vectorBaseGroup || !vectorReferenceGroup || !world || !lakes || !land || !landOutline || !labels || !el) return;
-
-    /**
-     * Ensure US states GeoJSON for the blank/base map is loaded into
-     * the `landSourceRef` so state outlines can be rendered above
-     * outlook polygons. Fetches data once and caches it in
-     * `cachedUsStatesGeoJSON`.
-     */
-    const loadUsStatesBoundaries = () => {
-      const landLoader: BlankLayerConfig = {
-        source: landSourceRef.current,
-        isLoaded: () => landSourceRef.current.getFeatures().length > 0,
-        url: 'https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json',
-        getCache: () => cachedUsStatesGeoJSON,
-        setCache: (data) => {
-          cachedUsStatesGeoJSON = data;
-        },
-      };
-      ensureBlankLayerLoaded(landLoader).catch(() => { /* US states outline fetch failed — non-fatal */ });
-    };
-
-    // Keep state outlines available above outlook polygons in every map style.
-    loadUsStatesBoundaries();
-
-    /** Clears the split OpenFreeMap base/reference groups so raster and blank modes stay isolated. */
-    const hideVectorBasemapGroups = () => {
-      vectorBaseGroup.setVisible(false);
-      vectorReferenceGroup.setVisible(false);
-      vectorBaseGroup.getLayers().clear();
-      vectorReferenceGroup.getLayers().clear();
-    };
-
-    if (baseMapStyle === 'blank') {
-      hideVectorBasemapGroups();
-      tile.setVisible(false);
-      world.setVisible(true);
-      lakes.setVisible(true);
-      land.setVisible(true);
-      landOutline.setVisible(true);
-      labels.setVisible(false);
-      // Deeper ocean blue
-      el.style.backgroundColor = '#7BA0C8';
-
-      const loaders: BlankLayerConfig[] = [
-        {
-          source: worldSourceRef.current,
-          isLoaded: () => worldSourceRef.current.getFeatures().length > 0,
-          url: 'https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_110m_admin_0_countries.geojson',
-          getCache: () => cachedWorldCountriesGeoJSON,
-          setCache: (data) => {
-            cachedWorldCountriesGeoJSON = data;
-          },
-          style: BLANK_WORLD_STYLE,
-        },
-        {
-          source: lakesSourceRef.current,
-          isLoaded: () => lakesSourceRef.current.getFeatures().length > 0,
-          url: 'https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_110m_lakes.geojson',
-          getCache: () => cachedLakesGeoJSON,
-          setCache: (data) => {
-            cachedLakesGeoJSON = data;
-          },
-          style: BLANK_LAKE_STYLE,
-        },
-        {
+      /**
+       * Ensure US states GeoJSON for the blank/base map is loaded into
+       * the `landSourceRef` so state outlines can be rendered above
+       * outlook polygons. Fetches data once and caches it in
+       * `cachedUsStatesGeoJSON`.
+       */
+      const loadUsStatesBoundaries = () => {
+        const landLoader: BlankLayerConfig = {
           source: landSourceRef.current,
           isLoaded: () => landSourceRef.current.getFeatures().length > 0,
-          url: 'https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json',
+          url: "https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json",
           getCache: () => cachedUsStatesGeoJSON,
           setCache: (data) => {
             cachedUsStatesGeoJSON = data;
           },
-        },
-      ];
-
-      loaders.forEach((loader) => {
-        ensureBlankLayerLoaded(loader).catch(() => { /* blank map layer fetch failed — non-fatal */ });
-      });
-      return;
-    }
-
-    if (isOpenFreeMapStyle(baseMapStyle)) {
-      const requestId = vectorStyleRequestRef.current + 1;
-      vectorStyleRequestRef.current = requestId;
-
-      tile.setVisible(false);
-      world.setVisible(false);
-      lakes.setVisible(false);
-      land.setVisible(false);
-      landOutline.setVisible(true);
-      labels.setVisible(false);
-      el.style.backgroundColor = '';
-      vectorBaseGroup.setVisible(false);
-      vectorReferenceGroup.setVisible(false);
-      vectorBaseGroup.getLayers().clear();
-      vectorReferenceGroup.getLayers().clear();
-
-      getOpenFreeMapStyleSet(baseMapStyle)
-        .then(({ baseStyle, overlayStyle }) => {
-          const nextBaseGroup = new LayerGroup();
-          const nextReferenceGroup = new LayerGroup();
-
-          return Promise.all([
-            apply(nextBaseGroup, baseStyle),
-            apply(nextReferenceGroup, overlayStyle),
-          ]).then(() => ({ nextBaseGroup, nextReferenceGroup }));
-        })
-        .then(({ nextBaseGroup, nextReferenceGroup }) => {
-          if (vectorStyleRequestRef.current !== requestId) {
-            return;
-          }
-
-          replaceLayerGroupLayers(vectorBaseGroup, nextBaseGroup);
-          replaceLayerGroupLayers(vectorReferenceGroup, nextReferenceGroup);
-          vectorBaseGroup.setVisible(true);
-          vectorReferenceGroup.setVisible(true);
-        })
-        .catch((error) => {
-          if (vectorStyleRequestRef.current !== requestId) {
-            return;
-          }
-
-          console.warn('[forecast-map] falling back to raster basemap after vector load failure', {
-            baseMapStyle,
-            error,
-          });
-          vectorBaseGroup.getLayers().clear();
-          vectorReferenceGroup.getLayers().clear();
-          tile.setSource(createTileSource(baseMapStyle));
-          tile.setVisible(true);
-          const labelSource = createLabelOverlaySource(baseMapStyle);
-          if (labelSource) {
-            labels.setSource(labelSource);
-            labels.setVisible(true);
-          }
+        };
+        ensureBlankLayerLoaded(landLoader).catch(() => {
+          /* US states outline fetch failed — non-fatal */
         });
-    } else {
-      hideVectorBasemapGroups();
-      tile.setVisible(true);
-      world.setVisible(false);
-      lakes.setVisible(false);
-      land.setVisible(false);
-      landOutline.setVisible(true);
-      el.style.backgroundColor = '';
-      tile.setSource(createTileSource(baseMapStyle as Exclude<BaseMapStyle, 'blank'>));
-      const labelSource = createLabelOverlaySource(baseMapStyle as Exclude<BaseMapStyle, 'blank'>);
-      if (labelSource) {
-        labels.setSource(labelSource);
-        labels.setVisible(true);
-      } else {
+      };
+
+      // Keep state outlines available above outlook polygons in every map style.
+      loadUsStatesBoundaries();
+
+      /** Clears the split OpenFreeMap base/reference groups so raster and blank modes stay isolated. */
+      const hideVectorBasemapGroups = () => {
+        vectorBaseGroup.setVisible(false);
+        vectorReferenceGroup.setVisible(false);
+        vectorBaseGroup.getLayers().clear();
+        vectorReferenceGroup.getLayers().clear();
+      };
+
+      if (baseMapStyle === "blank") {
+        hideVectorBasemapGroups();
+        tile.setVisible(false);
+        world.setVisible(true);
+        lakes.setVisible(true);
+        land.setVisible(true);
+        landOutline.setVisible(true);
         labels.setVisible(false);
-      }
-    }
-  }, [baseMapStyle]);
+        // Deeper ocean blue
+        el.style.backgroundColor = "#7BA0C8";
 
-  useEffect(() => {
-    const map = mapRef.current;
-    if (!map) return;
+        const loaders: BlankLayerConfig[] = [
+          {
+            source: worldSourceRef.current,
+            isLoaded: () => worldSourceRef.current.getFeatures().length > 0,
+            url: "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_110m_admin_0_countries.geojson",
+            getCache: () => cachedWorldCountriesGeoJSON,
+            setCache: (data) => {
+              cachedWorldCountriesGeoJSON = data;
+            },
+            style: BLANK_WORLD_STYLE,
+          },
+          {
+            source: lakesSourceRef.current,
+            isLoaded: () => lakesSourceRef.current.getFeatures().length > 0,
+            url: "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_110m_lakes.geojson",
+            getCache: () => cachedLakesGeoJSON,
+            setCache: (data) => {
+              cachedLakesGeoJSON = data;
+            },
+            style: BLANK_LAKE_STYLE,
+          },
+          {
+            source: landSourceRef.current,
+            isLoaded: () => landSourceRef.current.getFeatures().length > 0,
+            url: "https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json",
+            getCache: () => cachedUsStatesGeoJSON,
+            setCache: (data) => {
+              cachedUsStatesGeoJSON = data;
+            },
+          },
+        ];
 
-    if (drawRef.current) {
-      map.removeInteraction(drawRef.current);
-      drawRef.current = null;
-    }
-
-    if (interactionMode !== 'draw') {
-      return;
-    }
-
-    if (!isDrawableOutlookType({ outlookType: drawingState.activeOutlookType })) {
-      return;
-    }
-
-    const drawSource = drawingState.activeOutlookType === 'categorical' ? catSourceRef.current : vectorSourceRef.current;
-    const draw = new Draw({ source: drawSource, type: 'Polygon' });
-    draw.on('drawend', (event) => {
-      const format = new GeoJSON();
-      const olGeometry = event.feature.getGeometry();
-      if (!olGeometry) {
-        return;
-      }
-
-      // Convert the drawn geometry to GeoJSON format with the correct projections for storage in Redux.
-      const geometry = format.writeGeometryObject(olGeometry, {
-        dataProjection: 'EPSG:4326',
-        featureProjection: 'EPSG:3857'
-      });
-      // Create a new feature object with the drawn geometry and current drawing state properties,
-      // then dispatch an action to add it to the Redux store.
-      const feature: GeoJsonFeature<Polygon, GeoJsonProperties> = {
-        type: 'Feature',
-        id: uuidv4(),
-        geometry: geometry as Polygon,
-        properties: {
-          outlookType: drawingState.activeOutlookType,
-          probability: drawingState.activeProbability,
-          isSignificant: drawingState.isSignificant
-        }
-      };
-      dispatch(addFeature({ feature }));
-    });
-    map.addInteraction(draw);
-    drawRef.current = draw;
-
-    // OpenLayers evaluates interactions in reverse insertion order.
-    // Re-adding snap interactions here ensures snap runs before draw,
-    // so the cursor actually snaps instead of only showing a snap hint.
-    if (snapRef.current) {
-      map.removeInteraction(snapRef.current);
-      map.addInteraction(snapRef.current);
-    }
-    if (catSnapRef.current) {
-      map.removeInteraction(catSnapRef.current);
-      map.addInteraction(catSnapRef.current);
-    }
-    if (ghostSnapRef.current) {
-      map.removeInteraction(ghostSnapRef.current);
-      map.addInteraction(ghostSnapRef.current);
-    }
-  }, [dispatch, drawingState.activeOutlookType, drawingState.activeProbability, drawingState.isSignificant, interactionMode]);
-
-  useEffect(() => {
-    const source = vectorSourceRef.current;
-    const catSource = catSourceRef.current;
-    const ghostSource = ghostSourceRef.current;
-    source.clear();
-    catSource.clear();
-    ghostSource.clear();
-    const format = new GeoJSON();
-
-    // Find the maximum z-index for bold styling
-    let maxZIndex = -Infinity;
-    serializedFeatures.forEach(({ outlookType, probability }) => {
-      const zIndex = computeZIndex(outlookType as EditableOutlookType, probability);
-      if (zIndex > maxZIndex) maxZIndex = zIndex;
-    });
-
-    serializedFeatures.forEach(({ outlookType, probability, feature }) => {
-      const isCategorical = outlookType === 'categorical';
-      const targetSource = isCategorical ? catSource : source;
-
-      const olFeature = format.readFeature(feature, {
-        dataProjection: 'EPSG:4326',
-        featureProjection: 'EPSG:3857'
-      });
-
-      const zIndex = computeZIndex(outlookType as EditableOutlookType, probability);
-      const isTopLayer = zIndex === maxZIndex;
-
-      // Apply styles and properties to the feature, then add it to the appropriate source.
-      const applyProps = (f: OLFeature<Geometry>) => {
-        f.setStyle(toOlStyle(
-          { outlookType, probability },
-          { isTopLayer }
-        ));
-        f.set('featureId', feature.id as string);
-        f.set('outlookType', outlookType);
-        f.set('probability', probability);
-        f.set('isSignificant', Boolean(feature.properties?.isSignificant));
-        f.set('derivedFrom', feature.properties?.derivedFrom);
-        targetSource.addFeature(f);
-      };
-
-      if (Array.isArray(olFeature)) {
-        olFeature.forEach((item: FeatureLike) => applyProps(item as OLFeature<Geometry>));
-      } else {
-        applyProps(olFeature as OLFeature<Geometry>);
-      }
-    });
-
-    Object.entries(outlooks).forEach(([outlookType, probs]) => {
-      if (outlookType === drawingState.activeOutlookType || !ghostOutlooks[outlookType as EditableOutlookType]) {
-        return;
-      }
-
-      if (!(probs instanceof Map)) return;
-
-      probs.forEach((features: GeoJsonFeature[], probability: string) => {
-        const isCategorical = outlookType === 'categorical';
-
-        features.forEach((feature) => {
-          const olFeature = format.readFeature(feature, {
-            dataProjection: 'EPSG:4326',
-            featureProjection: 'EPSG:3857'
+        loaders.forEach((loader) => {
+          ensureBlankLayerLoaded(loader).catch(() => {
+            /* blank map layer fetch failed — non-fatal */
           });
+        });
+        return;
+      }
 
-          /** Apply ghost styling/metadata and add the feature to the ghost source. */
-          const applyGhostProps = (f: OLFeature<Geometry>) => {
-            f.setStyle(toGhostOlStyle({ outlookType, probability, isCategorical }));
-            f.set('featureId', feature.id as string);
-            f.set('outlookType', outlookType);
-            f.set('probability', probability);
-            f.set('isSignificant', Boolean(feature.properties?.isSignificant));
-            f.set('derivedFrom', feature.properties?.derivedFrom);
-            ghostSource.addFeature(f);
-          };
+      if (isOpenFreeMapStyle(baseMapStyle)) {
+        const requestId = vectorStyleRequestRef.current + 1;
+        vectorStyleRequestRef.current = requestId;
 
-          if (Array.isArray(olFeature)) {
-            olFeature.forEach((item: FeatureLike) => applyGhostProps(item as OLFeature<Geometry>));
-          } else {
-            applyGhostProps(olFeature as OLFeature<Geometry>);
-          }
+        tile.setVisible(false);
+        world.setVisible(false);
+        lakes.setVisible(false);
+        land.setVisible(false);
+        landOutline.setVisible(true);
+        labels.setVisible(false);
+        el.style.backgroundColor = "";
+        vectorBaseGroup.setVisible(false);
+        vectorReferenceGroup.setVisible(false);
+        vectorBaseGroup.getLayers().clear();
+        vectorReferenceGroup.getLayers().clear();
+
+        getOpenFreeMapStyleSet(baseMapStyle)
+          .then(({ baseStyle, overlayStyle }) => {
+            const nextBaseGroup = new LayerGroup();
+            const nextReferenceGroup = new LayerGroup();
+
+            return Promise.all([
+              apply(nextBaseGroup, baseStyle),
+              apply(nextReferenceGroup, overlayStyle),
+            ]).then(() => ({ nextBaseGroup, nextReferenceGroup }));
+          })
+          .then(({ nextBaseGroup, nextReferenceGroup }) => {
+            if (vectorStyleRequestRef.current !== requestId) {
+              return;
+            }
+
+            replaceLayerGroupLayers(vectorBaseGroup, nextBaseGroup);
+            replaceLayerGroupLayers(vectorReferenceGroup, nextReferenceGroup);
+            vectorBaseGroup.setVisible(true);
+            vectorReferenceGroup.setVisible(true);
+          })
+          .catch((error) => {
+            if (vectorStyleRequestRef.current !== requestId) {
+              return;
+            }
+
+            console.warn(
+              "[forecast-map] falling back to raster basemap after vector load failure",
+              {
+                baseMapStyle,
+                error,
+              },
+            );
+            vectorBaseGroup.getLayers().clear();
+            vectorReferenceGroup.getLayers().clear();
+            tile.setSource(createTileSource(baseMapStyle));
+            tile.setVisible(true);
+            const labelSource = createLabelOverlaySource(baseMapStyle);
+            if (labelSource) {
+              labels.setSource(labelSource);
+              labels.setVisible(true);
+            }
+          });
+      } else {
+        hideVectorBasemapGroups();
+        tile.setVisible(true);
+        world.setVisible(false);
+        lakes.setVisible(false);
+        land.setVisible(false);
+        landOutline.setVisible(true);
+        el.style.backgroundColor = "";
+        tile.setSource(
+          createTileSource(baseMapStyle as Exclude<BaseMapStyle, "blank">),
+        );
+        const labelSource = createLabelOverlaySource(
+          baseMapStyle as Exclude<BaseMapStyle, "blank">,
+        );
+        if (labelSource) {
+          labels.setSource(labelSource);
+          labels.setVisible(true);
+        } else {
+          labels.setVisible(false);
+        }
+      }
+    }, [baseMapStyle]);
+
+    useEffect(() => {
+      const map = mapRef.current;
+      if (!map) return;
+
+      if (drawRef.current) {
+        map.removeInteraction(drawRef.current);
+        drawRef.current = null;
+      }
+
+      if (interactionMode !== "draw") {
+        return;
+      }
+
+      if (
+        !isDrawableOutlookType({ outlookType: drawingState.activeOutlookType })
+      ) {
+        return;
+      }
+
+      const drawSource =
+        drawingState.activeOutlookType === "categorical"
+          ? catSourceRef.current
+          : vectorSourceRef.current;
+      const draw = new Draw({ source: drawSource, type: "Polygon" });
+      draw.on("drawend", (event) => {
+        const format = new GeoJSON();
+        const olGeometry = event.feature.getGeometry();
+        if (!olGeometry) {
+          return;
+        }
+
+        // Convert the drawn geometry to GeoJSON format with the correct projections for storage in Redux.
+        const geometry = format.writeGeometryObject(olGeometry, {
+          dataProjection: "EPSG:4326",
+          featureProjection: "EPSG:3857",
+        });
+        // Create a new feature object with the drawn geometry and current drawing state properties,
+        // then dispatch an action to add it to the Redux store.
+        const feature: GeoJsonFeature<Polygon, GeoJsonProperties> = {
+          type: "Feature",
+          id: uuidv4(),
+          geometry: geometry as Polygon,
+          properties: {
+            outlookType: drawingState.activeOutlookType,
+            probability: drawingState.activeProbability,
+            isSignificant: drawingState.isSignificant,
+          },
+        };
+        dispatch(addFeature({ feature }));
+      });
+      map.addInteraction(draw);
+      drawRef.current = draw;
+
+      // OpenLayers evaluates interactions in reverse insertion order.
+      // Re-adding snap interactions here ensures snap runs before draw,
+      // so the cursor actually snaps instead of only showing a snap hint.
+      if (snapRef.current) {
+        map.removeInteraction(snapRef.current);
+        map.addInteraction(snapRef.current);
+      }
+      if (catSnapRef.current) {
+        map.removeInteraction(catSnapRef.current);
+        map.addInteraction(catSnapRef.current);
+      }
+      if (ghostSnapRef.current) {
+        map.removeInteraction(ghostSnapRef.current);
+        map.addInteraction(ghostSnapRef.current);
+      }
+    }, [
+      dispatch,
+      drawingState.activeOutlookType,
+      drawingState.activeProbability,
+      drawingState.isSignificant,
+      interactionMode,
+    ]);
+
+    useEffect(() => {
+      const source = vectorSourceRef.current;
+      const catSource = catSourceRef.current;
+      const ghostSource = ghostSourceRef.current;
+      source.clear();
+      catSource.clear();
+      ghostSource.clear();
+      const format = new GeoJSON();
+
+      // Find the maximum z-index for bold styling
+      let maxZIndex = -Infinity;
+      serializedFeatures.forEach(({ outlookType, probability }) => {
+        const zIndex = computeZIndex(
+          outlookType as EditableOutlookType,
+          probability,
+        );
+        if (zIndex > maxZIndex) maxZIndex = zIndex;
+      });
+
+      serializedFeatures.forEach(({ outlookType, probability, feature }) => {
+        const isCategorical = outlookType === "categorical";
+        const targetSource = isCategorical ? catSource : source;
+
+        const olFeature = format.readFeature(feature, {
+          dataProjection: "EPSG:4326",
+          featureProjection: "EPSG:3857",
+        });
+
+        const zIndex = computeZIndex(
+          outlookType as EditableOutlookType,
+          probability,
+        );
+        const isTopLayer = zIndex === maxZIndex;
+
+        // Apply styles and properties to the feature, then add it to the appropriate source.
+        const applyProps = (f: OLFeature<Geometry>) => {
+          f.setStyle(toOlStyle({ outlookType, probability }, { isTopLayer }));
+          f.set("featureId", feature.id as string);
+          f.set("outlookType", outlookType);
+          f.set("probability", probability);
+          f.set("isSignificant", Boolean(feature.properties?.isSignificant));
+          f.set("derivedFrom", feature.properties?.derivedFrom);
+          targetSource.addFeature(f);
+        };
+
+        if (Array.isArray(olFeature)) {
+          olFeature.forEach((item: FeatureLike) =>
+            applyProps(item as OLFeature<Geometry>),
+          );
+        } else {
+          applyProps(olFeature as OLFeature<Geometry>);
+        }
+      });
+
+      Object.entries(outlooks).forEach(([outlookType, probs]) => {
+        if (
+          outlookType === drawingState.activeOutlookType ||
+          !ghostOutlooks[outlookType as EditableOutlookType]
+        ) {
+          return;
+        }
+
+        if (!(probs instanceof Map)) return;
+
+        probs.forEach((features: GeoJsonFeature[], probability: string) => {
+          const isCategorical = outlookType === "categorical";
+
+          features.forEach((feature) => {
+            const olFeature = format.readFeature(feature, {
+              dataProjection: "EPSG:4326",
+              featureProjection: "EPSG:3857",
+            });
+
+            /** Apply ghost styling/metadata and add the feature to the ghost source. */
+            const applyGhostProps = (f: OLFeature<Geometry>) => {
+              f.setStyle(
+                toGhostOlStyle({ outlookType, probability, isCategorical }),
+              );
+              f.set("featureId", feature.id as string);
+              f.set("outlookType", outlookType);
+              f.set("probability", probability);
+              f.set(
+                "isSignificant",
+                Boolean(feature.properties?.isSignificant),
+              );
+              f.set("derivedFrom", feature.properties?.derivedFrom);
+              ghostSource.addFeature(f);
+            };
+
+            if (Array.isArray(olFeature)) {
+              olFeature.forEach((item: FeatureLike) =>
+                applyGhostProps(item as OLFeature<Geometry>),
+              );
+            } else {
+              applyGhostProps(olFeature as OLFeature<Geometry>);
+            }
+          });
         });
       });
-    });
-  }, [serializedFeatures, outlooks, drawingState.activeOutlookType, ghostOutlooks]);
+    }, [
+      serializedFeatures,
+      outlooks,
+      drawingState.activeOutlookType,
+      ghostOutlooks,
+    ]);
 
-  // Handlers for toolbar buttons to switch interaction modes and toggle style picker.
-  const handleSetModePan = () => {
-    setInteractionMode('pan');
-  };
+    // Handlers for toolbar buttons to switch interaction modes and toggle style picker.
+    const handleSetModePan = () => {
+      setInteractionMode("pan");
+    };
 
-  // Draw mode allows users to draw new polygons on the map, which are then added to the Redux store and rendered on the map.
-  const handleSetModeDraw = () => {
-    setInteractionMode('draw');
-  };
+    // Draw mode allows users to draw new polygons on the map, which are then added to the Redux store and rendered on the map.
+    const handleSetModeDraw = () => {
+      setInteractionMode("draw");
+    };
 
-  // Delete mode allows users to click on existing polygons to remove them from the map and the Redux store.
-  const handleSetModeDelete = () => {
-    setInteractionMode('delete');
-  };
+    // Delete mode allows users to click on existing polygons to remove them from the map and the Redux store.
+    const handleSetModeDelete = () => {
+      setInteractionMode("delete");
+    };
 
-  
-
-  return (
-    <div className="map-container">
-      <div ref={mapElementRef} style={{ width: '100%', height: '100%' }} />
-      <div
-        ref={popupRef}
-        className="ol-popup"
-        style={{
-          display: popupInfo ? 'block' : 'none',
-        }}
-      >
-        {popupInfo && (
-          <div className="ol-popup-content">
-            <div className="text-sm font-semibold capitalize">{popupInfo.outlookType}</div>
-            <div className="text-xs">
-              {popupInfo.probability}{popupInfo.isSignificant ? ' (Significant)' : ''}
+    return (
+      <div className="map-container">
+        <div ref={mapElementRef} style={{ width: "100%", height: "100%" }} />
+        <div
+          ref={popupRef}
+          className="ol-popup"
+          style={{
+            display: popupInfo ? "block" : "none",
+          }}
+        >
+          {popupInfo && (
+            <div className="ol-popup-content">
+              <div className="text-sm font-semibold capitalize">
+                {popupInfo.outlookType}
+              </div>
+              <div className="text-xs">
+                {popupInfo.probability}
+                {popupInfo.isSignificant ? " (Significant)" : ""}
+              </div>
             </div>
+          )}
+        </div>
+        <div className="map-toolbar-bottom-right">
+          <div className="map-toolbar-surface">
+            <button
+              type="button"
+              className={`map-toolbar-button mode-pan ${interactionMode === "pan" ? "active" : ""}`}
+              onClick={handleSetModePan}
+              title="Pan map"
+              aria-label="Pan map"
+            >
+              Pan
+            </button>
+            <button
+              type="button"
+              onClick={handleSetModeDraw}
+              className={`map-toolbar-button mode-draw ${interactionMode === "draw" ? "active" : ""}`}
+              title="Draw polygons"
+              aria-label="Draw polygons"
+            >
+              Draw
+            </button>
+            <button
+              type="button"
+              onClick={handleSetModeDelete}
+              className={`map-toolbar-button mode-delete ${interactionMode === "delete" ? "active" : ""}`}
+              title="Delete polygons"
+              aria-label="Delete polygons"
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              className={`map-toolbar-button mode-key ${showDesktopLegend ? "active" : ""}`}
+              onClick={() => setShowDesktopLegend((isVisible) => !isVisible)}
+              title={showDesktopLegend ? "Hide map key" : "Show map key"}
+              aria-label={showDesktopLegend ? "Hide map key" : "Show map key"}
+              aria-expanded={showDesktopLegend}
+            >
+              Key
+            </button>
           </div>
-        )}
-      </div>
-      <div className="map-toolbar-bottom-right">
-        <div className="map-toolbar-surface">
-          <button
-            type="button"
-            className={`map-toolbar-button mode-pan ${interactionMode === 'pan' ? 'active' : ''}`}
-            onClick={handleSetModePan}
-            title="Pan map"
-            aria-label="Pan map"
-          >
-            Pan
-          </button>
-          <button
-            type="button"
-            onClick={handleSetModeDraw}
-            className={`map-toolbar-button mode-draw ${interactionMode === 'draw' ? 'active' : ''}`}
-            title="Draw polygons"
-            aria-label="Draw polygons"
-          >
-            Draw
-          </button>
-          <button
-            type="button"
-            onClick={handleSetModeDelete}
-            className={`map-toolbar-button mode-delete ${interactionMode === 'delete' ? 'active' : ''}`}
-            title="Delete polygons"
-            aria-label="Delete polygons"
-          >
-            Delete
-          </button>
-          <button
-            type="button"
-            className={`map-toolbar-button mode-key ${showDesktopLegend ? 'active' : ''}`}
-            onClick={() => setShowDesktopLegend((isVisible) => !isVisible)}
-            title={showDesktopLegend ? 'Hide map key' : 'Show map key'}
-            aria-label={showDesktopLegend ? 'Hide map key' : 'Show map key'}
-            aria-expanded={showDesktopLegend}
-          >
-            Key
-          </button>
+          <div className="map-toolbar-help-surface">
+            {interactionMode === "draw" &&
+              "Draw mode: click to place points, double-click to finish polygon."}
+            {interactionMode === "delete" &&
+              "Delete mode: click any polygon to remove it."}
+            {interactionMode === "pan" &&
+              "Pan mode: drag map to move, scroll to zoom. Click a polygon to see its details."}
+          </div>
         </div>
-        <div className="map-toolbar-help-surface">
-          {interactionMode === 'draw' && 'Draw mode: click to place points, double-click to finish polygon.'}
-          {interactionMode === 'delete' && 'Delete mode: click any polygon to remove it.'}
-          {interactionMode === 'pan' && 'Pan mode: drag map to move, scroll to zoom. Click a polygon to see its details.'}
-        </div>
+        <Legend desktopOpen={showDesktopLegend} mobileOpen={showMobileLegend} />
+        <button
+          type="button"
+          className={`map-key-popout-button ${showMobileLegend ? "active" : ""}`}
+          onClick={() => setShowMobileLegend((isVisible) => !isVisible)}
+          title={showMobileLegend ? "Hide map key" : "Show map key"}
+          aria-label={showMobileLegend ? "Hide map key" : "Show map key"}
+          aria-expanded={showMobileLegend}
+        >
+          <span aria-hidden="true">{showMobileLegend ? "▾" : "▴"}</span>
+          Key
+        </button>
+        <StatusOverlay />
+        <UnofficialBadge />
       </div>
-      <Legend desktopOpen={showDesktopLegend} mobileOpen={showMobileLegend} />
-      <button
-        type="button"
-        className={`map-key-popout-button ${showMobileLegend ? 'active' : ''}`}
-        onClick={() => setShowMobileLegend((isVisible) => !isVisible)}
-        title={showMobileLegend ? 'Hide map key' : 'Show map key'}
-        aria-label={showMobileLegend ? 'Hide map key' : 'Show map key'}
-        aria-expanded={showMobileLegend}
-      >
-        <span aria-hidden="true">{showMobileLegend ? '▾' : '▴'}</span>
-        Key
-      </button>
-      <StatusOverlay />
-      <UnofficialBadge />
-    </div>
-  );
-});
+    );
+  },
+);
 
-OpenLayersForecastMap.displayName = 'OpenLayersForecastMap';
+OpenLayersForecastMap.displayName = "OpenLayersForecastMap";
 
 export default OpenLayersForecastMap;

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -668,6 +668,25 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref
 
     mapRef.current = map;
 
+    // Some browsers/devices (notably some Chromebooks) can mount the map into a container
+    // that temporarily measures 0x0 due to flex/layout timing. OpenLayers logs a warning
+    // and may not render until updateSize() is called after layout stabilizes.
+    const targetEl = mapElementRef.current;
+    const updateSizeSafely = () => {
+      try {
+        map.updateSize();
+      } catch {
+        // Non-fatal: map may be disposing.
+      }
+    };
+    const raf1 = window.requestAnimationFrame(updateSizeSafely);
+    const raf2 = window.requestAnimationFrame(updateSizeSafely);
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined' && targetEl) {
+      resizeObserver = new ResizeObserver(() => updateSizeSafely());
+      resizeObserver.observe(targetEl);
+    }
+
     // Create popup overlay
     if (popupRef.current) {
       const overlay = new Overlay({
@@ -794,6 +813,11 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>((_, ref
     selectRef.current = select;
 
     return () => {
+      window.cancelAnimationFrame(raf1);
+      window.cancelAnimationFrame(raf2);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
       if (drawRef.current) {
         map.removeInteraction(drawRef.current);
       }

--- a/src/components/Map/OpenLayersVerificationMap.tsx
+++ b/src/components/Map/OpenLayersVerificationMap.tsx
@@ -520,7 +520,29 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
 
     mapRef.current = map;
 
+    // As with the forecast map, ensure we recover if the target container is 0x0 at mount.
+    const targetEl = mapElementRef.current;
+    const updateSizeSafely = () => {
+      try {
+        map.updateSize();
+      } catch {
+        // ignore
+      }
+    };
+    const raf1 = window.requestAnimationFrame(updateSizeSafely);
+    const raf2 = window.requestAnimationFrame(updateSizeSafely);
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined' && targetEl) {
+      resizeObserver = new ResizeObserver(() => updateSizeSafely());
+      resizeObserver.observe(targetEl);
+    }
+
     return () => {
+      window.cancelAnimationFrame(raf1);
+      window.cancelAnimationFrame(raf2);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
       map.setTarget();
       mapRef.current = null;
       vectorBaseGroupRef.current = null;

--- a/src/components/Map/OpenLayersVerificationMap.tsx
+++ b/src/components/Map/OpenLayersVerificationMap.tsx
@@ -1,41 +1,60 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import 'ol/ol.css';
-import OLMap from 'ol/Map';
-import View from 'ol/View';
-import LayerGroup from 'ol/layer/Group';
-import TileLayer from 'ol/layer/Tile';
-import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
-import OSM from 'ol/source/OSM';
-import XYZ from 'ol/source/XYZ';
-import GeoJSON from 'ol/format/GeoJSON';
-import { fromLonLat } from 'ol/proj';
-import { RootState } from '../../store';
-import { selectVerificationOutlooksForDay } from '../../store/verificationSlice';
-import { setBaseMapStyle } from '../../store/overlaysSlice';
-import type { BaseMapStyle } from '../../store/overlaysSlice';
-import { computeZIndex, getFeatureStyle } from '../../utils/mapStyleUtils';
-import { DayType } from '../../types/outlooks';
-import type { MapAdapterHandle } from '../../maps/contracts';
-import type { Feature as GeoJsonFeature } from 'geojson';
-import Feature from 'ol/Feature';
-import Point from 'ol/geom/Point';
-import { Circle, Fill as StyleFill, Stroke as StyleStroke, Style as OlStyle, Fill, Stroke, Style } from 'ol/style';
-import { apply } from 'ol-mapbox-style';
-import Legend from './Legend';
-import UnofficialBadge from './UnofficialBadge';
-import { getOpenFreeMapStyleSet, isOpenFreeMapStyle } from '../../lib/openFreeMap';
-import './ForecastMap.css';
-import { ReportType } from '../../types/stormReports';
-
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useDispatch, useSelector } from "react-redux";
+import "ol/ol.css";
+import OLMap from "ol/Map";
+import View from "ol/View";
+import LayerGroup from "ol/layer/Group";
+import TileLayer from "ol/layer/Tile";
+import VectorLayer from "ol/layer/Vector";
+import VectorSource from "ol/source/Vector";
+import OSM from "ol/source/OSM";
+import XYZ from "ol/source/XYZ";
+import GeoJSON from "ol/format/GeoJSON";
+import { fromLonLat } from "ol/proj";
+import { RootState } from "../../store";
+import { selectVerificationOutlooksForDay } from "../../store/verificationSlice";
+import { setBaseMapStyle } from "../../store/overlaysSlice";
+import type { BaseMapStyle } from "../../store/overlaysSlice";
+import { computeZIndex, getFeatureStyle } from "../../utils/mapStyleUtils";
+import { DayType } from "../../types/outlooks";
+import type { MapAdapterHandle } from "../../maps/contracts";
+import type { Feature as GeoJsonFeature } from "geojson";
+import Feature from "ol/Feature";
+import Point from "ol/geom/Point";
+import {
+  Circle,
+  Fill as StyleFill,
+  Stroke as StyleStroke,
+  Style as OlStyle,
+  Fill,
+  Stroke,
+  Style,
+} from "ol/style";
+import { apply } from "ol-mapbox-style";
+import Legend from "./Legend";
+import UnofficialBadge from "./UnofficialBadge";
+import {
+  getOpenFreeMapStyleSet,
+  isOpenFreeMapStyle,
+} from "../../lib/openFreeMap";
+import "./ForecastMap.css";
+import { ReportType } from "../../types/stormReports";
 
 interface OpenLayersVerificationMapProps {
-  activeOutlookType?: 'categorical' | 'tornado' | 'wind' | 'hail';
+  activeOutlookType?: "categorical" | "tornado" | "wind" | "hail";
   selectedDay?: DayType;
 }
 
-type VerificationOutlookType = NonNullable<OpenLayersVerificationMapProps['activeOutlookType']>;
+type VerificationOutlookType = NonNullable<
+  OpenLayersVerificationMapProps["activeOutlookType"]
+>;
 
 interface ColorWithOpacity {
   color: string;
@@ -58,23 +77,29 @@ const TOP_VECTOR_REFERENCE_LAYER_Z_INDEX = 1050;
 const TOP_LABEL_LAYER_Z_INDEX = 1100;
 
 /** Replaces all layers in the target group with the current layers from the source group. */
-export const replaceLayerGroupLayers = (target: LayerGroup, source: LayerGroup) => {
+export const replaceLayerGroupLayers = (
+  target: LayerGroup,
+  source: LayerGroup,
+) => {
   const targetLayers = target.getLayers();
   targetLayers.clear();
-  source.getLayers().getArray().forEach((layer) => {
-    targetLayers.push(layer);
-  });
+  source
+    .getLayers()
+    .getArray()
+    .forEach((layer) => {
+      targetLayers.push(layer);
+    });
 };
 
 // Define specific colors for each report type
 const reportColors = {
-  tornado: '#FF0000', // Red for tornado
-  wind: '#0000FF',    // Blue for wind
-  hail: '#00FF00',    // Green for hail
+  tornado: "#FF0000", // Red for tornado
+  wind: "#0000FF", // Blue for wind
+  hail: "#00FF00", // Green for hail
 };
 
 // Fallback color for report dots when the report type is not found in reportColors
-const FALLBACK_REPORT_COLOR = '#888888';
+const FALLBACK_REPORT_COLOR = "#888888";
 
 // Style function for storm reports
 const buildReportStyle = (type: ReportType) => {
@@ -85,7 +110,7 @@ const buildReportStyle = (type: ReportType) => {
         color: reportColors[type] || FALLBACK_REPORT_COLOR, // Fallback to grey
       }),
       stroke: new StyleStroke({
-        color: '#FFFFFF', // White border
+        color: "#FFFFFF", // White border
         width: 1,
       }),
     }),
@@ -97,13 +122,13 @@ let cachedUsStatesGeoJSONVerif: object | null = null;
 
 // Blank land fill for verification map.
 const BLANK_LAND_FILL_STYLE_VERIF = new Style({
-  fill: new Fill({ color: '#f2ede2' }),
+  fill: new Fill({ color: "#f2ede2" }),
 });
 
 // Blank land outlines rendered above outlook polygons.
 const BLANK_LAND_OUTLINE_STYLE_VERIF = new Style({
-  fill: new Fill({ color: 'rgba(0, 0, 0, 0)' }),
-  stroke: new Stroke({ color: '#9e9585', width: 1 }),
+  fill: new Fill({ color: "rgba(0, 0, 0, 0)" }),
+  stroke: new Stroke({ color: "#9e9585", width: 1 }),
 });
 
 /**
@@ -114,35 +139,37 @@ const BLANK_LAND_OUTLINE_STYLE_VERIF = new Style({
  * @param style - The selected base map style (excluding 'blank')
  * @returns An `XYZ` tile source for label-only tiles or `null`.
  */
-const createVerificationLabelOverlaySource = (style: Exclude<BaseMapStyle, 'blank'>): XYZ | null => {
+const createVerificationLabelOverlaySource = (
+  style: Exclude<BaseMapStyle, "blank">,
+): XYZ | null => {
   switch (style) {
-    case 'osm':
+    case "osm":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; OpenStreetMap &copy; CARTO',
+        url: "https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png",
+        attributions: "&copy; OpenStreetMap &copy; CARTO",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'carto-light':
+    case "carto-light":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; OpenStreetMap &copy; CARTO',
+        url: "https://{a-d}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png",
+        attributions: "&copy; OpenStreetMap &copy; CARTO",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'carto-dark':
+    case "carto-dark":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; OpenStreetMap &copy; CARTO',
+        url: "https://{a-d}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}{r}.png",
+        attributions: "&copy; OpenStreetMap &copy; CARTO",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'esri-satellite':
+    case "esri-satellite":
       return new XYZ({
-        url: 'https://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
-        attributions: 'Tiles &copy; Esri',
+        url: "https://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}",
+        attributions: "Tiles &copy; Esri",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
     default:
       return null;
@@ -150,55 +177,61 @@ const createVerificationLabelOverlaySource = (style: Exclude<BaseMapStyle, 'blan
 };
 
 // Function to create tile source based on selected base map style for verification map
-export const createVerifTileSource = (style: Exclude<BaseMapStyle, 'blank'>): OSM | XYZ => {
+export const createVerifTileSource = (
+  style: Exclude<BaseMapStyle, "blank">,
+): OSM | XYZ => {
   switch (style) {
-    case 'osm':
+    case "osm":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        url: "https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}{r}.png",
+        attributions:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'carto-light':
+    case "carto-light":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        url: "https://{a-d}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png",
+        attributions:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'carto-dark':
+    case "carto-dark":
       return new XYZ({
-        url: 'https://{a-d}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png',
-        attributions: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        url: "https://{a-d}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png",
+        attributions:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
-    case 'esri-satellite':
+    case "esri-satellite":
       return new XYZ({
-        url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-        attributions: 'Tiles &copy; Esri &mdash; Source: Esri i-cubed USDA USGS AEX GeoEye Getmapping Aerogrid IGN IGP UPR-EGP',
+        url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        attributions:
+          "Tiles &copy; Esri &mdash; Source: Esri i-cubed USDA USGS AEX GeoEye Getmapping Aerogrid IGN IGP UPR-EGP",
         maxZoom: 19,
-        crossOrigin: 'anonymous',
+        crossOrigin: "anonymous",
       });
     default:
-      return new OSM({ crossOrigin: 'anonymous' });
+      return new OSM({ crossOrigin: "anonymous" });
   }
 };
 
 // Function to create a hatch pattern for CIG overlays based on the CIG level
 export const createHatchPattern = (cigLevel: string): CanvasPattern | null => {
-  const canvas = document.createElement('canvas');
+  const canvas = document.createElement("canvas");
   const size = 10;
   canvas.width = size;
   canvas.height = size;
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext("2d");
 
   if (!ctx) return null;
 
-  ctx.strokeStyle = '#111111';
+  ctx.strokeStyle = "#111111";
   ctx.lineWidth = 1.1;
 
-  if (cigLevel === 'CIG1') {
+  if (cigLevel === "CIG1") {
     // Broken diagonal lines
     ctx.beginPath();
     ctx.moveTo(0, 0);
@@ -206,13 +239,13 @@ export const createHatchPattern = (cigLevel: string): CanvasPattern | null => {
     ctx.moveTo(5, 5);
     ctx.lineTo(10, 10);
     ctx.stroke();
-  } else if (cigLevel === 'CIG2') {
+  } else if (cigLevel === "CIG2") {
     // Solid diagonal lines
     ctx.beginPath();
     ctx.moveTo(0, 0);
     ctx.lineTo(size, size);
     ctx.stroke();
-  } else if (cigLevel === 'CIG3') {
+  } else if (cigLevel === "CIG3") {
     // Crosshatch
     ctx.beginPath();
     ctx.moveTo(0, 0);
@@ -222,16 +255,16 @@ export const createHatchPattern = (cigLevel: string): CanvasPattern | null => {
     ctx.stroke();
   }
 
-  return ctx.createPattern(canvas, 'repeat');
+  return ctx.createPattern(canvas, "repeat");
 };
 
 const FUNCTION_COLOR_NOTATION_REGEX = /^(rgba?|hsla?)\(/i;
-const CATEGORICAL_OUTLOOK: VerificationOutlookType = 'categorical';
-const CIG_PREFIX = 'CIG';
-const FALLBACK_FILL_COLOR = '#999999';
-const FALLBACK_STROKE_COLOR = '#000000';
-const TRANSPARENT_PATTERN_FILL = 'rgba(0,0,0,0)';
-const CIG_STROKE_COLOR = '#111111';
+const CATEGORICAL_OUTLOOK: VerificationOutlookType = "categorical";
+const CIG_PREFIX = "CIG";
+const FALLBACK_FILL_COLOR = "#999999";
+const FALLBACK_STROKE_COLOR = "#000000";
+const TRANSPARENT_PATTERN_FILL = "rgba(0,0,0,0)";
+const CIG_STROKE_COLOR = "#111111";
 const CIG_STROKE_WIDTH = 1.2;
 /** Returns true if the color string uses a CSS function notation like rgb(), rgba(), hsl(), or hsla(). */
 export const isFunctionColorNotation = (color: string): boolean => {
@@ -240,11 +273,14 @@ export const isFunctionColorNotation = (color: string): boolean => {
 
 /** Returns `value` as a number if it already is one, otherwise returns `fallback`. */
 export const coerceNumber = (value: unknown, fallback: number): number => {
-  return typeof value === 'number' ? value : fallback;
+  return typeof value === "number" ? value : fallback;
 };
 
 /** Resolves fill opacity from the style payload, defaulting to 0.25 when missing. */
-export const resolveFillOpacity = (_outlookType: VerificationOutlookType, fillOpacity: unknown): number => {
+export const resolveFillOpacity = (
+  _outlookType: VerificationOutlookType,
+  fillOpacity: unknown,
+): number => {
   return coerceNumber(fillOpacity, 0.25);
 };
 
@@ -264,9 +300,15 @@ export const isCigProbability = (probability: string): boolean => {
 };
 
 /** Computes the rendering z-index for verification features: CIG overlays use a high-based rank; regular probabilities use the shared computeZIndex utility. */
-export const getVerificationStyleZIndex = ({ outlookType, probability }: OutlookStyleDescriptor): number => {
-  const regularZ = computeZIndex(outlookType as VerificationOutlookType, probability);
-  const cigRank = parseInt(probability.replace(CIG_PREFIX, ''), 10) || 0;
+export const getVerificationStyleZIndex = ({
+  outlookType,
+  probability,
+}: OutlookStyleDescriptor): number => {
+  const regularZ = computeZIndex(
+    outlookType as VerificationOutlookType,
+    probability,
+  );
+  const cigRank = parseInt(probability.replace(CIG_PREFIX, ""), 10) || 0;
   const cigZ = 1000 + cigRank;
 
   // CIG overlays must always render above regular probabilities.
@@ -282,8 +324,8 @@ export const buildCigStyleParts = (probability: string) => {
     fill: new Fill({ color: hatchFill }),
     stroke: new Stroke({
       color: CIG_STROKE_COLOR,
-      width: CIG_STROKE_WIDTH
-    })
+      width: CIG_STROKE_WIDTH,
+    }),
   };
 };
 
@@ -297,10 +339,14 @@ export const toRgbaColor = ({ color, alpha }: ColorWithOpacity): string => {
     return color;
   }
 
-  const hex = color.replace('#', '');
-  const normalized = hex.length === 3
-    ? hex.split('').map((char) => `${char}${char}`).join('')
-    : hex;
+  const hex = color.replace("#", "");
+  const normalized =
+    hex.length === 3
+      ? hex
+          .split("")
+          .map((char) => `${char}${char}`)
+          .join("")
+      : hex;
 
   if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
     return color;
@@ -313,23 +359,34 @@ export const toRgbaColor = ({ color, alpha }: ColorWithOpacity): string => {
 };
 
 /** Creates an OL Fill with an rgba color derived from the given hex/rgb color and alpha value. */
-export const createStandardFill = ({ color, alpha }: ColorWithOpacity): Fill => {
+export const createStandardFill = ({
+  color,
+  alpha,
+}: ColorWithOpacity): Fill => {
   return new Fill({ color: toRgbaColor({ color, alpha }) });
 };
 
 /** Creates a standard OpenLayers Stroke from a color, opacity, and width descriptor. */
-export const createStandardStroke = ({ color, opacity, width }: StrokeDescriptor): Stroke => {
+export const createStandardStroke = ({
+  color,
+  opacity,
+  width,
+}: StrokeDescriptor): Stroke => {
   return new Stroke({
     color: toRgbaColor({ color, alpha: opacity }),
-    width
+    width,
   });
 };
 
 // Function to build OpenLayers style for a given feature based on its outlook type and probability,
-export const buildStyle = (
-  { outlookType, probability }: OutlookStyleDescriptor
-) => {
-  const style = getFeatureStyle(outlookType as VerificationOutlookType, probability);
+export const buildStyle = ({
+  outlookType,
+  probability,
+}: OutlookStyleDescriptor) => {
+  const style = getFeatureStyle(
+    outlookType as VerificationOutlookType,
+    probability,
+  );
   const fillColor = String(style.fillColor || FALLBACK_FILL_COLOR);
   const strokeColor = String(style.color || FALLBACK_STROKE_COLOR);
   const fillOpacity = resolveFillOpacity(outlookType, style.fillOpacity);
@@ -340,14 +397,18 @@ export const buildStyle = (
   const styleParts = isCig
     ? buildCigStyleParts(probability)
     : {
-      fill: createStandardFill({ color: fillColor, alpha: fillOpacity }),
-      stroke: createStandardStroke({ color: strokeColor, opacity: strokeOpacity, width: strokeWidth }),
-    };
+        fill: createStandardFill({ color: fillColor, alpha: fillOpacity }),
+        stroke: createStandardStroke({
+          color: strokeColor,
+          opacity: strokeOpacity,
+          width: strokeWidth,
+        }),
+      };
 
   return new Style({
     zIndex: styleZ,
     stroke: styleParts.stroke,
-    fill: styleParts.fill
+    fill: styleParts.fill,
   });
 };
 
@@ -357,18 +418,20 @@ const VerifMapStylePicker: React.FC<{
   onSelect: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }> = ({ baseMapStyle, onSelect }) => (
   <div className="absolute bottom-full mb-2 right-0 rounded-md bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow-lg p-2 flex flex-col gap-1 min-w-[120px] z-50">
-    {([
-      { value: 'blank', label: 'Blank (Weather)' },
-      { value: 'osm', label: 'OpenStreetMap' },
-      { value: 'carto-light', label: 'Light' },
-      { value: 'carto-dark', label: 'Dark' },
-      { value: 'esri-satellite', label: 'Satellite' },
-    ] as { value: BaseMapStyle; label: string }[]).map(({ value, label }) => (
+    {(
+      [
+        { value: "blank", label: "Blank (Weather)" },
+        { value: "osm", label: "OpenStreetMap" },
+        { value: "carto-light", label: "Light" },
+        { value: "carto-dark", label: "Dark" },
+        { value: "esri-satellite", label: "Satellite" },
+      ] as { value: BaseMapStyle; label: string }[]
+    ).map(({ value, label }) => (
       <button
         key={value}
         data-style={value}
         type="button"
-        className={`text-left px-2 py-1 rounded text-xs hover:bg-gray-100 dark:hover:bg-gray-700 ${baseMapStyle === value ? 'font-bold bg-gray-100 dark:bg-gray-700' : ''}`}
+        className={`text-left px-2 py-1 rounded text-xs hover:bg-gray-100 dark:hover:bg-gray-700 ${baseMapStyle === value ? "font-bold bg-gray-100 dark:bg-gray-700" : ""}`}
         onClick={onSelect}
       >
         {label}
@@ -402,10 +465,10 @@ const VerifMapStylePickerButton: React.FC<{
 
 // OpenLayers map component for verification view,
 // supporting categorical and probabilistic outlooks with storm report overlays and base map style switching.
-const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLayersVerificationMapProps>(({ 
-  activeOutlookType = CATEGORICAL_OUTLOOK,
-  selectedDay = 1
-}, ref) => {
+const OpenLayersVerificationMap = forwardRef<
+  MapAdapterHandle<OLMap> | null,
+  OpenLayersVerificationMapProps
+>(({ activeOutlookType = CATEGORICAL_OUTLOOK, selectedDay = 1 }, ref) => {
   const dispatch = useDispatch();
   const [showStylePicker, setShowStylePicker] = useState(false);
   const mapElementRef = useRef<HTMLDivElement>(null);
@@ -421,13 +484,21 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
   const vectorSourceRef = useRef<VectorSource>(new VectorSource());
   const outlookLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
   const stormReportsSourceRef = useRef<VectorSource>(new VectorSource()); // New source for storm reports
-  const mapView = useSelector((state: RootState) => state.forecast.currentMapView);
+  const mapView = useSelector(
+    (state: RootState) => state.forecast.currentMapView,
+  );
   const initialMapViewRef = useRef(mapView);
-  const outlooks = useSelector((state: RootState) => selectVerificationOutlooksForDay(state, selectedDay));
-  const baseMapStyle = useSelector((state: RootState) => state.overlays.baseMapStyle);
-  const { reports, visible: reportsVisible, filterByType } = useSelector(
-    (state: RootState) => state.stormReports
-  ); // Select storm reports state
+  const outlooks = useSelector((state: RootState) =>
+    selectVerificationOutlooksForDay(state, selectedDay),
+  );
+  const baseMapStyle = useSelector(
+    (state: RootState) => state.overlays.baseMapStyle,
+  );
+  const {
+    reports,
+    visible: reportsVisible,
+    filterByType,
+  } = useSelector((state: RootState) => state.stormReports); // Select storm reports state
 
   // Memoize active features based on selected outlook type and available outlooks for the day,
   const activeFeatures = useMemo(() => {
@@ -447,19 +518,25 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
     return items;
   }, [activeOutlookType, outlooks]);
 
-  useImperativeHandle(ref, () => ({
-    getMap: () => mapRef.current,
-    getEngine: () => 'openlayers',
-    getView: () => ({
-      center: mapView.center,
-      zoom: mapView.zoom
-    })
-  }), [mapView.center, mapView.zoom]);
+  useImperativeHandle(
+    ref,
+    () => ({
+      getMap: () => mapRef.current,
+      getEngine: () => "openlayers",
+      getView: () => ({
+        center: mapView.center,
+        zoom: mapView.zoom,
+      }),
+    }),
+    [mapView.center, mapView.zoom],
+  );
 
   useEffect(() => {
     if (!mapElementRef.current || mapRef.current) return undefined;
 
-    const baseTileLayer = new TileLayer({ source: new OSM({ crossOrigin: 'anonymous' }) });
+    const baseTileLayer = new TileLayer({
+      source: new OSM({ crossOrigin: "anonymous" }),
+    });
     tileLayerRef.current = baseTileLayer;
     const vectorBaseGroup = new LayerGroup({
       visible: false,
@@ -486,10 +563,13 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
       style: BLANK_LAND_OUTLINE_STYLE_VERIF,
     });
     landOutlineLayerRef.current = landOutlineLayer;
-    const outlookLayer = new VectorLayer({ source: vectorSourceRef.current, zIndex: 3 });
+    const outlookLayer = new VectorLayer({
+      source: vectorSourceRef.current,
+      zIndex: 3,
+    });
     outlookLayerRef.current = outlookLayer;
     const labelLayer = new TileLayer({
-      source: createVerificationLabelOverlaySource('osm') ?? undefined,
+      source: createVerificationLabelOverlaySource("osm") ?? undefined,
       visible: true,
       zIndex: TOP_LABEL_LAYER_Z_INDEX,
     });
@@ -508,20 +588,25 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
         new VectorLayer({
           source: stormReportsSourceRef.current,
           zIndex: 4,
-          style: (feature) => buildReportStyle(feature.get('type') as ReportType),
+          style: (feature) =>
+            buildReportStyle(feature.get("type") as ReportType),
         }),
         labelLayer,
       ],
       view: new View({
-        center: fromLonLat([initialMapViewRef.current.center[1], initialMapViewRef.current.center[0]]),
-        zoom: initialMapViewRef.current.zoom
-      })
+        center: fromLonLat([
+          initialMapViewRef.current.center[1],
+          initialMapViewRef.current.center[0],
+        ]),
+        zoom: initialMapViewRef.current.zoom,
+      }),
     });
 
     mapRef.current = map;
 
     // As with the forecast map, ensure we recover if the target container is 0x0 at mount.
     const targetEl = mapElementRef.current;
+    // Same with the forecast map, update the map safely when timing occurs incorrectly
     const updateSizeSafely = () => {
       try {
         map.updateSize();
@@ -532,7 +617,7 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
     const raf1 = window.requestAnimationFrame(updateSizeSafely);
     const raf2 = window.requestAnimationFrame(updateSizeSafely);
     let resizeObserver: ResizeObserver | null = null;
-    if (typeof ResizeObserver !== 'undefined' && targetEl) {
+    if (typeof ResizeObserver !== "undefined" && targetEl) {
       resizeObserver = new ResizeObserver(() => updateSizeSafely());
       resizeObserver.observe(targetEl);
     }
@@ -559,7 +644,10 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
     const currentCenter = view.getCenter();
     const currentZoom = view.getZoom() || 4;
 
-    const centerChanged = !currentCenter || Math.abs(currentCenter[0] - targetCenter[0]) > 0.01 || Math.abs(currentCenter[1] - targetCenter[1]) > 0.01;
+    const centerChanged =
+      !currentCenter ||
+      Math.abs(currentCenter[0] - targetCenter[0]) > 0.01 ||
+      Math.abs(currentCenter[1] - targetCenter[1]) > 0.01;
     const zoomChanged = Math.abs(currentZoom - mapView.zoom) > 0.000001;
 
     if (!centerChanged && !zoomChanged) {
@@ -579,7 +667,16 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
     const landOutline = landOutlineLayerRef.current;
     const labels = labelLayerRef.current;
     const el = mapElementRef.current;
-    if (!tile || !vectorBaseGroup || !vectorReferenceGroup || !land || !landOutline || !labels || !el) return;
+    if (
+      !tile ||
+      !vectorBaseGroup ||
+      !vectorReferenceGroup ||
+      !land ||
+      !landOutline ||
+      !labels ||
+      !el
+    )
+      return;
 
     /**
      * Load US state boundary features into the `landSourceRef` if they
@@ -599,19 +696,23 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
       const loadStates = async () => {
         let geoData = cachedUsStatesGeoJSONVerif;
         if (!geoData) {
-          const res = await fetch('https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json');
+          const res = await fetch(
+            "https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json",
+          );
           geoData = await res.json();
           cachedUsStatesGeoJSONVerif = geoData;
         }
         const format = new GeoJSON();
         const features = format.readFeatures(geoData, {
-          dataProjection: 'EPSG:4326',
-          featureProjection: 'EPSG:3857',
+          dataProjection: "EPSG:4326",
+          featureProjection: "EPSG:3857",
         });
         landSourceRef.current.addFeatures(features as Feature[]);
       };
 
-      loadStates().catch(() => { /* US states layer fetch failed — non-fatal */ });
+      loadStates().catch(() => {
+        /* US states layer fetch failed — non-fatal */
+      });
     };
 
     // Keep state outlines above outlook polygons across base-map styles.
@@ -625,13 +726,13 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
       vectorReferenceGroup.getLayers().clear();
     };
 
-    if (baseMapStyle === 'blank') {
+    if (baseMapStyle === "blank") {
       hideVectorBasemapGroups();
       tile.setVisible(false);
       land.setVisible(true);
       landOutline.setVisible(true);
       labels.setVisible(false);
-      el.style.backgroundColor = '#b8d4e8';
+      el.style.backgroundColor = "#b8d4e8";
       return;
     }
 
@@ -643,7 +744,7 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
       land.setVisible(false);
       landOutline.setVisible(true);
       labels.setVisible(false);
-      el.style.backgroundColor = '';
+      el.style.backgroundColor = "";
       vectorBaseGroup.setVisible(false);
       vectorReferenceGroup.setVisible(false);
       vectorBaseGroup.getLayers().clear();
@@ -674,15 +775,19 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
             return;
           }
 
-          console.warn('[verification-map] falling back to raster basemap after vector load failure', {
-            baseMapStyle,
-            error,
-          });
+          console.warn(
+            "[verification-map] falling back to raster basemap after vector load failure",
+            {
+              baseMapStyle,
+              error,
+            },
+          );
           vectorBaseGroup.getLayers().clear();
           vectorReferenceGroup.getLayers().clear();
           tile.setSource(createVerifTileSource(baseMapStyle));
           tile.setVisible(true);
-          const labelSource = createVerificationLabelOverlaySource(baseMapStyle);
+          const labelSource =
+            createVerificationLabelOverlaySource(baseMapStyle);
           if (labelSource) {
             labels.setSource(labelSource);
             labels.setVisible(true);
@@ -693,9 +798,13 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
       tile.setVisible(true);
       land.setVisible(false);
       landOutline.setVisible(true);
-      el.style.backgroundColor = '';
-      tile.setSource(createVerifTileSource(baseMapStyle as Exclude<BaseMapStyle, 'blank'>));
-      const labelSource = createVerificationLabelOverlaySource(baseMapStyle as Exclude<BaseMapStyle, 'blank'>);
+      el.style.backgroundColor = "";
+      tile.setSource(
+        createVerifTileSource(baseMapStyle as Exclude<BaseMapStyle, "blank">),
+      );
+      const labelSource = createVerificationLabelOverlaySource(
+        baseMapStyle as Exclude<BaseMapStyle, "blank">,
+      );
       if (labelSource) {
         labels.setSource(labelSource);
         labels.setVisible(true);
@@ -723,22 +832,35 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
     // Sort features by computed z-index to ensure correct rendering order in OpenLayers,
     // since it doesn't automatically handle SVG-style layering based on feature properties. Higher z-index features will be added last and rendered on top. CIG overlays are always on top, with CIG3 above CIG2 above CIG1, followed by regular probabilities sorted by their computed z-index.
     const sortedFeatures = [...activeFeatures].sort((a, b) => {
-      return computeZIndex(activeOutlookType as VerificationOutlookType, a.probability) - computeZIndex(activeOutlookType as VerificationOutlookType, b.probability);
+      return (
+        computeZIndex(
+          activeOutlookType as VerificationOutlookType,
+          a.probability,
+        ) -
+        computeZIndex(
+          activeOutlookType as VerificationOutlookType,
+          b.probability,
+        )
+      );
     });
 
     sortedFeatures.forEach(({ feature, probability }) => {
       const olFeature = format.readFeature(feature, {
-        dataProjection: 'EPSG:4326',
-        featureProjection: 'EPSG:3857'
+        dataProjection: "EPSG:4326",
+        featureProjection: "EPSG:3857",
       });
 
       if (Array.isArray(olFeature)) {
         olFeature.forEach((item) => {
-          item.setStyle(buildStyle({ outlookType: activeOutlookType, probability }));
+          item.setStyle(
+            buildStyle({ outlookType: activeOutlookType, probability }),
+          );
           source.addFeature(item);
         });
       } else {
-        olFeature.setStyle(buildStyle({ outlookType: activeOutlookType, probability }));
+        olFeature.setStyle(
+          buildStyle({ outlookType: activeOutlookType, probability }),
+        );
         source.addFeature(olFeature);
       }
     });
@@ -768,8 +890,10 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
         return report.type === activeOutlookType;
       });
 
-      filteredReports.forEach(report => {
-        const geometry = new Point(fromLonLat([report.longitude, report.latitude]));
+      filteredReports.forEach((report) => {
+        const geometry = new Point(
+          fromLonLat([report.longitude, report.latitude]),
+        );
         // Create a new feature for each storm report with the appropriate geometry and styling based on its type,
         // then add it to the storm reports source.
         const feature = new Feature({
@@ -801,7 +925,7 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
 
   return (
     <div className="forecast-map-container">
-      <div ref={mapElementRef} style={{ width: '100%', height: '100%' }} />
+      <div ref={mapElementRef} style={{ width: "100%", height: "100%" }} />
       <div className="map-toolbar-bottom-right">
         <div className="flex items-center gap-1 rounded-md bg-white dark:bg-gray-800 p-1 shadow-md border border-gray-300 dark:border-gray-600">
           <VerifMapStylePickerButton
@@ -818,6 +942,6 @@ const OpenLayersVerificationMap = forwardRef<MapAdapterHandle<OLMap> | null, Ope
   );
 });
 
-OpenLayersVerificationMap.displayName = 'OpenLayersVerificationMap';
+OpenLayersVerificationMap.displayName = "OpenLayersVerificationMap";
 
 export default OpenLayersVerificationMap;

--- a/src/pages/AccountPage.test.tsx
+++ b/src/pages/AccountPage.test.tsx
@@ -1,35 +1,38 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router-dom';
-import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
-import forecastReducer from '../store/forecastSlice';
-import { AccountPage } from './AccountPage';
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import forecastReducer from "../store/forecastSlice";
+import { AccountPage } from "./AccountPage";
 
-jest.mock('../auth/AuthProvider', () => ({
+jest.mock("../auth/AuthProvider", () => ({
   useAuth: jest.fn(),
 }));
-jest.mock('../billing/EntitlementProvider', () => ({
+jest.mock("../billing/EntitlementProvider", () => ({
   useEntitlement: jest.fn(),
 }));
-jest.mock('../metrics/useUserMetrics', () => ({
+jest.mock("../metrics/useUserMetrics", () => ({
   useUserMetrics: jest.fn(),
 }));
 
-const mockUseAuth = jest.requireMock('../auth/AuthProvider').useAuth as jest.Mock;
-const mockUseEntitlement = jest.requireMock('../billing/EntitlementProvider').useEntitlement as jest.Mock;
-const mockUseUserMetrics = jest.requireMock('../metrics/useUserMetrics').useUserMetrics as jest.Mock;
+const mockUseAuth = jest.requireMock("../auth/AuthProvider")
+  .useAuth as jest.Mock;
+const mockUseEntitlement = jest.requireMock("../billing/EntitlementProvider")
+  .useEntitlement as jest.Mock;
+const mockUseUserMetrics = jest.requireMock("../metrics/useUserMetrics")
+  .useUserMetrics as jest.Mock;
 let store: ReturnType<typeof configureStore>;
 
-describe('AccountPage', () => {
+describe("AccountPage", () => {
   beforeEach(() => {
     localStorage.clear();
     mockUseEntitlement.mockReturnValue({
-      entitlementStatus: 'free',
+      entitlementStatus: "free",
       premiumActive: false,
       planInterval: null,
-      billingStatus: 'inactive',
-      effectiveSource: 'none',
+      billingStatus: "inactive",
+      effectiveSource: "none",
       cancelAtPeriodEnd: false,
       currentPeriodEnd: null,
       stripeCustomerId: null,
@@ -37,22 +40,22 @@ describe('AccountPage', () => {
       checkoutEnabled: false,
       billingEnabled: false,
       annualPromoActive: false,
-      monthlyDisplayPrice: '$3/month',
-      annualDisplayPrice: '$30/year',
+      monthlyDisplayPrice: "$3/month",
+      annualDisplayPrice: "$30/year",
       error: null,
       openCheckout: jest.fn(),
       openBillingPortal: jest.fn(),
     });
     mockUseUserMetrics.mockReturnValue({
       metrics: {
-        uid: 'user-1',
+        uid: "user-1",
         activeDayStreak: 4,
         totalActiveDays: 10,
         cyclesCreated: 3,
         cloudCyclesSaved: 2,
         discussionsWritten: 1,
         verificationSessionsRun: 5,
-        lastActiveDate: '2026-03-30',
+        lastActiveDate: "2026-03-30",
         updatedAt: null,
       },
       loading: false,
@@ -63,17 +66,20 @@ describe('AccountPage', () => {
     store = configureStore({
       reducer: { forecast: forecastReducer },
       middleware: (getDefaultMiddleware) =>
-        getDefaultMiddleware({ serializableCheck: false, immutableCheck: false }),
+        getDefaultMiddleware({
+          serializableCheck: false,
+          immutableCheck: false,
+        }),
     });
   });
 
   test.each([
     {
-      name: 'shows the local-only fallback when hosted auth is disabled',
+      name: "shows the local-only fallback when hosted auth is disabled",
       authState: {
         hostedAuthEnabled: false,
-        status: 'disabled',
-        settingsSyncStatus: 'disabled',
+        status: "disabled",
+        settingsSyncStatus: "disabled",
         user: null,
         syncedSettings: null,
         error: null,
@@ -84,17 +90,23 @@ describe('AccountPage', () => {
         updateSyncedSettings: jest.fn(),
       },
       assertion: () => {
-        expect(screen.getByRole('heading', { name: /^Account$/i })).toBeInTheDocument();
-        expect(screen.getByRole('heading', { name: /Local-only mode/i })).toBeInTheDocument();
-        expect(screen.getByText(/running in local-only mode/i)).toBeInTheDocument();
+        expect(
+          screen.getByRole("heading", { name: /^Account$/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("heading", { name: /Local-only mode/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/running in local-only mode/i),
+        ).toBeInTheDocument();
       },
     },
     {
-      name: 'shows confirm password only in create-account mode',
+      name: "shows confirm password only in create-account mode",
       authState: {
         hostedAuthEnabled: true,
-        status: 'signed_out',
-        settingsSyncStatus: 'idle',
+        status: "signed_out",
+        settingsSyncStatus: "idle",
         user: null,
         syncedSettings: null,
         error: null,
@@ -105,12 +117,16 @@ describe('AccountPage', () => {
         updateSyncedSettings: jest.fn(),
       },
       assertion: () => {
-        expect(screen.queryByLabelText(/Confirm Password/i)).not.toBeInTheDocument();
-        fireEvent.click(screen.getByRole('button', { name: /Create Account/i }));
+        expect(
+          screen.queryByLabelText(/Confirm Password/i),
+        ).not.toBeInTheDocument();
+        fireEvent.click(
+          screen.getByRole("button", { name: /Create Account/i }),
+        );
         expect(screen.getByLabelText(/Confirm Password/i)).toBeInTheDocument();
       },
     },
-  ])('$name', ({ authState, assertion }) => {
+  ])("$name", ({ authState, assertion }) => {
     mockUseAuth.mockReturnValue(authState);
 
     render(
@@ -118,25 +134,25 @@ describe('AccountPage', () => {
         <Provider store={store}>
           <AccountPage />
         </Provider>
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     assertion();
   });
 
-  test('shows a simplified signed-in account view with one sync status badge', () => {
+  test("shows a simplified signed-in account view with one sync status badge", () => {
     mockUseAuth.mockReturnValue({
       hostedAuthEnabled: true,
-      status: 'signed_in',
-      settingsSyncStatus: 'synced',
+      status: "signed_in",
+      settingsSyncStatus: "synced",
       betaAccess: false,
       user: {
-        email: 'alex@example.com',
-        displayName: 'Alex',
-        providerData: [{ providerId: 'google.com' }],
+        email: "alex@example.com",
+        displayName: "Alex",
+        providerData: [{ providerId: "google.com" }],
       },
       syncedSettings: {
-        defaultForecasterName: 'Alex',
+        defaultForecasterName: "Alex",
       },
       error: null,
       signInWithGoogle: jest.fn(),
@@ -151,80 +167,47 @@ describe('AccountPage', () => {
         <Provider store={store}>
           <AccountPage />
         </Provider>
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
-    expect(screen.getAllByText('alex@example.com')).toHaveLength(2);
-    expect(screen.getAllByText('Google')).toHaveLength(2);
-    expect(screen.getByDisplayValue('Alex')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Sign Out/i })).toBeInTheDocument();
+    expect(screen.getAllByText("alex@example.com")).toHaveLength(2);
+    expect(screen.getAllByText("Google")).toHaveLength(2);
+    expect(screen.getByDisplayValue("Alex")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Sign Out/i }),
+    ).toBeInTheDocument();
     expect(screen.getAllByText(/^Synced$/i)).toHaveLength(1);
-    expect(screen.getByRole('link', { name: /View Pricing/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /View Pricing/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText(/^4$/)).toBeInTheDocument();
     expect(screen.getByText(/^10$/)).toBeInTheDocument();
   });
 
-  test('lets beta users switch the Forecast workspace experiment from account settings', async () => {
-    const user = userEvent.setup();
-    const updateSyncedSettings = jest.fn().mockImplementation(() => Promise.resolve());
-
-    mockUseAuth.mockReturnValue({
-      hostedAuthEnabled: true,
-      status: 'signed_in',
-      settingsSyncStatus: 'synced',
-      betaAccess: true,
-      user: {
-        email: 'alex@example.com',
-        displayName: 'Alex',
-        providerData: [{ providerId: 'google.com' }],
-      },
-      syncedSettings: {
-        defaultForecasterName: 'Alex',
-        forecastUiVariant: 'integrated',
-      },
-      error: null,
-      signInWithGoogle: jest.fn(),
-      signInWithEmail: jest.fn(),
-      signUpWithEmail: jest.fn(),
-      signOutUser: jest.fn(),
-      updateSyncedSettings,
-    });
-
-    render(
-      <BrowserRouter>
-        <Provider store={store}>
-          <AccountPage />
-        </Provider>
-      </BrowserRouter>
-    );
-
-    const tabButton = screen.getByRole('button', { name: /tabbed toolbar/i });
-    expect(tabButton).toBeInTheDocument();
-    await user.click(tabButton);
-
-    expect(updateSyncedSettings).toHaveBeenCalledWith({ forecastUiVariant: 'tabbed_toolbar' });
-    expect(await screen.findByText(/will open by default on Forecast/i)).toBeInTheDocument();
-  });
-
-  test('handles premium billing, saving defaults, and sign-out actions', async () => {
+  test("handles premium billing, saving defaults, and sign-out actions", async () => {
     const user = userEvent.setup();
     const signOutUser = jest.fn().mockResolvedValue();
     const updateSyncedSettings = jest.fn().mockResolvedValue();
-    const openBillingPortal = jest.fn().mockRejectedValue(new Error('Portal unavailable'));
+    const openBillingPortal = jest
+      .fn()
+      .mockRejectedValue(new Error("Portal unavailable"));
 
     mockUseAuth.mockReturnValue({
       hostedAuthEnabled: true,
-      status: 'signed_in',
-      settingsSyncStatus: 'error',
+      status: "signed_in",
+      settingsSyncStatus: "error",
       betaAccess: false,
       user: {
-        email: 'alex@example.com',
-        displayName: 'Alex',
-        providerData: [{ providerId: 'password' }, { providerId: 'github.com' }],
+        email: "alex@example.com",
+        displayName: "Alex",
+        providerData: [
+          { providerId: "password" },
+          { providerId: "github.com" },
+        ],
       },
       syncedSettings: {
-        defaultForecasterName: 'Alex',
-        forecastUiVariant: 'integrated',
+        defaultForecasterName: "Alex",
+        forecastUiVariant: "integrated",
       },
       error: null,
       signInWithGoogle: jest.fn(),
@@ -235,20 +218,20 @@ describe('AccountPage', () => {
     });
 
     mockUseEntitlement.mockReturnValue({
-      entitlementStatus: 'premium',
+      entitlementStatus: "premium",
       premiumActive: true,
-      planInterval: 'annual',
-      billingStatus: 'active',
-      effectiveSource: 'beta_override',
+      planInterval: "annual",
+      billingStatus: "active",
+      effectiveSource: "beta_override",
       cancelAtPeriodEnd: false,
-      currentPeriodEnd: '2026-04-30',
-      stripeCustomerId: 'cus_123',
+      currentPeriodEnd: "2026-04-30",
+      stripeCustomerId: "cus_123",
       betaOverrideActive: true,
       checkoutEnabled: false,
       billingEnabled: true,
       annualPromoActive: false,
-      monthlyDisplayPrice: '$3/month',
-      annualDisplayPrice: '$30/year',
+      monthlyDisplayPrice: "$3/month",
+      annualDisplayPrice: "$30/year",
       error: null,
       openCheckout: jest.fn(),
       openBillingPortal,
@@ -256,7 +239,7 @@ describe('AccountPage', () => {
 
     mockUseUserMetrics.mockReturnValue({
       metrics: {
-        uid: 'user-1',
+        uid: "user-1",
         activeDayStreak: 0,
         totalActiveDays: 0,
         cyclesCreated: 0,
@@ -275,42 +258,55 @@ describe('AccountPage', () => {
         <Provider store={store}>
           <AccountPage />
         </Provider>
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     expect(screen.getByText(/Needs Attention/i)).toBeInTheDocument();
     expect(screen.getByText(/Premium Annual/i)).toBeInTheDocument();
     expect(screen.getByText(/\$30\/year/i)).toBeInTheDocument();
-    expect(screen.getByText(/Premium is currently being granted through the beta override path/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Premium is currently being granted through the beta override path/i,
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText(/No activity yet/i)).toBeInTheDocument();
-    expect(screen.getByText('github.com')).toBeInTheDocument();
+    expect(screen.getByText("github.com")).toBeInTheDocument();
 
     await user.clear(screen.getByLabelText(/Default forecaster name/i));
-    await user.type(screen.getByLabelText(/Default forecaster name/i), 'Taylor');
-    await user.click(screen.getByRole('button', { name: /Save Changes/i }));
-    expect(updateSyncedSettings).toHaveBeenCalledWith({ defaultForecasterName: 'Taylor' });
-    expect(await screen.findByText(/Saved to your account/i)).toBeInTheDocument();
+    await user.type(
+      screen.getByLabelText(/Default forecaster name/i),
+      "Taylor",
+    );
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+    expect(updateSyncedSettings).toHaveBeenCalledWith({
+      defaultForecasterName: "Taylor",
+    });
+    expect(
+      await screen.findByText(/Saved to your account/i),
+    ).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /Manage Subscription/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Manage Subscription/i }),
+    );
     expect(await screen.findByText(/Portal unavailable/i)).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /Sign Out/i }));
+    await user.click(screen.getByRole("button", { name: /Sign Out/i }));
     expect(signOutUser).toHaveBeenCalled();
   });
 
-  test('shows monthly premium pricing and annual promo copy for standard billing', () => {
+  test("shows monthly premium pricing and annual promo copy for standard billing", () => {
     mockUseAuth.mockReturnValue({
       hostedAuthEnabled: true,
-      status: 'signed_in',
-      settingsSyncStatus: 'synced',
+      status: "signed_in",
+      settingsSyncStatus: "synced",
       betaAccess: false,
       user: {
-        email: 'alex@example.com',
-        displayName: 'Alex',
-        providerData: [{ providerId: 'google.com' }],
+        email: "alex@example.com",
+        displayName: "Alex",
+        providerData: [{ providerId: "google.com" }],
       },
       syncedSettings: {
-        defaultForecasterName: 'Alex',
+        defaultForecasterName: "Alex",
       },
       error: null,
       signInWithGoogle: jest.fn(),
@@ -321,20 +317,20 @@ describe('AccountPage', () => {
     });
 
     mockUseEntitlement.mockReturnValue({
-      entitlementStatus: 'premium',
+      entitlementStatus: "premium",
       premiumActive: true,
-      planInterval: 'monthly',
-      billingStatus: 'active',
-      effectiveSource: 'stripe',
+      planInterval: "monthly",
+      billingStatus: "active",
+      effectiveSource: "stripe",
       cancelAtPeriodEnd: false,
-      currentPeriodEnd: '2026-04-30',
+      currentPeriodEnd: "2026-04-30",
       stripeCustomerId: null,
       betaOverrideActive: false,
       checkoutEnabled: false,
       billingEnabled: false,
       annualPromoActive: true,
-      monthlyDisplayPrice: '$3/month',
-      annualDisplayPrice: '$30/year',
+      monthlyDisplayPrice: "$3/month",
+      annualDisplayPrice: "$30/year",
       error: null,
       openCheckout: jest.fn(),
       openBillingPortal: jest.fn(),
@@ -342,14 +338,14 @@ describe('AccountPage', () => {
 
     mockUseUserMetrics.mockReturnValue({
       metrics: {
-        uid: 'user-1',
+        uid: "user-1",
         activeDayStreak: 4,
         totalActiveDays: 10,
         cyclesCreated: 3,
         cloudCyclesSaved: 2,
         discussionsWritten: 1,
         verificationSessionsRun: 5,
-        lastActiveDate: '2026-03-30',
+        lastActiveDate: "2026-03-30",
         updatedAt: null,
       },
       loading: false,
@@ -361,27 +357,31 @@ describe('AccountPage', () => {
         <Provider store={store}>
           <AccountPage />
         </Provider>
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     expect(screen.getByText(/Premium Monthly/i)).toBeInTheDocument();
     expect(screen.getByText(/\$3\/month/i)).toBeInTheDocument();
-    expect(screen.getByText(/Annual intro pricing is currently active on this deployment/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Annual intro pricing is currently active on this deployment/i,
+      ),
+    ).toBeInTheDocument();
   });
 
-  test('shows loading metrics and an account metrics error when data is pending', () => {
+  test("shows loading metrics and an account metrics error when data is pending", () => {
     mockUseAuth.mockReturnValue({
       hostedAuthEnabled: true,
-      status: 'signed_in',
-      settingsSyncStatus: 'loading',
+      status: "signed_in",
+      settingsSyncStatus: "loading",
       betaAccess: false,
       user: {
-        email: 'alex@example.com',
-        displayName: 'Alex',
-        providerData: [{ providerId: 'google.com' }],
+        email: "alex@example.com",
+        displayName: "Alex",
+        providerData: [{ providerId: "google.com" }],
       },
       syncedSettings: {
-        defaultForecasterName: 'Alex',
+        defaultForecasterName: "Alex",
       },
       error: null,
       signInWithGoogle: jest.fn(),
@@ -393,7 +393,7 @@ describe('AccountPage', () => {
 
     mockUseUserMetrics.mockReturnValue({
       metrics: {
-        uid: 'user-1',
+        uid: "user-1",
         activeDayStreak: 0,
         totalActiveDays: 0,
         cyclesCreated: 0,
@@ -404,7 +404,7 @@ describe('AccountPage', () => {
         updatedAt: null,
       },
       loading: true,
-      error: 'Metrics sync pending',
+      error: "Metrics sync pending",
     });
 
     render(
@@ -412,20 +412,20 @@ describe('AccountPage', () => {
         <Provider store={store}>
           <AccountPage />
         </Provider>
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
-    expect(screen.getAllByText('Loading...').length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Loading...").length).toBeGreaterThan(0);
     expect(screen.getByText(/Metrics sync pending/i)).toBeInTheDocument();
   });
 
-  test('shows password mismatch errors in sign-up mode', async () => {
+  test("shows password mismatch errors in sign-up mode", async () => {
     const user = userEvent.setup();
 
     mockUseAuth.mockReturnValue({
       hostedAuthEnabled: true,
-      status: 'signed_out',
-      settingsSyncStatus: 'idle',
+      status: "signed_out",
+      settingsSyncStatus: "idle",
       user: null,
       syncedSettings: null,
       error: null,
@@ -441,27 +441,31 @@ describe('AccountPage', () => {
         <Provider store={store}>
           <AccountPage />
         </Provider>
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
-    await user.click(screen.getByRole('button', { name: /Create Account/i }));
-    await user.type(screen.getByLabelText(/Email/i), 'alex@example.com');
-    await user.type(screen.getByLabelText(/^Password$/i), 'secret123');
-    await user.type(screen.getByLabelText(/Confirm Password/i), 'different123');
-    await user.click(screen.getAllByRole('button', { name: /Create Account/i })[1]);
+    await user.click(screen.getByRole("button", { name: /Create Account/i }));
+    await user.type(screen.getByLabelText(/Email/i), "alex@example.com");
+    await user.type(screen.getByLabelText(/^Password$/i), "secret123");
+    await user.type(screen.getByLabelText(/Confirm Password/i), "different123");
+    await user.click(
+      screen.getAllByRole("button", { name: /Create Account/i })[1],
+    );
 
     expect(screen.getByText(/Passwords do not match/i)).toBeInTheDocument();
   });
 
-  test('shows sign-in errors for email and Google sign-in', async () => {
+  test("shows sign-in errors for email and Google sign-in", async () => {
     const user = userEvent.setup();
-    const signInWithEmail = jest.fn().mockRejectedValue(new Error('Bad login'));
-    const signInWithGoogle = jest.fn().mockRejectedValue(new Error('Google unavailable'));
+    const signInWithEmail = jest.fn().mockRejectedValue(new Error("Bad login"));
+    const signInWithGoogle = jest
+      .fn()
+      .mockRejectedValue(new Error("Google unavailable"));
 
     mockUseAuth.mockReturnValue({
       hostedAuthEnabled: true,
-      status: 'signed_out',
-      settingsSyncStatus: 'idle',
+      status: "signed_out",
+      settingsSyncStatus: "idle",
       user: null,
       syncedSettings: null,
       error: null,
@@ -477,15 +481,19 @@ describe('AccountPage', () => {
         <Provider store={store}>
           <AccountPage />
         </Provider>
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
-    await user.type(screen.getByLabelText(/Email/i), 'alex@example.com');
-    await user.type(screen.getByLabelText(/^Password$/i), 'secret123');
-    await user.click(screen.getByRole('button', { name: /Sign In with Email/i }));
+    await user.type(screen.getByLabelText(/Email/i), "alex@example.com");
+    await user.type(screen.getByLabelText(/^Password$/i), "secret123");
+    await user.click(
+      screen.getByRole("button", { name: /Sign In with Email/i }),
+    );
     expect(await screen.findByText(/Bad login/i)).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /Continue with Google/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Continue with Google/i }),
+    );
     expect(await screen.findByText(/Google unavailable/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -707,7 +707,6 @@ const SignedInPrimaryCard: React.FC<{
   providerLabels,
   defaultForecasterName,
   setDefaultForecasterName,
-  forecastUiMessage,
   savingDefaults,
   saveMessage,
   onSaveDefaults,

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -1,41 +1,55 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
-import { Activity, CircleUserRound, Cloud, Crown, LoaderCircle, LogOut, Mail } from 'lucide-react';
-import { Badge, type BadgeProps } from '../components/ui/badge';
-import { Button } from '../components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
-import { Input } from '../components/ui/input';
-import { useAuth } from '../auth/AuthProvider';
-import { useEntitlement } from '../billing/EntitlementProvider';
-import { useUserMetrics } from '../metrics/useUserMetrics';
-import { cn } from '../lib/utils';
-import type { RootState } from '../store';
-import { selectForecastCycle, selectSavedCycles } from '../store/forecastSlice';
-import { computeHomeStats } from './homeUtils';
+import React, { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+import {
+  Activity,
+  CircleUserRound,
+  Cloud,
+  Crown,
+  LoaderCircle,
+  LogOut,
+  Mail,
+} from "lucide-react";
+import { Badge, type BadgeProps } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card";
+import { Input } from "../components/ui/input";
+import { useAuth } from "../auth/AuthProvider";
+import { useEntitlement } from "../billing/EntitlementProvider";
+import { useUserMetrics } from "../metrics/useUserMetrics";
+import { cn } from "../lib/utils";
+import type { RootState } from "../store";
+import { selectForecastCycle, selectSavedCycles } from "../store/forecastSlice";
+import { computeHomeStats } from "./homeUtils";
 import {
   DEFAULT_FORECAST_UI_VARIANT,
   FORECAST_UI_VARIANT_OPTIONS,
   readStoredForecastUiVariant,
   type ForecastUiVariant,
-} from '../utils/forecastUiVariant';
-import './AccountPage.css';
+} from "../utils/forecastUiVariant";
+import "./AccountPage.css";
 
-type AuthMode = 'sign_in' | 'sign_up';
-type SyncStatus = ReturnType<typeof useAuth>['settingsSyncStatus'];
+type AuthMode = "sign_in" | "sign_up";
+type SyncStatus = ReturnType<typeof useAuth>["settingsSyncStatus"];
 
 interface SyncStatusMeta {
   label: string;
-  variant: BadgeProps['variant'];
+  variant: BadgeProps["variant"];
 }
 
 /** Maps Firebase provider ids to short labels for the account UI. */
 const getProviderLabel = (providerId: string): string => {
   switch (providerId) {
-    case 'google.com':
-      return 'Google';
-    case 'password':
-      return 'Email / Password';
+    case "google.com":
+      return "Google";
+    case "password":
+      return "Email / Password";
     default:
       return providerId;
   }
@@ -44,24 +58,28 @@ const getProviderLabel = (providerId: string): string => {
 /** Converts the raw settings status into the one compact badge shown on the signed-in account page. */
 const getSyncStatusMeta = (settingsSyncStatus: SyncStatus): SyncStatusMeta => {
   switch (settingsSyncStatus) {
-    case 'synced':
-      return { label: 'Synced', variant: 'success' };
-    case 'syncing':
-      return { label: 'Syncing', variant: 'secondary' };
-    case 'error':
-      return { label: 'Needs Attention', variant: 'warning' };
-    case 'disabled':
-      return { label: 'Local Only', variant: 'outline' };
-    case 'idle':
+    case "synced":
+      return { label: "Synced", variant: "success" };
+    case "syncing":
+      return { label: "Syncing", variant: "secondary" };
+    case "error":
+      return { label: "Needs Attention", variant: "warning" };
+    case "disabled":
+      return { label: "Local Only", variant: "outline" };
+    case "idle":
     default:
-      return { label: 'Ready', variant: 'secondary' };
+      return { label: "Ready", variant: "secondary" };
   }
 };
 
 /** Renders the save button label while optionally showing a loading spinner. */
-const renderSaveDefaultsButtonLabel = (savingDefaults: boolean): React.ReactNode => (
+const renderSaveDefaultsButtonLabel = (
+  savingDefaults: boolean,
+): React.ReactNode => (
   <>
-    {savingDefaults ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : null}
+    {savingDefaults ? (
+      <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+    ) : null}
     Save Changes
   </>
 );
@@ -69,84 +87,91 @@ const renderSaveDefaultsButtonLabel = (savingDefaults: boolean): React.ReactNode
 /** Returns the user-facing current plan price based on the active entitlement interval. */
 const getPlanLabel = (
   premiumActive: boolean,
-  planInterval: ReturnType<typeof useEntitlement>['planInterval'],
-  effectiveSource: ReturnType<typeof useEntitlement>['effectiveSource']
+  planInterval: ReturnType<typeof useEntitlement>["planInterval"],
+  effectiveSource: ReturnType<typeof useEntitlement>["effectiveSource"],
 ): string => {
   if (!premiumActive) {
-    return 'Free Plan';
+    return "Free Plan";
   }
 
-  if (planInterval === 'annual') {
-    return 'Premium Annual';
+  if (planInterval === "annual") {
+    return "Premium Annual";
   }
 
-  if (planInterval === 'monthly') {
-    return 'Premium Monthly';
+  if (planInterval === "monthly") {
+    return "Premium Monthly";
   }
 
-  return effectiveSource === 'beta_override' ? 'Premium Beta Access' : 'Premium';
+  return effectiveSource === "beta_override"
+    ? "Premium Beta Access"
+    : "Premium";
 };
 
 /** Returns the short helper copy used under the billing summary grid. */
 const getBillingSupportCopy = (
-  effectiveSource: ReturnType<typeof useEntitlement>['effectiveSource'],
+  effectiveSource: ReturnType<typeof useEntitlement>["effectiveSource"],
   premiumActive: boolean,
-  annualPromoActive: boolean
+  annualPromoActive: boolean,
 ): string | null => {
-  if (effectiveSource === 'beta_override') {
-    return 'Premium is currently being granted through the beta override path, so no live Stripe subscription is required yet.';
+  if (effectiveSource === "beta_override") {
+    return "Premium is currently being granted through the beta override path, so no live Stripe subscription is required yet.";
   }
 
   if (!premiumActive) {
-    return 'If premium lapses later, cloud writes and background sync will be disabled while local work remains fully available.';
+    return "If premium lapses later, cloud writes and background sync will be disabled while local work remains fully available.";
   }
 
   if (annualPromoActive) {
-    return 'Annual intro pricing is currently active on this deployment.';
+    return "Annual intro pricing is currently active on this deployment.";
   }
 
   return null;
 };
 
 /** Returns the CTA variant for the pricing button based on current entitlement state. */
-const getPricingButtonVariant = (premiumActive: boolean): 'outline' | 'default' =>
-  premiumActive ? 'outline' : 'default';
+const getPricingButtonVariant = (
+  premiumActive: boolean,
+): "outline" | "default" => (premiumActive ? "outline" : "default");
 
 /** Returns the current plan price shown in the billing summary card. */
 const getCurrentPlanPrice = (
   premiumActive: boolean,
-  planInterval: ReturnType<typeof useEntitlement>['planInterval'],
+  planInterval: ReturnType<typeof useEntitlement>["planInterval"],
   monthlyDisplayPrice: string,
-  annualDisplayPrice: string
+  annualDisplayPrice: string,
 ): string => {
   if (!premiumActive) {
-    return '$0';
+    return "$0";
   }
 
-  if (planInterval === 'annual') {
+  if (planInterval === "annual") {
     return annualDisplayPrice;
   }
 
-  if (planInterval === 'monthly') {
+  if (planInterval === "monthly") {
     return monthlyDisplayPrice;
   }
 
-  return 'Included';
+  return "Included";
 };
 
 /** Returns the current Forecast workspace experiment label for status copy. */
 const getForecastUiVariantLabel = (variant: ForecastUiVariant): string =>
-  FORECAST_UI_VARIANT_OPTIONS.find((option) => option.value === variant)?.label ?? variant;
+  FORECAST_UI_VARIANT_OPTIONS.find((option) => option.value === variant)
+    ?.label ?? variant;
 
 /** Resolves the current Forecast workspace experiment from synced settings first, then local storage, then default. */
 const getAccountForecastUiVariant = (
-  syncedSettings: ReturnType<typeof useAuth>['syncedSettings']
-): ForecastUiVariant => syncedSettings?.forecastUiVariant ?? readStoredForecastUiVariant() ?? DEFAULT_FORECAST_UI_VARIANT;
+  syncedSettings: ReturnType<typeof useAuth>["syncedSettings"],
+): ForecastUiVariant =>
+  syncedSettings?.forecastUiVariant ??
+  readStoredForecastUiVariant() ??
+  DEFAULT_FORECAST_UI_VARIANT;
 
 /** Formats the last recorded active-day key into a compact account-friendly date label. */
 const formatLastActiveDate = (value: string | null): string => {
   if (!value) {
-    return 'No activity yet';
+    return "No activity yet";
   }
 
   const parsed = new Date(`${value}T00:00:00`);
@@ -155,9 +180,9 @@ const formatLastActiveDate = (value: string | null): string => {
   }
 
   return parsed.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
+    month: "short",
+    day: "numeric",
+    year: "numeric",
   });
 };
 
@@ -196,7 +221,9 @@ const AccountHero: React.FC<{
 }> = ({ description, children }) => (
   <section className="account-hero">
     <AccountHeroBackdrop />
-    <AccountHeroContent description={description}>{children}</AccountHeroContent>
+    <AccountHeroContent description={description}>
+      {children}
+    </AccountHeroContent>
   </section>
 );
 
@@ -222,7 +249,10 @@ const AccountIdentityChips: React.FC<{
 );
 
 /** Small summary tile that keeps the profile card readable and compact. */
-const SummaryTile: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+const SummaryTile: React.FC<{ label: string; value: string }> = ({
+  label,
+  value,
+}) => (
   <div className="account-summary-tile">
     <p>{label}</p>
     <strong>{value}</strong>
@@ -238,7 +268,9 @@ const ProfileSummaryGrid: React.FC<{
     <SummaryTile label="Email" value={email} />
     <SummaryTile
       label="Sign-in Method"
-      value={providerLabels.length > 0 ? providerLabels.join(', ') : 'Unavailable'}
+      value={
+        providerLabels.length > 0 ? providerLabels.join(", ") : "Unavailable"
+      }
     />
   </div>
 );
@@ -252,12 +284,16 @@ const DiscussionDefaultsSection: React.FC<{
     <div className="account-subsection-header">
       <h2>Discussion defaults</h2>
       <p>
-        Set the name that should prefill the forecaster field when you write a discussion.
+        Set the name that should prefill the forecaster field when you write a
+        discussion.
       </p>
     </div>
 
     <div className="account-field-group">
-      <label htmlFor="default-forecaster-name" className="text-sm font-medium text-foreground">
+      <label
+        htmlFor="default-forecaster-name"
+        className="text-sm font-medium text-foreground"
+      >
         Default forecaster name
       </label>
       <Input
@@ -272,78 +308,6 @@ const DiscussionDefaultsSection: React.FC<{
   </div>
 );
 
-/** Forecast beta-flag controls for switching between workspace experiments. */
-const ForecastWorkspaceExperimentSection: React.FC<{
-  forecastUiVariant: ForecastUiVariant;
-  savingForecastUiVariant: ForecastUiVariant | null;
-  forecastUiMessage: string | null;
-  onForecastUiVariantChange: (variant: ForecastUiVariant) => void;
-}> = ({
-  forecastUiVariant,
-  savingForecastUiVariant,
-  forecastUiMessage,
-  onForecastUiVariantChange,
-}) => (
-  <div className="account-subsection-card">
-    <div className="account-subsection-header">
-      <h2>Forecast beta flags</h2>
-      <p>
-        Choose which Forecast workspace experiment should open by default for this account. Query-string overrides like
-        <code className="mx-1 rounded bg-muted px-1 py-0.5 text-[11px]">?forecastUi=tabbed_toolbar</code>
-        still work for one-off local checks.
-      </p>
-    </div>
-
-    <div className="grid gap-3">
-      {FORECAST_UI_VARIANT_OPTIONS.map((option) => {
-        const isActive = forecastUiVariant === option.value;
-        const isSaving = savingForecastUiVariant === option.value;
-
-        return (
-          <button
-            key={option.value}
-            type="button"
-            onClick={() => onForecastUiVariantChange(option.value)}
-            disabled={Boolean(savingForecastUiVariant)}
-            className={cn(
-              'account-variant-option mode-toggle-btn rounded-2xl border px-4 py-3 text-left transition-colors',
-              isActive ? 'is-active' : 'is-inactive',
-              Boolean(savingForecastUiVariant) && !isSaving && 'opacity-70'
-            )}
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <p className="text-sm font-semibold text-foreground">{option.label}</p>
-                <p className="mt-1 text-sm text-muted-foreground">{option.description}</p>
-              </div>
-              <div className="shrink-0">
-                {isSaving ? (
-                  <LoaderCircle className="h-4 w-4 animate-spin text-primary" />
-                ) : (
-                  <span
-                    className={cn(
-                      'account-variant-status rounded-full px-2 py-1 text-[11px] font-semibold uppercase tracking-wide',
-                      isActive ? 'is-active' : 'is-available'
-                    )}
-                  >
-                    {isActive ? 'Active' : 'Available'}
-                  </span>
-                )}
-              </div>
-            </div>
-          </button>
-        );
-      })}
-    </div>
-
-    <p className="account-support-copy">
-      This beta setting syncs to your account and becomes the default Forecast layout once the update completes.
-    </p>
-
-    {forecastUiMessage ? <p className="mt-3 text-sm text-muted-foreground">{forecastUiMessage}</p> : null}
-  </div>
-);
-
 /** Bottom action row for saving defaults and ending the current session. */
 const SignedInActionRow: React.FC<{
   savingDefaults: boolean;
@@ -351,13 +315,21 @@ const SignedInActionRow: React.FC<{
   onSaveDefaults: () => void;
   onOpenForecast: () => void;
   onSignOut: () => void;
-}> = ({ savingDefaults, saveMessage, onSaveDefaults, onOpenForecast, onSignOut }) => (
+}> = ({
+  savingDefaults,
+  saveMessage,
+  onSaveDefaults,
+  onOpenForecast,
+  onSignOut,
+}) => (
   <div className="account-action-row">
     <div className="account-action-group">
       <Button onClick={onSaveDefaults} disabled={savingDefaults}>
         {renderSaveDefaultsButtonLabel(savingDefaults)}
       </Button>
-      {saveMessage ? <p className="account-inline-message">{saveMessage}</p> : null}
+      {saveMessage ? (
+        <p className="account-inline-message">{saveMessage}</p>
+      ) : null}
     </div>
 
     <div className="account-button-row">
@@ -384,7 +356,8 @@ const CloudLibraryCardHeader: React.FC = () => (
           Cloud Cycles
         </CardTitle>
         <CardDescription>
-          Access, save, and organize your forecasts in the cloud. Available on all your devices.
+          Access, save, and organize your forecasts in the cloud. Available on
+          all your devices.
         </CardDescription>
       </div>
     </div>
@@ -395,7 +368,9 @@ const CloudLibraryCardHeader: React.FC = () => (
 const CloudLibraryCardContent: React.FC = () => (
   <CardContent className="account-section-content">
     <p className="mb-4 text-sm text-muted-foreground">
-      Your premium subscription includes hosted access to all your saved forecast cycles. Save time by reusing previous patterns and maintain consistency across multiple devices.
+      Your premium subscription includes hosted access to all your saved
+      forecast cycles. Save time by reusing previous patterns and maintain
+      consistency across multiple devices.
     </p>
     <Button asChild>
       <Link to="/cloud">
@@ -432,10 +407,14 @@ const BillingCardHeader: React.FC<{
       <div className="account-section-copy">
         <CardTitle className="text-2xl">Billing & Premium</CardTitle>
         <CardDescription>
-          Premium funds hosted sync and storage. Core forecasting workflows remain free.
+          Premium funds hosted sync and storage. Core forecasting workflows
+          remain free.
         </CardDescription>
       </div>
-      <Badge variant={premiumActive ? 'success' : 'outline'} className="account-plan-badge">
+      <Badge
+        variant={premiumActive ? "success" : "outline"}
+        className="account-plan-badge"
+      >
         {planLabel}
       </Badge>
     </div>
@@ -448,7 +427,7 @@ const BillingSummaryGrid: React.FC<{
   currentPlanPrice: string;
 }> = ({ billingStatus, currentPlanPrice }) => (
   <div className="account-summary-grid">
-    <SummaryTile label="Billing status" value={billingStatus || 'inactive'} />
+    <SummaryTile label="Billing status" value={billingStatus || "inactive"} />
     <SummaryTile label="Current plan price" value={currentPlanPrice} />
   </div>
 );
@@ -460,11 +439,19 @@ const BillingActionRow: React.FC<{
   openingPortal: boolean;
   premiumActive: boolean;
   onOpenPortal: () => void;
-}> = ({ stripeCustomerId, billingEnabled, openingPortal, premiumActive, onOpenPortal }) => (
+}> = ({
+  stripeCustomerId,
+  billingEnabled,
+  openingPortal,
+  premiumActive,
+  onOpenPortal,
+}) => (
   <div className="account-button-row">
     {stripeCustomerId && billingEnabled ? (
       <Button variant="outline" onClick={onOpenPortal} disabled={openingPortal}>
-        {openingPortal ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : null}
+        {openingPortal ? (
+          <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+        ) : null}
         Manage Subscription
       </Button>
     ) : null}
@@ -485,8 +472,12 @@ const BillingCardMessages: React.FC<{
   error: string | null;
 }> = ({ supportCopy, portalMessage, error }) => (
   <>
-    {supportCopy ? <p className="text-sm text-muted-foreground">{supportCopy}</p> : null}
-    {portalMessage || error ? <p className="text-sm text-destructive">{portalMessage ?? error}</p> : null}
+    {supportCopy ? (
+      <p className="text-sm text-muted-foreground">{supportCopy}</p>
+    ) : null}
+    {portalMessage || error ? (
+      <p className="text-sm text-destructive">{portalMessage ?? error}</p>
+    ) : null}
   </>
 );
 
@@ -515,8 +506,15 @@ const BillingCardContent: React.FC<{
   onOpenPortal,
 }) => (
   <CardContent className="account-section-content">
-    <BillingSummaryGrid billingStatus={billingStatus} currentPlanPrice={currentPlanPrice} />
-    <BillingCardMessages supportCopy={supportCopy} portalMessage={portalMessage} error={error} />
+    <BillingSummaryGrid
+      billingStatus={billingStatus}
+      currentPlanPrice={currentPlanPrice}
+    />
+    <BillingCardMessages
+      supportCopy={supportCopy}
+      portalMessage={portalMessage}
+      error={error}
+    />
     <BillingActionRow
       stripeCustomerId={stripeCustomerId}
       billingEnabled={billingEnabled}
@@ -545,9 +543,18 @@ const BillingCard: React.FC = () => {
   const [portalMessage, setPortalMessage] = useState<string | null>(null);
   const [openingPortal, setOpeningPortal] = useState(false);
 
-  const currentPlanPrice = getCurrentPlanPrice(premiumActive, planInterval, monthlyDisplayPrice, annualDisplayPrice);
+  const currentPlanPrice = getCurrentPlanPrice(
+    premiumActive,
+    planInterval,
+    monthlyDisplayPrice,
+    annualDisplayPrice,
+  );
   const planLabel = getPlanLabel(premiumActive, planInterval, effectiveSource);
-  const supportCopy = getBillingSupportCopy(effectiveSource, premiumActive, annualPromoActive);
+  const supportCopy = getBillingSupportCopy(
+    effectiveSource,
+    premiumActive,
+    annualPromoActive,
+  );
 
   /** Opens the Stripe billing portal and surfaces any failure as local account feedback. */
   const handleOpenPortal = async () => {
@@ -557,7 +564,11 @@ const BillingCard: React.FC = () => {
     try {
       await openBillingPortal();
     } catch (nextError) {
-      setPortalMessage(nextError instanceof Error ? nextError.message : 'Unable to open billing management right now.');
+      setPortalMessage(
+        nextError instanceof Error
+          ? nextError.message
+          : "Unable to open billing management right now.",
+      );
     } finally {
       setOpeningPortal(false);
     }
@@ -599,7 +610,8 @@ const MetricsCardHeader: React.FC = () => (
           Forecast Workspace Stats
         </CardTitle>
         <CardDescription>
-          Activity and forecasting totals for the work you have already put into GFC.
+          Activity and forecasting totals for the work you have already put into
+          GFC.
         </CardDescription>
       </div>
     </div>
@@ -608,39 +620,66 @@ const MetricsCardHeader: React.FC = () => (
 
 /** Main metric grid and support copy for the signed-in user's activity card. */
 const MetricsCardContent: React.FC<{
-  metrics: ReturnType<typeof useUserMetrics>['metrics'];
+  metrics: ReturnType<typeof useUserMetrics>["metrics"];
   localStats: ReturnType<typeof computeHomeStats>;
   loading: boolean;
   error: string | null;
 }> = ({ metrics, localStats, loading, error }) => (
   <CardContent className="account-section-content">
     <div className="account-summary-grid">
-      <SummaryTile label="Active day streak" value={loading ? 'Loading...' : `${metrics.activeDayStreak}`} />
-      <SummaryTile label="Total active days" value={loading ? 'Loading...' : `${metrics.totalActiveDays}`} />
-      <SummaryTile label="Forecast saves" value={loading ? 'Loading...' : `${metrics.cyclesCreated}`} />
-      <SummaryTile label="Cloud saves" value={loading ? 'Loading...' : `${metrics.cloudCyclesSaved}`} />
-      <SummaryTile label="Discussions saved" value={loading ? 'Loading...' : `${metrics.discussionsWritten}`} />
+      <SummaryTile
+        label="Active day streak"
+        value={loading ? "Loading..." : `${metrics.activeDayStreak}`}
+      />
+      <SummaryTile
+        label="Total active days"
+        value={loading ? "Loading..." : `${metrics.totalActiveDays}`}
+      />
+      <SummaryTile
+        label="Forecast saves"
+        value={loading ? "Loading..." : `${metrics.cyclesCreated}`}
+      />
+      <SummaryTile
+        label="Cloud saves"
+        value={loading ? "Loading..." : `${metrics.cloudCyclesSaved}`}
+      />
+      <SummaryTile
+        label="Discussions saved"
+        value={loading ? "Loading..." : `${metrics.discussionsWritten}`}
+      />
       <SummaryTile
         label="Verification runs"
-        value={loading ? 'Loading...' : `${metrics.verificationSessionsRun}`}
+        value={loading ? "Loading..." : `${metrics.verificationSessionsRun}`}
       />
     </div>
 
     <div className="account-subsection-card">
       <div className="account-subsection-header">
         <h2>Forecast workspace stats</h2>
-        <p>Local forecasting activity moved here so the Home page can stay focused on getting back into work.</p>
+        <p>
+          Local forecasting activity moved here so the Home page can stay
+          focused on getting back into work.
+        </p>
       </div>
 
       <div className="account-summary-grid">
         <SummaryTile label="Streak" value={`${localStats.forecastStreak}`} />
-        <SummaryTile label="Total forecasts made" value={`${localStats.totalForecastsMade}`} />
-        <SummaryTile label="Total cycles made" value={`${localStats.totalCyclesMade}`} />
+        <SummaryTile
+          label="Total forecasts made"
+          value={`${localStats.totalForecastsMade}`}
+        />
+        <SummaryTile
+          label="Total cycles made"
+          value={`${localStats.totalCyclesMade}`}
+        />
       </div>
     </div>
 
     <p className="account-support-copy">
-      Last active day: <strong>{loading ? 'Loading...' : formatLastActiveDate(metrics.lastActiveDate)}</strong>
+      Last active day:{" "}
+      <strong>
+        {loading ? "Loading..." : formatLastActiveDate(metrics.lastActiveDate)}
+      </strong>
     </p>
     {error ? <p className="text-sm text-muted-foreground">{error}</p> : null}
   </CardContent>
@@ -650,13 +689,23 @@ const MetricsCardContent: React.FC<{
 const MetricsCard: React.FC = () => {
   const { metrics, loading, error } = useUserMetrics();
   const forecastCycle = useSelector(selectForecastCycle);
-  const savedCycles = useSelector((state: RootState) => selectSavedCycles(state));
-  const localStats = useMemo(() => computeHomeStats(forecastCycle, savedCycles), [forecastCycle, savedCycles]);
+  const savedCycles = useSelector((state: RootState) =>
+    selectSavedCycles(state),
+  );
+  const localStats = useMemo(
+    () => computeHomeStats(forecastCycle, savedCycles),
+    [forecastCycle, savedCycles],
+  );
 
   return (
     <Card className="account-surface-card">
       <MetricsCardHeader />
-      <MetricsCardContent metrics={metrics} localStats={localStats} loading={loading} error={error} />
+      <MetricsCardContent
+        metrics={metrics}
+        localStats={localStats}
+        loading={loading}
+        error={error}
+      />
     </Card>
   );
 };
@@ -697,7 +746,8 @@ const SignedInPrimaryCard: React.FC<{
     <CardHeader className="account-section-header">
       <CardTitle className="text-2xl">Profile & Preferences</CardTitle>
       <CardDescription>
-        Keep your sign-in details and your default discussion byline ready wherever you open GFC.
+        Keep your sign-in details and your default discussion byline ready
+        wherever you open GFC.
       </CardDescription>
       <ProfileSummaryGrid email={email} providerLabels={providerLabels} />
     </CardHeader>
@@ -707,14 +757,6 @@ const SignedInPrimaryCard: React.FC<{
         defaultForecasterName={defaultForecasterName}
         setDefaultForecasterName={setDefaultForecasterName}
       />
-      {showForecastWorkspaceExperiment ? (
-        <ForecastWorkspaceExperimentSection
-          forecastUiVariant={forecastUiVariant}
-          savingForecastUiVariant={savingForecastUiVariant}
-          forecastUiMessage={forecastUiMessage}
-          onForecastUiVariantChange={onForecastUiVariantChange}
-        />
-      ) : null}
       <SignedInActionRow
         savingDefaults={savingDefaults}
         saveMessage={saveMessage}
@@ -728,24 +770,41 @@ const SignedInPrimaryCard: React.FC<{
 
 /** Signed-in account experience focused on identity, defaults, and session control. */
 const SignedInAccountView: React.FC = () => {
-  const { user, signOutUser, settingsSyncStatus, syncedSettings, updateSyncedSettings, betaAccess } = useAuth();
+  const {
+    user,
+    signOutUser,
+    settingsSyncStatus,
+    syncedSettings,
+    updateSyncedSettings,
+    betaAccess,
+  } = useAuth();
   const [defaultForecasterName, setDefaultForecasterName] = useState(
-    () => syncedSettings?.defaultForecasterName ?? user?.displayName ?? ''
+    () => syncedSettings?.defaultForecasterName ?? user?.displayName ?? "",
   );
-  const [forecastUiVariant, setForecastUiVariant] = useState<ForecastUiVariant>(() => getAccountForecastUiVariant(syncedSettings));
-  const [savingForecastUiVariant, setSavingForecastUiVariant] = useState<ForecastUiVariant | null>(null);
-  const [forecastUiMessage, setForecastUiMessage] = useState<string | null>(null);
+  const [forecastUiVariant, setForecastUiVariant] = useState<ForecastUiVariant>(
+    () => getAccountForecastUiVariant(syncedSettings),
+  );
+  const [savingForecastUiVariant, setSavingForecastUiVariant] =
+    useState<ForecastUiVariant | null>(null);
+  const [forecastUiMessage, setForecastUiMessage] = useState<string | null>(
+    null,
+  );
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [savingDefaults, setSavingDefaults] = useState(false);
 
   const providerLabels = useMemo(
-    () => (user?.providerData ?? []).map((provider) => getProviderLabel(provider.providerId)).filter(Boolean),
-    [user]
+    () =>
+      (user?.providerData ?? [])
+        .map((provider) => getProviderLabel(provider.providerId))
+        .filter(Boolean),
+    [user],
   );
   const statusMeta = getSyncStatusMeta(settingsSyncStatus);
 
   useEffect(() => {
-    setDefaultForecasterName(syncedSettings?.defaultForecasterName ?? user?.displayName ?? '');
+    setDefaultForecasterName(
+      syncedSettings?.defaultForecasterName ?? user?.displayName ?? "",
+    );
   }, [syncedSettings?.defaultForecasterName, user?.displayName]);
 
   useEffect(() => {
@@ -761,16 +820,20 @@ const SignedInAccountView: React.FC = () => {
       await updateSyncedSettings({
         defaultForecasterName: defaultForecasterName.trim(),
       });
-      setSaveMessage('Saved to your account.');
+      setSaveMessage("Saved to your account.");
     } catch (error) {
-      setSaveMessage(error instanceof Error ? error.message : 'Unable to save right now.');
+      setSaveMessage(
+        error instanceof Error ? error.message : "Unable to save right now.",
+      );
     } finally {
       setSavingDefaults(false);
     }
   };
 
   /** Updates the synced Forecast workspace experiment and mirrors it into local storage for this device. */
-  const handleForecastUiVariantChange = async (nextVariant: ForecastUiVariant) => {
+  const handleForecastUiVariantChange = async (
+    nextVariant: ForecastUiVariant,
+  ) => {
     if (savingForecastUiVariant) {
       return;
     }
@@ -781,10 +844,14 @@ const SignedInAccountView: React.FC = () => {
 
     try {
       await updateSyncedSettings({ forecastUiVariant: nextVariant });
-      setForecastUiMessage(`${getForecastUiVariantLabel(nextVariant)} will open by default on Forecast.`);
+      setForecastUiMessage(
+        `${getForecastUiVariantLabel(nextVariant)} will open by default on Forecast.`,
+      );
     } catch (error) {
       setForecastUiMessage(
-        error instanceof Error ? error.message : 'Unable to update the Forecast beta flag right now.'
+        error instanceof Error
+          ? error.message
+          : "Unable to update the Forecast beta flag right now.",
       );
     } finally {
       setSavingForecastUiVariant(null);
@@ -806,7 +873,7 @@ const SignedInAccountView: React.FC = () => {
   };
 
   /** Clear any forecast UI message when opening forecast. */
-const handleOpenForecastClick = () => {
+  const handleOpenForecastClick = () => {
     setForecastUiMessage(null);
   };
 
@@ -819,11 +886,9 @@ const handleOpenForecastClick = () => {
 
   return (
     <div className="account-page-stack">
-      <AccountHero
-        description="Keep your profile and app defaults ready across devices while the core forecasting workflow stays yours."
-      >
+      <AccountHero description="Keep your profile and app defaults ready across devices while the core forecasting workflow stays yours.">
         <AccountIdentityChips
-          email={user?.email ?? 'Unavailable'}
+          email={user?.email ?? "Unavailable"}
           providerLabels={providerLabels}
           statusMeta={statusMeta}
         />
@@ -832,7 +897,7 @@ const handleOpenForecastClick = () => {
       <div className="account-signed-grid">
         <div className="account-main-stack">
           <SignedInPrimaryCard
-            email={user?.email ?? 'Unavailable'}
+            email={user?.email ?? "Unavailable"}
             providerLabels={providerLabels}
             defaultForecasterName={defaultForecasterName}
             setDefaultForecasterName={setDefaultForecasterName}
@@ -863,7 +928,8 @@ const SignInCardHeader: React.FC = () => (
   <CardHeader className="account-section-header">
     <CardTitle className="text-2xl">Sign in or create an account</CardTitle>
     <CardDescription>
-      Keep your profile and app defaults ready across devices. Signing in is optional, and core forecasting stays free.
+      Keep your profile and app defaults ready across devices. Signing in is
+      optional, and core forecasting stays free.
     </CardDescription>
   </CardHeader>
 );
@@ -904,17 +970,28 @@ const EmailAuthForm: React.FC<{
     </div>
 
     <div className="account-mode-toggle">
-      <Button variant={mode === 'sign_in' ? 'default' : 'outline'} onClick={() => onModeChange('sign_in')} disabled={isBusy}>
+      <Button
+        variant={mode === "sign_in" ? "default" : "outline"}
+        onClick={() => onModeChange("sign_in")}
+        disabled={isBusy}
+      >
         Sign In
       </Button>
-      <Button variant={mode === 'sign_up' ? 'default' : 'outline'} onClick={() => onModeChange('sign_up')} disabled={isBusy}>
+      <Button
+        variant={mode === "sign_up" ? "default" : "outline"}
+        onClick={() => onModeChange("sign_up")}
+        disabled={isBusy}
+      >
         Create Account
       </Button>
     </div>
 
     <form className="account-form-fields" onSubmit={onEmailSubmit}>
       <div className="account-field-group">
-        <label htmlFor="account-email" className="text-sm font-medium text-foreground">
+        <label
+          htmlFor="account-email"
+          className="text-sm font-medium text-foreground"
+        >
           Email
         </label>
         <Input
@@ -928,7 +1005,10 @@ const EmailAuthForm: React.FC<{
       </div>
 
       <div className="account-field-group">
-        <label htmlFor="account-password" className="text-sm font-medium text-foreground">
+        <label
+          htmlFor="account-password"
+          className="text-sm font-medium text-foreground"
+        >
           Password
         </label>
         <Input
@@ -936,15 +1016,20 @@ const EmailAuthForm: React.FC<{
           type="password"
           value={password}
           onChange={(e) => onPasswordChange(e.target.value)}
-          autoComplete={mode === 'sign_in' ? 'current-password' : 'new-password'}
+          autoComplete={
+            mode === "sign_in" ? "current-password" : "new-password"
+          }
           minLength={6}
           required
         />
       </div>
 
-      {mode === 'sign_up' ? (
+      {mode === "sign_up" ? (
         <div className="account-field-group">
-          <label htmlFor="account-confirm-password" className="text-sm font-medium text-foreground">
+          <label
+            htmlFor="account-confirm-password"
+            className="text-sm font-medium text-foreground"
+          >
             Confirm Password
           </label>
           <Input
@@ -960,14 +1045,16 @@ const EmailAuthForm: React.FC<{
       ) : null}
 
       {formError || authError ? (
-        <div className="account-error-box">
-          {formError ?? authError}
-        </div>
+        <div className="account-error-box">{formError ?? authError}</div>
       ) : null}
 
       <Button type="submit" disabled={isBusy}>
-        {isBusy ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : <Mail className="mr-2 h-4 w-4" />}
-        {mode === 'sign_in' ? 'Sign In with Email' : 'Create Account'}
+        {isBusy ? (
+          <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <Mail className="mr-2 h-4 w-4" />
+        )}
+        {mode === "sign_in" ? "Sign In with Email" : "Create Account"}
       </Button>
     </form>
   </div>
@@ -1006,7 +1093,12 @@ const SignInPrimaryCard: React.FC<{
   <Card className="account-surface-card">
     <SignInCardHeader />
     <CardContent className="account-section-content">
-      <Button variant="outline" className="w-full justify-center" onClick={onGoogleSignIn} disabled={isBusy}>
+      <Button
+        variant="outline"
+        className="w-full justify-center"
+        onClick={onGoogleSignIn}
+        disabled={isBusy}
+      >
         <Cloud className="mr-2 h-4 w-4" />
         Continue with Google
       </Button>
@@ -1034,17 +1126,27 @@ const SignedOutSupportCard: React.FC = () => (
   <Card className="account-surface-card account-support-card">
     <CardHeader className="account-section-header">
       <CardTitle className="text-2xl">Why keep an account</CardTitle>
-      <CardDescription>Use hosted identity and saved defaults without changing the local-first workflow.</CardDescription>
+      <CardDescription>
+        Use hosted identity and saved defaults without changing the local-first
+        workflow.
+      </CardDescription>
     </CardHeader>
     <CardContent className="account-section-content">
       <ul className="account-support-list">
         <li>Keep your map and app preferences ready across devices.</li>
         <li>Store the forecaster name you want prefilled in discussions.</li>
-        <li>Use the same account on different machines without changing the local workflow.</li>
-        <li>Upgrade later for hosted premium storage without changing what stays free.</li>
+        <li>
+          Use the same account on different machines without changing the local
+          workflow.
+        </li>
+        <li>
+          Upgrade later for hosted premium storage without changing what stays
+          free.
+        </li>
       </ul>
       <p className="account-support-copy">
-        Forecasting, discussions, exports, verification, and local history remain available with or without an account.
+        Forecasting, discussions, exports, verification, and local history
+        remain available with or without an account.
       </p>
       <Button asChild variant="outline" className="w-full">
         <Link to="/pricing">
@@ -1062,13 +1164,14 @@ const LocalOnlyCard: React.FC = () => (
     <CardHeader className="account-section-header">
       <CardTitle className="text-2xl">Local-only mode</CardTitle>
       <CardDescription>
-        Hosted accounts are turned off here, but the full local forecasting workflow is still ready to go.
+        Hosted accounts are turned off here, but the full local forecasting
+        workflow is still ready to go.
       </CardDescription>
     </CardHeader>
     <CardContent className="account-local-only-content">
       <p className="account-support-copy">
-        Forecast drawing, discussions, verification, imports, exports, and local history keep working exactly as
-        expected.
+        Forecast drawing, discussions, verification, imports, exports, and local
+        history keep working exactly as expected.
       </p>
       <Button asChild variant="outline">
         <Link to="/">Back to Home</Link>
@@ -1079,19 +1182,20 @@ const LocalOnlyCard: React.FC = () => (
 
 /** Signed-out account experience focused on a clean auth flow plus one concise reassurance card. */
 const SignedOutAccountView: React.FC = () => {
-  const { signInWithEmail, signInWithGoogle, signUpWithEmail, error, status } = useAuth();
-  const [mode, setMode] = useState<AuthMode>('sign_in');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
+  const { signInWithEmail, signInWithGoogle, signUpWithEmail, error, status } =
+    useAuth();
+  const [mode, setMode] = useState<AuthMode>("sign_in");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  const isBusy = submitting || status === 'loading';
+  const isBusy = submitting || status === "loading";
 
   useEffect(() => {
-    if (mode === 'sign_in') {
-      setConfirmPassword('');
+    if (mode === "sign_in") {
+      setConfirmPassword("");
     }
   }, [mode]);
 
@@ -1100,23 +1204,27 @@ const SignedOutAccountView: React.FC = () => {
     e.preventDefault();
     setFormError(null);
 
-    if (mode === 'sign_up' && password !== confirmPassword) {
-      setFormError('Passwords do not match.');
+    if (mode === "sign_up" && password !== confirmPassword) {
+      setFormError("Passwords do not match.");
       return;
     }
 
     setSubmitting(true);
 
     try {
-      if (mode === 'sign_in') {
+      if (mode === "sign_in") {
         await signInWithEmail(email, password);
       } else {
         await signUpWithEmail(email, password);
       }
-      setPassword('');
-      setConfirmPassword('');
+      setPassword("");
+      setConfirmPassword("");
     } catch (nextError) {
-      setFormError(nextError instanceof Error ? nextError.message : 'Unable to complete that request right now.');
+      setFormError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Unable to complete that request right now.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -1130,7 +1238,11 @@ const SignedOutAccountView: React.FC = () => {
     try {
       await signInWithGoogle();
     } catch (nextError) {
-      setFormError(nextError instanceof Error ? nextError.message : 'Unable to start Google sign-in right now.');
+      setFormError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Unable to start Google sign-in right now.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -1187,8 +1299,12 @@ const AccountPage: React.FC = () => {
     <div className="h-full overflow-auto bg-gradient-to-br from-background via-background to-muted/20">
       <div className="mx-auto max-w-7xl px-6 py-8 md:px-8 md:py-10">
         {!hostedAuthEnabled ? <DisabledStateView /> : null}
-        {hostedAuthEnabled && status === 'signed_in' ? <SignedInAccountView /> : null}
-        {hostedAuthEnabled && status !== 'signed_in' ? <SignedOutAccountView /> : null}
+        {hostedAuthEnabled && status === "signed_in" ? (
+          <SignedInAccountView />
+        ) : null}
+        {hostedAuthEnabled && status !== "signed_in" ? (
+          <SignedOutAccountView />
+        ) : null}
       </div>
     </div>
   );

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -26,12 +26,6 @@ import { useUserMetrics } from "../metrics/useUserMetrics";
 import type { RootState } from "../store";
 import { selectForecastCycle, selectSavedCycles } from "../store/forecastSlice";
 import { computeHomeStats } from "./homeUtils";
-import {
-  DEFAULT_FORECAST_UI_VARIANT,
-  FORECAST_UI_VARIANT_OPTIONS,
-  readStoredForecastUiVariant,
-  type ForecastUiVariant,
-} from "../utils/forecastUiVariant";
 import "./AccountPage.css";
 
 type AuthMode = "sign_in" | "sign_up";
@@ -754,7 +748,6 @@ const SignedInAccountView: React.FC = () => {
     settingsSyncStatus,
     syncedSettings,
     updateSyncedSettings,
-    betaAccess,
   } = useAuth();
   const [defaultForecasterName, setDefaultForecasterName] = useState(
     () => syncedSettings?.defaultForecasterName ?? user?.displayName ?? "",

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -23,7 +23,6 @@ import { Input } from "../components/ui/input";
 import { useAuth } from "../auth/AuthProvider";
 import { useEntitlement } from "../billing/EntitlementProvider";
 import { useUserMetrics } from "../metrics/useUserMetrics";
-import { cn } from "../lib/utils";
 import type { RootState } from "../store";
 import { selectForecastCycle, selectSavedCycles } from "../store/forecastSlice";
 import { computeHomeStats } from "./homeUtils";
@@ -154,19 +153,6 @@ const getCurrentPlanPrice = (
 
   return "Included";
 };
-
-/** Returns the current Forecast workspace experiment label for status copy. */
-const getForecastUiVariantLabel = (variant: ForecastUiVariant): string =>
-  FORECAST_UI_VARIANT_OPTIONS.find((option) => option.value === variant)
-    ?.label ?? variant;
-
-/** Resolves the current Forecast workspace experiment from synced settings first, then local storage, then default. */
-const getAccountForecastUiVariant = (
-  syncedSettings: ReturnType<typeof useAuth>["syncedSettings"],
-): ForecastUiVariant =>
-  syncedSettings?.forecastUiVariant ??
-  readStoredForecastUiVariant() ??
-  DEFAULT_FORECAST_UI_VARIANT;
 
 /** Formats the last recorded active-day key into a compact account-friendly date label. */
 const formatLastActiveDate = (value: string | null): string => {
@@ -716,13 +702,9 @@ const SignedInPrimaryCard: React.FC<{
   providerLabels: string[];
   defaultForecasterName: string;
   setDefaultForecasterName: React.Dispatch<React.SetStateAction<string>>;
-  showForecastWorkspaceExperiment: boolean;
-  forecastUiVariant: ForecastUiVariant;
-  savingForecastUiVariant: ForecastUiVariant | null;
   forecastUiMessage: string | null;
   savingDefaults: boolean;
   saveMessage: string | null;
-  onForecastUiVariantChange: (variant: ForecastUiVariant) => void;
   onSaveDefaults: () => void;
   onOpenForecast: () => void;
   onSignOut: () => void;
@@ -731,13 +713,9 @@ const SignedInPrimaryCard: React.FC<{
   providerLabels,
   defaultForecasterName,
   setDefaultForecasterName,
-  showForecastWorkspaceExperiment,
-  forecastUiVariant,
-  savingForecastUiVariant,
   forecastUiMessage,
   savingDefaults,
   saveMessage,
-  onForecastUiVariantChange,
   onSaveDefaults,
   onOpenForecast,
   onSignOut,
@@ -781,11 +759,6 @@ const SignedInAccountView: React.FC = () => {
   const [defaultForecasterName, setDefaultForecasterName] = useState(
     () => syncedSettings?.defaultForecasterName ?? user?.displayName ?? "",
   );
-  const [forecastUiVariant, setForecastUiVariant] = useState<ForecastUiVariant>(
-    () => getAccountForecastUiVariant(syncedSettings),
-  );
-  const [savingForecastUiVariant, setSavingForecastUiVariant] =
-    useState<ForecastUiVariant | null>(null);
   const [forecastUiMessage, setForecastUiMessage] = useState<string | null>(
     null,
   );
@@ -807,10 +780,6 @@ const SignedInAccountView: React.FC = () => {
     );
   }, [syncedSettings?.defaultForecasterName, user?.displayName]);
 
-  useEffect(() => {
-    setForecastUiVariant(getAccountForecastUiVariant(syncedSettings));
-  }, [syncedSettings?.forecastUiVariant]);
-
   /** Saves the discussion default byline into the synced user settings document. */
   const handleSaveDefaults = async () => {
     setSavingDefaults(true);
@@ -827,34 +796,6 @@ const SignedInAccountView: React.FC = () => {
       );
     } finally {
       setSavingDefaults(false);
-    }
-  };
-
-  /** Updates the synced Forecast workspace experiment and mirrors it into local storage for this device. */
-  const handleForecastUiVariantChange = async (
-    nextVariant: ForecastUiVariant,
-  ) => {
-    if (savingForecastUiVariant) {
-      return;
-    }
-
-    setForecastUiVariant(nextVariant);
-    setForecastUiMessage(null);
-    setSavingForecastUiVariant(nextVariant);
-
-    try {
-      await updateSyncedSettings({ forecastUiVariant: nextVariant });
-      setForecastUiMessage(
-        `${getForecastUiVariantLabel(nextVariant)} will open by default on Forecast.`,
-      );
-    } catch (error) {
-      setForecastUiMessage(
-        error instanceof Error
-          ? error.message
-          : "Unable to update the Forecast beta flag right now.",
-      );
-    } finally {
-      setSavingForecastUiVariant(null);
     }
   };
 
@@ -877,13 +818,6 @@ const SignedInAccountView: React.FC = () => {
     setForecastUiMessage(null);
   };
 
-  /** Wraps the async workspace-toggle action so the button handlers stay synchronous. */
-  const handleForecastUiVariantClick = (nextVariant: ForecastUiVariant) => {
-    handleForecastUiVariantChange(nextVariant).catch(() => {
-      // Beta-flag feedback is already surfaced by handleForecastUiVariantChange.
-    });
-  };
-
   return (
     <div className="account-page-stack">
       <AccountHero description="Keep your profile and app defaults ready across devices while the core forecasting workflow stays yours.">
@@ -901,13 +835,9 @@ const SignedInAccountView: React.FC = () => {
             providerLabels={providerLabels}
             defaultForecasterName={defaultForecasterName}
             setDefaultForecasterName={setDefaultForecasterName}
-            showForecastWorkspaceExperiment={betaAccess}
-            forecastUiVariant={forecastUiVariant}
-            savingForecastUiVariant={savingForecastUiVariant}
             forecastUiMessage={forecastUiMessage}
             savingDefaults={savingDefaults}
             saveMessage={saveMessage}
-            onForecastUiVariantChange={handleForecastUiVariantClick}
             onSaveDefaults={handleSaveDefaultsClick}
             onOpenForecast={handleOpenForecastClick}
             onSignOut={handleSignOutClick}

--- a/src/pages/ForecastPage.css
+++ b/src/pages/ForecastPage.css
@@ -1,0 +1,16 @@
+.forecast-page-shell {
+  width: 100%;
+  overflow: hidden;
+
+  /* Fallback for browsers that don't support dynamic viewport units (dvh). */
+  height: calc(100vh - var(--app-header-height, 64px));
+  max-height: calc(100vh - var(--app-header-height, 64px));
+}
+
+@supports (height: 100dvh) {
+  .forecast-page-shell {
+    height: calc(100dvh - var(--app-header-height, 64px));
+    max-height: calc(100dvh - var(--app-header-height, 64px));
+  }
+}
+

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -53,6 +53,7 @@ import {
   resolveForecastUiVariant,
   type ForecastUiVariant,
 } from '../utils/forecastUiVariant';
+import './ForecastPage.css';
 
 interface PageContext {
   addToast: AddToastFn;
@@ -1257,10 +1258,7 @@ export const ForecastPage: React.FC = () => {
   });
 
   return (
-    <div
-      className="forecast-page-shell w-full overflow-hidden"
-      style={{ height: 'calc(100dvh - var(--app-header-height, 64px))', maxHeight: 'calc(100dvh - var(--app-header-height, 64px))' }}
-    >
+    <div className="forecast-page-shell">
       {renderForecastWorkspaceLayout(forecastUiVariant, {
         mapRef,
         controller: workspaceController,


### PR DESCRIPTION
## Summary

- Add a 100vh fallback for the forecast page shell when dynamic viewport units (dvh) are unsupported.
- Ensure OpenLayers maps call updateSize after mount and on resize so they recover from 0x0 container mounts (Chromebook reports).
- Updated version to v1.5.1
- Removed beta selector that wasn't removed before stable release

## Test plan

- pnpm run build
- pnpm test -- --runTestsByPath src/components/Map/OpenLayersForecastMap.test.ts src/components/Map/OpenLayersVerificationMap.test.ts src/pages/ForecastPage.test.tsx

Made with [Cursor](https://cursor.com)