### PR TITLE
Fix button background color and remove old export check

### DIFF
--- a/src/components/DrawingTools/useExportMap.test.tsx
+++ b/src/components/DrawingTools/useExportMap.test.tsx
@@ -59,15 +59,12 @@ describe('useExportMap', () => {
       disabled: false,
       current: {
         getEngine: () => 'openlayers',
-        getMap: () => ({}),
+        getMap: () => null,
         getView: () => ({ center: [0, 0], zoom: 1 }),
       },
     });
     act(() => result.current.initiateExport());
-    expect(addToast).toHaveBeenCalledWith(
-      'Map export is only available for Leaflet maps right now. The current OpenLayers map cannot be exported.',
-      'warning'
-    );
+    expect(addToast).toHaveBeenCalledWith('Map not fully loaded. Please try again.', 'error');
 
     rerender({
       disabled: false,
@@ -172,10 +169,6 @@ describe('useExportMap', () => {
 
     act(() => result.current.initiateExport());
 
-    expect(addToast).toHaveBeenCalledWith(
-      'Map export is only available for Leaflet maps right now. The current OpenLayers map cannot be exported.',
-      'warning'
-    );
-    expect(result.current.isModalOpen).toBe(false);
+    expect(result.current.isModalOpen).toBe(true);
   });
 });

