### PR TITLE
Fix server uuid CVE-2026-41907 (Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "weekly"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
         "@sentry/node": "^10.53.1",
         "express": "^4.21.2",
         "express-rate-limit": "^8.5.1",
-        "firebase-admin": "^13.8.0",
+        "firebase-admin": "^13.10.0",
         "stripe": "^18.4.0"
       },
       "engines": {
@@ -310,16 +310,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -1861,9 +1851,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
-      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -1873,9 +1863,7 @@
         "fast-deep-equal": "^3.1.1",
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.4.0",
-        "uuid": "^11.0.2"
+        "jwks-rsa": "^3.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1970,20 +1958,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gcp-metadata": {
@@ -2193,20 +2167,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/google-gax/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/google-logging-utils": {
@@ -2816,15 +2776,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/object-hash": {
@@ -3458,20 +3409,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3547,6 +3484,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "optional": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -11,13 +11,14 @@
     "@sentry/node": "^10.53.1",
     "express": "^4.21.2",
     "express-rate-limit": "^8.5.1",
-    "firebase-admin": "^13.8.0",
+    "firebase-admin": "^13.10.0",
     "stripe": "^18.4.0"
   },
   "overrides": {
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
-    "@tootallnate/once": "3.0.1"
+    "@tootallnate/once": "3.0.1",
+    "uuid": "11.1.1"
   },
   "engines": {
     "node": ">=18"

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
     "@tootallnate/once": "3.0.1",
-    "uuid": "11.1.1"
+    "uuid": "^11.1.1"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert for transitive `uuid@8.3.2` (and `9.x`) under `firebase-admin` in `server/` by adding an npm `overrides` pin to patched `uuid@11.1.1` (GHSA-w5hq-g745-h8pq / CVE-2026-41907).
- Bumps `firebase-admin` from `^13.8.0` to `^13.10.0` (latest 13.x; Google Cloud clients still declare older `uuid` ranges, so the override remains required).
- Adds a Dependabot npm entry for `server/` so future server lockfile updates are tracked separately from the Vite app.

## Context

Dependabot could not auto-fix because `@google-cloud/storage` still requires `uuid@^8.0.0` while other Firebase/Google packages require `^9` or `^11`, and there is no patched release on the 8.x/9.x lines—only `11.1.1+`, `12.0.1+`, `13.0.1+`, or `14.0.0`.

The root app already depends on `uuid@^14.0.0` via pnpm; only the analytics server npm tree was affected.

## Test plan

- [x] `npm ls uuid` in `server/` shows a single `uuid@11.1.1` (deduped/overridden)
- [x] `npm audit` in `server/` no longer reports the uuid advisory (remaining findings are unrelated `qs` via Express)
- [x] Smoke: `require('firebase-admin')` and `require('uuid')` load successfully