### PR TITLE
fix: GFC-WEB-4 monitor circular import + keyboard guard follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## v1.6
 
 ### Fixed
-- **Forecast keyboard shortcuts:** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (reported in production via Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts.
+- **Forecast keyboard shortcuts:** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (reported in production via Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts. Centralized the guard in `keyboardShortcutKey` and applied it to forecast, navbar, and day-selector shortcuts.
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
 
 ## v1.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 ## v1.6
 
 ### Fixed
-- **Forecast keyboard shortcuts:** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (reported in production via Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts. Centralized the guard in `keyboardShortcutKey` and applied it to forecast, navbar, and day-selector shortcuts.
+- **GFC-WEB-4 (monitor startup):** Break circular import between `monitor/types` and `monitorSettingsNormalize` that crashed the hosted app at load (`Gv is not iterable` / `MONITOR_OUTLOOK_LAYER_TYPES` before initialization when spreading outlook layer types).
+- **Forecast keyboard shortcuts (GFC-WEB-3):** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts. Centralized the guard in `keyboardShortcutKey` and applied it to forecast, navbar, and day-selector shortcuts.
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
 
 ## v1.5.3

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -272,6 +272,7 @@ export const mergeUserSettingsDocument = (
   ...patch,
 });
 
+/** Writes a merged settings document to Firestore with an updated server timestamp. */
 const writeHostedSettingsDocument = async (
   settingsRef: ReturnType<typeof doc>,
   nextSettings: UserSettingsDocument,
@@ -286,6 +287,7 @@ const writeHostedSettingsDocument = async (
   );
 };
 
+/** Builds a full settings snapshot from local UI state when hosted sync has no baseline yet. */
 const buildHostedAccountFallbackSettings = (
   darkMode: boolean,
   overlays: OverlaysState,
@@ -313,6 +315,7 @@ interface PersistHostedSettingsContext {
   setError: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
+/** Merges a settings patch into the hosted document and updates local sync state. */
 const persistHostedSettingsUpdate = async (
   context: PersistHostedSettingsContext,
   patch: Partial<UserSettingsDocument>,

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -25,7 +25,8 @@ import { applyMonitorSettings } from '../store/monitorSlice';
 import { auth, db, googleAuthProvider, isHostedAuthEnabled, requireAuth, requireDb } from '../lib/firebase';
 import { queueProductMetric } from '../utils/productMetrics';
 import type { MonitorSettings } from '../monitor/types';
-import { DEFAULT_MONITOR_SETTINGS, areMonitorSettingsEqual, normalizeMonitorSettings } from '../monitor/types';
+import { DEFAULT_MONITOR_SETTINGS, areMonitorSettingsEqual } from '../monitor/types';
+import { normalizeMonitorSettings } from '../monitor/monitorSettingsNormalize';
 import {
   DEFAULT_FORECAST_UI_VARIANT,
   normalizeForecastUiVariant,

--- a/src/components/DaySelector/DaySelectorPanel.test.tsx
+++ b/src/components/DaySelector/DaySelectorPanel.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
-import DaySelectorPanel from './DaySelectorPanel';
+import DaySelectorPanel, { getForecastDayFromDigitKeyDown } from './DaySelectorPanel';
 import forecastReducer from '../../store/forecastSlice';
 import type { OutlookDay } from '../../types/outlooks';
 
@@ -109,5 +109,18 @@ describe('DaySelectorPanel', () => {
     fireEvent.click(buttons[buttons.length - 1]);
     expect(store.getState().forecast.forecastCycle.currentDay).toBe(4);
     expect(container.querySelector('.text-center')).toHaveTextContent('15% and 30% only');
+  });
+});
+
+describe('getForecastDayFromDigitKeyDown', () => {
+  it('returns null when the browser omits KeyboardEvent.key', () => {
+    const event = new KeyboardEvent('keydown', { bubbles: true });
+    Object.defineProperty(event, 'key', { value: undefined });
+
+    expect(getForecastDayFromDigitKeyDown(event)).toBeNull();
+  });
+
+  it('returns the matching day for digit keys 1-8', () => {
+    expect(getForecastDayFromDigitKeyDown(new KeyboardEvent('keydown', { key: '3' }))).toBe(3);
   });
 });

--- a/src/components/DaySelector/DaySelectorPanel.tsx
+++ b/src/components/DaySelector/DaySelectorPanel.tsx
@@ -126,6 +126,7 @@ export const getForecastDayFromDigitKeyDown = (event: KeyboardEvent): DayType | 
 // Custom hook: listen for number keys 1-8 to select forecast days
 const useDayNumberShortcuts = (dispatch: ReturnType<typeof useDispatch>) => {
   useEffect(() => {
+    /** Dispatches day selection when the user presses digit keys 1–8. */
     const handleKeyDown = (event: KeyboardEvent) => {
       const day = getForecastDayFromDigitKeyDown(event);
       if (day) dispatch(setForecastDay(day));

--- a/src/components/DaySelector/DaySelectorPanel.tsx
+++ b/src/components/DaySelector/DaySelectorPanel.tsx
@@ -14,7 +14,11 @@ import {
 import { selectForecastCycle, setForecastDay, setCycleDate } from '../../store/forecastSlice';
 import { DayType } from '../../types/outlooks';
 import { cn } from '../../lib/utils';
-import { keyboardShortcutKey } from '../../utils/keyboardShortcutKey';
+import {
+  hasAnyModifierKey,
+  isTypingTarget,
+  keyboardShortcutKey,
+} from '../../utils/keyboardShortcutKey';
 
 const DAYS: DayType[] = [1, 2, 3, 4, 5, 6, 7, 8];
 
@@ -106,18 +110,10 @@ const DayTabs: React.FC<{ currentDay: DayType; days: ForecastDays; onDayButtonCl
   </div>
 );
 
-/** Returns true when the event target is a text field that should consume keystrokes. */
-export const isEditableTypingTarget = (target: EventTarget | null): boolean =>
-  target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
-
-/** Returns true when any modifier would make a digit key a combo shortcut instead of day select. */
-export const keyboardEventHasModifier = (event: KeyboardEvent): boolean =>
-  event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
-
 /** Maps a digit keydown to a forecast day (1-8), or null when the event should be ignored. */
 export const getForecastDayFromDigitKeyDown = (event: KeyboardEvent): DayType | null => {
-  if (isEditableTypingTarget(event.target)) return null;
-  if (keyboardEventHasModifier(event)) return null;
+  if (isTypingTarget(event.target)) return null;
+  if (hasAnyModifierKey(event)) return null;
 
   const key = keyboardShortcutKey(event);
   if (!key) return null;
@@ -180,12 +176,10 @@ export const DaySelectorPanel: React.FC = () => {
     setTempDate(e.target.value);
   }, []);
 
-  // Keyboard shortcuts for day navigation (1-8)
   const handleCancelDateEdit = useCallback(() => {
     setIsEditingDate(false);
   }, []);
 
-  // Keyboard shortcuts for day navigation (1-8)
   const handleStartDateEdit = useCallback(() => {
     setTempDate(forecastCycle.cycleDate);
     setIsEditingDate(true);
@@ -201,7 +195,6 @@ export const DaySelectorPanel: React.FC = () => {
     handleDayChange(day);
   }, [handleDayChange]);
 
-  // Keyboard shortcuts for day navigation (1-8)
   // Keyboard shortcuts for day navigation (1-8)
   useDayNumberShortcuts(dispatch);
 

--- a/src/components/DaySelector/DaySelectorPanel.tsx
+++ b/src/components/DaySelector/DaySelectorPanel.tsx
@@ -14,6 +14,7 @@ import {
 import { selectForecastCycle, setForecastDay, setCycleDate } from '../../store/forecastSlice';
 import { DayType } from '../../types/outlooks';
 import { cn } from '../../lib/utils';
+import { keyboardShortcutKey } from '../../utils/keyboardShortcutKey';
 
 const DAYS: DayType[] = [1, 2, 3, 4, 5, 6, 7, 8];
 
@@ -118,7 +119,10 @@ const useDayNumberShortcuts = (dispatch: ReturnType<typeof useDispatch>) => {
       if (isEditable(e.target as EventTarget | null)) return;
       if (hasModifier(e)) return;
 
-      const num = parseInt(e.key);
+      const key = keyboardShortcutKey(e);
+      if (!key) return;
+
+      const num = parseInt(key, 10);
       if (num >= 1 && num <= 8) dispatch(setForecastDay(num as DayType));
     };
 

--- a/src/components/DaySelector/DaySelectorPanel.tsx
+++ b/src/components/DaySelector/DaySelectorPanel.tsx
@@ -106,24 +106,33 @@ const DayTabs: React.FC<{ currentDay: DayType; days: ForecastDays; onDayButtonCl
   </div>
 );
 
+/** Returns true when the event target is a text field that should consume keystrokes. */
+export const isEditableTypingTarget = (target: EventTarget | null): boolean =>
+  target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
+
+/** Returns true when any modifier would make a digit key a combo shortcut instead of day select. */
+export const keyboardEventHasModifier = (event: KeyboardEvent): boolean =>
+  event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
+
+/** Maps a digit keydown to a forecast day (1-8), or null when the event should be ignored. */
+export const getForecastDayFromDigitKeyDown = (event: KeyboardEvent): DayType | null => {
+  if (isEditableTypingTarget(event.target)) return null;
+  if (keyboardEventHasModifier(event)) return null;
+
+  const key = keyboardShortcutKey(event);
+  if (!key) return null;
+
+  const num = parseInt(key, 10);
+  if (num >= 1 && num <= 8) return num as DayType;
+  return null;
+};
+
 // Custom hook: listen for number keys 1-8 to select forecast days
 const useDayNumberShortcuts = (dispatch: ReturnType<typeof useDispatch>) => {
-  /** Returns true if the given event target is a text-entry element that should absorb keystrokes. */
-  const isEditable = (t: EventTarget | null) => t instanceof HTMLInputElement || t instanceof HTMLTextAreaElement;
-  /** Returns true if any modifier key (Ctrl, Meta, Alt, Shift) is held, so shortcuts don't clash with combos. */
-  const hasModifier = (e: KeyboardEvent) => e.ctrlKey || e.metaKey || e.altKey || e.shiftKey;
-
   useEffect(() => {
-    /** Selects the forecast day matching the pressed digit key (1-8) unless focus is inside a text field. */
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (isEditable(e.target as EventTarget | null)) return;
-      if (hasModifier(e)) return;
-
-      const key = keyboardShortcutKey(e);
-      if (!key) return;
-
-      const num = parseInt(key, 10);
-      if (num >= 1 && num <= 8) dispatch(setForecastDay(num as DayType));
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const day = getForecastDayFromDigitKeyDown(event);
+      if (day) dispatch(setForecastDay(day));
     };
 
     window.addEventListener('keydown', handleKeyDown);

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -11,6 +11,7 @@ import { RootState } from '../../store';
 import { v4 as uuidv4 } from 'uuid';
 import { cn } from '../../lib/utils';
 import { NAVBAR_HEIGHT } from '../../lib/uiConstants';
+import { keyboardShortcutKey } from '../../utils/keyboardShortcutKey';
 
 export interface ToastItem {
   id: string;
@@ -117,10 +118,10 @@ export const AppLayout: React.FC = () => {
       }
 
       if (e.ctrlKey || e.metaKey) {
-        if (!e.key) return;
+        const key = keyboardShortcutKey(e);
+        if (!key) return;
 
         // Define Ctrl/Cmd+key shortcuts for navigation and actions
-        const key = e.key.toLowerCase();
         // Define shortcuts for navigation and actions
         const shortcuts: Record<string, () => void> = {
           h: () => navigate('/'),

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -122,7 +122,6 @@ export const AppLayout: React.FC = () => {
         if (!key) return;
 
         // Define Ctrl/Cmd+key shortcuts for navigation and actions
-        // Define shortcuts for navigation and actions
         const shortcuts: Record<string, () => void> = {
           h: () => navigate('/'),
           '1': () => navigate('/forecast'),
@@ -132,7 +131,7 @@ export const AppLayout: React.FC = () => {
           d: () => document.documentElement.classList.toggle('dark-mode'),
         };
 
-        // Example: Ctrl+H for home, Ctrl+1 for forecast, Ctrl+2 for discussion, Ctrl+3 for verification, Ctrl+D to toggle dark mode
+        // Ctrl+H home, Ctrl+1 forecast, Ctrl+2 discussion, Ctrl+3 verification, Ctrl+4 monitor, Ctrl+D dark mode
         const action = shortcuts[key];
         if (action) {
           e.preventDefault();

--- a/src/monitor/monitorSettings.test.ts
+++ b/src/monitor/monitorSettings.test.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_MONITOR_SETTINGS, normalizeMonitorSettings } from './types';
+import { DEFAULT_MONITOR_SETTINGS } from './types';
+import { normalizeMonitorSettings } from './monitorSettingsNormalize';
 import monitorReducer, { setRadarMode, setRadarSite } from '../store/monitorSlice';
 import { readStoredMonitorSettings, writeStoredMonitorSettings, MONITOR_SETTINGS_STORAGE_KEY } from './storage';
 

--- a/src/monitor/monitorSettings.test.ts
+++ b/src/monitor/monitorSettings.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MONITOR_SETTINGS } from './types';
+import { DEFAULT_MONITOR_SETTINGS, MONITOR_OUTLOOK_LAYER_TYPES } from './types';
 import { normalizeMonitorSettings } from './monitorSettingsNormalize';
 import monitorReducer, { setRadarMode, setRadarSite } from '../store/monitorSlice';
 import { readStoredMonitorSettings, writeStoredMonitorSettings, MONITOR_SETTINGS_STORAGE_KEY } from './storage';
@@ -6,6 +6,11 @@ import { readStoredMonitorSettings, writeStoredMonitorSettings, MONITOR_SETTINGS
 describe('monitor settings', () => {
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  test('loads outlook layer types without circular-import initialization errors', () => {
+    expect(MONITOR_OUTLOOK_LAYER_TYPES).toEqual(['tornado', 'wind', 'hail', 'categorical']);
+    expect(normalizeMonitorSettings({ outlookType: 'tornado' }).outlookType).toBe('tornado');
   });
 
   test('normalizes unknown settings with safe defaults and bounds', () => {

--- a/src/monitor/monitorSettingsNormalize.ts
+++ b/src/monitor/monitorSettingsNormalize.ts
@@ -15,7 +15,7 @@ const RADAR_MODES: MonitorRadarMode[] = ['none', 'mrms-conus', 'site'];
 const RADAR_PRODUCTS: MonitorRadarProduct[] = ['bref-qcd', 'cref-qcd', 'sr-bref', 'sr-bvel'];
 const SATELLITE_PRODUCTS: MonitorSatelliteProduct[] = ['none', 'goes-visible', 'goes-longwave', 'goes-water-vapor', 'goes-shortwave'];
 const OUTLOOK_KINDS: MonitorOutlookSourceKind[] = ['current', 'local-cycle', 'cloud-cycle'];
-const OUTLOOK_LAYER_TYPES: MonitorOutlookLayerType[] = [...MONITOR_OUTLOOK_LAYER_TYPES];
+const OUTLOOK_LAYER_TYPES: readonly MonitorOutlookLayerType[] = MONITOR_OUTLOOK_LAYER_TYPES;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));

--- a/src/monitor/storage.ts
+++ b/src/monitor/storage.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_MONITOR_SETTINGS, MonitorSettings, normalizeMonitorSettings } from './types';
+import { DEFAULT_MONITOR_SETTINGS, MonitorSettings } from './types';
+import { normalizeMonitorSettings } from './monitorSettingsNormalize';
 
 export const MONITOR_SETTINGS_STORAGE_KEY = 'gfc-monitor-settings';
 

--- a/src/monitor/types.ts
+++ b/src/monitor/types.ts
@@ -74,7 +74,5 @@ export const DEFAULT_MONITOR_SETTINGS: MonitorSettings = {
   alertsShowAdvisories: false,
 };
 
-export { normalizeMonitorSettings } from './monitorSettingsNormalize';
-
 export const areMonitorSettingsEqual = (left: MonitorSettings, right: MonitorSettings): boolean =>
   JSON.stringify(left) === JSON.stringify(right);

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -44,6 +44,7 @@ import { useCloudSync } from '../hooks/useCloudSync';
 import { CloudToolbarButton } from '../components/CloudCycleManager/CloudToolbarButton';
 import { countForecastMetrics } from '../utils/forecastMetrics';
 import { getLocalCalendarDate } from '../utils/localDate';
+import { keyboardShortcutKey } from '../utils/keyboardShortcutKey';
 import { queueProductMetric } from '../utils/productMetrics';
 import { ForecastTabbedToolbarLayout } from '../components/ForecastWorkspace/ForecastWorkspaceLayouts';
 import ForecastWorkspaceModals from '../components/ForecastWorkspace/ForecastWorkspaceModals';
@@ -593,9 +594,8 @@ export const processShortcutKeyDown = (
   e: KeyboardEvent,
   context: KeyboardShortcutContext
 ) => {
-  if (!e.key) return;
-
-  const key = e.key.toLowerCase();
+  const key = keyboardShortcutKey(e);
+  if (!key) return;
   if (isTypingTarget(e.target)) return;
 
   if (handleUndoRedoShortcuts(e, key, context)) return;

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -44,7 +44,9 @@ import { useCloudSync } from '../hooks/useCloudSync';
 import { CloudToolbarButton } from '../components/CloudCycleManager/CloudToolbarButton';
 import { countForecastMetrics } from '../utils/forecastMetrics';
 import { getLocalCalendarDate } from '../utils/localDate';
-import { keyboardShortcutKey } from '../utils/keyboardShortcutKey';
+import { hasAnyModifierKey, isTypingTarget, keyboardShortcutKey } from '../utils/keyboardShortcutKey';
+
+export { hasAnyModifierKey, isTypingTarget };
 import { queueProductMetric } from '../utils/productMetrics';
 import { ForecastTabbedToolbarLayout } from '../components/ForecastWorkspace/ForecastWorkspaceLayouts';
 import ForecastWorkspaceModals from '../components/ForecastWorkspace/ForecastWorkspaceModals';
@@ -345,7 +347,6 @@ const useForecastLoadAction = (
 
 const ARROW_KEYS = new Set(['arrowup', 'arrowright', 'arrowdown', 'arrowleft']);
 const INCREASE_PROBABILITY_KEYS = new Set(['arrowup', 'arrowright']);
-const MODIFIER_KEYS: Array<keyof Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey'>> = ['ctrlKey', 'metaKey', 'altKey', 'shiftKey'];
 type ShortcutDispatch = Dispatch<UnknownAction>;
 
 interface KeyboardShortcutContext {
@@ -373,11 +374,6 @@ const OUTLOOK_SHORTCUTS: Record<string, { type: OutlookType; label: string }> = 
   c: { type: 'categorical', label: 'Categorical' },
 };
 
-/** Returns true if the event target is an input or textarea that should receive keyboard text. */
-export const isTypingTarget = (target: EventTarget | null): boolean => {
-  return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
-};
-
 /** Normalises a probability string by converting legacy `#` suffix to `%` (e.g. `"10#"` → `"10%"`). */
 export const normalizeProbability = (value: string): string => value.replace('#', '%');
 
@@ -389,11 +385,6 @@ export const canToggleSignificantForState = (
   if (activeOutlookType === 'categorical') return false;
   if (activeOutlookType === 'tornado') return !['2%', '5%'].includes(activeProbability);
   return activeProbability !== '5%';
-};
-
-/** Returns true if any Ctrl / Meta / Alt / Shift modifier key is held during the event. */
-export const hasAnyModifierKey = (e: KeyboardEvent): boolean => {
-  return MODIFIER_KEYS.some((modifier) => e[modifier]);
 };
 
 const COMMAND_SHORTCUT_HANDLERS: Record<CommandShortcutKey, CommandShortcutHandler> = {

--- a/src/store/monitorSlice.ts
+++ b/src/store/monitorSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { MonitorMapView, MonitorOutlookLayerType, MonitorOutlookSourceSelection, MonitorSettings } from '../monitor/types';
-import { DEFAULT_MONITOR_SETTINGS, normalizeMonitorSettings } from '../monitor/types';
+import { DEFAULT_MONITOR_SETTINGS } from '../monitor/types';
+import { normalizeMonitorSettings } from '../monitor/monitorSettingsNormalize';
 import { resolveRadarProductForMode } from '../monitor/wms';
 
 export type MonitorState = MonitorSettings;

--- a/src/utils/keyboardShortcutKey.test.ts
+++ b/src/utils/keyboardShortcutKey.test.ts
@@ -1,0 +1,14 @@
+import { keyboardShortcutKey } from './keyboardShortcutKey';
+
+describe('keyboardShortcutKey', () => {
+  it('returns a lowercased key when present', () => {
+    expect(keyboardShortcutKey(new KeyboardEvent('keydown', { key: 'Z' }))).toBe('z');
+  });
+
+  it('returns null when the browser omits KeyboardEvent.key', () => {
+    const event = new KeyboardEvent('keydown', { bubbles: true, ctrlKey: true });
+    Object.defineProperty(event, 'key', { value: undefined });
+
+    expect(keyboardShortcutKey(event)).toBeNull();
+  });
+});

--- a/src/utils/keyboardShortcutKey.test.ts
+++ b/src/utils/keyboardShortcutKey.test.ts
@@ -1,4 +1,4 @@
-import { keyboardShortcutKey } from './keyboardShortcutKey';
+import { hasAnyModifierKey, isTypingTarget, keyboardShortcutKey } from './keyboardShortcutKey';
 
 describe('keyboardShortcutKey', () => {
   it('returns a lowercased key when present', () => {
@@ -10,5 +10,26 @@ describe('keyboardShortcutKey', () => {
     Object.defineProperty(event, 'key', { value: undefined });
 
     expect(keyboardShortcutKey(event)).toBeNull();
+  });
+});
+
+describe('isTypingTarget', () => {
+  it('returns true for input and textarea elements', () => {
+    expect(isTypingTarget(document.createElement('input'))).toBe(true);
+    expect(isTypingTarget(document.createElement('textarea'))).toBe(true);
+  });
+
+  it('returns false for other elements', () => {
+    expect(isTypingTarget(document.createElement('button'))).toBe(false);
+  });
+});
+
+describe('hasAnyModifierKey', () => {
+  it('returns true when a modifier is held', () => {
+    expect(hasAnyModifierKey(new KeyboardEvent('keydown', { ctrlKey: true }))).toBe(true);
+  });
+
+  it('returns false when no modifier is held', () => {
+    expect(hasAnyModifierKey(new KeyboardEvent('keydown'))).toBe(false);
   });
 });

--- a/src/utils/keyboardShortcutKey.ts
+++ b/src/utils/keyboardShortcutKey.ts
@@ -1,0 +1,11 @@
+/**
+ * Normalizes a keydown event key for app shortcuts.
+ * Some browsers (e.g. Opera) fire keydown with an undefined `key` while modifiers are held.
+ */
+export function keyboardShortcutKey(event: KeyboardEvent): string | null {
+  if (!event.key) {
+    return null;
+  }
+
+  return event.key.toLowerCase();
+}

--- a/src/utils/keyboardShortcutKey.ts
+++ b/src/utils/keyboardShortcutKey.ts
@@ -1,3 +1,10 @@
+const MODIFIER_KEYS: Array<keyof Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey'>> = [
+  'ctrlKey',
+  'metaKey',
+  'altKey',
+  'shiftKey',
+];
+
 /**
  * Normalizes a keydown event key for app shortcuts.
  * Some browsers (e.g. Opera) fire keydown with an undefined `key` while modifiers are held.
@@ -9,3 +16,11 @@ export function keyboardShortcutKey(event: KeyboardEvent): string | null {
 
   return event.key.toLowerCase();
 }
+
+/** Returns true if the event target is an input or textarea that should receive keyboard text. */
+export const isTypingTarget = (target: EventTarget | null): boolean =>
+  target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
+
+/** Returns true if any Ctrl / Meta / Alt / Shift modifier key is held during the event. */
+export const hasAnyModifierKey = (event: KeyboardEvent): boolean =>
+  MODIFIER_KEYS.some((modifier) => event[modifier]);


### PR DESCRIPTION
## Summary

Fixes **GFC-WEB-4** (Sentry [#7500524369](https://wxboysuper.sentry.io/issues/7500524369/)): site-wide startup crash from a circular import between `monitor/types.ts` and `monitorSettingsNormalize.ts` (minified as `Gv is not iterable` / TDZ on `MONITOR_OUTLOOK_LAYER_TYPES`).

- Breaks the cycle: remove `normalizeMonitorSettings` re-export from `types.ts`; callers import from `monitorSettingsNormalize.ts` directly; replace `[...MONITOR_OUTLOOK_LAYER_TYPES]` spread with a direct readonly reference.
- Adds a regression test for the circular-import pattern.
- **Follow-up (GFC-WEB-3 / keyboard):** centralize `keyboardShortcutKey()`, `isTypingTarget`, and `hasAnyModifierKey` in `src/utils/keyboardShortcutKey.ts` for `ForecastPage`, `AppLayout`, and day-selector digit shortcuts (guards missing `KeyboardEvent.key`).

## Context

PR #326 landed the initial keyboard guard on `ForecastPage` and `AppLayout`. This PR fixes the production monitor import crash and consolidates keyboard helpers so shortcut paths cannot regress.

## Test plan

- [x] `pnpm test` (focused): `keyboardShortcutKey`, `ForecastPage`, `AppLayout`, `DaySelectorPanel`, `monitorSettings`
- [x] CI green (build matrix, CodeQL, CodeScene, DeepSource, Greptile, Kilo)
- [x] Greptile 5/5