### PR TITLE
[Port][Conflicts] fix(sentry): align production monitoring with privacy policy → beta

### DIFF
--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -34,7 +34,14 @@ jobs:
 
       - name: Read app version
         id: app_version
-        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          VERSION=${VERSION//$'\n'/}
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid package version format: $VERSION" >&2
+            exit 1
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: pnpm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,52 @@
 
 All notable changes to this project will be documented in this file.
 
+<<<<<<< HEAD
 ## v1.6
+=======
+## v1.5.3
+
+### Discord announcement (draft)
+
+Copy/paste starting point — edit tone and channels as you like.
+
+---
+
+**GFC v1.5.3 is live** (production + beta)
+
+We shipped a **privacy-focused update** to how the hosted app handles error monitoring, plus an updated Privacy Policy.
+
+**What you will notice**
+- You may be asked to **accept the updated Privacy Policy (v1.2.0)** the next time you open GFC on gfc.weatherboysuper.com or beta-gfc.weatherboysuper.com.
+- No change to how you draw outlooks, save cycles, or use cloud features — this is infrastructure and disclosure, not a forecast-editor feature release.
+
+**What changed behind the scenes**
+- **Error monitoring (Sentry)** is enabled on hosted production and beta so we can fix crashes faster.
+- **Session replay is off** — we are not recording screen replays of your session.
+- **No IP/cookies in error reports by default** — monitoring is tuned for bug diagnosis, not ad-style tracking.
+- **Forecast map data is not attached** to error breadcrumbs (action names only for forecast edits).
+- Browser errors go through our **server tunnel** so ad blockers are less likely to block crash reports (helps us fix issues you hit).
+
+**Why we did this**
+- Catch production bugs we cannot reproduce locally.
+- Stay aligned with what the Privacy Policy says we collect.
+
+Questions → alex@weatherboysuper.com
+
+---
+
+### Changed
+- **Privacy policy v1.2.0:** Added a clear disclosure for hosted error monitoring (Sentry): what is collected, what is not (no session replay, no default IP/cookie payloads, forecast contents not sent in breadcrumbs), and separate production vs beta environments.
+- **In-app privacy modal:** Bumped to v1.2.0 with the same Sentry disclosure; users who accepted an older policy version will be prompted to accept again on next visit.
+- **Hosted error monitoring (Sentry):** Production and beta now use the same privacy-safe SDK settings — `sendDefaultPii: false`, session replay disabled, browser SDK routed through `/api/sentry-tunnel`, and server tunnel validation against the web project DSN (`SENTRY_BROWSER_DSN`).
+- **Analytics server:** Node Sentry init uses `sendDefaultPii: false`; deploy workflows set `SENTRY_BROWSER_DSN` from the web DSN secret so the tunnel accepts browser envelopes in the recommended two-project setup.
+- **Version:** Bumped package version to `1.5.3`.
+
+### Fixed
+- **Sentry tunnel security:** Removed client-controlled ingest URLs and query-string forwarding; malformed envelope bodies return 400 instead of 500.
+
+## v1.5.2
+>>>>>>> 089b92a (chore: release v1.5.3 with privacy-safe Sentry notes.)
 
 ### Fixed
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,39 +3,12 @@
 
 All notable changes to this project will be documented in this file.
 
-<<<<<<< HEAD
 ## v1.6
-=======
+
+### Fixed
+- **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
+
 ## v1.5.3
-
-### Discord announcement (draft)
-
-Copy/paste starting point — edit tone and channels as you like.
-
----
-
-**GFC v1.5.3 is live** (production + beta)
-
-We shipped a **privacy-focused update** to how the hosted app handles error monitoring, plus an updated Privacy Policy.
-
-**What you will notice**
-- You may be asked to **accept the updated Privacy Policy (v1.2.0)** the next time you open GFC on gfc.weatherboysuper.com or beta-gfc.weatherboysuper.com.
-- No change to how you draw outlooks, save cycles, or use cloud features — this is infrastructure and disclosure, not a forecast-editor feature release.
-
-**What changed behind the scenes**
-- **Error monitoring (Sentry)** is enabled on hosted production and beta so we can fix crashes faster.
-- **Session replay is off** — we are not recording screen replays of your session.
-- **No IP/cookies in error reports by default** — monitoring is tuned for bug diagnosis, not ad-style tracking.
-- **Forecast map data is not attached** to error breadcrumbs (action names only for forecast edits).
-- Browser errors go through our **server tunnel** so ad blockers are less likely to block crash reports (helps us fix issues you hit).
-
-**Why we did this**
-- Catch production bugs we cannot reproduce locally.
-- Stay aligned with what the Privacy Policy says we collect.
-
-Questions → alex@weatherboysuper.com
-
----
 
 ### Changed
 - **Privacy policy v1.2.0:** Added a clear disclosure for hosted error monitoring (Sentry): what is collected, what is not (no session replay, no default IP/cookie payloads, forecast contents not sent in breadcrumbs), and separate production vs beta environments.
@@ -48,10 +21,10 @@ Questions → alex@weatherboysuper.com
 - **Sentry tunnel security:** Removed client-controlled ingest URLs and query-string forwarding; malformed envelope bodies return 400 instead of 500.
 
 ## v1.5.2
->>>>>>> 089b92a (chore: release v1.5.3 with privacy-safe Sentry notes.)
 
-### Fixed
-- **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
+## Fixed
+- Fixed the primary button on the signed-out Home Page being incorrectly white/blank
+- Fixed an issue where you couldn't export an outlook as an image
 
 ## v1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ## v1.5.2
 
-## Fixed
+### Fixed
 - Fixed the primary button on the signed-out Home Page being incorrectly white/blank
 - Fixed an issue where you couldn't export an outlook as an image
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Add these GitHub Actions secrets (repo → Settings → Secrets and variables �
 | `SENTRY_ORG` | Your Sentry organization slug |
 | `SENTRY_PROJECT` | Web project slug (source maps) — not the API project |
 
+Deploy workflows copy `VITE_SENTRY_DSN` to `SENTRY_BROWSER_DSN` on the analytics VPS so `/api/sentry-tunnel` validates browser envelopes against the web project.
+
 After the next `main` deploy, verify in Sentry with a test error from the browser console on production (not from DevTools while paused — use a one-off button or `throw new Error('Sentry test')` in the console on the live site).
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphical-forecast-creator",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -46,11 +46,6 @@ function buildEnvelopeUrl(host, projectId) {
   return `https://${host}/api/${projectId}/envelope/`;
 }
 
-/** @returns {boolean} Whether the DSN host is a known Sentry ingest endpoint. */
-function isAllowedSentryHost(hostname) {
-  return SENTRY_DSN_PATTERN.test(`https://${hostname}/0`);
-}
-
 /** @returns {{ host: string, projectId: string } | null} Browser-facing Sentry ingest target for the tunnel. */
 function getConfiguredSentryEndpoint() {
   const browserDsn = process.env.SENTRY_BROWSER_DSN || process.env.SENTRY_DSN || '';
@@ -127,7 +122,6 @@ module.exports = {
   registerSentryTunnelRoutes,
   parseAllowedSentryEndpoint,
   parseSentryDsnString,
-  isAllowedSentryHost,
   buildEnvelopeUrl,
   getConfiguredSentryEndpoint,
 };

--- a/server/sentry-tunnel.test.js
+++ b/server/sentry-tunnel.test.js
@@ -43,8 +43,16 @@ describe('sentry-tunnel helpers', () => {
       projectId: '111',
     });
 
-    process.env.SENTRY_BROWSER_DSN = previousBrowser;
-    process.env.SENTRY_DSN = previousServer;
+    if (previousBrowser === undefined) {
+      delete process.env.SENTRY_BROWSER_DSN;
+    } else {
+      process.env.SENTRY_BROWSER_DSN = previousBrowser;
+    }
+    if (previousServer === undefined) {
+      delete process.env.SENTRY_DSN;
+    } else {
+      process.env.SENTRY_DSN = previousServer;
+    }
   });
 
   it('rejects malformed DSN values', () => {

--- a/server/sentry-tunnel.test.js
+++ b/server/sentry-tunnel.test.js
@@ -3,7 +3,6 @@
 const {
   parseAllowedSentryEndpoint,
   parseSentryDsnString,
-  isAllowedSentryHost,
   buildEnvelopeUrl,
   getConfiguredSentryEndpoint,
 } = require('./sentry-tunnel');
@@ -67,8 +66,4 @@ describe('sentry-tunnel helpers', () => {
     expect(parseSentryDsnString('http://evil.example/1')).toBeNull();
   });
 
-  it('rejects non-Sentry hosts', () => {
-    expect(isAllowedSentryHost('evil.example.com')).toBe(false);
-    expect(isAllowedSentryHost('o4511425762361344.ingest.us.sentry.io')).toBe(true);
-  });
 });

