### PR TITLE
fix: Safari IndexedDB disconnect after macOS sleep (v1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.6
+
+### Fixed
+- **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
+
 ## v1.5.1
 
 ### Fixed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import 'leaflet/dist/leaflet.css';
 import { isAnyOutlookEnabled, getFirstEnabledOutlookType } from './utils/featureFlagsUtils';
 
 import { useAutoSave } from './hooks/useAutoSave';
+import { useFirestoreSleepRecovery } from './hooks/useFirestoreSleepRecovery';
 import { useCycleHistoryPersistence } from './utils/cycleHistoryPersistence';
 import { AuthProvider } from './auth/AuthProvider';
 import { EntitlementProvider } from './billing/EntitlementProvider';
@@ -61,7 +62,10 @@ const AppHooks = () => {
   
   // Enable Auto-Save
   useAutoSave();
-  
+
+  // Pause Firestore while the tab sleeps (Safari IndexedDB recovery)
+  useFirestoreSleepRecovery();
+
   // Load cycle history from localStorage
   useCycleHistoryPersistence();
 

--- a/src/hooks/useFirestoreSleepRecovery.test.tsx
+++ b/src/hooks/useFirestoreSleepRecovery.test.tsx
@@ -7,24 +7,30 @@ jest.mock('firebase/firestore', () => ({
   enableNetwork: jest.fn(() => Promise.resolve()),
 }));
 
+let mockDb: { name: string } | null = { name: 'mock-db' };
+
 jest.mock('../lib/firebase', () => ({
-  db: { name: 'mock-db' },
+  get db() {
+    return mockDb;
+  },
 }));
 
 describe('useFirestoreSleepRecovery', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDb = { name: 'mock-db' };
     Object.defineProperty(document, 'hidden', { configurable: true, value: false });
   });
 
   it('disables Firestore network when the tab is hidden', () => {
     renderHook(() => useFirestoreSleepRecovery());
 
+    expect(enableNetwork).toHaveBeenCalledWith({ name: 'mock-db' });
+
     Object.defineProperty(document, 'hidden', { configurable: true, value: true });
     document.dispatchEvent(new Event('visibilitychange'));
 
     expect(disableNetwork).toHaveBeenCalledWith({ name: 'mock-db' });
-    expect(enableNetwork).not.toHaveBeenCalled();
   });
 
   it('re-enables Firestore network when the tab becomes visible', () => {
@@ -35,6 +41,28 @@ describe('useFirestoreSleepRecovery', () => {
     Object.defineProperty(document, 'hidden', { configurable: true, value: false });
     document.dispatchEvent(new Event('visibilitychange'));
 
+    expect(disableNetwork).toHaveBeenCalledWith({ name: 'mock-db' });
     expect(enableNetwork).toHaveBeenCalledWith({ name: 'mock-db' });
+  });
+
+  it('disables Firestore network on mount when the tab is already hidden', () => {
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+
+    renderHook(() => useFirestoreSleepRecovery());
+
+    expect(disableNetwork).toHaveBeenCalledWith({ name: 'mock-db' });
+    expect(enableNetwork).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when Firestore is not configured', () => {
+    mockDb = null;
+
+    renderHook(() => useFirestoreSleepRecovery());
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(disableNetwork).not.toHaveBeenCalled();
+    expect(enableNetwork).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useFirestoreSleepRecovery.test.tsx
+++ b/src/hooks/useFirestoreSleepRecovery.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { disableNetwork, enableNetwork } from 'firebase/firestore';
+import { useFirestoreSleepRecovery } from './useFirestoreSleepRecovery';
 
 jest.mock('firebase/firestore', () => ({
   disableNetwork: jest.fn(() => Promise.resolve()),
@@ -17,7 +18,6 @@ describe('useFirestoreSleepRecovery', () => {
   });
 
   it('disables Firestore network when the tab is hidden', () => {
-    const { useFirestoreSleepRecovery } = require('./useFirestoreSleepRecovery');
     renderHook(() => useFirestoreSleepRecovery());
 
     Object.defineProperty(document, 'hidden', { configurable: true, value: true });
@@ -28,7 +28,6 @@ describe('useFirestoreSleepRecovery', () => {
   });
 
   it('re-enables Firestore network when the tab becomes visible', () => {
-    const { useFirestoreSleepRecovery } = require('./useFirestoreSleepRecovery');
     renderHook(() => useFirestoreSleepRecovery());
 
     Object.defineProperty(document, 'hidden', { configurable: true, value: true });

--- a/src/hooks/useFirestoreSleepRecovery.test.tsx
+++ b/src/hooks/useFirestoreSleepRecovery.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react';
+import { disableNetwork, enableNetwork } from 'firebase/firestore';
+
+jest.mock('firebase/firestore', () => ({
+  disableNetwork: jest.fn(() => Promise.resolve()),
+  enableNetwork: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../lib/firebase', () => ({
+  db: { name: 'mock-db' },
+}));
+
+describe('useFirestoreSleepRecovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+  });
+
+  it('disables Firestore network when the tab is hidden', () => {
+    const { useFirestoreSleepRecovery } = require('./useFirestoreSleepRecovery');
+    renderHook(() => useFirestoreSleepRecovery());
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(disableNetwork).toHaveBeenCalledWith({ name: 'mock-db' });
+    expect(enableNetwork).not.toHaveBeenCalled();
+  });
+
+  it('re-enables Firestore network when the tab becomes visible', () => {
+    const { useFirestoreSleepRecovery } = require('./useFirestoreSleepRecovery');
+    renderHook(() => useFirestoreSleepRecovery());
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(enableNetwork).toHaveBeenCalledWith({ name: 'mock-db' });
+  });
+});

--- a/src/hooks/useFirestoreSleepRecovery.ts
+++ b/src/hooks/useFirestoreSleepRecovery.ts
@@ -14,20 +14,19 @@ export function useFirestoreSleepRecovery(): void {
 
     const firestore = db;
 
-    const handleVisibilityChange = () => {
+    /** Pauses or resumes Firestore sync when the document visibility changes. */
+    const handleVisibilityChange = (): void => {
       if (document.hidden) {
-        void disableNetwork(firestore).catch(() => {
-          // Best-effort: tab may already be tearing down storage.
-        });
+        disableNetwork(firestore).catch(() => undefined);
         return;
       }
 
-      void enableNetwork(firestore).catch(() => {
-        // Best-effort: network may recover on the next user action.
-      });
+      enableNetwork(firestore).catch(() => undefined);
     };
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, []);
 }

--- a/src/hooks/useFirestoreSleepRecovery.ts
+++ b/src/hooks/useFirestoreSleepRecovery.ts
@@ -14,8 +14,8 @@ export function useFirestoreSleepRecovery(): void {
 
     const firestore = db;
 
-    /** Pauses or resumes Firestore sync when the document visibility changes. */
-    const handleVisibilityChange = (): void => {
+    /** Pauses or resumes Firestore sync to match current tab visibility. */
+    const syncFirestoreNetworkToVisibility = (): void => {
       if (document.hidden) {
         disableNetwork(firestore).catch(() => undefined);
         return;
@@ -24,9 +24,10 @@ export function useFirestoreSleepRecovery(): void {
       enableNetwork(firestore).catch(() => undefined);
     };
 
-    document.addEventListener('visibilitychange', handleVisibilityChange);
+    syncFirestoreNetworkToVisibility();
+    document.addEventListener('visibilitychange', syncFirestoreNetworkToVisibility);
     return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      document.removeEventListener('visibilitychange', syncFirestoreNetworkToVisibility);
     };
   }, []);
 }

--- a/src/hooks/useFirestoreSleepRecovery.ts
+++ b/src/hooks/useFirestoreSleepRecovery.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { disableNetwork, enableNetwork } from 'firebase/firestore';
+import { db } from '../lib/firebase';
+
+/**
+ * Pauses Firestore network I/O while the tab is hidden (sleep/background).
+ * Reduces wake-from-sleep failures when WebKit restarts the IndexedDB server.
+ */
+export function useFirestoreSleepRecovery(): void {
+  useEffect(() => {
+    if (!db) {
+      return;
+    }
+
+    const firestore = db;
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        void disableNetwork(firestore).catch(() => {
+          // Best-effort: tab may already be tearing down storage.
+        });
+        return;
+      }
+
+      void enableNetwork(firestore).catch(() => {
+        // Best-effort: network may recover on the next user action.
+      });
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, []);
+}

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -26,12 +26,17 @@ describe('firebase configuration', () => {
     const getApps = jest.fn(() => []);
     const getAuth = jest.fn(() => ({ name: 'auth' }));
     const initializeFirestore = jest.fn(() => ({ name: 'db' }));
+    const getFirestore = jest.fn(() => ({ name: 'should-not-call' }));
     const memoryLocalCache = jest.fn(() => ({ kind: 'memory' }));
     const GoogleAuthProvider = jest.fn();
 
     jest.doMock('firebase/app', () => ({ initializeApp, getApp, getApps }));
     jest.doMock('firebase/auth', () => ({ getAuth, GoogleAuthProvider }));
-    jest.doMock('firebase/firestore', () => ({ initializeFirestore, memoryLocalCache }));
+    jest.doMock('firebase/firestore', () => ({
+      initializeFirestore,
+      getFirestore,
+      memoryLocalCache,
+    }));
 
     globalThis.__GFC_FIREBASE_API_KEY__ = 'api';
     globalThis.__GFC_FIREBASE_AUTH_DOMAIN__ = 'auth';
@@ -57,6 +62,45 @@ describe('firebase configuration', () => {
       expect(firebase.requireAuth()).toEqual({ name: 'auth' });
       expect(firebase.requireDb()).toEqual({ name: 'db' });
       expect(GoogleAuthProvider).toHaveBeenCalledTimes(1);
+      expect(getFirestore).not.toHaveBeenCalled();
+    });
+  });
+
+  test('reuses existing Firestore when initializeFirestore was already called', async () => {
+    const initializeApp = jest.fn(() => ({ name: 'app' }));
+    const getApp = jest.fn(() => ({ name: 'existing' }));
+    const getApps = jest.fn(() => [{ name: 'existing' }]);
+    const getAuth = jest.fn(() => ({ name: 'auth' }));
+    const initializeFirestore = jest.fn(() => {
+      throw new Error('Firestore has already been initialized');
+    });
+    const getFirestore = jest.fn(() => ({ name: 'existing-db' }));
+    const memoryLocalCache = jest.fn(() => ({ kind: 'memory' }));
+    const GoogleAuthProvider = jest.fn();
+
+    jest.doMock('firebase/app', () => ({ initializeApp, getApp, getApps }));
+    jest.doMock('firebase/auth', () => ({ getAuth, GoogleAuthProvider }));
+    jest.doMock('firebase/firestore', () => ({
+      initializeFirestore,
+      getFirestore,
+      memoryLocalCache,
+    }));
+
+    globalThis.__GFC_FIREBASE_API_KEY__ = 'api';
+    globalThis.__GFC_FIREBASE_AUTH_DOMAIN__ = 'auth';
+    globalThis.__GFC_FIREBASE_PROJECT_ID__ = 'project';
+    globalThis.__GFC_FIREBASE_APP_ID__ = 'app-id';
+
+    await jest.isolateModulesAsync(async () => {
+      const firebase = await import('./firebase');
+
+      expect(initializeFirestore).toHaveBeenCalledWith(
+        { name: 'existing' },
+        { localCache: { kind: 'memory' } }
+      );
+      expect(getFirestore).toHaveBeenCalledWith({ name: 'existing' });
+      expect(firebase.db).toEqual({ name: 'existing-db' });
+      expect(initializeApp).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -25,12 +25,13 @@ describe('firebase configuration', () => {
     const getApp = jest.fn(() => ({ name: 'existing' }));
     const getApps = jest.fn(() => []);
     const getAuth = jest.fn(() => ({ name: 'auth' }));
-    const getFirestore = jest.fn(() => ({ name: 'db' }));
+    const initializeFirestore = jest.fn(() => ({ name: 'db' }));
+    const memoryLocalCache = jest.fn(() => ({ kind: 'memory' }));
     const GoogleAuthProvider = jest.fn();
 
     jest.doMock('firebase/app', () => ({ initializeApp, getApp, getApps }));
     jest.doMock('firebase/auth', () => ({ getAuth, GoogleAuthProvider }));
-    jest.doMock('firebase/firestore', () => ({ getFirestore }));
+    jest.doMock('firebase/firestore', () => ({ initializeFirestore, memoryLocalCache }));
 
     globalThis.__GFC_FIREBASE_API_KEY__ = 'api';
     globalThis.__GFC_FIREBASE_AUTH_DOMAIN__ = 'auth';
@@ -48,7 +49,11 @@ describe('firebase configuration', () => {
         appId: 'app-id',
       });
       expect(getAuth).toHaveBeenCalledWith({ name: 'app' });
-      expect(getFirestore).toHaveBeenCalledWith({ name: 'app' });
+      expect(memoryLocalCache).toHaveBeenCalledTimes(1);
+      expect(initializeFirestore).toHaveBeenCalledWith(
+        { name: 'app' },
+        { localCache: { kind: 'memory' } }
+      );
       expect(firebase.requireAuth()).toEqual({ name: 'auth' });
       expect(firebase.requireDb()).toEqual({ name: 'db' });
       expect(GoogleAuthProvider).toHaveBeenCalledTimes(1);

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider, type Auth } from 'firebase/auth';
-import { getFirestore, type Firestore } from 'firebase/firestore';
+import { initializeFirestore, memoryLocalCache, type Firestore } from 'firebase/firestore';
 
 interface FirebaseClientConfig {
   apiKey: string;
@@ -26,7 +26,9 @@ let firestoreDb: Firestore | null = null;
 if (isHostedAuthEnabled) {
   firebaseApp = getApps().length > 0 ? getApp() : initializeApp(firebaseClientConfig);
   firebaseAuth = getAuth(firebaseApp);
-  firestoreDb = getFirestore(firebaseApp);
+  // Memory cache avoids Firestore's default IndexedDB persistence, which Safari can
+  // invalidate after sleep ("Connection to Indexed Database server lost").
+  firestoreDb = initializeFirestore(firebaseApp, { localCache: memoryLocalCache() });
 }
 
 export const app = firebaseApp;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,11 @@
 import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider, type Auth } from 'firebase/auth';
-import { initializeFirestore, memoryLocalCache, type Firestore } from 'firebase/firestore';
+import {
+  getFirestore,
+  initializeFirestore,
+  memoryLocalCache,
+  type Firestore,
+} from 'firebase/firestore';
 
 interface FirebaseClientConfig {
   apiKey: string;
@@ -23,12 +28,19 @@ let firebaseApp: FirebaseApp | null = null;
 let firebaseAuth: Auth | null = null;
 let firestoreDb: Firestore | null = null;
 
+/** Memory cache avoids IndexedDB persistence that Safari can invalidate after sleep. */
+function getOrInitFirestore(app: FirebaseApp): Firestore {
+  try {
+    return initializeFirestore(app, { localCache: memoryLocalCache() });
+  } catch {
+    return getFirestore(app);
+  }
+}
+
 if (isHostedAuthEnabled) {
   firebaseApp = getApps().length > 0 ? getApp() : initializeApp(firebaseClientConfig);
   firebaseAuth = getAuth(firebaseApp);
-  // Memory cache avoids Firestore's default IndexedDB persistence, which Safari can
-  // invalidate after sleep ("Connection to Indexed Database server lost").
-  firestoreDb = initializeFirestore(firebaseApp, { localCache: memoryLocalCache() });
+  firestoreDb = getOrInitFirestore(firebaseApp);
 }
 
 export const app = firebaseApp;


### PR DESCRIPTION
## Summary

- Switch hosted Firestore to memoryLocalCache so Safari/macOS sleep no longer trips WebKit IndexedDB server disconnect (Sentry GFC-WEB-2).
- Pause Firestore network sync while the tab is hidden and resume on wake via useFirestoreSleepRecovery.
- Document the fix under v1.6 in CHANGELOG.

## Test plan

- [ ] pnpm test -- --runTestsByPath src/lib/firebase.test.ts src/hooks/useFirestoreSleepRecovery.test.tsx
- [ ] On Safari/macOS: leave /forecast open overnight; confirm no new GFC-WEB-2 events after v1.6 deploy
- [ ] Smoke hosted flows (sign-in, entitlements, cloud library) still work online after tab background/foreground

Made with [Cursor](https://cursor.com)