### PR TITLE
fix: post-merge actually updates package.json on beta

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: /
+    target-branch: beta
     schedule:
-      interval: "weekly"
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /server
+    target-branch: beta
+    schedule:
+      interval: weekly

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -12,6 +12,12 @@ on:
   pull_request:
     types: [closed]
     branches: [main, beta]
+  workflow_dispatch:
+    inputs:
+      sync_beta_from_main:
+        description: Merge main into beta and set the next -beta.N version (recovery / bootstrap)
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -19,7 +25,9 @@ permissions:
 
 jobs:
   post-merge:
-    if: github.event.pull_request.merged == true
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,8 +46,36 @@ jobs:
         with:
           node-version: '24.x'
 
+      - name: Sync beta from main after release infrastructure merge
+        if: >-
+          (github.event_name == 'workflow_dispatch' && inputs.sync_beta_from_main) ||
+          (github.event_name == 'pull_request' &&
+            github.event.pull_request.base.ref == 'main' &&
+            startsWith(github.event.pull_request.head.ref, 'feature/release-'))
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          git fetch origin main beta
+          git show origin/main:package.json > /tmp/main-package.json
+          STABLE=$(node scripts/read-package-version.mjs /tmp/main-package.json)
+
+          git checkout beta
+          git pull origin beta
+          git merge origin/main -X theirs -m "chore: sync release automation from main"
+
+          node scripts/bump-beta-after-main-release.mjs "$STABLE"
+          NEXT=$(node scripts/read-package-version.mjs)
+
+          git add package.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: start beta cycle at $NEXT after main release v$STABLE"
+          fi
+          git push origin beta
+
       - name: Beta promotion merged into main
         if: >-
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
           github.event.pull_request.head.ref == 'beta'
         env:
@@ -73,6 +109,7 @@ jobs:
 
       - name: Release branch merged into main
         if: >-
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
           startsWith(github.event.pull_request.head.ref, 'release/')
         env:
@@ -98,6 +135,7 @@ jobs:
 
       - name: Hotfix merged into main
         if: >-
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
           startsWith(github.event.pull_request.head.ref, 'hotfix/')
         env:
@@ -118,10 +156,13 @@ jobs:
 
       - name: Integration merge into beta
         if: >-
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'beta' &&
           github.event.pull_request.head.ref != 'beta' &&
           !startsWith(github.event.pull_request.head.ref, 'port/') &&
           !startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5; do

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -42,6 +42,14 @@ Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from
 - Automation bumps the **patch** on `main` after merge (e.g. `1.6.0` → `1.6.1`).
 - Creates a **GitHub Release** for the new patch version from `CHANGELOG.md`.
 
+### `feature/release-*` → main (release infrastructure)
+
+- Merges **main** into **beta** so beta gets workflows/scripts.
+- Sets **beta** to the next development line (e.g. main `1.5.3` → beta `1.6.0-beta.1`).
+- Does **not** change `main` again (the PR already set the stable version).
+
+If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**).
+
 ## Branch rules (enforced in CI)
 
 | Head branch | Base branch | Allowed |


### PR DESCRIPTION
## Summary

- Post-merge ran on PR #329 but skipped all version steps (feature/release-* to main had no handler).
- Adds sync main into beta after release-infrastructure merges and workflow_dispatch bootstrap.

## After merge

Run Actions - Post-merge automation - Run workflow on main with sync beta from main enabled.

Made with [Cursor](https://cursor.com)