### PR TITLE
[Port][Conflicts] ci: release automation and PR governance (ship on main) → beta

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/beta_to_main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/beta_to_main.md
@@ -1,0 +1,19 @@
+## Beta → main promotion
+
+This PR promotes **beta** to **production** (`main`).
+
+### Before merge
+
+- [ ] CHANGELOG.md has an up-to-date section for this release (e.g. `## v1.6`)
+- [ ] CI and reviews (Greptile, Kilo) are green
+- [ ] Conflicts with `main` resolved here
+- [ ] Beta deployment smoke-tested
+
+### After merge (automatic)
+
+- Stable version committed on `main`
+- GitHub Release created from CHANGELOG
+- Beta bumped to the next development prerelease
+- Production deploy workflow runs
+
+You only need to click **Merge** — no manual Actions steps.

--- a/.github/PULL_REQUEST_TEMPLATE/release_to_main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_to_main.md
@@ -1,0 +1,8 @@
+## Release to main
+
+- [ ] Prepared via **Prepare Beta → Main Release PR** (`release/v*` → `main`)
+- [ ] CHANGELOG.md updated for this stable version
+- [ ] CI, Greptile, and Kilo are green
+- [ ] Merge conflicts with `main` resolved in this PR
+- [ ] Beta deployment smoke-tested
+- [ ] After merge: confirm production deploy; optionally run **Bump beta for next development cycle**

--- a/.github/workflows/bump-beta-after-main-release.yml
+++ b/.github/workflows/bump-beta-after-main-release.yml
@@ -1,0 +1,56 @@
+name: Bump beta for next development cycle
+
+# After a release PR merges to main, bump beta to the next minor beta prerelease (e.g. 1.6.0 → 1.7.0-beta.1).
+# Run manually when you are ready to start the next beta line — not automatic on every main merge.
+#
+# Required secret: GH_PAT (repo scope)
+on:
+  workflow_dispatch:
+    inputs:
+      stable_version:
+        description: 'Stable version just released on main (e.g. 1.6.0). Leave empty to read from origin/main.'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  bump-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve stable version from main
+        id: stable
+        env:
+          INPUT_STABLE: ${{ inputs.stable_version }}
+        run: |
+          git fetch origin main beta
+          if [[ -n "$INPUT_STABLE" ]]; then
+            echo "value=$INPUT_STABLE" >> "$GITHUB_OUTPUT"
+          else
+            git show origin/main:package.json > /tmp/main-package.json
+            STABLE=$(node scripts/read-package-version.mjs /tmp/main-package.json)
+            echo "value=$STABLE" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump beta package.json
+        env:
+          STABLE_VERSION: ${{ steps.stable.outputs.value }}
+        run: |
+          git checkout beta
+          git pull --ff-only origin beta
+          node scripts/bump-beta-after-main-release.mjs "$STABLE_VERSION"
+          git add package.json
+          git commit -m "chore: start next beta cycle after v$STABLE_VERSION main release"
+          git push origin beta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,59 @@ permissions:
   contents: read
 
 jobs:
+  pr-governance:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR branches
+        run: git fetch origin "${{ github.base_ref }}" "${{ github.head_ref }}"
+
+      - name: Branch policy
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: node scripts/validate-branch-policy.mjs
+
+      - name: Changelog policy
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-changelog-pr.mjs
+
+  package-version-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Validate release automation unit tests
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/version-bump.test.mjs
+
+      - name: Validate package version for target branch
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: node scripts/validate-package-version.mjs
+
   build-and-test:
