### PR TITLE
fix: post-merge version updates and Dependabot on beta

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: /
+    target-branch: beta
     schedule:
-      interval: "weekly"
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /server
+    target-branch: beta
+    schedule:
+      interval: weekly

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -46,6 +46,14 @@ jobs:
         with:
           node-version: '24.x'
 
+      - name: Validate workflow dispatch inputs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.sync_beta_from_main }}" != "true" ]; then
+            echo "Enable sync_beta_from_main or this workflow will not run any steps."
+            exit 1
+          fi
+
       - name: Sync beta from main after release infrastructure merge
         if: >-
           (github.event_name == 'workflow_dispatch' && inputs.sync_beta_from_main) ||
@@ -161,8 +169,6 @@ jobs:
           github.event.pull_request.head.ref != 'beta' &&
           !startsWith(github.event.pull_request.head.ref, 'port/') &&
           !startsWith(github.event.pull_request.head.ref, 'hotfix/')
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5; do

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -12,6 +12,12 @@ on:
   pull_request:
     types: [closed]
     branches: [main, beta]
+  workflow_dispatch:
+    inputs:
+      sync_beta_from_main:
+        description: Merge main into beta and set the next -beta.N version (recovery / bootstrap)
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -19,7 +25,9 @@ permissions:
 
 jobs:
   post-merge:
-    if: github.event.pull_request.merged == true
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,8 +46,36 @@ jobs:
         with:
           node-version: '24.x'
 
+      - name: Sync beta from main after release infrastructure merge
+        if: >-
+          (github.event_name == 'workflow_dispatch' && inputs.sync_beta_from_main) ||
+          (github.event_name == 'pull_request' &&
+            github.event.pull_request.base.ref == 'main' &&
+            startsWith(github.event.pull_request.head.ref, 'feature/release-'))
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          git fetch origin main beta
+          git show origin/main:package.json > /tmp/main-package.json
+          STABLE=$(node scripts/read-package-version.mjs /tmp/main-package.json)
+
+          git checkout beta
+          git pull origin beta
+          git merge origin/main -X theirs -m "chore: sync release automation from main"
+
+          node scripts/bump-beta-after-main-release.mjs "$STABLE"
+          NEXT=$(node scripts/read-package-version.mjs)
+
+          git add package.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: start beta cycle at $NEXT after main release v$STABLE"
+          fi
+          git push origin beta
+
       - name: Beta promotion merged into main
         if: >-
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
           github.event.pull_request.head.ref == 'beta'
         env:
@@ -73,6 +109,7 @@ jobs:
 
       - name: Release branch merged into main
         if: >-
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
           startsWith(github.event.pull_request.head.ref, 'release/')
         env:
@@ -98,6 +135,7 @@ jobs:
 
       - name: Hotfix merged into main
         if: >-
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
           startsWith(github.event.pull_request.head.ref, 'hotfix/')
         env:
@@ -118,10 +156,13 @@ jobs:
 
       - name: Integration merge into beta
         if: >-
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'beta' &&
           github.event.pull_request.head.ref != 'beta' &&
           !startsWith(github.event.pull_request.head.ref, 'port/') &&
           !startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5; do

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,13 @@ yarn-debug.log*
 yarn-error.log*
 
 # Personal Docs
+/personal-docs/
+/personal/
 */personal-docs/*
 */personal/*
+
+# Local review artifacts
+greptile-comment.txt
 
 /.idea
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Release automation:** Beta → main stays a normal PR; merge triggers stable versioning on `main`, GitHub Releases from CHANGELOG (including hotfixes), and beta prerelease bumps. CI enforces branch routing (preferred `feature/*`/`fix/*` → beta; only `hotfix/*` blocked on beta), changelog checks, and automated PR labels. Workflow definitions ship on `main` so GitHub can run them for repository pull requests.
+- **Post-merge bootstrap:** `feature/release-*` → `main` syncs automation to `beta` and starts the next `-beta.N` line; manual `workflow_dispatch` recovery when bootstrap was missed.
+- **Dependabot:** Version update PRs for root and `server/` npm ecosystems target `beta` (not `main`). Urgent production dependency fixes use `hotfix/*` → `main` or a beta promotion.
 
 ## v1.6
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -59,6 +59,7 @@ If you merged release automation before this step existed, run **Post-merge auto
 | Other names (not `hotfix/*`) | `beta` | Yes |
 | `hotfix/*` | `main` | Yes |
 | `beta` | `main` | Yes (promotion) |
+| `feature/release-*` | `main` | Yes (release infrastructure) |
 | `feature/*`, `fix/*`, other | `main` | **Blocked** |
 | `hotfix/*` | `beta` | **Blocked** |
 
@@ -71,6 +72,10 @@ If you merged release automation before this step existed, run **Post-merge auto
 | `beta` | Must include `-beta.N` (e.g. `1.6.0-beta.2`) |
 | `main` | Stable semver only (e.g. `1.6.0`) |
 | PR **beta → main** | May show `-beta` on the PR; stripped automatically after merge |
+
+## Dependabot
+
+Version update PRs from `.github/dependabot.yml` open against **beta** (root and `server/`). They ride the normal integration and **beta → main** promotion path. For an urgent CVE on production before the next promotion, use **hotfix/* → main** (or merge the dependency fix to `main` manually) instead of waiting on Dependabot alone.
 
 ## Changelog
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -42,6 +42,14 @@ Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from
 - Automation bumps the **patch** on `main` after merge (e.g. `1.6.0` → `1.6.1`).
 - Creates a **GitHub Release** for the new patch version from `CHANGELOG.md`.
 
+### `feature/release-*` → main (release infrastructure)
+
+- Merges **main** into **beta** so beta gets workflows/scripts.
+- Sets **beta** to the next development line (e.g. main `1.5.3` → beta `1.6.0-beta.1`).
+- Does **not** change `main` again (the PR already set the stable version).
+
+If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**).
+
 ## Branch rules (enforced in CI)
 
 | Head branch | Base branch | Allowed |

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -21,6 +21,11 @@ if (branchPolicy.kind === 'beta-promotion') {
   process.exit(0);
 }
 
+if (branchPolicy.kind === 'release-infrastructure') {
+  console.log('Skipping changelog check for release infrastructure PR (workflow/CI only).');
+  process.exit(0);
+}
+
 if (headRef.startsWith('port/')) {
   console.log('Skipping changelog check for automated port PR.');
   process.exit(0);

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -17,7 +17,12 @@ const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
 const branchPolicy = evaluateBranchPolicy({ baseRef, headRef });
 let changelogOk = true;
 
-if (branchPolicy.ok && branchPolicy.kind !== 'beta-promotion' && !headRef.startsWith('port/')) {
+if (
+  branchPolicy.ok &&
+  branchPolicy.kind !== 'beta-promotion' &&
+  branchPolicy.kind !== 'release-infrastructure' &&
+  !headRef.startsWith('port/')
+) {
   const changelogResult = changelogTouchesPr(changedFiles, prBody);
   changelogOk = changelogResult.ok;
 }


### PR DESCRIPTION
## Summary

- Post-merge bootstrap: sync main into beta, workflow_dispatch recovery
- Dependabot version PRs target beta (root + server)

## After merge

Run Post-merge automation workflow_dispatch on main with sync beta from main.

Made with [Cursor](https://cursor.com)