--- a/src/components/DrawingTools/useExportMap.ts
+++ b/src/components/DrawingTools/useExportMap.ts
@@ -40,17 +40,6 @@ async function performExport(
 }
 
 /**
- * Returns true when the given adapter reports a Leaflet engine.
- */
-const isMapEngineLeaflet = (current: MapAdapterHandle<unknown> | null): boolean => {
-  try {
-    return Boolean(current && typeof current.getEngine === 'function' && current.getEngine() === 'leaflet');
-  } catch {
-    return false;
-  }
-};
-
-/**
  * Validate common preconditions for running an export. Shows user-facing toasts
  * when a precondition fails. Kept as a top-level function to reduce hook complexity
  * and keep branching out of the hook body for easier testing.
@@ -67,11 +56,6 @@ const validateExportPreconditions = (
 
   if (!current) {
     addToast('Map reference not available. Cannot export.', 'error');
-    return false;
-  }
-
-  if (!isMapEngineLeaflet(current)) {
-    addToast('Map export is only available for Leaflet maps right now. The current OpenLayers map cannot be exported.', 'warning');
     return false;
   }
 

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,716 +1,776 @@
 .home-page-shell {
-  display: flex;
-  flex-direction: column;
-  gap: 2.75rem;
-  max-width: 80rem;
-  margin: 0 auto;
-  padding: 2.5rem 1.5rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.75rem;
+    max-width: 80rem;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 2rem;
 }
 
 .home-primary-grid {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(0, 1fr);
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: minmax(0, 1fr);
 }
 
 .home-signed-in-grid {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(0, 1fr);
-  align-items: start;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
 }
 
 .home-signed-in-main,
 .home-signed-in-side {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
 }
 
 .home-disclosure {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.85rem;
-  padding: 1.2rem 1.35rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.35rem;
-  background: var(--bg-primary);
-  box-shadow: var(--shadow-md);
-  font-size: 0.95rem;
-  color: var(--text-secondary);
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    padding: 1.2rem 1.35rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.35rem;
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-md);
+    font-size: 0.95rem;
+    color: var(--text-secondary);
 }
 
 .home-hero {
-  position: relative;
-  overflow: hidden;
-  padding: 2.5rem;
-  border: 1px solid var(--border-color);
-  border-radius: 2rem;
-  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary) 58%, var(--bg-primary));
-  box-shadow: var(--shadow-lg);
+    position: relative;
+    overflow: hidden;
+    padding: 2.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 2rem;
+    background: linear-gradient(
+        135deg,
+        var(--bg-secondary),
+        var(--bg-primary) 58%,
+        var(--bg-primary)
+    );
+    box-shadow: var(--shadow-lg);
 }
 
 .home-hero-signed-in {
-  padding: 2.75rem;
+    padding: 2.75rem;
 }
 
 .home-hero-grid {
-  position: relative;
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(0, 1fr);
+    position: relative;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: minmax(0, 1fr);
 }
 
 .home-hero-grid-single {
-  grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
 }
 
 .home-hero-main {
-  display: flex;
-  flex-direction: column;
-  gap: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
 }
 
 .home-signed-in-main .home-hero-main {
-  max-width: 48rem;
+    max-width: 48rem;
 }
 
 .home-signed-in-main .home-hero-text h1 {
-  max-width: none;
+    max-width: none;
 }
 
 .home-signed-in-main .home-hero-text p {
-  max-width: none;
+    max-width: none;
 }
 
 .home-signed-in-main .home-hero-grid-single .home-hero-main {
-  max-width: min(100%, 58rem);
+    max-width: min(100%, 58rem);
 }
 
 .home-signed-in-main .home-hero-grid-single .home-hero-text h1 {
-  max-width: none;
+    max-width: none;
 }
 
 .home-signed-in-main .home-hero-grid-single .home-hero-text p {
-  max-width: none;
+    max-width: none;
 }
 
 .home-pill {
-  display: inline-flex;
-  width: fit-content;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 999px;
-  background: var(--bg-primary);
-  color: var(--button-bg);
-  font-size: 0.9rem;
-  font-weight: 600;
+    display: inline-flex;
+    width: fit-content;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--bg-primary);
+    color: var(--button-bg);
+    font-size: 0.9rem;
+    font-weight: 600;
 }
 
 .home-hero-text {
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
 }
 
 .home-hero-text h1 {
-  margin: 0;
-  max-width: none;
-  font-size: clamp(2.35rem, 4vw, 3.9rem);
-  line-height: 1;
-  letter-spacing: -0.04em;
-  font-weight: 800;
-  color: var(--text-primary);
+    margin: 0;
+    max-width: none;
+    font-size: clamp(2.35rem, 4vw, 3.9rem);
+    line-height: 1;
+    letter-spacing: -0.04em;
+    font-weight: 800;
+    color: var(--text-primary);
 }
 
 .home-hero-text p {
-  margin: 0;
-  max-width: none;
-  font-size: 1.06rem;
-  line-height: 1.8;
-  color: var(--text-secondary);
+    margin: 0;
+    max-width: none;
+    font-size: 1.06rem;
+    line-height: 1.8;
+    color: var(--text-secondary);
 }
 
 .home-hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.85rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
 }
 
 .home-hero-side {
-  display: flex;
+    display: flex;
 }
 
 .home-hero-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  width: 100%;
-  padding: 2rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.75rem;
-  background: var(--bg-primary);
-  box-shadow: var(--shadow-md);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    width: 100%;
+    padding: 2rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.75rem;
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-md);
 }
 
 .home-home-summary-rail {
-  padding: 2rem;
+    padding: 2rem;
 }
 
 .home-home-summary-rail .home-hero-panel {
-  padding: 0;
-  border: none;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
 }
 
 .home-hero-panel-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
 }
 
 .home-hero-panel-header p {
-  margin: 0;
-  font-size: 0.82rem;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--button-bg);
+    margin: 0;
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--button-bg);
 }
 
 .home-hero-panel-header h2 {
-  margin: 0;
-  font-size: 1.45rem;
-  line-height: 1.2;
-  color: var(--text-primary);
+    margin: 0;
+    font-size: 1.45rem;
+    line-height: 1.2;
+    color: var(--text-primary);
 }
 
 .home-hero-panel-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.9rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
 }
 
 .home-hero-panel-item {
-  padding: 1rem 1.1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.2rem;
-  background: var(--bg-secondary);
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.2rem;
+    background: var(--bg-secondary);
 }
 
 .home-hero-panel-item-label {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
 }
 
 .home-hero-panel-item p {
-  margin: 0.55rem 0 0;
-  font-size: 0.95rem;
-  line-height: 1.75;
-  color: var(--text-secondary);
+    margin: 0.55rem 0 0;
+    font-size: 0.95rem;
+    line-height: 1.75;
+    color: var(--text-secondary);
 }
 
 .home-surface-card {
-  border: 1px solid var(--border-color);
-  background: var(--bg-primary);
-  box-shadow: var(--shadow-md);
-  border-radius: 1.75rem;
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-md);
+    border-radius: 1.75rem;
 }
 
 .home-section-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
-  padding: 2rem 2.25rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    padding: 2rem 2.25rem 1.5rem;
 }
 
 .home-section-content {
-  padding: 0 2.25rem 2.25rem;
+    padding: 0 2.25rem 2.25rem;
 }
 
 .home-main-content {
-  display: flex;
-  flex-direction: column;
-  gap: 1.85rem;
-  padding: 0 2.25rem 2.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.85rem;
+    padding: 0 2.25rem 2.25rem;
 }
 
 .home-workspace-header {
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
-  padding: 2rem 2.25rem 1.65rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    padding: 2rem 2.25rem 1.65rem;
 }
 
 .home-workspace-header-top {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
 .home-workspace-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-  max-width: 44rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    max-width: 44rem;
 }
 
 .home-save-pill {
-  display: inline-flex;
-  align-self: flex-start;
-  width: fit-content;
-  padding: 0.65rem 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--button-bg) 6%, var(--bg-primary));
-  box-shadow: var(--shadow-sm);
+    display: inline-flex;
+    align-self: flex-start;
+    width: fit-content;
+    padding: 0.65rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--button-bg) 6%, var(--bg-primary));
+    box-shadow: var(--shadow-sm);
 }
 
 .home-save-pill-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.92rem;
-  font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.92rem;
+    font-weight: 600;
 }
 
 .home-date-pill {
-  display: inline-flex;
-  width: fit-content;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.55rem 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--button-bg) 6%, var(--bg-primary));
-  color: var(--text-secondary);
-  font-size: 0.95rem;
+    display: inline-flex;
+    width: fit-content;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.55rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--button-bg) 6%, var(--bg-primary));
+    color: var(--text-secondary);
+    font-size: 0.95rem;
 }
 
 .home-main-stats-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: minmax(0, 1fr);
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr);
 }
 
 .home-workspace-stat {
-  padding: 1.15rem 1.2rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.35rem;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 90%, var(--bg-primary)), var(--bg-primary));
-  box-shadow: var(--shadow-sm);
+    padding: 1.15rem 1.2rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.35rem;
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--bg-secondary) 90%, var(--bg-primary)),
+        var(--bg-primary)
+    );
+    box-shadow: var(--shadow-sm);
 }
 
 .home-workspace-stat-label {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  font-size: 0.92rem;
-  font-weight: 600;
-  color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-size: 0.92rem;
+    font-weight: 600;
+    color: var(--text-primary);
 }
 
 .home-workspace-stat p {
-  margin: 0.8rem 0 0;
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--text-primary);
+    margin: 0.8rem 0 0;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--text-primary);
 }
 
 .home-day-grid-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
 }
 
 .home-day-grid-header h3 {
-  margin: 0;
-  font-size: 1rem;
-  color: var(--text-primary);
+    margin: 0;
+    font-size: 1rem;
+    color: var(--text-primary);
 }
 
 .home-day-grid-header p {
-  margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.7;
-  color: var(--text-secondary);
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.7;
+    color: var(--text-secondary);
 }
 
 .home-day-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.95rem;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.95rem;
 }
 
 .home-day-button {
-  text-align: left;
-  min-height: 7.1rem;
-  padding: 1rem 0.9rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.2rem;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 88%, var(--bg-primary)), var(--bg-primary));
-  box-shadow: var(--shadow-sm);
-  transition: transform 150ms ease, border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+    text-align: left;
+    min-height: 7.1rem;
+    padding: 1rem 0.9rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.2rem;
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--bg-secondary) 88%, var(--bg-primary)),
+        var(--bg-primary)
+    );
+    box-shadow: var(--shadow-sm);
+    transition:
+        transform 150ms ease,
+        border-color 150ms ease,
+        box-shadow 150ms ease,
+        background-color 150ms ease;
 }
 
 .home-day-button:hover {
-  transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--button-bg) 24%, var(--border-color));
-  box-shadow: var(--shadow-sm);
+    transform: translateY(-1px);
+    border-color: color-mix(in srgb, var(--button-bg) 24%, var(--border-color));
+    box-shadow: var(--shadow-sm);
 }
 
 .home-day-button.is-populated {
-  border-color: color-mix(in srgb, var(--button-bg) 18%, var(--border-color));
+    border-color: color-mix(in srgb, var(--button-bg) 18%, var(--border-color));
 }
 
 .home-day-button.is-current {
-  background: color-mix(in srgb, var(--button-bg) 12%, var(--bg-primary));
-  border-color: color-mix(in srgb, var(--button-bg) 45%, var(--border-color));
-  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--button-bg) 42%, transparent);
+    background: color-mix(in srgb, var(--button-bg) 12%, var(--bg-primary));
+    border-color: color-mix(in srgb, var(--button-bg) 45%, var(--border-color));
+    box-shadow: inset 0 0 0 2px
+        color-mix(in srgb, var(--button-bg) 42%, transparent);
 }
 
 .home-day-button-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 0.45rem;
-  width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 0.45rem;
+    width: 100%;
 }
 
 .home-utility-card {
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
-  padding: 1.5rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.6rem;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 88%, var(--bg-primary)), var(--bg-primary));
-  box-shadow: var(--shadow-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    padding: 1.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.6rem;
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--bg-secondary) 88%, var(--bg-primary)),
+        var(--bg-primary)
+    );
+    box-shadow: var(--shadow-sm);
 }
 
 .home-utility-grid {
-  display: grid;
-  gap: 0.9rem;
-  grid-template-columns: minmax(0, 1fr);
+    display: grid;
+    gap: 0.9rem;
+    grid-template-columns: minmax(0, 1fr);
 }
 
 .home-utility-button {
-  min-height: 3rem;
+    min-height: 3rem;
 }
 
 .home-utility-button {
-  border-color: var(--border-color) !important;
-  background: var(--bg-primary) !important;
-  color: var(--text-primary) !important;
+    border-color: var(--border-color) !important;
+    background: var(--bg-primary) !important;
+    color: var(--text-primary) !important;
 }
 
 .home-utility-button:hover {
-  border-color: color-mix(in srgb, var(--button-bg) 22%, var(--border-color)) !important;
-  background: color-mix(in srgb, var(--bg-secondary) 88%, var(--bg-primary)) !important;
+    border-color: color-mix(
+        in srgb,
+        var(--button-bg) 22%,
+        var(--border-color)
+    ) !important;
+    background: color-mix(
+        in srgb,
+        var(--bg-secondary) 88%,
+        var(--bg-primary)
+    ) !important;
 }
 
 .home-utility-button-primary {
-  border-color: color-mix(in srgb, var(--button-bg) 28%, var(--border-color)) !important;
-  background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary)) !important;
+    border-color: color-mix(
+        in srgb,
+        var(--button-bg) 28%,
+        var(--border-color)
+    ) !important;
+    background: color-mix(
+        in srgb,
+        var(--button-bg) 8%,
+        var(--bg-primary)
+    ) !important;
 }
 
 .home-utility-button-primary:hover {
-  border-color: color-mix(in srgb, var(--button-bg) 45%, var(--border-color)) !important;
-  background: color-mix(in srgb, var(--button-bg) 12%, var(--bg-primary)) !important;
+    border-color: color-mix(
+        in srgb,
+        var(--button-bg) 45%,
+        var(--border-color)
+    ) !important;
+    background: color-mix(
+        in srgb,
+        var(--button-bg) 12%,
+        var(--bg-primary)
+    ) !important;
 }
 
 .home-stat-card {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.25rem 1.35rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.25rem 1.35rem;
 }
 
 .home-stat-card-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 1rem;
-  background: color-mix(in srgb, var(--button-bg) 10%, var(--bg-primary));
-  color: var(--button-bg);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 1rem;
+    background: color-mix(in srgb, var(--button-bg) 10%, var(--bg-primary));
+    color: var(--button-bg);
 }
 
 .home-stat-card-label {
-  margin: 0;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--text-tertiary);
+    margin: 0;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
 }
 
 .home-stat-card-value {
-  margin: 0.55rem 0 0;
-  font-size: 1.95rem;
-  line-height: 1;
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  color: var(--text-primary);
+    margin: 0.55rem 0 0;
+    font-size: 1.95rem;
+    line-height: 1;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    color: var(--text-primary);
 }
 
 .home-guidance-section,
 .home-info-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
 .home-guidance-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
 }
 
 .home-guidance-header h2,
 .home-guidance-header h3 {
-  margin: 0;
-  font-size: 1.3rem;
-  line-height: 1.2;
-  color: var(--text-primary);
+    margin: 0;
+    font-size: 1.3rem;
+    line-height: 1.2;
+    color: var(--text-primary);
 }
 
 .home-guidance-header p,
 .home-info-panel p {
-  margin: 0;
-  font-size: 0.96rem;
-  line-height: 1.75;
-  color: var(--text-secondary);
+    margin: 0;
+    font-size: 0.96rem;
+    line-height: 1.75;
+    color: var(--text-secondary);
 }
 
 .home-step-list,
 .home-glance-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
 }
 
 .home-step-card {
-  display: flex;
-  gap: 0.9rem;
-  padding: 1rem 1.05rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.25rem;
-  background: var(--bg-secondary);
+    display: flex;
+    gap: 0.9rem;
+    padding: 1rem 1.05rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.25rem;
+    background: var(--bg-secondary);
 }
 
 .home-step-number {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.1rem;
-  height: 2.1rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--button-bg) 10%, var(--bg-primary));
-  color: var(--button-bg);
-  font-weight: 700;
-  flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.1rem;
+    height: 2.1rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--button-bg) 10%, var(--bg-primary));
+    color: var(--button-bg);
+    font-weight: 700;
+    flex-shrink: 0;
 }
 
 .home-step-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
 }
 
 .home-step-copy h3 {
-  margin: 0;
-  font-size: 1rem;
-  color: var(--text-primary);
+    margin: 0;
+    font-size: 1rem;
+    color: var(--text-primary);
 }
 
 .home-step-copy p {
-  margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.7;
-  color: var(--text-secondary);
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.7;
+    color: var(--text-secondary);
 }
 
 .home-info-panel {
-  padding: 1.35rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.4rem;
-  background: var(--bg-secondary);
+    padding: 1.35rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.4rem;
+    background: var(--bg-secondary);
 }
 
 .home-info-panel-footer {
-  margin-top: auto;
+    margin-top: auto;
 }
 
 .home-sidebar-content {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 2rem;
 }
 
 .home-cycle-button {
-  padding: 1rem 1.05rem;
-  border: 1px solid var(--border-color);
-  border-radius: 1.25rem;
-  background: var(--bg-secondary);
-  text-align: left;
-  transition: transform 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+    padding: 1rem 1.05rem;
+    border: 1px solid var(--border-color);
+    border-radius: 1.25rem;
+    background: var(--bg-secondary);
+    text-align: left;
+    transition:
+        transform 150ms ease,
+        border-color 150ms ease,
+        box-shadow 150ms ease;
 }
 
 .home-cycle-button:hover {
-  border-color: color-mix(in srgb, var(--button-bg) 35%, var(--border-color));
-  box-shadow: var(--shadow-sm);
-  transform: translateY(-1px);
+    border-color: color-mix(in srgb, var(--button-bg) 35%, var(--border-color));
+    box-shadow: var(--shadow-sm);
+    transform: translateY(-1px);
 }
 
 .home-cycle-button-compact {
-  width: 100%;
+    width: 100%;
 }
 
 .home-recent-content {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
 }
 
 .home-recent-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: minmax(0, 1fr);
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr);
 }
 
 @media (min-width: 768px) {
-  .home-page-shell {
-    gap: 3rem;
-    padding: 2.75rem 2rem 2.25rem;
-  }
+    .home-page-shell {
+        gap: 3rem;
+        padding: 2.75rem 2rem 2.25rem;
+    }
 
-  .home-hero,
-  .home-hero-signed-in {
-    padding: 3rem;
-  }
+    .home-hero,
+    .home-hero-signed-in {
+        padding: 3rem;
+    }
 
-  .home-main-stats-grid,
-  .home-primary-grid,
-  .home-signed-in-grid,
-  .home-utility-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+    .home-main-stats-grid,
+    .home-primary-grid,
+    .home-signed-in-grid,
+    .home-utility-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 
-  .home-day-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
+    .home-day-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
 
-  .home-recent-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+    .home-recent-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 
-  .home-workspace-header-top {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: start;
-    gap: 1rem 1.5rem;
-  }
+    .home-workspace-header-top {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: start;
+        gap: 1rem 1.5rem;
+    }
 
-  .home-save-pill {
-    align-self: start;
-  }
+    .home-save-pill {
+        align-self: start;
+    }
 }
 
 @media (min-width: 1024px) {
-  .home-signed-in-grid {
-    grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.9fr);
-  }
+    .home-signed-in-grid {
+        grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.9fr);
+    }
 
-  .home-primary-grid {
-    grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.9fr);
-    align-items: start;
-  }
+    .home-primary-grid {
+        grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.9fr);
+        align-items: start;
+    }
 
-  .home-primary-grid-signed-out {
-    grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.95fr);
-  }
+    .home-primary-grid-signed-out {
+        grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.95fr);
+    }
 
-  .home-hero-grid {
-    grid-template-columns: minmax(0, 1.7fr) minmax(340px, 0.95fr);
-    gap: 2.5rem;
-    align-items: start;
-  }
+    .home-hero-grid {
+        grid-template-columns: minmax(0, 1.7fr) minmax(340px, 0.95fr);
+        gap: 2.5rem;
+        align-items: start;
+    }
 
-  .home-hero-grid-single {
-    grid-template-columns: minmax(0, 1fr);
-  }
+    .home-hero-grid-single {
+        grid-template-columns: minmax(0, 1fr);
+    }
 
-  .home-main-stats-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
+    .home-main-stats-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
 
-  .home-recent-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
+    .home-recent-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
 }
 
 .home-concept-page {
-  min-height: 100%;
-  background:
-    radial-gradient(circle at 18% 68%, color-mix(in srgb, var(--button-bg) 7%, transparent), transparent 28rem),
-    linear-gradient(180deg, var(--bg-primary), color-mix(in srgb, var(--bg-secondary) 45%, var(--bg-primary)));
-  color: var(--text-primary);
+    min-height: 100%;
+    background:
+        radial-gradient(
+            circle at 18% 68%,
+            color-mix(in srgb, var(--button-bg) 7%, transparent),
+            transparent 28rem
+        ),
+        linear-gradient(
+            180deg,
+            var(--bg-primary),
+            color-mix(in srgb, var(--bg-secondary) 45%, var(--bg-primary))
+        );
+    color: var(--text-primary);
 }
 
 .home-concept-shell {
-  position: relative;
-  isolation: isolate;
-  width: 100%;
-  min-height: calc(100vh - 4.5rem);
-  overflow: hidden;
+    position: relative;
+    isolation: isolate;
+    width: 100%;
+    min-height: calc(100vh - 4.5rem);
+    overflow: hidden;
 }
 
 .home-concept-map-bg {
-  position: absolute;
-  inset: auto 0 0;
-  z-index: -1;
-  height: min(42vh, 26rem);
-  opacity: 0.42;
-  color: color-mix(in srgb, var(--button-bg) 18%, transparent);
-  background-image: radial-gradient(color-mix(in srgb, var(--button-bg) 12%, transparent) 0.8px, transparent 0.8px);
-  background-size: 8px 8px;
-  pointer-events: none;
+    position: absolute;
+    inset: auto 0 0;
+    z-index: -1;
+    height: min(42vh, 26rem);
+    opacity: 0.42;
+    color: color-mix(in srgb, var(--button-bg) 18%, transparent);
+    background-image: radial-gradient(
+        color-mix(in srgb, var(--button-bg) 12%, transparent) 0.8px,
+        transparent 0.8px
+    );
+    background-size: 8px 8px;
+    pointer-events: none;
 }
 
 .home-concept-map-bg svg {
-  width: 100%;
-  height: 100%;
+    width: 100%;
+    height: 100%;
 }
 
 .home-concept-map-bg path {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.1;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.1;
 }
 
 .home-concept-shell-signed-in {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
 
 .home-concept-cycle-bar {
-  display: grid;
-  gap: 1.4rem;
-  align-items: center;
-  padding: 2.25rem clamp(1.25rem, 3vw, 3rem);
-  border-bottom: 1px solid var(--border-color);
-  background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+    display: grid;
+    gap: 1.4rem;
+    align-items: center;
+    padding: 2.25rem clamp(1.25rem, 3vw, 3rem);
+    border-bottom: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
 }
 
 .home-concept-cycle-meta,
@@ -718,382 +778,390 @@
 .home-concept-start-row,
 .home-concept-quick-notes,
 .home-concept-link {
-  display: flex;
-  align-items: center;
+    display: flex;
+    align-items: center;
 }
 
 .home-concept-cycle-meta {
-  flex-wrap: wrap;
-  gap: 1rem;
+    flex-wrap: wrap;
+    gap: 1rem;
 }
 
 .home-concept-cycle-meta p,
 .home-concept-glance h2,
 .home-concept-recent h2 {
-  margin: 0 0 0.4rem;
-  color: var(--button-bg);
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
+    margin: 0 0 0.4rem;
+    color: var(--button-bg);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
 }
 
 .home-concept-cycle-meta h1 {
-  margin: 0;
-  font-size: clamp(1.2rem, 2vw, 1.55rem);
-  line-height: 1.2;
-  color: var(--text-primary);
+    margin: 0;
+    font-size: clamp(1.2rem, 2vw, 1.55rem);
+    line-height: 1.2;
+    color: var(--text-primary);
 }
 
 .home-concept-icon-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  width: 4.25rem;
-  height: 4.25rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
-  color: var(--button-bg);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 4.25rem;
+    height: 4.25rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
+    color: var(--button-bg);
 }
 
 .home-concept-unsaved {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  color: #f18700;
-  font-size: 0.9rem;
-  font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: #f18700;
+    font-size: 0.9rem;
+    font-weight: 600;
 }
 
 .home-concept-unsaved::before {
-  content: "";
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 999px;
-  background: currentColor;
+    content: "";
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 999px;
+    background: currentColor;
 }
 
 .home-concept-cycle-actions {
-  flex-wrap: wrap;
-  gap: 0.85rem;
+    flex-wrap: wrap;
+    gap: 0.85rem;
 }
 
 .home-concept-top-primary,
 .home-concept-top-secondary,
 .home-concept-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0.5rem;
-  font-weight: 700;
-  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.5rem;
+    font-weight: 700;
+    transition:
+        transform 160ms ease,
+        border-color 160ms ease,
+        box-shadow 160ms ease,
+        background-color 160ms ease;
 }
 
 .home-concept-top-primary,
 .home-concept-action-primary {
-  border: 1px solid var(--button-bg);
-  background: linear-gradient(135deg, color-mix(in srgb, var(--button-bg) 86%, #7b61ff), var(--button-bg));
-  color: #fff;
-  box-shadow: 0 1.15rem 2rem color-mix(in srgb, var(--button-bg) 20%, transparent);
+    border: 1px solid var(--button-bg);
+    background: linear-gradient(135deg, #7b61ff, var(--button-bg));
+    color: #067aff;
+    box-shadow: 0 1.15rem 2rem
+        rgba(0, 123, 255, 0.18);
 }
 
 .home-concept-top-primary {
-  gap: 1.8rem;
-  min-height: 3.15rem;
-  padding: 0 1.55rem;
+    gap: 1.8rem;
+    min-height: 3.15rem;
+    padding: 0 1.55rem;
 }
 
 .home-concept-top-secondary {
-  gap: 0.65rem;
-  min-height: 3.15rem;
-  padding: 0 1.2rem;
-  border: 1px solid var(--border-color);
-  background: var(--bg-primary);
-  color: var(--text-primary);
+    gap: 0.65rem;
+    min-height: 3.15rem;
+    padding: 0 1.2rem;
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary);
+    color: var(--text-primary);
 }
 
 .home-concept-top-primary:hover,
 .home-concept-top-secondary:hover,
 .home-concept-action:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
 }
 
 .home-concept-signed-in-grid {
-  display: grid;
-  gap: clamp(2rem, 5vw, 5rem);
-  grid-template-columns: minmax(0, 1fr);
-  flex: 1;
-  padding: clamp(3rem, 8vw, 7rem) clamp(1.25rem, 8vw, 8rem) 4rem;
+    display: grid;
+    gap: clamp(2rem, 5vw, 5rem);
+    grid-template-columns: minmax(0, 1fr);
+    flex: 1;
+    padding: clamp(3rem, 8vw, 7rem) clamp(1.25rem, 8vw, 8rem) 4rem;
 }
 
 .home-concept-continue {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  max-width: 34rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 34rem;
 }
 
 .home-concept-continue h2,
 .home-concept-landing-hero h1 {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0;
-  margin: 0;
-  color: var(--text-primary);
-  font-size: clamp(3rem, 6vw, 5rem);
-  font-weight: 850;
-  line-height: 1.05;
-  letter-spacing: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+    margin: 0;
+    color: var(--text-primary);
+    font-size: clamp(3rem, 6vw, 5rem);
+    font-weight: 850;
+    line-height: 1.05;
+    letter-spacing: 0;
 }
 
 .home-concept-heading-line {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.65rem;
-  white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    white-space: nowrap;
 }
 
 .home-concept-continue h2 svg,
 .home-concept-landing-hero h1 svg {
-  flex: 0 0 auto;
-  color: var(--button-bg);
+    flex: 0 0 auto;
+    color: var(--button-bg);
 }
 
 .home-concept-continue p,
 .home-concept-landing-hero > p {
-  margin: 1.4rem 0 0;
-  max-width: 35rem;
-  color: var(--text-secondary);
-  font-size: clamp(1.05rem, 1.4vw, 1.25rem);
-  line-height: 1.55;
+    margin: 1.4rem 0 0;
+    max-width: 35rem;
+    color: var(--text-secondary);
+    font-size: clamp(1.05rem, 1.4vw, 1.25rem);
+    line-height: 1.55;
 }
 
 .home-concept-continue-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin-top: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 2.5rem;
 }
 
 .home-concept-action {
-  justify-content: flex-start;
-  gap: 1rem;
-  width: 100%;
-  min-height: 4.25rem;
-  padding: 0 1.45rem;
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--button-bg);
-  text-align: left;
+    justify-content: flex-start;
+    gap: 1rem;
+    width: 100%;
+    min-height: 4.25rem;
+    padding: 0 1.45rem;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--button-bg);
+    text-align: left;
 }
 
 .home-concept-action.home-concept-action-primary {
-  border-color: var(--button-bg);
-  background: linear-gradient(135deg, color-mix(in srgb, var(--button-bg) 86%, #7b61ff), var(--button-bg));
-  color: #fff;
-  box-shadow: 0 1.15rem 2rem color-mix(in srgb, var(--button-bg) 20%, transparent);
+    border-color: var(--button-bg);
+    background: linear-gradient(135deg, #7b61ff, var(--button-bg));
+    color: #067aff;
+    box-shadow: 0 1.15rem 2rem
+        rgba(0, 123, 255, 0.18);
 }
 
 .home-concept-action strong,
 .home-concept-action small {
-  display: block;
+    display: block;
 }
 
 .home-concept-action small {
-  margin-top: 0.3rem;
-  color: var(--text-secondary);
-  font-weight: 500;
+    margin-top: 0.3rem;
+    color: var(--text-secondary);
+    font-weight: 500;
 }
 
 .home-concept-action.home-concept-action-primary small,
 .home-concept-action.home-concept-action-primary svg {
-  color: #fff;
+    color: #fff;
 }
 
 .home-concept-action-arrow {
-  margin-left: auto;
+    margin-left: auto;
 }
 
 .home-concept-side-rail {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  border-left: 1px solid var(--border-color);
-  padding-left: clamp(1.5rem, 4vw, 3rem);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    border-left: 1px solid var(--border-color);
+    padding-left: clamp(1.5rem, 4vw, 3rem);
 }
 
 .home-concept-glance dl {
-  display: flex;
-  flex-direction: column;
-  gap: 1.15rem;
-  margin: 1.5rem 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.15rem;
+    margin: 1.5rem 0 0;
 }
 
 .home-concept-glance div {
-  display: grid;
-  grid-template-columns: minmax(9rem, auto) minmax(0, 1fr);
-  gap: 1rem;
-  align-items: center;
+    display: grid;
+    grid-template-columns: minmax(9rem, auto) minmax(0, 1fr);
+    gap: 1rem;
+    align-items: center;
 }
 
 .home-concept-glance dt,
 .home-concept-glance dd {
-  margin: 0;
+    margin: 0;
 }
 
 .home-concept-glance dt {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  color: var(--text-primary);
-  font-weight: 700;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--text-primary);
+    font-weight: 700;
 }
 
 .home-concept-glance dd {
-  color: var(--text-secondary);
-  text-align: right;
+    color: var(--text-secondary);
+    text-align: right;
 }
 
 .home-concept-recent {
-  border-top: 1px solid var(--border-color);
-  padding-top: 1.5rem;
+    border-top: 1px solid var(--border-color);
+    padding-top: 1.5rem;
 }
 
 .home-concept-timeline {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  margin-top: 1.35rem;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    margin-top: 1.35rem;
 }
 
 .home-concept-timeline::before {
-  content: "";
-  position: absolute;
-  top: 0.75rem;
-  bottom: 0.75rem;
-  left: 0.5rem;
-  width: 1px;
-  background: var(--border-color);
+    content: "";
+    position: absolute;
+    top: 0.75rem;
+    bottom: 0.75rem;
+    left: 0.5rem;
+    width: 1px;
+    background: var(--border-color);
 }
 
 .home-concept-cycle-row {
-  position: relative;
-  display: grid;
-  grid-template-columns: 1rem minmax(0, 1fr) auto auto;
-  gap: 1rem;
-  align-items: center;
-  width: 100%;
-  padding: 0.65rem 0;
-  border: 0;
-  background: transparent;
-  color: var(--text-primary);
-  text-align: left;
+    position: relative;
+    display: grid;
+    grid-template-columns: 1rem minmax(0, 1fr) auto auto;
+    gap: 1rem;
+    align-items: center;
+    width: 100%;
+    padding: 0.65rem 0;
+    border: 0;
+    background: transparent;
+    color: var(--text-primary);
+    text-align: left;
 }
 
 .home-concept-dot {
-  position: relative;
-  z-index: 1;
-  width: 0.9rem;
-  height: 0.9rem;
-  border: 2px solid var(--text-tertiary);
-  border-radius: 999px;
-  background: var(--bg-primary);
+    position: relative;
+    z-index: 1;
+    width: 0.9rem;
+    height: 0.9rem;
+    border: 2px solid var(--text-tertiary);
+    border-radius: 999px;
+    background: var(--bg-primary);
 }
 
 .home-concept-dot.is-active {
-  border-color: var(--button-bg);
-  box-shadow: inset 0 0 0 2px var(--bg-primary);
-  background: var(--button-bg);
+    border-color: var(--button-bg);
+    box-shadow: inset 0 0 0 2px var(--bg-primary);
+    background: var(--button-bg);
 }
 
 .home-concept-cycle-copy strong,
 .home-concept-cycle-copy small {
-  display: block;
+    display: block;
 }
 
 .home-concept-cycle-copy small {
-  margin-top: 0.28rem;
-  color: var(--text-secondary);
+    margin-top: 0.28rem;
+    color: var(--text-secondary);
 }
 
 .home-concept-resume,
 .home-concept-link {
-  color: var(--button-bg);
-  font-weight: 700;
+    color: var(--button-bg);
+    font-weight: 700;
 }
 
 .home-concept-link {
-  gap: 0.65rem;
-  margin-top: 1.2rem;
-  border: 0;
-  background: transparent;
-  padding: 0.2rem 0;
-  border-radius: 0;
+    gap: 0.65rem;
+    margin-top: 1.2rem;
+    border: 0;
+    background: transparent;
+    padding: 0.2rem 0;
+    border-radius: 0;
 }
 
 .home-concept-muted {
-  color: var(--text-secondary);
+    color: var(--text-secondary);
 }
 
 .home-concept-shell-signed-out {
-  padding: clamp(3rem, 8vw, 7rem) clamp(1.25rem, 7vw, 7rem) 4rem;
+    padding: clamp(3rem, 8vw, 7rem) clamp(1.25rem, 7vw, 7rem) 4rem;
 }
 
 .home-concept-landing-grid {
-  display: grid;
-  gap: clamp(2rem, 5vw, 4rem);
-  max-width: 110rem;
-  margin: 0 auto;
+    display: grid;
+    gap: clamp(2rem, 5vw, 4rem);
+    max-width: 110rem;
+    margin: 0 auto;
 }
 
 .home-concept-landing-hero {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  min-width: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
 }
 
 .home-concept-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.65rem;
-  width: fit-content;
-  margin-top: 2rem;
-  padding: 0.75rem 1.4rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
-  color: var(--button-bg);
-  font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    width: fit-content;
+    margin-top: 2rem;
+    padding: 0.75rem 1.4rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
+    color: var(--button-bg);
+    font-weight: 700;
 }
 
 .home-concept-start-row {
-  flex-wrap: wrap;
-  gap: 1.25rem;
-  margin-top: 2rem;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    margin-top: 2rem;
 }
 
 .home-concept-start-row .home-concept-action {
-  max-width: 22rem;
-  min-height: 5.4rem;
-  border-color: var(--border-color);
-  background: var(--bg-primary);
-  color: var(--text-primary);
+    max-width: 22rem;
+    min-height: 5.4rem;
+    border-color: var(--border-color);
+    background: var(--bg-primary);
+    color: var(--text-primary);
 }
 
-.home-concept-start-row .home-concept-action-primary {
-  color: #fff;
+.home-concept-start-row .home-concept-action.home-concept-action-primary {
+    border-color: var(--button-bg);
+    background: linear-gradient(135deg, #7b61ff, var(--button-bg));
+    color: #fff;
 }
 
 .home-concept-account-strip {
-  display: grid;
-  gap: 1rem;
-  align-items: center;
-  margin-top: 3rem;
-  padding-top: 2rem;
-  border-top: 1px solid var(--border-color);
+    display: grid;
+    gap: 1rem;
+    align-items: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border-color);
 }
 
 .home-concept-account-strip p,
@@ -1101,112 +1169,120 @@
 .home-concept-feature p,
 .home-concept-account-card > p,
 .home-concept-privacy {
-  margin: 0.35rem 0 0;
-  color: var(--text-secondary);
-  line-height: 1.55;
+    margin: 0.35rem 0 0;
+    color: var(--text-secondary);
+    line-height: 1.55;
 }
 
 .home-concept-quick-notes {
-  flex-wrap: wrap;
-  gap: 1.8rem;
-  margin-top: 2rem;
-  color: var(--text-secondary);
-  font-size: 0.92rem;
+    flex-wrap: wrap;
+    gap: 1.8rem;
+    margin-top: 2rem;
+    color: var(--text-secondary);
+    font-size: 0.92rem;
 }
 
 .home-concept-quick-notes span,
 .home-concept-privacy {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
 }
 
 .home-concept-quick-notes svg,
 .home-concept-privacy svg {
-  color: var(--button-bg);
+    color: var(--button-bg);
 }
 
 .home-concept-tool-rail {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  border-left: 1px solid var(--border-color);
-  padding-left: clamp(1.5rem, 4vw, 3rem);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    border-left: 1px solid var(--border-color);
+    padding-left: clamp(1.5rem, 4vw, 3rem);
 }
 
 .home-concept-feature-list,
 .home-concept-account-card {
-  display: flex;
-  flex-direction: column;
-  gap: 1.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.8rem;
 }
 
 .home-concept-feature-list h2,
 .home-concept-account-card h2 {
-  margin: 0;
-  font-size: 1.35rem;
-  color: var(--text-primary);
+    margin: 0;
+    font-size: 1.35rem;
+    color: var(--text-primary);
 }
 
 .home-concept-feature,
 .home-concept-benefit {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 1.2rem;
-  align-items: center;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 1.2rem;
+    align-items: center;
 }
 
 .home-concept-feature h3 {
-  margin: 0;
-  color: var(--text-primary);
-  font-size: 1rem;
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1rem;
 }
 
 .home-concept-account-card {
-  gap: 1.3rem;
-  padding: 1.6rem;
-  border-radius: 0.5rem;
-  background: color-mix(in srgb, var(--button-bg) 5%, var(--bg-secondary));
+    gap: 1.3rem;
+    padding: 1.6rem;
+    border-radius: 0.5rem;
+    background: color-mix(in srgb, var(--button-bg) 5%, var(--bg-secondary));
 }
 
 .home-concept-benefit {
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  padding-bottom: 1.3rem;
-  border-bottom: 1px solid var(--border-color);
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    padding-bottom: 1.3rem;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .home-concept-badge {
-  border-radius: 999px;
-  padding: 0.5rem 0.95rem;
-  background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
-  color: var(--button-bg);
-  font-size: 0.8rem;
-  font-weight: 700;
+    border-radius: 999px;
+    padding: 0.5rem 0.95rem;
+    background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
+    color: var(--button-bg);
+    font-size: 0.8rem;
+    font-weight: 700;
 }
 
 .dark-mode .home-concept-page {
-  background:
-    radial-gradient(circle at 16% 62%, rgba(82, 106, 135, 0.12), transparent 30rem),
-    radial-gradient(circle at 82% 16%, rgba(255, 255, 255, 0.035), transparent 24rem),
-    linear-gradient(180deg, #111214 0%, #171717 12rem, #181818 100%);
-  color: #f3f1ec;
-  --home-concept-surface: #1f1f1f;
-  --home-concept-surface-raised: #252422;
-  --home-concept-border: rgba(246, 241, 229, 0.12);
-  --home-concept-muted: #cbc6ba;
-  --home-concept-soft-muted: #948e82;
-  --home-concept-accent: #7f95ad;
-  --home-concept-accent-strong: #9fb2c8;
-  --home-concept-action-bg: #242424;
-  --home-concept-action-hover: #2d333b;
-  --home-concept-primary-bg: #2b3440;
-  --home-concept-primary-hover: #354151;
+    background:
+        radial-gradient(
+            circle at 16% 62%,
+            rgba(82, 106, 135, 0.12),
+            transparent 30rem
+        ),
+        radial-gradient(
+            circle at 82% 16%,
+            rgba(255, 255, 255, 0.035),
+            transparent 24rem
+        ),
+        linear-gradient(180deg, #111214 0%, #171717 12rem, #181818 100%);
+    color: #f3f1ec;
+    --home-concept-surface: #1f1f1f;
+    --home-concept-surface-raised: #252422;
+    --home-concept-border: rgba(246, 241, 229, 0.12);
+    --home-concept-muted: #cbc6ba;
+    --home-concept-soft-muted: #948e82;
+    --home-concept-accent: #7f95ad;
+    --home-concept-accent-strong: #9fb2c8;
+    --home-concept-action-bg: #242424;
+    --home-concept-action-hover: #2d333b;
+    --home-concept-primary-bg: #2b3440;
+    --home-concept-primary-hover: #354151;
 }
 
 .dark-mode .home-concept-cycle-bar {
-  border-bottom-color: var(--home-concept-border);
-  background: linear-gradient(180deg, #121212, #181818);
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03);
+    border-bottom-color: var(--home-concept-border);
+    background: linear-gradient(180deg, #121212, #181818);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .dark-mode .home-concept-cycle-meta h1,
@@ -1219,7 +1295,7 @@
 .dark-mode .home-concept-cycle-row,
 .dark-mode .home-concept-benefit strong,
 .dark-mode .home-concept-account-strip strong {
-  color: #f7f4ed;
+    color: #f7f4ed;
 }
 
 .dark-mode .home-concept-cycle-meta p,
@@ -1231,7 +1307,7 @@
 .dark-mode .home-concept-privacy svg,
 .dark-mode .home-concept-continue h2 svg,
 .dark-mode .home-concept-landing-hero h1 svg {
-  color: var(--home-concept-accent-strong);
+    color: var(--home-concept-accent-strong);
 }
 
 .dark-mode .home-concept-continue p,
@@ -1245,61 +1321,67 @@
 .dark-mode .home-concept-account-card > p,
 .dark-mode .home-concept-privacy,
 .dark-mode .home-concept-quick-notes {
-  color: var(--home-concept-muted);
+    color: var(--home-concept-muted);
 }
 
 .dark-mode .home-concept-icon-chip {
-  background: rgba(82, 106, 135, 0.18);
-  color: var(--home-concept-accent-strong);
-  box-shadow: inset 0 0 0 1px rgba(159, 178, 200, 0.15);
+    background: rgba(82, 106, 135, 0.18);
+    color: var(--home-concept-accent-strong);
+    box-shadow: inset 0 0 0 1px rgba(159, 178, 200, 0.15);
 }
 
 .dark-mode .home-concept-top-primary,
 .dark-mode .home-concept-action.home-concept-action-primary {
-  border-color: rgba(159, 178, 200, 0.28);
-  background: linear-gradient(180deg, var(--home-concept-primary-hover), var(--home-concept-primary-bg));
-  color: #edf3f8;
-  box-shadow: 0 0.9rem 2rem rgba(0, 0, 0, 0.2);
+    border-color: rgba(159, 178, 200, 0.28);
+    background: linear-gradient(
+        180deg,
+        var(--home-concept-primary-hover),
+        var(--home-concept-primary-bg)
+    );
+    color: #edf3f8;
+    box-shadow: 0 0.9rem 2rem rgba(0, 0, 0, 0.2);
 }
 
 .dark-mode .home-concept-top-primary:hover,
 .dark-mode .home-concept-action.home-concept-action-primary:hover {
-  border-color: rgba(159, 178, 200, 0.4);
-  background: linear-gradient(180deg, #3c4a5c, #303b49);
-  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.24);
+    border-color: rgba(159, 178, 200, 0.4);
+    background: linear-gradient(180deg, #3c4a5c, #303b49);
+    box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.24);
 }
 
 .dark-mode .home-concept-top-secondary {
-  border-color: rgba(246, 241, 229, 0.12);
-  background: var(--home-concept-action-bg);
-  color: #eee9df;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    border-color: rgba(246, 241, 229, 0.12);
+    background: var(--home-concept-action-bg);
+    color: #eee9df;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .dark-mode .home-concept-top-secondary:hover {
-  border-color: rgba(159, 178, 200, 0.24);
-  background: var(--home-concept-action-hover);
+    border-color: rgba(159, 178, 200, 0.24);
+    background: var(--home-concept-action-hover);
 }
 
 .dark-mode .home-concept-action {
-  border-color: rgba(246, 241, 229, 0.12);
-  background: var(--home-concept-action-bg);
-  color: #eee9df;
-  box-shadow: none;
+    border-color: rgba(246, 241, 229, 0.12);
+    background: var(--home-concept-action-bg);
+    color: #eee9df;
+    box-shadow: none;
 }
 
 .dark-mode .home-concept-action:not(.home-concept-action-primary):hover {
-  border-color: rgba(159, 178, 200, 0.22);
-  background: var(--home-concept-action-hover);
-  box-shadow: none;
+    border-color: rgba(159, 178, 200, 0.22);
+    background: var(--home-concept-action-hover);
+    box-shadow: none;
 }
 
-.dark-mode .home-concept-start-row .home-concept-action:not(.home-concept-action-primary),
+.dark-mode
+    .home-concept-start-row
+    .home-concept-action:not(.home-concept-action-primary),
 .dark-mode .home-concept-account-card {
-  border-color: var(--home-concept-border);
-  background: var(--home-concept-surface);
-  color: #f7f4ed;
-  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.16);
+    border-color: var(--home-concept-border);
+    background: var(--home-concept-surface);
+    color: #f7f4ed;
+    box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.16);
 }
 
 .dark-mode .home-concept-side-rail,
@@ -1307,159 +1389,180 @@
 .dark-mode .home-concept-recent,
 .dark-mode .home-concept-account-strip,
 .dark-mode .home-concept-benefit {
-  border-color: var(--home-concept-border);
+    border-color: var(--home-concept-border);
 }
 
 .dark-mode .home-concept-timeline::before {
-  background: var(--home-concept-border);
+    background: var(--home-concept-border);
 }
 
 .dark-mode .home-concept-dot {
-  border-color: var(--home-concept-soft-muted);
-  background: #191919;
+    border-color: var(--home-concept-soft-muted);
+    background: #191919;
 }
 
 .dark-mode .home-concept-dot.is-active {
-  border-color: var(--home-concept-accent-strong);
-  background: var(--home-concept-accent-strong);
-  box-shadow: inset 0 0 0 2px #191919;
+    border-color: var(--home-concept-accent-strong);
+    background: var(--home-concept-accent-strong);
+    box-shadow: inset 0 0 0 2px #191919;
 }
 
 .dark-mode .home-concept-cycle-row:hover {
-  color: #fff;
+    color: #fff;
 }
 
 .dark-mode .home-concept-link {
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
-  color: var(--home-concept-accent-strong);
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    color: var(--home-concept-accent-strong);
 }
 
 .dark-mode .home-concept-link:hover,
 .dark-mode .home-concept-link:focus-visible {
-  color: #f4f8fc;
-  background: transparent;
-  box-shadow: inset 0 -2px 0 rgba(159, 178, 200, 0.48);
+    color: #f4f8fc;
+    background: transparent;
+    box-shadow: inset 0 -2px 0 rgba(159, 178, 200, 0.48);
 }
 
 .dark-mode .home-concept-map-bg {
-  opacity: 0.2;
-  color: rgba(82, 106, 135, 0.16);
-  background-image: radial-gradient(rgba(82, 106, 135, 0.07) 0.8px, transparent 0.8px);
+    opacity: 0.2;
+    color: rgba(82, 106, 135, 0.16);
+    background-image: radial-gradient(
+        rgba(82, 106, 135, 0.07) 0.8px,
+        transparent 0.8px
+    );
 }
 
 .dark-mode .home-concept-badge {
-  background: rgba(82, 106, 135, 0.18);
-  color: #b8c7d8;
+    background: rgba(82, 106, 135, 0.18);
+    color: #b8c7d8;
 }
 
-.dark-mode .home-concept-page .home-concept-action:not(.home-concept-action-primary),
+.dark-mode
+    .home-concept-page
+    .home-concept-action:not(.home-concept-action-primary),
 .dark-mode .home-concept-page .home-concept-top-secondary {
-  border-color: rgba(246, 241, 229, 0.12);
-  background: #242424;
-  color: #eee9df;
-  box-shadow: none;
+    border-color: rgba(246, 241, 229, 0.12);
+    background: #242424;
+    color: #eee9df;
+    box-shadow: none;
 }
 
-.dark-mode .home-concept-page .home-concept-action:not(.home-concept-action-primary) svg,
+.dark-mode
+    .home-concept-page
+    .home-concept-action:not(.home-concept-action-primary)
+    svg,
 .dark-mode .home-concept-page .home-concept-top-secondary svg {
-  color: #d8d1c3;
+    color: #d8d1c3;
 }
 
-.dark-mode .home-concept-page .home-concept-action:not(.home-concept-action-primary):hover,
+.dark-mode
+    .home-concept-page
+    .home-concept-action:not(.home-concept-action-primary):hover,
 .dark-mode .home-concept-page .home-concept-top-secondary:hover {
-  border-color: rgba(159, 178, 200, 0.22);
-  background: #2d333b;
-  box-shadow: none;
+    border-color: rgba(159, 178, 200, 0.22);
+    background: #2d333b;
+    box-shadow: none;
 }
 
 .dark-mode .home-concept-page .home-concept-link {
-  width: fit-content;
-  color: #9fb2c8;
-  background: transparent;
-  box-shadow: inset 0 -1px 0 rgba(159, 178, 200, 0.35);
+    width: fit-content;
+    color: #9fb2c8;
+    background: transparent;
+    box-shadow: inset 0 -1px 0 rgba(159, 178, 200, 0.35);
 }
 
-body.dark-mode .home-concept-page button.home-concept-action:not(.home-concept-action-primary),
+body.dark-mode
+    .home-concept-page
+    button.home-concept-action:not(.home-concept-action-primary),
 body.dark-mode .home-concept-page button.home-concept-top-secondary {
-  border-color: rgba(246, 241, 229, 0.14) !important;
-  background: #242424 !important;
-  color: #eee9df !important;
-  box-shadow: none !important;
+    border-color: rgba(246, 241, 229, 0.14) !important;
+    background: #242424 !important;
+    color: #eee9df !important;
+    box-shadow: none !important;
 }
 
-body.dark-mode .home-concept-page button.home-concept-action:not(.home-concept-action-primary) *,
+body.dark-mode
+    .home-concept-page
+    button.home-concept-action:not(.home-concept-action-primary)
+    *,
 body.dark-mode .home-concept-page button.home-concept-top-secondary * {
-  color: #eee9df !important;
+    color: #eee9df !important;
 }
 
-body.dark-mode .home-concept-page button.home-concept-action:not(.home-concept-action-primary):hover,
-body.dark-mode .home-concept-page button.home-concept-action:not(.home-concept-action-primary):focus-visible,
+body.dark-mode
+    .home-concept-page
+    button.home-concept-action:not(.home-concept-action-primary):hover,
+body.dark-mode
+    .home-concept-page
+    button.home-concept-action:not(.home-concept-action-primary):focus-visible,
 body.dark-mode .home-concept-page button.home-concept-top-secondary:hover,
-body.dark-mode .home-concept-page button.home-concept-top-secondary:focus-visible {
-  border-color: rgba(159, 178, 200, 0.25) !important;
-  background: #2d333b !important;
-  color: #f4f8fc !important;
-  box-shadow: none !important;
+body.dark-mode
+    .home-concept-page
+    button.home-concept-top-secondary:focus-visible {
+    border-color: rgba(159, 178, 200, 0.25) !important;
+    background: #2d333b !important;
+    color: #f4f8fc !important;
+    box-shadow: none !important;
 }
 
 body.dark-mode .home-concept-page button.home-concept-link {
-  width: fit-content !important;
-  border: 0 !important;
-  border-radius: 0 !important;
-  background: transparent !important;
-  color: #9fb2c8 !important;
-  box-shadow: inset 0 -1px 0 rgba(159, 178, 200, 0.38) !important;
+    width: fit-content !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    color: #9fb2c8 !important;
+    box-shadow: inset 0 -1px 0 rgba(159, 178, 200, 0.38) !important;
 }
 
 body.dark-mode .home-concept-page button.home-concept-link * {
-  color: #9fb2c8 !important;
+    color: #9fb2c8 !important;
 }
 
 @media (max-width: 767px) {
-  .home-concept-cycle-actions,
-  .home-concept-start-row {
-    align-items: stretch;
-    flex-direction: column;
-  }
+    .home-concept-cycle-actions,
+    .home-concept-start-row {
+        align-items: stretch;
+        flex-direction: column;
+    }
 
-  .home-concept-top-primary,
-  .home-concept-top-secondary,
-  .home-concept-start-row .home-concept-action {
-    width: 100%;
-    max-width: none;
-  }
+    .home-concept-top-primary,
+    .home-concept-top-secondary,
+    .home-concept-start-row .home-concept-action {
+        width: 100%;
+        max-width: none;
+    }
 
-  .home-concept-side-rail,
-  .home-concept-tool-rail {
-    border-left: 0;
-    padding-left: 0;
-  }
+    .home-concept-side-rail,
+    .home-concept-tool-rail {
+        border-left: 0;
+        padding-left: 0;
+    }
 
-  .home-concept-glance div {
-    grid-template-columns: minmax(0, 1fr);
-  }
+    .home-concept-glance div {
+        grid-template-columns: minmax(0, 1fr);
+    }
 
-  .home-concept-glance dd {
-    text-align: left;
-  }
+    .home-concept-glance dd {
+        text-align: left;
+    }
 }
 
 @media (min-width: 900px) {
-  .home-concept-cycle-bar {
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
+    .home-concept-cycle-bar {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
 
-  .home-concept-signed-in-grid {
-    grid-template-columns: minmax(0, 1.6fr) minmax(22rem, 0.75fr);
-  }
+    .home-concept-signed-in-grid {
+        grid-template-columns: minmax(0, 1.6fr) minmax(22rem, 0.75fr);
+    }
 
-  .home-concept-landing-grid {
-    grid-template-columns: minmax(0, 1.45fr) minmax(22rem, 0.85fr);
-  }
+    .home-concept-landing-grid {
+        grid-template-columns: minmax(0, 1.45fr) minmax(22rem, 0.85fr);
+    }
 
-  .home-concept-account-strip {
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
+    .home-concept-account-strip {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+    }
 }


### PR DESCRIPTION
This pull request includes two main groups of changes: updates to the map export logic and its tests, and extensive formatting and design improvements to the `HomePage.css` stylesheet. The map export logic has been simplified to remove engine-specific checks and improve user feedback when the map is not loaded. The CSS changes focus on improving readability, consistency, and visual appearance, especially for gradients, transitions, and dark mode support.

**Map Export Logic and Tests:**

* Removed the `isMapEngineLeaflet` check and associated warning, so export is now only blocked if the map is not loaded, with a clearer error message shown to the user (`useExportMap.ts`, `useExportMap.test.tsx`). [[1]](diffhunk://#diff-e1fd611b643c2d7cb0f75523f2e453474706112951f1f6ff0448b1eb8ffce47dL42-L52) [[2]](diffhunk://#diff-e1fd611b643c2d7cb0f75523f2e453474706112951f1f6ff0448b1eb8ffce47dL73-L77) [[3]](diffhunk://#diff-5e4318bc73e56a1c710956e32e47627897b387c2aeabec64e6b408fa87a214bdL62-R67) [[4]](diffhunk://#diff-5e4318bc73e56a1c710956e32e47627897b387c2aeabec64e6b408fa87a214bdL175-R172)

**Home Page CSS Formatting and Design:**

* Reformatted multi-line gradients, transitions, and color-mix usages for improved readability and maintainability throughout `HomePage.css` (affecting buttons, cards, backgrounds, etc.). [[1]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L49-R54) [[2]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L308-R317) [[3]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L359-R378) [[4]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L377-R395) [[5]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L395-R417) [[6]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L416-R473) [[7]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L567-R616) [[8]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L666-R724) [[9]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L686-R746) [[10]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L790-R863) [[11]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L895-R963) [[12]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1086-R1154) [[13]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1189-R1266) [[14]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1260-R1340) [[15]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1297-R1379) [[16]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1349-R1462) [[17]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1384-R1503)
* Updated primary button and action styles for both light and dark modes, including color, gradients, and shadows for a more modern appearance (`HomePage.css`). [[1]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L790-R863) [[2]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L895-R963) [[3]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1086-R1154) [[4]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1260-R1340)
* Improved dark mode support by refining background gradients, button colors, and border styles for better contrast and consistency (`HomePage.css`). [[1]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1189-R1266) [[2]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1260-R1340) [[3]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1297-R1379) [[4]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1349-R1462) [[5]](diffhunk://#diff-8bafed9e4bd3d9bd054bd31d435f1b2bb651e95630f10b1675df0e64efc7caa2L1384-R1503)