+    needs: [package-version-policy, pr-governance]
+    if: >-
+      always() &&
+      needs.package-version-policy.result == 'success' &&
+      (needs.pr-governance.result == 'success' || needs.pr-governance.result == 'skipped')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -35,13 +35,18 @@ jobs:
       - name: Read app version
         id: app_version
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          VERSION=${VERSION//$'\n'/}
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
-            echo "Invalid package version format: $VERSION" >&2
+          RAW=$(node scripts/read-package-version.mjs)
+          STABLE=$(node --input-type=module -e "
+            import { deriveStableVersion } from './scripts/lib/package-version.mjs';
+            const stable = deriveStableVersion(process.argv[1]);
+            console.log(stable ?? process.argv[1]);
+          " "$RAW")
+          if ! printf '%s' "$RAW" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid package version format: $RAW" >&2
             exit 1
           fi
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "value=$RAW" >> "$GITHUB_OUTPUT"
+          echo "sentry_release=$STABLE" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: pnpm run build
@@ -105,7 +110,7 @@ jobs:
           SENTRY_DSN=${{ secrets.SENTRY_DSN }}
           SENTRY_BROWSER_DSN=${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_ENVIRONMENT=production
-          SENTRY_RELEASE=graphical-forecast-creator@${{ steps.app_version.outputs.value }}
+          SENTRY_RELEASE=graphical-forecast-creator@${{ steps.app_version.outputs.sentry_release }}
           EOF
           rsync -avz prod-server.env root@${{ secrets.PROD_SSH_HOST }}:/opt/gfc-analytics/.env
 

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -1,0 +1,100 @@
+name: Post-merge automation
+
+# Runs after a PR merges. No manual workflow dispatch needed for normal releases.
+#
+# beta → main: strip stable version on main, GitHub Release from CHANGELOG, start next beta line.
+# feature/*|fix/*|other → beta: bump -beta.N on beta (hotfix/* is the only blocked target).
+# hotfix/* → main: bump patch on main and create GitHub Release.
+#
+# Required secret: GH_PAT (repo scope)
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, beta]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  post-merge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Beta promotion merged into main
+        if: >-
+          github.event.pull_request.base.ref == 'main' &&
+          github.event.pull_request.head.ref == 'beta'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          git fetch origin main beta
+          git checkout main
+          git pull --ff-only origin main
+
+          BETA_VERSION=$(node scripts/read-package-version.mjs)
+          node scripts/strip-beta-prerelease-version.mjs
+          STABLE=$(node scripts/read-package-version.mjs)
+
+          if ! git diff --quiet package.json; then
+            git add package.json
+            git commit -m "chore: set stable v$STABLE on main after beta promotion"
+            git push origin main
+          fi
+
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$STABLE" main
+
+          git checkout beta
+          git pull --ff-only origin beta
+          node scripts/bump-beta-after-main-release.mjs "$STABLE"
+          git add package.json
+          git commit -m "chore: start next beta cycle after v$STABLE main release (was $BETA_VERSION)"
+          git push origin beta
+
+      - name: Hotfix merged into main
+        if: >-
+          github.event.pull_request.base.ref == 'main' &&
+          startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          git fetch origin main
+          git checkout main
+          git pull --ff-only origin main
+          PREVIOUS=$(node scripts/read-package-version.mjs)
+          node scripts/apply-version-bump.mjs main
+          STABLE=$(node scripts/read-package-version.mjs)
+          git add package.json
+          git commit -m "chore: bump patch version after hotfix merge (was $PREVIOUS)"
+          git push origin main
+
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$STABLE" main
+
+      - name: Integration merge into beta
+        if: >-
+          github.event.pull_request.base.ref == 'beta' &&
+          github.event.pull_request.head.ref != 'beta' &&
+          !startsWith(github.event.pull_request.head.ref, 'port/') &&
+          !startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        run: |
+          git fetch origin beta
+          git checkout beta
+          git pull --ff-only origin beta
+          PREVIOUS=$(node scripts/read-package-version.mjs)
+          node scripts/apply-version-bump.mjs beta
+          git add package.json
+          git commit -m "chore: bump beta prerelease after merge (was $PREVIOUS)"
+          git push origin beta

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,183 @@
+name: PR governance
+
+# Branch routing, changelog expectations, and PR labels on open/update and when CI finishes.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: read
+
+jobs:
+  policy:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR branches
+        run: |
+          git fetch origin "${{ github.base_ref }}" "${{ github.head_ref }}"
+
+      - name: Branch policy
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: node scripts/validate-branch-policy.mjs
+
+      - name: Changelog policy
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-changelog-pr.mjs
+
+      - name: Apply routing labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const labelDefs = [
+              ['promotion', '1d76db'],
+              ['feature', '0e8a16'],
+              ['fix', 'd4c5f9'],
+              ['hotfix', 'b60205'],
+              ['release', '5319e7'],
+              ['port', 'c5def5'],
+              ['has conflicts', 'e11d21'],
+              ['draft', 'ededed'],
+              ['ci:pending', 'fbca04'],
+              ['ci:passing', '0e8a16'],
+              ['ci:failing', 'd73a4a'],
+              ['integration:primary', '1f6feb'],
+              ['integration:other', 'c2e0c6'],
+            ];
+            for (const [name, color] of labelDefs) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name, color });
+                }
+              }
+            }
+
+            const pr = context.payload.pull_request;
+            const head = pr.head.ref;
+            const base = pr.base.ref;
+            const labels = new Set();
+
+            if (head === 'beta' && base === 'main') labels.add('promotion');
+            if (head.startsWith('feature/')) labels.add('feature');
+            if (head.startsWith('fix/')) labels.add('fix');
+            if (head.startsWith('hotfix/')) labels.add('hotfix');
+            if (head.startsWith('release/')) labels.add('release');
+            if (head.startsWith('port/')) labels.add('port');
+
+            if (base === 'beta' && !head.startsWith('hotfix/')) {
+              if (head.startsWith('feature/') || head.startsWith('fix/')) {
+                labels.add('integration:primary');
+              } else if (head !== 'beta' && !head.startsWith('port/')) {
+                labels.add('integration:other');
+              }
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            if (pull.mergeable === false) labels.add('has conflicts');
+            if (pull.draft) labels.add('draft');
+
+            const existing = (await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            })).data.map((label) => label.name);
+
+            const managed = [
+              'promotion', 'feature', 'fix', 'hotfix', 'release', 'port',
+              'integration:primary', 'integration:other',
+              'has conflicts', 'draft', 'ci:pending', 'ci:passing', 'ci:failing',
+              'changelog:ok', 'changelog:missing',
+            ];
+
+            for (const name of managed) {
+              if (existing.includes(name)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name,
+                });
+              }
+            }
+
+            for (const name of labels) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [name],
+              });
+            }
+
+  refresh-labels:
+    if: >-
+      github.event_name == 'check_suite' &&
+      github.event.check_suite.pull_requests[0] != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update CI labels from check suite
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = github.event.check_suite.pull_requests[0];
+            if (!pr) return;
+
+            const conclusion = github.event.check_suite.conclusion;
+            const managed = ['ci:pending', 'ci:passing', 'ci:failing'];
+            const existing = (await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            })).data.map((l) => l.name);
+
+            for (const name of managed) {
+              if (existing.includes(name)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name,
+                });
+              }
+            }
+
+            if (!conclusion) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: ['ci:pending'],
+              });
+              return;
+            }
+
+            const label = conclusion === 'success' ? 'ci:passing' : 'ci:failing';
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: [label],
+            });

