### PR TITLE
[Port] fix: ignore keydown events without KeyboardEvent.key to feature/v1-6-monitor-page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## v1.6
 
 ### Fixed
+- **Forecast keyboard shortcuts:** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (reported in production via Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts.
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
 
 ## v1.5.3

--- a/src/components/Layout/AppLayout.test.tsx
+++ b/src/components/Layout/AppLayout.test.tsx
@@ -119,4 +119,13 @@ describe('AppLayout', () => {
     fireEvent.click(screen.getByText('Close Privacy'));
     expect(screen.queryByTestId('privacy')).not.toBeInTheDocument();
   });
+
+  it('does not throw when Ctrl/Cmd keydown omits KeyboardEvent.key', () => {
+    renderWithRouter(<AppLayout />);
+
+    const event = new KeyboardEvent('keydown', { bubbles: true, ctrlKey: true });
+    Object.defineProperty(event, 'key', { value: undefined });
+
+    expect(() => window.dispatchEvent(event)).not.toThrow();
+  });
 });

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -117,6 +117,8 @@ export const AppLayout: React.FC = () => {
       }
 
       if (e.ctrlKey || e.metaKey) {
+        if (!e.key) return;
+
         // Define Ctrl/Cmd+key shortcuts for navigation and actions
         const key = e.key.toLowerCase();
         // Define shortcuts for navigation and actions

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -302,4 +302,32 @@ describe('ForecastPage helpers', () => {
     processShortcutKeyDown(inputEvent, context);
     expect(addToast).not.toHaveBeenCalledWith('Switched to Day 3', 'info');
   });
+
+  it('ignores keydown events when the browser omits KeyboardEvent.key', () => {
+    const dispatch = jest.fn();
+    const addToast = jest.fn();
+    const handleSave = jest.fn();
+    const context = {
+      dispatch,
+      addToast,
+      isSaved: false,
+      canUndo: false,
+      canRedo: false,
+      handleSave,
+      fileInputRef: { current: null },
+      mapRef: { current: null },
+      currentDay: 1,
+      activeOutlookType: 'tornado' as const,
+      activeProbability: '10%',
+      isSignificant: false,
+    };
+
+    const event = new KeyboardEvent('keydown', { bubbles: true });
+    Object.defineProperty(event, 'key', { value: undefined });
+
+    expect(() => processShortcutKeyDown(event, context)).not.toThrow();
+    expect(handleSave).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(addToast).not.toHaveBeenCalled();
+  });
 });

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -593,6 +593,8 @@ export const processShortcutKeyDown = (
   e: KeyboardEvent,
   context: KeyboardShortcutContext
 ) => {
+  if (!e.key) return;
+
   const key = e.key.toLowerCase();
   if (isTypingTarget(e.target)) return;
 


### PR DESCRIPTION
Automated port of the original commits from PR #326 into feature/v1-6-monitor-page after merge into beta.