### PR TITLE
fix: ignore keydown events without KeyboardEvent.key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## v1.6
 
 ### Fixed
+- **Forecast keyboard shortcuts:** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (reported in production via Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts.
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
 
 ## v1.5.3

--- a/src/components/Layout/AppLayout.test.tsx
+++ b/src/components/Layout/AppLayout.test.tsx
@@ -119,4 +119,13 @@ describe('AppLayout', () => {
     fireEvent.click(screen.getByText('Close Privacy'));
     expect(screen.queryByTestId('privacy')).not.toBeInTheDocument();
   });
+
+  it('does not throw when Ctrl/Cmd keydown omits KeyboardEvent.key', () => {
+    renderWithRouter(<AppLayout />);
+
+    const event = new KeyboardEvent('keydown', { bubbles: true, ctrlKey: true });
+    Object.defineProperty(event, 'key', { value: undefined });
+
+    expect(() => window.dispatchEvent(event)).not.toThrow();
+  });
 });

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -117,6 +117,8 @@ export const AppLayout: React.FC = () => {
       }
 
       if (e.ctrlKey || e.metaKey) {
+        if (!e.key) return;
+
         // Define Ctrl/Cmd+key shortcuts for navigation and actions
         const key = e.key.toLowerCase();
         // Define shortcuts for navigation and actions

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -300,4 +300,32 @@ describe('ForecastPage helpers', () => {
     processShortcutKeyDown(inputEvent, context);
     expect(addToast).not.toHaveBeenCalledWith('Switched to Day 3', 'info');
   });
+
+  it('ignores keydown events when the browser omits KeyboardEvent.key', () => {
+    const dispatch = jest.fn();
+    const addToast = jest.fn();
+    const handleSave = jest.fn();
+    const context = {
+      dispatch,
+      addToast,
+      isSaved: false,
+      canUndo: false,
+      canRedo: false,
+      handleSave,
+      fileInputRef: { current: null },
+      mapRef: { current: null },
+      currentDay: 1,
+      activeOutlookType: 'tornado' as const,
+      activeProbability: '10%',
+      isSignificant: false,
+    };
+
+    const event = new KeyboardEvent('keydown', { bubbles: true });
+    Object.defineProperty(event, 'key', { value: undefined });
+
+    expect(() => processShortcutKeyDown(event, context)).not.toThrow();
+    expect(handleSave).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(addToast).not.toHaveBeenCalled();
+  });
 });

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -593,6 +593,8 @@ export const processShortcutKeyDown = (
   e: KeyboardEvent,
   context: KeyboardShortcutContext
 ) => {
+  if (!e.key) return;
+
   const key = e.key.toLowerCase();
   if (isTypingTarget(e.target)) return;
 


### PR DESCRIPTION
## Summary

- Guard forecast editor and app-layout keydown handlers when KeyboardEvent.key is missing so production no longer throws TypeError: Cannot read properties of undefined (reading 'toLowerCase') (Sentry gfc-web issue on \/forecast\, release 1.5.3).
- Add regression tests and document under **v1.6** in CHANGELOG.

## Repro steps (pre-fix)

1. Open production forecast editor: https://gfc.weatherboysuper.com/forecast (or local build on \/forecast\).
2. Use a browser that can emit \keydown\ without \key\ (first seen in **Opera 131** on production).
3. Press keys that trigger non-standard events (e.g. some dead-key / IME / modifier combinations, or simulate in devtools).
4. Before fix: unhandled error in global shortcut handler (\processShortcutKeyDown\ → \.key.toLowerCase()\), reported in Sentry as issue **7500386974**.

**DevTools simulation:**

\\\js
const e = new KeyboardEvent('keydown', { bubbles: true });
Object.defineProperty(e, 'key', { value: undefined });
window.dispatchEvent(e);
\\\

## Test plan

- [x] \pnpm test -- --runTestsByPath src/pages/ForecastPage.test.tsx src/components/Layout/AppLayout.test.tsx\
- [ ] CI green (excluding Kilo code review)
- [ ] After deploy to beta: repeat repro simulation on \/forecast\ — no console error, no new Sentry events for this stack
- [ ] Smoke: normal shortcuts still work (Ctrl+S save, day/outlook keys, Ctrl+1/2/3 nav in layout)

## Sentry

- Issue: https://wxboysuper.sentry.io/issues/7500386974/
- Target: v1.6 release