### PR TITLE
fix(sentry): align production monitoring with privacy policy

### DIFF
--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -34,7 +34,14 @@ jobs:
 
       - name: Read app version
         id: app_version
-        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          VERSION=${VERSION//$'\n'/}
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid package version format: $VERSION" >&2
+            exit 1
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -34,14 +34,7 @@ jobs:
 
       - name: Read app version
         id: app_version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          VERSION=${VERSION//$'\n'/}
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
-            echo "Invalid package version format: $VERSION" >&2
-            exit 1
-          fi
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: pnpm run build
@@ -103,6 +96,7 @@ jobs:
           FIREBASE_ADMIN_CLIENT_EMAIL=${{ secrets.FIREBASE_ADMIN_CLIENT_EMAIL }}
           FIREBASE_ADMIN_PRIVATE_KEY=${{ secrets.FIREBASE_ADMIN_PRIVATE_KEY }}
           SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+          SENTRY_BROWSER_DSN=${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_ENVIRONMENT=production
           SENTRY_RELEASE=graphical-forecast-creator@${{ steps.app_version.outputs.value }}
           EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.5.3
+
+### Discord announcement (draft)
+
+Copy/paste starting point — edit tone and channels as you like.
+
+---
+
+**GFC v1.5.3 is live** (production + beta)
+
+We shipped a **privacy-focused update** to how the hosted app handles error monitoring, plus an updated Privacy Policy.
+
+**What you will notice**
+- You may be asked to **accept the updated Privacy Policy (v1.2.0)** the next time you open GFC on gfc.weatherboysuper.com or beta-gfc.weatherboysuper.com.
+- No change to how you draw outlooks, save cycles, or use cloud features — this is infrastructure and disclosure, not a forecast-editor feature release.
+
+**What changed behind the scenes**
+- **Error monitoring (Sentry)** is enabled on hosted production and beta so we can fix crashes faster.
+- **Session replay is off** — we are not recording screen replays of your session.
+- **No IP/cookies in error reports by default** — monitoring is tuned for bug diagnosis, not ad-style tracking.
+- **Forecast map data is not attached** to error breadcrumbs (action names only for forecast edits).
+- Browser errors go through our **server tunnel** so ad blockers are less likely to block crash reports (helps us fix issues you hit).
+
+**Why we did this**
+- Catch production bugs we cannot reproduce locally.
+- Stay aligned with what the Privacy Policy says we collect.
+
+Questions → alex@weatherboysuper.com
+
+---
+
+### Changed
+- **Privacy policy v1.2.0:** Added a clear disclosure for hosted error monitoring (Sentry): what is collected, what is not (no session replay, no default IP/cookie payloads, forecast contents not sent in breadcrumbs), and separate production vs beta environments.
+- **In-app privacy modal:** Bumped to v1.2.0 with the same Sentry disclosure; users who accepted an older policy version will be prompted to accept again on next visit.
+- **Hosted error monitoring (Sentry):** Production and beta now use the same privacy-safe SDK settings — `sendDefaultPii: false`, session replay disabled, browser SDK routed through `/api/sentry-tunnel`, and server tunnel validation against the web project DSN (`SENTRY_BROWSER_DSN`).
+- **Analytics server:** Node Sentry init uses `sendDefaultPii: false`; deploy workflows set `SENTRY_BROWSER_DSN` from the web DSN secret so the tunnel accepts browser envelopes in the recommended two-project setup.
+- **Version:** Bumped package version to `1.5.3`.
+
+### Fixed
+- **Sentry tunnel security:** Removed client-controlled ingest URLs and query-string forwarding; malformed envelope bodies return 400 instead of 500.
+
 ## v1.5.2
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,35 +5,6 @@ All notable changes to this project will be documented in this file.
 
 ## v1.5.3
 
-### Discord announcement (draft)
-
-Copy/paste starting point — edit tone and channels as you like.
-
----
-
-**GFC v1.5.3 is live** (production + beta)
-
-We shipped a **privacy-focused update** to how the hosted app handles error monitoring, plus an updated Privacy Policy.
-
-**What you will notice**
-- You may be asked to **accept the updated Privacy Policy (v1.2.0)** the next time you open GFC on gfc.weatherboysuper.com or beta-gfc.weatherboysuper.com.
-- No change to how you draw outlooks, save cycles, or use cloud features — this is infrastructure and disclosure, not a forecast-editor feature release.
-
-**What changed behind the scenes**
-- **Error monitoring (Sentry)** is enabled on hosted production and beta so we can fix crashes faster.
-- **Session replay is off** — we are not recording screen replays of your session.
-- **No IP/cookies in error reports by default** — monitoring is tuned for bug diagnosis, not ad-style tracking.
-- **Forecast map data is not attached** to error breadcrumbs (action names only for forecast edits).
-- Browser errors go through our **server tunnel** so ad blockers are less likely to block crash reports (helps us fix issues you hit).
-
-**Why we did this**
-- Catch production bugs we cannot reproduce locally.
-- Stay aligned with what the Privacy Policy says we collect.
-
-Questions → alex@weatherboysuper.com
-
----
-
 ### Changed
 - **Privacy policy v1.2.0:** Added a clear disclosure for hosted error monitoring (Sentry): what is collected, what is not (no session replay, no default IP/cookie payloads, forecast contents not sent in breadcrumbs), and separate production vs beta environments.
 - **In-app privacy modal:** Bumped to v1.2.0 with the same Sentry disclosure; users who accepted an older policy version will be prompted to accept again on next visit.

--- a/README.md
+++ b/README.md
@@ -118,17 +118,19 @@ Run the app with beta-only features locally (useful for testing forecast redesig
 
 - To enable hosted auth locally, provide Firebase web config via env vars: VITE_FIREBASE_API_KEY, VITE_FIREBASE_AUTH_DOMAIN, VITE_FIREBASE_PROJECT_ID, VITE_FIREBASE_APP_ID and restart the dev server.
 
-### Production monitoring (Sentry, main only)
+### Hosted error monitoring (Sentry)
 
-Sentry is wired for **production** (`main` branch deploys to gfc.weatherboysuper.com). Beta and local dev builds omit the DSN and stay inert.
+Sentry is enabled on **production** (`main` → gfc.weatherboysuper.com) and **beta** (`beta` → beta-gfc.weatherboysuper.com) when deploy secrets provide a DSN. Local dev builds without `VITE_SENTRY_DSN` stay inert. Events are separated in Sentry by environment (`production` vs `beta`).
 
-Production web monitoring includes:
+Hosted monitoring includes:
 
 - Error monitoring (React 19 `reactErrorHandler` + unhandled errors)
-- Performance tracing (React Router v7 navigation)
-- Session Replay (10% of sessions; 100% when an error occurs; text masked, media blocked)
+- Performance tracing (React Router v7 navigation, 10% sample)
 - Redux action breadcrumbs (forecast map payloads stripped from breadcrumbs)
 - Structured logs (`Sentry.logger.*`)
+- Server-side errors on the analytics API (`@sentry/node`)
+
+Session replay is **disabled**. `sendDefaultPii` is **false** (no IP/cookies in error payloads by default).
 
 Create two Sentry projects (recommended):
 
@@ -144,6 +146,8 @@ Add these GitHub Actions secrets (repo → Settings → Secrets and variables �
 | `SENTRY_AUTH_TOKEN` | Upload source maps during the main deploy build (use a Sentry **Organization Auth Token**; `org:ci` scope is correct and fixed) |
 | `SENTRY_ORG` | Your Sentry organization slug |
 | `SENTRY_PROJECT` | Web project slug (source maps) — not the API project |
+
+Deploy workflows copy `VITE_SENTRY_DSN` to `SENTRY_BROWSER_DSN` on the analytics VPS so `/api/sentry-tunnel` validates browser envelopes against the web project.
 
 After the next `main` deploy, verify in Sentry with a test error from the browser console on production (not from DevTools while paused — use a one-off button or `throw new Error('Sentry test')` in the console on the live site).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphical-forecast-creator",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"

--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -28,6 +28,8 @@ We also generate a browser-scoped anonymous installation identifier to help esti
 
 Separately from product metrics, the hosted service may keep short operational request logs such as page path, referrer, timestamp, and user-agent for maintenance and debugging. These logs are not used to inspect forecast contents and are kept separate from the product metrics dashboard.
 
+On production and beta hosted deployments, we use Sentry (a third-party error monitoring service) to capture application errors and limited performance data so we can fix bugs quickly. This is separate from product analytics above. We do not use Sentry for advertising or the sale of personal data. Error reports are designed to exclude forecast map payloads, do not use session replay, and are configured without sending IP addresses or cookies by default. Events are tagged by environment (production or beta) so staging issues stay separate from production.
+
 **6. Data Retention & Deletion**
 You own your data. You have the right to delete your account and associated cloud data at any time. Upon account deletion, your cloud-hosted cycles, profile data, synced settings, and user-linked progress metrics will be permanently removed from our Firebase servers. Your local, offline saves will remain completely untouched on your device.
 

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -46,11 +46,6 @@ function buildEnvelopeUrl(host, projectId) {
   return `https://${host}/api/${projectId}/envelope/`;
 }
 
-/** @returns {boolean} Whether the DSN host is a known Sentry ingest endpoint. */
-function isAllowedSentryHost(hostname) {
-  return SENTRY_DSN_PATTERN.test(`https://${hostname}/0`);
-}
-
 /** @returns {{ host: string, projectId: string } | null} Browser-facing Sentry ingest target for the tunnel. */
 function getConfiguredSentryEndpoint() {
   const browserDsn = process.env.SENTRY_BROWSER_DSN || process.env.SENTRY_DSN || '';
@@ -127,7 +122,6 @@ module.exports = {
   registerSentryTunnelRoutes,
   parseAllowedSentryEndpoint,
   parseSentryDsnString,
-  isAllowedSentryHost,
   buildEnvelopeUrl,
   getConfiguredSentryEndpoint,
 };

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -1,35 +1,86 @@
 'use strict';
 
-const SENTRY_INGEST_HOST_PATTERN = /^o\d+\.ingest(\.[a-z]{2})?\.sentry\.io$/i;
+const SENTRY_DSN_PATTERN =
+  /^https:\/\/(?:[^@/]+@)?(o\d+\.ingest(?:\.[a-z]{2})?\.sentry\.io)\/(\d+)\/?$/iu;
 
-/** @returns {URL | null} DSN parsed from the first envelope header line. */
-function parseEnvelopeDsn(envelopeBody) {
+/** @returns {{ host: string, projectId: string } | null} Parsed ingest target from a Sentry DSN string. */
+function parseSentryDsnString(dsnString) {
+  if (!dsnString || typeof dsnString !== 'string') {
+    return null;
+  }
+
+  const match = dsnString.trim().match(SENTRY_DSN_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    host: match[1],
+    projectId: match[2],
+  };
+}
+
+/** @returns {{ host: string, projectId: string } | null} Parsed Sentry ingest target from an envelope header DSN. */
+function parseAllowedSentryEndpoint(envelopeBody) {
   const firstLine = envelopeBody.toString('utf8').split('\n').find((line) => line.trim());
   if (!firstLine) {
     return null;
   }
 
-  const header = JSON.parse(firstLine);
+  let header;
+  try {
+    header = JSON.parse(firstLine);
+  } catch {
+    return null;
+  }
+
   if (!header?.dsn || typeof header.dsn !== 'string') {
     return null;
   }
 
-  return new URL(header.dsn);
+  return parseSentryDsnString(header.dsn);
+}
+
+/** @returns {string} Upstream envelope URL for a validated Sentry host and project id. */
+function buildEnvelopeUrl(host, projectId) {
+  return `https://${host}/api/${projectId}/envelope/`;
 }
 
 /** @returns {boolean} Whether the DSN host is a known Sentry ingest endpoint. */
 function isAllowedSentryHost(hostname) {
-  return SENTRY_INGEST_HOST_PATTERN.test(hostname);
+  return SENTRY_DSN_PATTERN.test(`https://${hostname}/0`);
 }
 
-/** @returns {string} Upstream envelope URL for a validated Sentry DSN. */
-function buildEnvelopeUrl(dsn) {
-  const projectId = dsn.pathname.replace(/^\//, '');
-  return `https://${dsn.host}/api/${projectId}/envelope/`;
+/** @returns {{ host: string, projectId: string } | null} Browser-facing Sentry ingest target for the tunnel. */
+function getConfiguredSentryEndpoint() {
+  const browserDsn = process.env.SENTRY_BROWSER_DSN || process.env.SENTRY_DSN || '';
+  return parseSentryDsnString(browserDsn);
+}
+
+/** @returns {boolean} Whether the client envelope targets the same Sentry project as the server. */
+function clientEndpointMatchesConfigured(clientEndpoint, configuredEndpoint) {
+  if (!clientEndpoint) {
+    return false;
+  }
+
+  return (
+    clientEndpoint.host === configuredEndpoint.host &&
+    clientEndpoint.projectId === configuredEndpoint.projectId
+  );
 }
 
 /** Registers POST /api/sentry-tunnel to proxy browser envelopes past ad blockers. */
 function registerSentryTunnelRoutes(app, express, rateLimit) {
+  const configuredEndpoint = getConfiguredSentryEndpoint();
+  if (!configuredEndpoint) {
+    console.warn(
+      '[analytics] sentry tunnel disabled: SENTRY_BROWSER_DSN (or SENTRY_DSN) is missing or invalid'
+    );
+    return;
+  }
+
+  const targetUrl = buildEnvelopeUrl(configuredEndpoint.host, configuredEndpoint.projectId);
+
   const tunnelRateLimit = rateLimit({
     windowMs: 60 * 1000,
     max: 120,
@@ -49,14 +100,11 @@ function registerSentryTunnelRoutes(app, express, rateLimit) {
           return;
         }
 
-        const dsn = parseEnvelopeDsn(envelopeBody);
-        if (!dsn || !isAllowedSentryHost(dsn.hostname)) {
+        const clientEndpoint = parseAllowedSentryEndpoint(envelopeBody);
+        if (!clientEndpointMatchesConfigured(clientEndpoint, configuredEndpoint)) {
           res.status(400).end();
           return;
         }
-
-        const query = new URLSearchParams(req.query).toString();
-        const targetUrl = query ? `${buildEnvelopeUrl(dsn)}?${query}` : buildEnvelopeUrl(dsn);
 
         const upstream = await fetch(targetUrl, {
           method: 'POST',
@@ -77,7 +125,9 @@ function registerSentryTunnelRoutes(app, express, rateLimit) {
 
 module.exports = {
   registerSentryTunnelRoutes,
-  parseEnvelopeDsn,
+  parseAllowedSentryEndpoint,
+  parseSentryDsnString,
   isAllowedSentryHost,
   buildEnvelopeUrl,
+  getConfiguredSentryEndpoint,
 };

--- a/server/sentry-tunnel.test.js
+++ b/server/sentry-tunnel.test.js
@@ -1,15 +1,62 @@
 'use strict';
 
-const { parseEnvelopeDsn, isAllowedSentryHost, buildEnvelopeUrl } = require('./sentry-tunnel');
+const {
+  parseAllowedSentryEndpoint,
+  parseSentryDsnString,
+  isAllowedSentryHost,
+  buildEnvelopeUrl,
+  getConfiguredSentryEndpoint,
+} = require('./sentry-tunnel');
 
 describe('sentry-tunnel helpers', () => {
   it('parses DSN from an envelope header', () => {
     const body = Buffer.from(
       `${JSON.stringify({ dsn: 'https://key@o123.ingest.us.sentry.io/456' })}\n{"type":"session"}`
     );
-    const dsn = parseEnvelopeDsn(body);
-    expect(dsn?.hostname).toBe('o123.ingest.us.sentry.io');
-    expect(buildEnvelopeUrl(dsn)).toBe('https://o123.ingest.us.sentry.io/api/456/envelope/');
+    const endpoint = parseAllowedSentryEndpoint(body);
+    expect(endpoint).toEqual({ host: 'o123.ingest.us.sentry.io', projectId: '456' });
+    expect(buildEnvelopeUrl(endpoint.host, endpoint.projectId)).toBe(
+      'https://o123.ingest.us.sentry.io/api/456/envelope/'
+    );
+  });
+
+  it('parses configured DSN strings', () => {
+    expect(parseSentryDsnString('https://key@o123.ingest.us.sentry.io/456')).toEqual({
+      host: 'o123.ingest.us.sentry.io',
+      projectId: '456',
+    });
+  });
+
+  it('returns null for non-JSON envelope headers', () => {
+    const body = Buffer.from('not-json\n{}');
+    expect(parseAllowedSentryEndpoint(body)).toBeNull();
+  });
+
+  it('prefers SENTRY_BROWSER_DSN over SENTRY_DSN for tunnel validation', () => {
+    const previousBrowser = process.env.SENTRY_BROWSER_DSN;
+    const previousServer = process.env.SENTRY_DSN;
+    process.env.SENTRY_BROWSER_DSN = 'https://key@o111.ingest.us.sentry.io/111';
+    process.env.SENTRY_DSN = 'https://key@o222.ingest.us.sentry.io/222';
+
+    expect(getConfiguredSentryEndpoint()).toEqual({
+      host: 'o111.ingest.us.sentry.io',
+      projectId: '111',
+    });
+
+    process.env.SENTRY_BROWSER_DSN = previousBrowser;
+    process.env.SENTRY_DSN = previousServer;
+  });
+
+  it('rejects malformed DSN values', () => {
+    const httpBody = Buffer.from(
+      `${JSON.stringify({ dsn: 'http://o123.ingest.us.sentry.io/456' })}\n{}`
+    );
+    const invalidProjectBody = Buffer.from(
+      `${JSON.stringify({ dsn: 'https://o123.ingest.us.sentry.io/not-a-project' })}\n{}`
+    );
+    expect(parseAllowedSentryEndpoint(httpBody)).toBeNull();
+    expect(parseAllowedSentryEndpoint(invalidProjectBody)).toBeNull();
+    expect(parseSentryDsnString('http://evil.example/1')).toBeNull();
   });
 
   it('rejects non-Sentry hosts', () => {

--- a/server/sentry-tunnel.test.js
+++ b/server/sentry-tunnel.test.js
@@ -43,8 +43,16 @@ describe('sentry-tunnel helpers', () => {
       projectId: '111',
     });
 
-    process.env.SENTRY_BROWSER_DSN = previousBrowser;
-    process.env.SENTRY_DSN = previousServer;
+    if (previousBrowser === undefined) {
+      delete process.env.SENTRY_BROWSER_DSN;
+    } else {
+      process.env.SENTRY_BROWSER_DSN = previousBrowser;
+    }
+    if (previousServer === undefined) {
+      delete process.env.SENTRY_DSN;
+    } else {
+      process.env.SENTRY_DSN = previousServer;
+    }
   });
 
   it('rejects malformed DSN values', () => {

--- a/server/sentry-tunnel.test.js
+++ b/server/sentry-tunnel.test.js
@@ -3,7 +3,6 @@
 const {
   parseAllowedSentryEndpoint,
   parseSentryDsnString,
-  isAllowedSentryHost,
   buildEnvelopeUrl,
   getConfiguredSentryEndpoint,
 } = require('./sentry-tunnel');
@@ -67,8 +66,4 @@ describe('sentry-tunnel helpers', () => {
     expect(parseSentryDsnString('http://evil.example/1')).toBeNull();
   });
 
-  it('rejects non-Sentry hosts', () => {
-    expect(isAllowedSentryHost('evil.example.com')).toBe(false);
-    expect(isAllowedSentryHost('o4511425762361344.ingest.us.sentry.io')).toBe(true);
-  });
 });

--- a/server/sentry.js
+++ b/server/sentry.js
@@ -1,31 +1,61 @@
 'use strict';
 
+/** @returns {string} Trimmed Sentry DSN or empty when unset. */
+function getSentryDsn() {
+  return (process.env.SENTRY_DSN || '').trim();
+}
+
+/** @returns {string | undefined} Release label when configured. */
+function getSentryRelease() {
+  const release = (process.env.SENTRY_RELEASE || '').trim();
+  return release || undefined;
+}
+
+/** @returns {string} Sentry environment name. */
+function getSentryEnvironment() {
+  return (process.env.SENTRY_ENVIRONMENT || 'production').trim() || 'production';
+}
+
+/** @returns {number} Trace sample rate clamped to the valid 0–1 range. */
+function getTracesSampleRate() {
+  const parsed = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1');
+  if (!Number.isFinite(parsed)) {
+    return 0.1;
+  }
+  return Math.max(0, Math.min(1, parsed));
+}
+
+/** @returns {object | null} Sentry.init options, or null when no DSN is configured. */
+function buildSentryInitOptions() {
+  const dsn = getSentryDsn();
+  if (!dsn) {
+    return null;
+  }
+
+  return {
+    dsn,
+    environment: getSentryEnvironment(),
+    release: getSentryRelease(),
+    sendDefaultPii: false,
+    tracesSampleRate: getTracesSampleRate(),
+  };
+}
+
 /** @returns {boolean} Whether Sentry was initialized for this process. */
 function initSentry() {
-  const dsn = (process.env.SENTRY_DSN || '').trim();
-  if (!dsn) {
+  const options = buildSentryInitOptions();
+  if (!options) {
     return false;
   }
 
   const Sentry = require('@sentry/node');
-  const release = (process.env.SENTRY_RELEASE || '').trim() || undefined;
-  const environment = (process.env.SENTRY_ENVIRONMENT || 'production').trim() || 'production';
-  const tracesSampleRate = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1');
-
-  Sentry.init({
-    dsn,
-    environment,
-    release,
-    sendDefaultPii: false,
-    tracesSampleRate: Number.isFinite(tracesSampleRate) ? tracesSampleRate : 0.1,
-  });
-
+  Sentry.init(options);
   return true;
 }
 
 /** Registers the Express error handler when Sentry is configured. */
 function setupExpressErrorHandler(app) {
-  if (!(process.env.SENTRY_DSN || '').trim()) {
+  if (!getSentryDsn()) {
     return;
   }
 

--- a/server/sentry.js
+++ b/server/sentry.js
@@ -1,60 +1,31 @@
 'use strict';
 
-/** @returns {string} Trimmed Sentry DSN or empty when unset. */
-function getSentryDsn() {
-  return (process.env.SENTRY_DSN || '').trim();
-}
-
-/** @returns {string | undefined} Release label when configured. */
-function getSentryRelease() {
-  const release = (process.env.SENTRY_RELEASE || '').trim();
-  return release || undefined;
-}
-
-/** @returns {string} Sentry environment name. */
-function getSentryEnvironment() {
-  return (process.env.SENTRY_ENVIRONMENT || 'production').trim() || 'production';
-}
-
-/** @returns {number} Trace sample rate clamped to the valid 0–1 range. */
-function getTracesSampleRate() {
-  const parsed = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1');
-  if (!Number.isFinite(parsed)) {
-    return 0.1;
-  }
-  return Math.max(0, Math.min(1, parsed));
-}
-
-/** @returns {object | null} Sentry.init options, or null when no DSN is configured. */
-function buildSentryInitOptions() {
-  const dsn = getSentryDsn();
-  if (!dsn) {
-    return null;
-  }
-
-  return {
-    dsn,
-    environment: getSentryEnvironment(),
-    release: getSentryRelease(),
-    tracesSampleRate: getTracesSampleRate(),
-  };
-}
-
 /** @returns {boolean} Whether Sentry was initialized for this process. */
 function initSentry() {
-  const options = buildSentryInitOptions();
-  if (!options) {
+  const dsn = (process.env.SENTRY_DSN || '').trim();
+  if (!dsn) {
     return false;
   }
 
   const Sentry = require('@sentry/node');
-  Sentry.init(options);
+  const release = (process.env.SENTRY_RELEASE || '').trim() || undefined;
+  const environment = (process.env.SENTRY_ENVIRONMENT || 'production').trim();
+  const tracesSampleRate = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1');
+
+  Sentry.init({
+    dsn,
+    environment,
+    release,
+    sendDefaultPii: false,
+    tracesSampleRate: Number.isFinite(tracesSampleRate) ? tracesSampleRate : 0.1,
+  });
+
   return true;
 }
 
 /** Registers the Express error handler when Sentry is configured. */
 function setupExpressErrorHandler(app) {
-  if (!getSentryDsn()) {
+  if (!(process.env.SENTRY_DSN || '').trim()) {
     return;
   }
 

--- a/server/sentry.js
+++ b/server/sentry.js
@@ -9,7 +9,7 @@ function initSentry() {
 
   const Sentry = require('@sentry/node');
   const release = (process.env.SENTRY_RELEASE || '').trim() || undefined;
-  const environment = (process.env.SENTRY_ENVIRONMENT || 'production').trim();
+  const environment = (process.env.SENTRY_ENVIRONMENT || 'production').trim() || 'production';
   const tracesSampleRate = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1');
 
   Sentry.init({

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
@@ -16,7 +16,7 @@ describe('PrivacyPolicyModal Utils', () => {
   });
 
   test('hasAcceptedPrivacyPolicy returns true when accepted current version', () => {
-    localStorage.setItem('gfc-privacy-policy-accepted', '1.1.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.2.0');
     expect(hasAcceptedPrivacyPolicy()).toBe(true);
   });
 
@@ -67,7 +67,7 @@ describe('PrivacyPolicyModal component', () => {
     fireEvent.click(acceptButton);
 
     expect(onAcceptMock).toHaveBeenCalled();
-    expect(localStorage.getItem('gfc-privacy-policy-accepted')).toBe('1.1.0');
+    expect(localStorage.getItem('gfc-privacy-policy-accepted')).toBe('1.2.0');
   });
 
   test('renders view-only mode when specified', () => {

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -3,7 +3,7 @@ import './PrivacyPolicyModal.css';
 
 // Bump this version string whenever the Privacy Policy changes materially.
 // Users who accepted an older version will be asked to re-accept.
-const PRIVACY_POLICY_VERSION = '1.1.0';
+const PRIVACY_POLICY_VERSION = '1.2.0';
 const STORAGE_KEY = 'gfc-privacy-policy-accepted';
 
 /** Returns true if the user has accepted the current version of the Privacy Policy. */
@@ -94,6 +94,13 @@ const PrivacyPolicyContent: React.FC = () => (
       referrer, timestamp, and user-agent for maintenance and debugging. These logs are not used to inspect forecast
       contents and are kept separate from the product metrics dashboard.
     </p>
+    <p>
+      On production and beta hosted deployments, we use Sentry (a third-party error monitoring service) to capture
+      application errors and limited performance data so we can fix bugs quickly. This is separate from product analytics
+      above. We do not use Sentry for advertising or the sale of personal data. Error reports are designed to exclude
+      forecast map payloads, do not use session replay, and are configured without sending IP addresses or cookies by
+      default. Events are tagged by environment (production or beta) so staging issues stay separate from production.
+    </p>
 
     <h3>6. Data Retention &amp; Deletion</h3>
     <p>
@@ -155,7 +162,7 @@ const PrivacyPolicyAcceptanceFooter: React.FC<{
         onChange={onCheckedChange}
       />
       I have read and agree to the Privacy Policy. I understand what data stays local, what data may be stored for
-      hosted features, and how GFC handles anonymous product analytics.
+      hosted features, product analytics, and error monitoring as described in this policy.
     </label>
     <div className="privacy-button-row">
       <button className="privacy-btn-decline" onClick={onDecline}>

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -46,8 +46,6 @@ describe('instrument', () => {
           enableLogs: true,
           normalizeDepth: 10,
           tracesSampleRate: 0.1,
-          replaysSessionSampleRate: 0,
-          replaysOnErrorSampleRate: 0,
           tracePropagationTargets: expect.arrayContaining([
             'localhost',
             expect.any(RegExp),

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/react';
 jest.mock('@sentry/react', () => ({
   init: jest.fn(),
   reactRouterV7BrowserTracingIntegration: jest.fn(() => ({})),
-  replayIntegration: jest.fn(() => ({})),
 }));
 
 describe('instrument', () => {
@@ -23,18 +22,18 @@ describe('instrument', () => {
   it('is disabled without a DSN', () => {
     jest.isolateModules(() => {
       globalScope.__GFC_SENTRY_DSN__ = '';
-      // skipcq: JS-0359
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
       const { isSentryEnabled: enabled } = require('./instrument');
       expect(enabled()).toBe(false);
       expect(Sentry.init).not.toHaveBeenCalled();
     });
   });
 
-  it('initializes Sentry with replay, tracing, and logging when a DSN is configured', () => {
+  it('initializes Sentry with tracing and logging when a DSN is configured', () => {
     jest.isolateModules(() => {
       globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
       globalScope.__GFC_SENTRY_ENVIRONMENT__ = 'production';
-      // skipcq: JS-0359
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
       const { isSentryEnabled: enabled } = require('./instrument');
       expect(enabled()).toBe(true);
       expect(Sentry.init).toHaveBeenCalledWith(
@@ -43,23 +42,22 @@ describe('instrument', () => {
           tunnel: '/api/sentry-tunnel',
           environment: 'production',
           release: 'graphical-forecast-creator@1.0.0',
-          sendDefaultPii: true,
+          sendDefaultPii: false,
           enableLogs: true,
           normalizeDepth: 10,
           tracesSampleRate: 0.1,
-          replaysSessionSampleRate: 0.1,
-          replaysOnErrorSampleRate: 1.0,
+          replaysSessionSampleRate: 0,
+          replaysOnErrorSampleRate: 0,
           tracePropagationTargets: expect.arrayContaining([
             'localhost',
+            expect.any(RegExp),
             expect.any(RegExp),
             expect.any(RegExp),
           ]),
         })
       );
-      expect(Sentry.replayIntegration).toHaveBeenCalledWith({
-        maskAllText: true,
-        blockAllMedia: true,
-      });
+      const initCall = (Sentry.init as jest.Mock).mock.calls[0][0];
+      expect(initCall.integrations).toHaveLength(1);
     });
   });
 });

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -64,8 +64,6 @@ export function initSentry(): void {
       /^https:\/\/beta-gfc\.weatherboysuper\.com/,
       /^\/api/,
     ],
-    replaysSessionSampleRate: 0,
-    replaysOnErrorSampleRate: 0,
   });
 }
 

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -11,30 +11,30 @@ declare const __GFC_SENTRY_DSN__: string;
 declare const __GFC_SENTRY_ENVIRONMENT__: string;
 declare const __GFC_APP_VERSION__: string;
 
-/** Build-time Sentry DSN injected by Vite (`VITE_SENTRY_DSN`). */
+/** Returns the Sentry DSN baked in at build time, or an empty string when monitoring is off. */
 function getSentryDsn(): string {
   return typeof __GFC_SENTRY_DSN__ !== 'undefined' ? __GFC_SENTRY_DSN__ : '';
 }
 
-/** True when a production DSN was baked into the build (main deploy only). */
+/** True when a DSN was baked into the build (hosted production or beta deploys). */
 export function isSentryEnabled(): boolean {
   return Boolean(getSentryDsn().trim());
 }
 
-/** Sentry release name tied to the app package version. */
+/** Returns the Sentry release string derived from the app version, when available. */
 function getRelease(): string | undefined {
   const version = typeof __GFC_APP_VERSION__ !== 'undefined' ? __GFC_APP_VERSION__ : '';
   return version ? `graphical-forecast-creator@${version}` : undefined;
 }
 
-/** Sentry environment label (e.g. production on main deploy). */
+/** Returns the configured Sentry environment label (production, beta, etc.). */
 function getEnvironment(): string {
   const configured =
     typeof __GFC_SENTRY_ENVIRONMENT__ !== 'undefined' ? __GFC_SENTRY_ENVIRONMENT__ : '';
   return configured.trim() || 'production';
 }
 
-/** Initializes Sentry when a DSN is present. No-op in local dev and beta builds. */
+/** Initializes Sentry when a DSN is present. No-op in local dev without a DSN. */
 export function initSentry(): void {
   if (!isSentryEnabled()) {
     return;
@@ -45,7 +45,7 @@ export function initSentry(): void {
     tunnel: '/api/sentry-tunnel',
     environment: getEnvironment(),
     release: getRelease(),
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     enableLogs: true,
     normalizeDepth: 10,
     integrations: [
@@ -56,19 +56,16 @@ export function initSentry(): void {
         createRoutesFromChildren,
         matchRoutes,
       }),
-      Sentry.replayIntegration({
-        maskAllText: true,
-        blockAllMedia: true,
-      }),
     ],
     tracesSampleRate: 0.1,
     tracePropagationTargets: [
       'localhost',
       /^https:\/\/gfc\.weatherboysuper\.com/,
+      /^https:\/\/beta-gfc\.weatherboysuper\.com/,
       /^\/api/,
     ],
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 0,
   });
 }
 


### PR DESCRIPTION
## Summary

- Disable Sentry session replay and set sendDefaultPii to false on browser and Node so production matches the privacy policy.
- Harden /api/sentry-tunnel (server-configured ingest URL, SENTRY_BROWSER_DSN validation, safe envelope parsing) and wire the SDK tunnel option so browser events bypass ad blockers.
- Update privacy policy and in-app modal to v1.2.0 with a Sentry disclosure; document deploy secrets in README.

## Test plan

- [x] pnpm test --runTestsByPath src/instrument.test.ts src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
- [x] pnpm run build
- [ ] After merge: main deploy; confirm Sentry environment=production, no replay, test error via tunnel
- [ ] Users on privacy 1.1.0 prompted to accept 1.2.0

Made with [Cursor](https://cursor.com)