### PR TITLE
fix: privacy policy May 22 date and v1.2.0 what's new

### DIFF
--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -1,5 +1,5 @@
 # Privacy Policy
-**Last Updated: March 30, 2026**
+**Last Updated: May 22, 2026**
 
 **TL;DR:** Your local forecasts stay on your device. If you choose to make an account, we only collect what is strictly necessary to sync your work and securely manage your subscription. 
 

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.css
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.css
@@ -86,6 +86,35 @@
   margin-top: 0;
 }
 
+.privacy-whats-new {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.privacy-whats-new h3 {
+  margin: 0 0 8px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.privacy-whats-new ul {
+  margin: 0 0 0 18px;
+  padding: 0;
+  color: var(--text-secondary);
+}
+
+.privacy-whats-new ul li {
+  margin-bottom: 4px;
+}
+
+.privacy-whats-new ul li:last-child {
+  margin-bottom: 0;
+}
+
 .privacy-modal-body p {
   margin: 0 0 10px;
   color: var(--text-secondary);

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.css
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.css
@@ -96,7 +96,7 @@
 
 .privacy-whats-new h3 {
   margin: 0 0 8px;
-  font-size: 0.88rem;
+  font-size: 0.875rem;
   font-weight: 700;
   color: var(--text-primary);
 }

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
@@ -52,6 +52,21 @@ describe('PrivacyPolicyModal component', () => {
     expect(screen.getByText('Accept & Continue')).toBeDisabled();
   });
 
+  test('shows last updated date and whats new in acceptance mode', () => {
+    render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
+    expect(screen.getByText(/Last updated May 22, 2026/i)).toBeInTheDocument();
+    expect(screen.getByRole('note')).toBeInTheDocument();
+    expect(screen.getByText(/What's new in version 1\.2\.0/i)).toBeInTheDocument();
+    expect(screen.getByText(/hosted error monitoring \(Sentry\)/i)).toBeInTheDocument();
+  });
+
+  test('hides whats new in view-only mode but shows version date', () => {
+    render(<PrivacyPolicyModal onAccept={onAcceptMock} viewOnly onClose={onCloseMock} />);
+    expect(screen.getByText(/Version 1\.2\.0 — Last updated May 22, 2026/i)).toBeInTheDocument();
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+    expect(screen.queryByText(/What's new in version/i)).not.toBeInTheDocument();
+  });
+
   test('enables accept button when checkbox is checked', () => {
     render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
     const checkbox = screen.getByRole('checkbox');

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import PrivacyPolicyModal, { hasAcceptedPrivacyPolicy } from './PrivacyPolicyModal';
+import PrivacyPolicyModal, {
+  hasAcceptedPrivacyPolicy,
+  isPrivacyPolicyUpgrade,
+} from './PrivacyPolicyModal';
 
 describe('PrivacyPolicyModal Utils', () => {
   beforeEach(() => {
@@ -31,6 +34,20 @@ describe('PrivacyPolicyModal Utils', () => {
     });
     expect(hasAcceptedPrivacyPolicy()).toBe(false);
   });
+
+  test('isPrivacyPolicyUpgrade returns false when not previously accepted', () => {
+    expect(isPrivacyPolicyUpgrade()).toBe(false);
+  });
+
+  test('isPrivacyPolicyUpgrade returns true when an older version was accepted', () => {
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.0.0');
+    expect(isPrivacyPolicyUpgrade()).toBe(true);
+  });
+
+  test('isPrivacyPolicyUpgrade returns false when current version was accepted', () => {
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.2.0');
+    expect(isPrivacyPolicyUpgrade()).toBe(false);
+  });
 });
 
 describe('PrivacyPolicyModal component', () => {
@@ -52,17 +69,25 @@ describe('PrivacyPolicyModal component', () => {
     expect(screen.getByText('Accept & Continue')).toBeDisabled();
   });
 
-  test('shows last updated date and whats new in acceptance mode', () => {
+  test('shows last updated date and whats new when upgrading from an older policy', () => {
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.0.0');
     render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
-    expect(screen.getByText(/Last updated May 22, 2026/i)).toBeInTheDocument();
+    expect(screen.getByText(/Last updated May 22, 2026/u)).toBeInTheDocument();
     expect(screen.getByRole('note')).toBeInTheDocument();
-    expect(screen.getByText(/What's new in version 1\.2\.0/i)).toBeInTheDocument();
-    expect(screen.getByText(/hosted error monitoring \(Sentry\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/What's new in version 1\.2\.0/u)).toBeInTheDocument();
+    expect(screen.getByText(/hosted error monitoring \(Sentry\)/u)).toBeInTheDocument();
+  });
+
+  test('hides whats new for first-time users in acceptance mode', () => {
+    render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
+    expect(screen.getByText(/Last updated May 22, 2026/u)).toBeInTheDocument();
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+    expect(screen.queryByText(/What's new in version/u)).not.toBeInTheDocument();
   });
 
   test('hides whats new in view-only mode but shows version date', () => {
     render(<PrivacyPolicyModal onAccept={onAcceptMock} viewOnly onClose={onCloseMock} />);
-    expect(screen.getByText(/Version 1\.2\.0 — Last updated May 22, 2026/i)).toBeInTheDocument();
+    expect(screen.getByText(/Version 1\.2\.0 — Last updated May 22, 2026/u)).toBeInTheDocument();
     expect(screen.queryByRole('note')).not.toBeInTheDocument();
     expect(screen.queryByText(/What's new in version/i)).not.toBeInTheDocument();
   });

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -22,6 +22,16 @@ export function hasAcceptedPrivacyPolicy(): boolean {
   }
 }
 
+/** Returns true when the user previously accepted an older policy and must re-accept. */
+export function isPrivacyPolicyUpgrade(): boolean {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored != null && stored !== PRIVACY_POLICY_VERSION;
+  } catch {
+    return false;
+  }
+}
+
 // Records acceptance of the current Privacy Policy version in localStorage.
 function acceptPrivacyPolicy(): void {
   try {
@@ -242,7 +252,7 @@ const PrivacyPolicyModal: React.FC<PrivacyPolicyModalProps> = ({ onAccept, viewO
       <div className="privacy-modal">
         <PrivacyPolicyHeader viewOnly={viewOnly} onClose={onClose} />
         <div className="privacy-modal-body">
-          <PrivacyPolicyContent showWhatsNew={!viewOnly} />
+          <PrivacyPolicyContent showWhatsNew={!viewOnly && isPrivacyPolicyUpgrade()} />
         </div>
 
         {viewOnly ? (

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -4,7 +4,14 @@ import './PrivacyPolicyModal.css';
 // Bump this version string whenever the Privacy Policy changes materially.
 // Users who accepted an older version will be asked to re-accept.
 const PRIVACY_POLICY_VERSION = '1.2.0';
+const PRIVACY_POLICY_LAST_UPDATED = 'May 22, 2026';
 const STORAGE_KEY = 'gfc-privacy-policy-accepted';
+
+const PRIVACY_POLICY_WHATS_NEW: string[] = [
+  'We added a disclosure for hosted error monitoring (Sentry) on production and beta deployments.',
+  'Error monitoring does not use session replay and does not send IP addresses or cookies by default.',
+  'Forecast map data is not attached to error reports; only limited diagnostic data is collected to fix bugs.',
+];
 
 /** Returns true if the user has accepted the current version of the Privacy Policy. */
 export function hasAcceptedPrivacyPolicy(): boolean {
@@ -30,9 +37,22 @@ interface PrivacyPolicyModalProps {
   onClose?: () => void;
 }
 
+/** Highlights material changes in the current policy version for users who must re-accept. */
+const PrivacyPolicyWhatsNew: React.FC = () => (
+  <aside className="privacy-whats-new" aria-labelledby="privacy-whats-new-title" role="note">
+    <h3 id="privacy-whats-new-title">What&apos;s new in version {PRIVACY_POLICY_VERSION}</h3>
+    <ul>
+      {PRIVACY_POLICY_WHATS_NEW.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  </aside>
+);
+
 /** Renders the current in-app Privacy Policy content for both acceptance and view-only modes. */
-const PrivacyPolicyContent: React.FC = () => (
+const PrivacyPolicyContent: React.FC<{ showWhatsNew?: boolean }> = ({ showWhatsNew = false }) => (
   <>
+    {showWhatsNew && <PrivacyPolicyWhatsNew />}
     <p>
       <strong>TL;DR:</strong> Your local forecasts stay on your device. If you choose to make an account, we only
       collect what is strictly necessary to sync your work and securely manage your subscription.
@@ -181,7 +201,11 @@ const PrivacyPolicyHeader: React.FC<{ viewOnly: boolean; onClose?: () => void }>
     <div className="privacy-modal-header-row">
       <div>
         <h2 id="privacy-title">Privacy Policy</h2>
-        <p>Please read and accept before using Graphical Forecast Creator &mdash; Last Updated March 30, 2026</p>
+        <p>
+          {viewOnly
+            ? `Version ${PRIVACY_POLICY_VERSION} — Last updated ${PRIVACY_POLICY_LAST_UPDATED}`
+            : `Please read and accept before using Graphical Forecast Creator — Last updated ${PRIVACY_POLICY_LAST_UPDATED}`}
+        </p>
       </div>
       {viewOnly && (
         <button className="privacy-close-view-btn" onClick={onClose} aria-label="Close">
@@ -218,7 +242,7 @@ const PrivacyPolicyModal: React.FC<PrivacyPolicyModalProps> = ({ onAccept, viewO
       <div className="privacy-modal">
         <PrivacyPolicyHeader viewOnly={viewOnly} onClose={onClose} />
         <div className="privacy-modal-body">
-          <PrivacyPolicyContent />
+          <PrivacyPolicyContent showWhatsNew={!viewOnly} />
         </div>
 
         {viewOnly ? (


### PR DESCRIPTION
## Summary

- Updates the in-app privacy policy header and \privacy_policy.md\ last-updated date to **May 22, 2026** (was still hardcoded March 30 after #316).
- Adds a **What's new in version 1.2.0** callout when users must re-accept the policy, summarizing the Sentry monitoring disclosure.

## Test plan

- [x] \pnpm test -- --runTestsByPath src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx\ (13 passed)
- [ ] Merge and confirm production deploy shows May 22 and the callout for users without \gfc-privacy-policy-accepted\ = 1.2.0