--- a/server/sentry.js
+++ b/server/sentry.js
@@ -1,31 +1,61 @@
 'use strict';
 
+/** @returns {string} Trimmed Sentry DSN or empty when unset. */
+function getSentryDsn() {
+  return (process.env.SENTRY_DSN || '').trim();
+}
+
+/** @returns {string | undefined} Release label when configured. */
+function getSentryRelease() {
+  const release = (process.env.SENTRY_RELEASE || '').trim();
+  return release || undefined;
+}
+
+/** @returns {string} Sentry environment name. */
+function getSentryEnvironment() {
+  return (process.env.SENTRY_ENVIRONMENT || 'production').trim() || 'production';
+}
+
+/** @returns {number} Trace sample rate clamped to the valid 0–1 range. */
+function getTracesSampleRate() {
+  const parsed = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1');
+  if (!Number.isFinite(parsed)) {
+    return 0.1;
+  }
+  return Math.max(0, Math.min(1, parsed));
+}
+
+/** @returns {object | null} Sentry.init options, or null when no DSN is configured. */
+function buildSentryInitOptions() {
+  const dsn = getSentryDsn();
+  if (!dsn) {
+    return null;
+  }
+
+  return {
+    dsn,
+    environment: getSentryEnvironment(),
+    release: getSentryRelease(),
+    sendDefaultPii: false,
+    tracesSampleRate: getTracesSampleRate(),
+  };
+}
+
 /** @returns {boolean} Whether Sentry was initialized for this process. */
 function initSentry() {
-  const dsn = (process.env.SENTRY_DSN || '').trim();
-  if (!dsn) {
+  const options = buildSentryInitOptions();
+  if (!options) {
     return false;
   }
 
   const Sentry = require('@sentry/node');
-  const release = (process.env.SENTRY_RELEASE || '').trim() || undefined;
-  const environment = (process.env.SENTRY_ENVIRONMENT || 'production').trim() || 'production';
-  const tracesSampleRate = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1');
-
-  Sentry.init({
-    dsn,
-    environment,
-    release,
-    sendDefaultPii: false,
-    tracesSampleRate: Number.isFinite(tracesSampleRate) ? tracesSampleRate : 0.1,
-  });
-
+  Sentry.init(options);
   return true;
 }
 
 /** Registers the Express error handler when Sentry is configured. */
 function setupExpressErrorHandler(app) {
-  if (!(process.env.SENTRY_DSN || '').trim()) {
+  if (!getSentryDsn()) {
     return;
   }
 

--- a/server/sentry.js
+++ b/server/sentry.js
@@ -9,7 +9,7 @@ function initSentry() {
 
   const Sentry = require('@sentry/node');
   const release = (process.env.SENTRY_RELEASE || '').trim() || undefined;
-  const environment = (process.env.SENTRY_ENVIRONMENT || 'production').trim();
+  const environment = (process.env.SENTRY_ENVIRONMENT || 'production').trim() || 'production';
   const tracesSampleRate = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1');
 
   Sentry.init({

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -46,8 +46,6 @@ describe('instrument', () => {
           enableLogs: true,
           normalizeDepth: 10,
           tracesSampleRate: 0.1,
-          replaysSessionSampleRate: 0,
-          replaysOnErrorSampleRate: 0,
           tracePropagationTargets: expect.arrayContaining([
             'localhost',
             expect.any(RegExp),

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -64,8 +64,6 @@ export function initSentry(): void {
       /^https:\/\/beta-gfc\.weatherboysuper\.com/,
       /^\/api/,
     ],
-    replaysSessionSampleRate: 0,
-    replaysOnErrorSampleRate: 0,
   });
 }
 


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #316 — fix(sentry): align production monitoring with privacy policy |
| Source branch | `fix/sentry-privacy-production` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `CHANGELOG.md`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/316-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #316, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.