--- a/.github/workflows/prepare-beta-main-release-pr.yml
+++ b/.github/workflows/prepare-beta-main-release-pr.yml
@@ -1,0 +1,113 @@
+name: Prepare Beta → Main Release PR (optional)
+
+# OPTIONAL — not required for normal releases.
+# Default path: open a beta → main PR and merge; post-merge-automation.yml handles the rest.
+#
+# This workflow creates release/vX.Y.Z from beta if you prefer a separate promotion branch.
+#
+# Required secret: GH_PAT (repo scope) — same as pr-porting.yml
+on:
+  workflow_dispatch:
+    inputs:
+      refresh_existing:
+        description: 'Force-update the release branch from latest beta (recommended)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Read beta version and derive release branch
+        id: meta
+        run: |
+          git fetch origin beta main
+          git checkout origin/beta
+          BETA_VERSION=$(node scripts/read-package-version.mjs)
+          STABLE_VERSION=$(node --input-type=module -e "
+            import { deriveStableVersion } from './scripts/lib/package-version.mjs';
+            const stable = deriveStableVersion(process.argv[1]);
+            if (!stable) process.exit(1);
+            console.log(stable);
+          " "$BETA_VERSION")
+          RELEASE_BRANCH="release/v${STABLE_VERSION}"
+          echo "beta_version=$BETA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "stable_version=$STABLE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Build release branch with stable package version
+        env:
+          RELEASE_BRANCH: ${{ steps.meta.outputs.release_branch }}
+          STABLE_VERSION: ${{ steps.meta.outputs.stable_version }}
+          REFRESH: ${{ inputs.refresh_existing }}
+        run: |
+          git checkout -B "$RELEASE_BRANCH" origin/beta
+          node scripts/prepare-main-release-version.mjs
+          if git diff --quiet package.json; then
+            echo "package.json already at $STABLE_VERSION on $RELEASE_BRANCH"
+          else
+            git add package.json
+            git commit -m "chore: prepare v$STABLE_VERSION for main release"
+          fi
+          if [[ "$REFRESH" == "true" ]]; then
+            git push --force-with-lease origin "$RELEASE_BRANCH"
+          else
+            git push origin "$RELEASE_BRANCH" || {
+              echo "Release branch exists. Re-run with refresh_existing=true or delete $RELEASE_BRANCH first."
+              exit 1
+            }
+          fi
+
+      - name: Open or refresh pull request to main
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          RELEASE_BRANCH: ${{ steps.meta.outputs.release_branch }}
+          STABLE_VERSION: ${{ steps.meta.outputs.stable_version }}
+          BETA_VERSION: ${{ steps.meta.outputs.beta_version }}
+        run: |
+          EXISTING=$(gh pr list --base main --head "$RELEASE_BRANCH" --state open --json number --jq '.[0].number // empty')
+          BODY_FILE=$(mktemp)
+          cat > "$BODY_FILE" <<EOF
+          ## Beta → main release (automated prepare)
+
+          This PR promotes **beta** to **main** with a stable \`package.json\` version (\`$STABLE_VERSION\`) while **beta** stays on \`$BETA_VERSION\`.
+
+          ### Before merge
+          - Resolve merge conflicts with \`main\` here (not on a direct \`beta\` → \`main\` PR).
+          - Confirm CHANGELOG.md has a dated section for **v$STABLE_VERSION**.
+          - Wait for CI, Greptile, and Kilo on this PR.
+          - Smoke-test the beta deployment one last time.
+
+          ### After merge
+          - Production deploy runs from \`main\` (Deploy Production to VPS).
+          - Optional: run **Bump beta for next development cycle** when starting the next minor line on beta.
+
+          Prepared by prepare-beta-main-release-pr.yml.
+          EOF
+
+          if [[ -n "$EXISTING" ]]; then
+            gh pr comment "$EXISTING" --body "Release branch refreshed from latest \`beta\` (stable \`$STABLE_VERSION\`)."
+            echo "Updated open PR #$EXISTING"
+            gh pr view "$EXISTING" --web=false --json url --jq .url
+          else
+            gh pr create \
+              --base main \
+              --head "$RELEASE_BRANCH" \
+              --title "release: promote v$STABLE_VERSION to main" \
+              --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -1,34 +1,38 @@
-name: Promote Beta to Main
+name: (Legacy) Direct promote beta → main
 
 permissions:
   contents: read
 
-# Manually triggered from the GitHub Actions tab.
-# Merges the beta branch into main, then pushes — which triggers deploy-main-to-vps.yml.
+# DEPRECATED — do not use for normal releases.
+#
+# Normal promotion path:
+#   1. Actions → "Prepare Beta → Main Release PR" (prepare-beta-main-release-pr.yml)
+#   2. Review and merge the release/vX.Y.Z → main pull request
+#   3. Optional: "Bump beta for next development cycle"
+#
+# This workflow bypasses the release PR, final review, and conflict resolution in GitHub.
+# It remains only for documented emergency recovery when a PAT push to main is required.
 #
 # Required secrets:
 #   GH_PAT — Personal Access Token with `repo` scope.
-#             GITHUB_TOKEN pushes do NOT trigger other workflow runs (GitHub safety rule),
-#             so a PAT is required here to make the deploy workflow fire automatically.
 on:
   workflow_dispatch:
     inputs:
-      confirm:
-        description: 'Type "yes" to confirm promotion of beta → main'
+      confirm_legacy:
+        description: 'Type LEGACY-DIRECT-PROMOTE to confirm (bypasses release PR process)'
         required: true
-        default: 'no'
+        default: ''
 
 jobs:
   promote:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.confirm == 'yes' }}
+    if: ${{ github.event.inputs.confirm_legacy == 'LEGACY-DIRECT-PROMOTE' }}
 
     steps:
       - name: Checkout with full history
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Use GH_PAT so the push below triggers deploy-main-to-vps.yml
           token: ${{ secrets.GH_PAT }}
 
       - name: Configure git identity
@@ -38,9 +42,21 @@ jobs:
 
       - name: Merge beta into main
         run: |
+          git fetch origin beta main
           git checkout main
-          git merge --no-ff origin/beta -m "chore: promote beta → main [automated]"
+          git merge --no-ff origin/beta -m "chore: promote beta → main [legacy direct]"
 
-      # This push (via GH_PAT) triggers deploy-main-to-vps.yml
+      - name: Strip beta prerelease from package version on main
+        run: node scripts/strip-beta-prerelease-version.mjs
+
+      - name: Commit stable version on main when changed
+        run: |
+          if git diff --quiet package.json; then
+            echo "package.json version already stable on main."
+          else
+            git add package.json
+            git commit -m "chore: set stable package version for main promotion [legacy]"
+          fi
+
       - name: Push main
         run: git push origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,23 @@
 
 All notable changes to this project will be documented in this file.
 
+<<<<<<< HEAD
 ## v1.6
 
 ### Fixed
 - **GFC-WEB-4 (monitor startup):** Break circular import between `monitor/types` and `monitorSettingsNormalize` that crashed the hosted app at load (`Gv is not iterable` / `MONITOR_OUTLOOK_LAYER_TYPES` before initialization when spreading outlook layer types).
 - **Forecast keyboard shortcuts (GFC-WEB-3):** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts. Centralized the guard in `keyboardShortcutKey` and applied it to forecast, navbar, and day-selector shortcuts.
+=======
+## [Unreleased]
+
+### Changed
+- **Release automation:** Beta → main stays a normal PR; merge triggers stable versioning on `main`, GitHub Releases from CHANGELOG (including hotfixes), and beta prerelease bumps. CI enforces branch routing (preferred `feature/*`/`fix/*` → beta; only `hotfix/*` blocked on beta), changelog checks, and automated PR labels. Workflow definitions ship on `main` so GitHub can run them for repository pull requests.
+
+## v1.6
+
+### Fixed
+- **Forecast keyboard shortcuts:** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (reported in production via Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts.
+>>>>>>> 9570940 (ci: release automation and PR governance on main)
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
 
 ## v1.5.3

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,98 @@
+# Release workflow
+
+Your normal flow stays simple: **open a PR, review it, click merge**. Automation handles versions, changelog gates, labels, GitHub Releases, and beta prerelease bumps.
+
+## Your day-to-day (short answer)
+
+| Goal | What you do |
+|------|-------------|
+| Feature work | Prefer `feature/*` or `fix/*` → PR into **beta** → merge (other branch names are allowed except `hotfix/*`) |
+| Promote to production | PR **beta → main** → merge (nothing else required) |
+| Production hotfix | Branch `hotfix/*` → PR into **main** → merge (GitHub Release created automatically) |
+
+After merge, **Post-merge automation** runs on its own (no Actions button).
+
+## What happens when you merge
+
+### beta → main (promotion)
+
+1. You merge the **beta → main** PR (same as today).
+2. **Post-merge automation** (`post-merge-automation.yml`):
+   - Strips `-beta` from `package.json` on `main` (e.g. `1.6.0-beta.3` → `1.6.0`) and pushes.
+   - Creates a **GitHub Release** `v1.6.0` using the matching section in `CHANGELOG.md`.
+   - Bumps **beta** to the next line (e.g. `1.7.0-beta.1`) for continued development.
+3. **Deploy Production to VPS** runs on the push to `main` (Sentry release uses the **stable** version even if the merge commit still had `-beta` briefly).
+
+### Integrations → beta
+
+- Preferred: `feature/*` and `fix/*` (labeled `integration:primary`).
+- Other branch names are allowed into beta except `hotfix/*` (labeled `integration:other`).
+- Automation increments the beta prerelease on each merge: `1.6.0-beta.1` → `1.6.0-beta.2`, etc.
+- Port branches (`port/*`) skip the version bump.
+
+### hotfix/* → main
+
+- Automation bumps the **patch** on `main` after merge (e.g. `1.6.0` → `1.6.1`).
+- Creates a **GitHub Release** for the new patch version from `CHANGELOG.md`.
+
+## Branch rules (enforced in CI)
+
+| Head branch | Base branch | Allowed |
+|-------------|-------------|---------|
+| `feature/*` | `beta` | Yes (preferred) |
+| `fix/*` | `beta` | Yes (preferred) |
+| Other names (not `hotfix/*`) | `beta` | Yes |
+| `hotfix/*` | `main` | Yes |
+| `beta` | `main` | Yes (promotion) |
+| `feature/*`, `fix/*`, other | `main` | **Blocked** |
+| `hotfix/*` | `beta` | **Blocked** |
+
+`main` and `beta` are protected; direct pushes are already restricted.
+
+## Version policy
+
+| Branch | `package.json` |
+|--------|----------------|
+| `beta` | Must include `-beta.N` (e.g. `1.6.0-beta.2`) |
+| `main` | Stable semver only (e.g. `1.6.0`) |
+| PR **beta → main** | May show `-beta` on the PR; stripped automatically after merge |
+
+## Changelog
+
+For PRs into **beta** (feature/fix) and **hotfix → main**:
+
+- Edit `CHANGELOG.md` in the PR, **or**
+- Add a `## Changelog` section with bullets in the PR description.
+
+**beta → main** promotion PRs skip the file check (verify the release section in CHANGELOG before merge).
+
+## PR labels (automatic)
+
+`pr-governance.yml` manages labels such as:
+
+- `promotion`, `feature`, `fix`, `hotfix`
+- `has conflicts`, `draft`
+- `ci:pending`, `ci:passing`, `ci:failing`
+
+Create these labels in the repo once (any color); the workflow applies them on each PR.
+
+## Optional / legacy workflows
+
+| Workflow | When to use |
+|----------|-------------|
+| **Prepare Beta → Main Release PR** | Optional alternate path using `release/v*` branches (not required if you use beta → main PR). |
+| **Bump beta for next development cycle** | Manual override if post-merge bump did not run. |
+| **(Legacy) Direct promote beta → main** | Emergency only (`LEGACY-DIRECT-PROMOTE`); bypasses PR review. |
+
+## Required secret
+
+- **GH_PAT** — same token as PR porting (`repo` scope), used for post-merge commits and releases.
+
+## Local scripts
+
+| Script | Purpose |
+|--------|---------|
+| `node scripts/validate-branch-policy.mjs` | Branch routing check |
+| `node scripts/validate-package-version.mjs` | Version policy check |
+| `node scripts/check-changelog-pr.mjs` | Changelog check |
+| `node --test scripts/lib/package-version.test.mjs` | Policy unit tests |

--- a/scripts/apply-version-bump.mjs
+++ b/scripts/apply-version-bump.mjs
@@ -1,0 +1,23 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { bumpVersionForMergeTarget } from './lib/version-bump.mjs';
+
+const target = process.argv[2];
+const packagePath = 'package.json';
+
+if (target !== 'beta' && target !== 'main') {
+  console.error('Usage: node scripts/apply-version-bump.mjs <beta|main>');
+  process.exit(1);
+}
+
+const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+const previous = pkg.version;
+const next = bumpVersionForMergeTarget(previous, target);
+
+if (!next) {
+  console.error(`Cannot bump ${target} version from "${previous}".`);
+  process.exit(1);
+}
+
+pkg.version = next;
+writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+console.log(`Bumped package.json: ${previous} -> ${next} (target ${target})`);

--- a/scripts/bump-beta-after-main-release.mjs
+++ b/scripts/bump-beta-after-main-release.mjs
@@ -1,0 +1,33 @@
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { deriveStableVersion } from './lib/package-version.mjs';
+
+const stableInput = process.argv[2] ?? process.env.STABLE_VERSION ?? '';
+const packagePath = 'package.json';
+
+const stable = stableInput.trim();
+if (!stable) {
+  console.error('Provide stable version as argv[2] (e.g. 1.6.0).');
+  process.exit(1);
+}
+
+const normalized = deriveStableVersion(stable) ?? stable;
+const parts = normalized.split('.').map(Number);
+if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+  console.error(`Invalid stable version "${stable}".`);
+  process.exit(1);
+}
+
+const nextBeta = `${parts[0]}.${parts[1] + 1}.0-beta.1`;
+const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+const previous = pkg.version;
+pkg.version = nextBeta;
+writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+const outputPath = process.env.GITHUB_OUTPUT;
+if (outputPath) {
+  appendFileSync(outputPath, `previous_beta_version=${previous}\n`);
+  appendFileSync(outputPath, `next_beta_version=${nextBeta}\n`);
+  appendFileSync(outputPath, `stable_version=${normalized}\n`);
+}
+
+console.log(`Updated beta package.json: ${previous} -> ${nextBeta} (after main release ${normalized})`);

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { changelogTouchesPr } from './lib/changelog.mjs';
+import { evaluateBranchPolicy } from './lib/branch-policy.mjs';
+
+const baseRef = process.env.GITHUB_BASE_REF ?? '';
+const headRef = process.env.GITHUB_HEAD_REF ?? '';
+const prBody = process.env.PR_BODY ?? '';
+
+if (!baseRef || !headRef) {
+  console.log('No PR base/head branch; skipping changelog check.');
+  process.exit(0);
+}
+
+const branchPolicy = evaluateBranchPolicy({ baseRef, headRef });
+if (!branchPolicy.ok) {
+  process.exit(0);
+}
+
+if (branchPolicy.kind === 'beta-promotion') {
+  console.log('Skipping changelog file check for beta → main promotion PR (verify release notes before merge).');
+  process.exit(0);
+}
+
+if (headRef.startsWith('port/')) {
+  console.log('Skipping changelog check for automated port PR.');
+  process.exit(0);
+}
+
+const changedFiles = execSync(`git diff --name-only origin/${baseRef}...origin/${headRef}`, {
+  encoding: 'utf8',
+})
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const result = changelogTouchesPr(changedFiles, prBody);
+
+if (!result.ok) {
+  console.error(result.reason);
+  process.exit(1);
+}
+
+console.log(result.reason);

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -1,0 +1,34 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { extractChangelogSection } from './lib/changelog.mjs';
+
+const stableVersion = process.argv[2];
+const targetBranch = process.argv[3] ?? 'main';
+
+if (!stableVersion) {
+  console.error('Usage: node scripts/create-github-release.mjs <stable-version> [target-branch]');
+  process.exit(1);
+}
+
+const changelog = readFileSync('CHANGELOG.md', 'utf8');
+const section = extractChangelogSection(changelog, stableVersion);
+
+if (!section) {
+  console.error(`No CHANGELOG section found for v${stableVersion}.`);
+  process.exit(1);
+}
+
+const notesFile = process.env.NOTES_FILE ?? 'release-notes.md';
+writeFileSync(notesFile, `${section}\n`);
+
+const tag = `v${stableVersion}`;
+try {
+  execSync(`gh release view "${tag}"`, { stdio: 'ignore' });
+  console.log(`GitHub release ${tag} already exists.`);
+} catch {
+  execSync(
+    `gh release create "${tag}" --title "${tag}" --notes-file "${notesFile}" --target "${targetBranch}"`,
+    { stdio: 'inherit' },
+  );
+  console.log(`Created GitHub release ${tag}.`);
+}

--- a/scripts/lib/branch-policy.mjs
+++ b/scripts/lib/branch-policy.mjs
@@ -1,0 +1,89 @@
+/** @typedef {{ ok: true, kind: string }} BranchPolicyOk */
+/** @typedef {{ ok: false, message: string }} BranchPolicyFail */
+/** @typedef {BranchPolicyOk | BranchPolicyFail} BranchPolicyResult */
+
+const PORT_BRANCH_PATTERN = /^port\/\d+-to-/;
+const RELEASE_INFRA_BRANCH_PATTERN = /^feature\/release-/;
+
+/**
+ * @param {string} headRef
+ */
+export const isFeatureBranch = (headRef) => headRef.startsWith('feature/');
+
+/**
+ * @param {string} headRef
+ */
+export const isFixBranch = (headRef) => headRef.startsWith('fix/');
+
+/**
+ * @param {string} headRef
+ */
+export const isHotfixBranch = (headRef) => headRef.startsWith('hotfix/');
+
+/**
+ * @param {string} headRef
+ */
+export const isPortBranch = (headRef) => PORT_BRANCH_PATTERN.test(headRef);
+
+/**
+ * Branch routing for protected integration branches.
+ *
+ * @param {{ baseRef: string; headRef: string }} context
+ * @returns {BranchPolicyResult}
+ */
+export const evaluateBranchPolicy = ({ baseRef, headRef }) => {
+  if (baseRef === 'main') {
+    if (headRef === 'beta') {
+      return { ok: true, kind: 'beta-promotion' };
+    }
+    if (isHotfixBranch(headRef)) {
+      return { ok: true, kind: 'hotfix' };
+    }
+    if (headRef.startsWith('release/')) {
+      return { ok: true, kind: 'release' };
+    }
+    if (RELEASE_INFRA_BRANCH_PATTERN.test(headRef)) {
+      return { ok: true, kind: 'release-infrastructure' };
+    }
+    if (isFeatureBranch(headRef)) {
+      return {
+        ok: false,
+        message: 'feature/* branches must merge into beta, not main.',
+      };
+    }
+    if (isFixBranch(headRef)) {
+      return {
+        ok: false,
+        message: 'fix/* branches must merge into beta, not main.',
+      };
+    }
+    return {
+      ok: false,
+      message: `Branch "${headRef}" cannot target main. Use beta (promotion), hotfix/*, or release/*.`,
+    };
+  }
+
+  if (baseRef === 'beta') {
+    if (isHotfixBranch(headRef)) {
+      return {
+        ok: false,
+        message: 'hotfix/* branches merge into main, not beta.',
+      };
+    }
+    if (headRef === 'main') {
+      return { ok: false, message: 'Do not open PRs from main into beta.' };
+    }
+    if (isFeatureBranch(headRef)) {
+      return { ok: true, kind: 'beta-integration-feature' };
+    }
+    if (isFixBranch(headRef)) {
+      return { ok: true, kind: 'beta-integration-fix' };
+    }
+    if (isPortBranch(headRef) || headRef === 'beta') {
+      return { ok: true, kind: 'beta-integration' };
+    }
+    return { ok: true, kind: 'beta-integration-other' };
+  }
+
+  return { ok: true, kind: 'other' };
+};

--- a/scripts/lib/branch-policy.test.mjs
+++ b/scripts/lib/branch-policy.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { evaluateBranchPolicy } from './branch-policy.mjs';
+
+describe('branch policy', () => {
+  it('allows beta promotion to main', () => {
+    const result = evaluateBranchPolicy({ baseRef: 'main', headRef: 'beta' });
+    assert.equal(result.ok, true);
+    assert.equal(result.kind, 'beta-promotion');
+  });
+
+  it('blocks feature branches to main', () => {
+    const result = evaluateBranchPolicy({ baseRef: 'main', headRef: 'feature/foo' });
+    assert.equal(result.ok, false);
+  });
+
+  it('allows hotfix to main', () => {
+    const result = evaluateBranchPolicy({ baseRef: 'main', headRef: 'hotfix/urgent' });
+    assert.equal(result.ok, true);
+  });
+
+  it('prioritizes feature to beta', () => {
+    const result = evaluateBranchPolicy({ baseRef: 'beta', headRef: 'feature/foo' });
+    assert.equal(result.ok, true);
+    assert.equal(result.kind, 'beta-integration-feature');
+  });
+
+  it('prioritizes fix to beta', () => {
+    const result = evaluateBranchPolicy({ baseRef: 'beta', headRef: 'fix/foo' });
+    assert.equal(result.ok, true);
+    assert.equal(result.kind, 'beta-integration-fix');
+  });
+
+  it('allows other branch names to beta', () => {
+    const result = evaluateBranchPolicy({ baseRef: 'beta', headRef: 'chore/docs' });
+    assert.equal(result.ok, true);
+    assert.equal(result.kind, 'beta-integration-other');
+  });
+
+  it('blocks hotfix to beta', () => {
+    const result = evaluateBranchPolicy({ baseRef: 'beta', headRef: 'hotfix/urgent' });
+    assert.equal(result.ok, false);
+  });
+});

--- a/scripts/lib/changelog.mjs
+++ b/scripts/lib/changelog.mjs
@@ -1,0 +1,49 @@
+/**
+ * @param {string} changelog
+ * @param {string} stableVersion e.g. 1.6.0
+ * @returns {string | null}
+ */
+export const extractChangelogSection = (changelog, stableVersion) => {
+  const [major, minor] = stableVersion.split('.');
+  const headings = [
+    `## v${stableVersion}`,
+    `## v${major}.${minor}`,
+    `## v${major}.${Number(minor)}`,
+  ];
+
+  for (const heading of headings) {
+    const start = changelog.indexOf(heading);
+    if (start === -1) continue;
+
+    const afterHeading = start + heading.length;
+    const rest = changelog.slice(afterHeading);
+    const nextSection = rest.search(/\n## v[0-9]/);
+    const body = (nextSection === -1 ? rest : rest.slice(0, nextSection)).trim();
+    if (body) {
+      return `${heading}\n\n${body}`.trim();
+    }
+  }
+
+  return null;
+};
+
+/**
+ * @param {string[]} changedFiles
+ * @param {string} prBody
+ */
+export const changelogTouchesPr = (changedFiles, prBody) => {
+  if (changedFiles.some((file) => file === 'CHANGELOG.md' || file.endsWith('/CHANGELOG.md'))) {
+    return { ok: true, reason: 'CHANGELOG.md modified in this PR.' };
+  }
+
+  const body = prBody ?? '';
+  if (/##\s*changelog/i.test(body) && /^\s*[-*]/m.test(body)) {
+    return { ok: true, reason: 'PR description includes a Changelog section with bullets.' };
+  }
+
+  return {
+    ok: false,
+    reason:
+      'Update CHANGELOG.md in this PR or add a "## Changelog" section with bullet points in the PR description.',
+  };
+};

--- a/scripts/lib/package-version.mjs
+++ b/scripts/lib/package-version.mjs
@@ -1,0 +1,82 @@
+/** @typedef {{ ok: true }} VersionPolicyOk */
+/** @typedef {{ ok: false, message: string }} VersionPolicyFail */
+/** @typedef {VersionPolicyOk | VersionPolicyFail} VersionPolicyResult */
+
+const BETA_PRERELEASE_PATTERN = /-beta(\.|$)/i;
+const STABLE_VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+const RELEASE_BRANCH_PATTERN = /^release\/v[0-9]+\.[0-9]+\.[0-9]+$/;
+
+/**
+ * @param {string} version
+ */
+export const hasBetaPrerelease = (version) => BETA_PRERELEASE_PATTERN.test(version);
+
+/**
+ * @param {string} version
+ * @returns {string | null}
+ */
+export const deriveStableVersion = (version) => {
+  const stable = version.replace(/-beta(\.[0-9A-Za-z.-]*)?$/i, '');
+  if (stable === version) {
+    return STABLE_VERSION_PATTERN.test(stable) ? stable : null;
+  }
+  return STABLE_VERSION_PATTERN.test(stable) ? stable : null;
+};
+
+/**
+ * @param {string} stableVersion
+ */
+export const releaseBranchForStable = (stableVersion) => `release/v${stableVersion}`;
+
+/**
+ * @param {string} headRef
+ */
+export const isReleasePromotionBranch = (headRef) => RELEASE_BRANCH_PATTERN.test(headRef);
+
+/**
+ * @param {{
+ *   version: string;
+ *   targetBranch: string;
+ *   headRef?: string;
+ *   eventName?: string;
+ * }} context
+ * @returns {VersionPolicyResult}
+ */
+export const evaluateVersionPolicy = ({ version, targetBranch, headRef = '', eventName = '' }) => {
+  const hasBeta = hasBetaPrerelease(version);
+  const isPullRequest = eventName === 'pull_request';
+
+  if (targetBranch === 'beta' && !hasBeta) {
+    return {
+      ok: false,
+      message:
+        `package.json version "${version}" must include a -beta prerelease on branch "${targetBranch}" ` +
+        '(for example 1.6.0-beta.1).',
+    };
+  }
+
+  if (targetBranch === 'main') {
+    const isBetaPromotionPr = isPullRequest && headRef === 'beta';
+
+    if (hasBeta && !isBetaPromotionPr) {
+      const promotionHint = isPullRequest
+        ? 'Open a beta → main promotion PR (head branch beta) or hotfix/* with a stable version.'
+        : 'main must only receive stable semver versions.';
+      return {
+        ok: false,
+        message: `package.json version "${version}" must not include a -beta prerelease on "${targetBranch}". ${promotionHint}`,
+      };
+    }
+
+    if (isBetaPromotionPr && !hasBeta) {
+      return {
+        ok: false,
+        message:
+          `Beta → main promotion PRs should carry a -beta prerelease on beta (got "${version}"). ` +
+          'CI will strip to stable on merge automatically.',
+      };
+    }
+  }
+
+  return { ok: true };
+};

--- a/scripts/lib/package-version.test.mjs
+++ b/scripts/lib/package-version.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  deriveStableVersion,
+  evaluateVersionPolicy,
+  hasBetaPrerelease,
+  isReleasePromotionBranch,
+  releaseBranchForStable,
+} from './package-version.mjs';
+
+describe('package-version policy', () => {
+  it('detects beta prerelease', () => {
+    assert.equal(hasBetaPrerelease('1.6.0-beta.1'), true);
+    assert.equal(hasBetaPrerelease('1.6.0'), false);
+  });
+
+  it('derives stable from beta prerelease', () => {
+    assert.equal(deriveStableVersion('1.6.0-beta.2'), '1.6.0');
+    assert.equal(deriveStableVersion('1.6.0'), '1.6.0');
+  });
+
+  it('builds release branch name', () => {
+    assert.equal(releaseBranchForStable('1.6.0'), 'release/v1.6.0');
+    assert.equal(isReleasePromotionBranch('release/v1.6.0'), true);
+  });
+
+  it('requires beta prerelease on beta branch', () => {
+    const result = evaluateVersionPolicy({
+      version: '1.6.0',
+      targetBranch: 'beta',
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('allows beta to main promotion pull requests with beta version', () => {
+    const result = evaluateVersionPolicy({
+      version: '1.6.0-beta.1',
+      targetBranch: 'main',
+      headRef: 'beta',
+      eventName: 'pull_request',
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('rejects feature branches targeting main with beta version', () => {
+    const result = evaluateVersionPolicy({
+      version: '1.6.0-beta.1',
+      targetBranch: 'main',
+      headRef: 'feature/foo',
+      eventName: 'pull_request',
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('allows release branch PR to main with stable version', () => {
+    const result = evaluateVersionPolicy({
+      version: '1.6.0',
+      targetBranch: 'main',
+      headRef: 'release/v1.6.0',
+      eventName: 'pull_request',
+    });
+    assert.equal(result.ok, true);
+  });
+});

--- a/scripts/lib/version-bump.mjs
+++ b/scripts/lib/version-bump.mjs
@@ -1,0 +1,47 @@
+import { deriveStableVersion, hasBetaPrerelease } from './package-version.mjs';
+
+/**
+ * @param {string} version
+ * @returns {string | null}
+ */
+export const incrementBetaPrerelease = (version) => {
+  const match = version.match(/^(\d+\.\d+\.\d+)-beta\.(\d+)$/i);
+  if (match) {
+    const next = Number(match[2]) + 1;
+    return `${match[1]}-beta.${next}`;
+  }
+
+  const stable = deriveStableVersion(version);
+  if (stable) {
+    return `${stable}-beta.1`;
+  }
+
+  return null;
+};
+
+/**
+ * @param {string} version
+ * @returns {string | null}
+ */
+export const incrementPatchVersion = (version) => {
+  const stable = deriveStableVersion(version) ?? version;
+  const parts = stable.split('.').map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+    return null;
+  }
+  return `${parts[0]}.${parts[1]}.${parts[2] + 1}`;
+};
+
+/**
+ * @param {string} version
+ * @param {'beta' | 'main'} target
+ */
+export const bumpVersionForMergeTarget = (version, target) => {
+  if (target === 'beta') {
+    return incrementBetaPrerelease(version);
+  }
+  if (target === 'main' && !hasBetaPrerelease(version)) {
+    return incrementPatchVersion(version);
+  }
+  return null;
+};

--- a/scripts/lib/version-bump.test.mjs
+++ b/scripts/lib/version-bump.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { incrementBetaPrerelease, incrementPatchVersion } from './version-bump.mjs';
+
+describe('version bump', () => {
+  it('increments beta prerelease counter', () => {
+    assert.equal(incrementBetaPrerelease('1.6.0-beta.1'), '1.6.0-beta.2');
+  });
+
+  it('starts beta line from stable', () => {
+    assert.equal(incrementBetaPrerelease('1.6.0'), '1.6.0-beta.1');
+  });
+
+  it('increments patch on main', () => {
+    assert.equal(incrementPatchVersion('1.6.0'), '1.6.1');
+  });
+});

--- a/scripts/prepare-main-release-version.mjs
+++ b/scripts/prepare-main-release-version.mjs
@@ -1,0 +1,30 @@
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { deriveStableVersion, releaseBranchForStable } from './lib/package-version.mjs';
+
+const packagePath = 'package.json';
+const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+const original = pkg.version;
+const stable = deriveStableVersion(original);
+
+if (!stable) {
+  console.error(`Cannot prepare main release from package version "${original}".`);
+  process.exit(1);
+}
+
+if (stable !== original) {
+  pkg.version = stable;
+  writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(`Updated package.json version: ${original} -> ${stable}`);
+} else {
+  console.log(`package.json already at stable version ${stable}`);
+}
+
+const releaseBranch = releaseBranchForStable(stable);
+const outputPath = process.env.GITHUB_OUTPUT;
+if (outputPath) {
+  appendFileSync(outputPath, `stable_version=${stable}\n`);
+  appendFileSync(outputPath, `release_branch=${releaseBranch}\n`);
+  appendFileSync(outputPath, `beta_version=${original}\n`);
+}
+
+console.log(`Release branch: ${releaseBranch}`);

--- a/scripts/read-package-version.mjs
+++ b/scripts/read-package-version.mjs
@@ -1,0 +1,5 @@
+import { readFileSync } from 'node:fs';
+
+const path = process.argv[2] ?? 'package.json';
+const version = JSON.parse(readFileSync(path, 'utf8')).version;
+console.log(version);

--- a/scripts/strip-beta-prerelease-version.mjs
+++ b/scripts/strip-beta-prerelease-version.mjs
@@ -1,0 +1,25 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { deriveStableVersion } from './lib/package-version.mjs';
+
+const packagePath = 'package.json';
+const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+const original = pkg.version;
+
+const stable = deriveStableVersion(original);
+if (!stable) {
+  if (original.replace(/-beta(\.[0-9A-Za-z.-]*)?$/i, '') === original) {
+    console.log(`Version "${original}" is already a stable release identifier.`);
+    process.exit(0);
+  }
+  console.error(`Cannot derive stable version from "${original}".`);
+  process.exit(1);
+}
+
+if (stable === original) {
+  console.log(`Version "${original}" is already a stable release identifier.`);
+  process.exit(0);
+}
+
+pkg.version = stable;
+writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+console.log(`Updated package.json version: ${original} -> ${stable}`);

--- a/scripts/validate-branch-policy.mjs
+++ b/scripts/validate-branch-policy.mjs
@@ -1,0 +1,18 @@
+import { evaluateBranchPolicy } from './lib/branch-policy.mjs';
+
+const baseRef = process.env.GITHUB_BASE_REF ?? '';
+const headRef = process.env.GITHUB_HEAD_REF ?? '';
+
+if (!baseRef || !headRef) {
+  console.log('No PR base/head branch; skipping branch policy check.');
+  process.exit(0);
+}
+
+const result = evaluateBranchPolicy({ baseRef, headRef });
+
+if (!result.ok) {
+  console.error(result.message);
+  process.exit(1);
+}
+
+console.log(`Branch policy OK: ${headRef} → ${baseRef} (${result.kind}).`);

--- a/scripts/validate-package-version.mjs
+++ b/scripts/validate-package-version.mjs
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { evaluateVersionPolicy } from './lib/package-version.mjs';
+
+const version = JSON.parse(readFileSync('package.json', 'utf8')).version;
+const eventName = process.env.GITHUB_EVENT_NAME ?? '';
+const baseRef = process.env.GITHUB_BASE_REF ?? '';
+const refName = process.env.GITHUB_REF_NAME ?? '';
+const headRef = process.env.GITHUB_HEAD_REF ?? '';
+
+const targetBranch = eventName === 'pull_request' ? baseRef : refName;
+
+if (!targetBranch) {
+  console.log('No target branch resolved; skipping package version policy check.');
+  process.exit(0);
+}
+
+const result = evaluateVersionPolicy({
+  version,
+  targetBranch,
+  headRef,
+  eventName,
+});
+
+if (!result.ok) {
+  console.error(result.message);
+  process.exit(1);
+}
+
+console.log(`package.json version "${version}" satisfies policy for branch "${targetBranch}".`);


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #329 — ci: release automation and PR governance (ship on main) |
| Source branch | `feature/release-version-policy` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `CHANGELOG.md`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/329-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #329, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.