### PR TITLE
fix: restore map transparencyScale after main sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## v1.6
 
 ### Fixed
+- **Map layer transparency:** Restored `transparencyScale` on forecast map fill/stroke opacity after the main sync dropped the multiplier (fixes CI on `beta`).
 - **GFC-WEB-4 (monitor startup):** Break circular import between `monitor/types` and `monitorSettingsNormalize` that crashed the hosted app at load (`Gv is not iterable` / `MONITOR_OUTLOOK_LAYER_TYPES` before initialization when spreading outlook layer types).
 - **Forecast keyboard shortcuts (GFC-WEB-3):** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts. Centralized the guard in `keyboardShortcutKey` and applied it to forecast, navbar, and day-selector shortcuts.
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -361,8 +361,10 @@ export const toOlStyle = (
     probability,
   );
   const fillColor = String(style.fillColor || "#ffffff");
-  const fillOpacity = resolveFillOpacity({ fillOpacity: style.fillOpacity });
-  const strokeOpacity = typeof style.opacity === "number" ? style.opacity : 1;
+  const fillOpacity =
+    resolveFillOpacity({ fillOpacity: style.fillOpacity }) * alphaScale;
+  const strokeOpacity =
+    (typeof style.opacity === "number" ? style.opacity : 1) * alphaScale;
   const strokeColor = String(style.color || "#000000");
   const zIndex = computeZIndex(outlookType as EditableOutlookType, probability);
   const fill = createOutlookFill({ probability, fillColor, fillOpacity });


### PR DESCRIPTION
## Summary

Beta CI failed after the release-infrastructure sync from `main`: `toOlStyle` computed `alphaScale` from `transparencyScale` but no longer applied it to fill/stroke opacity.

This restores the multiplier so layered outlook styling and the existing unit test behave as intended.

## Changelog

- **Map layer transparency:** Restored `transparencyScale` on forecast map fill/stroke opacity after the main sync dropped the multiplier.

## Test plan

- [x] `pnpm test -- --runTestsByPath src/components/Map/OpenLayersForecastMap.test.ts`
- [ ] CI green on this PR (build-and-test, pr-governance, Greptile, Kilo)