### PR TITLE
fix: GitHub Release on post-merge main→beta bootstrap

### DIFF
--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -5,6 +5,7 @@ name: Post-merge automation
 # beta → main: strip stable version on main, GitHub Release from CHANGELOG, start next beta line.
 # release/* → main: GitHub Release from CHANGELOG, start next beta line (optional prepare workflow).
 # feature/*|fix/*|other → beta: bump -beta.N on beta (hotfix/* is the only blocked target).
+# feature/release-* → main (and workflow_dispatch bootstrap): sync beta + GitHub Release for stable on main.
 # hotfix/* → main: bump patch on main and create GitHub Release.
 #
 # Required secret: GH_PAT (repo scope)
@@ -67,6 +68,10 @@ jobs:
           git fetch origin main beta
           git show origin/main:package.json > /tmp/main-package.json
           STABLE=$(node scripts/read-package-version.mjs /tmp/main-package.json)
+
+          export NOTES_FILE=$(mktemp)
+          git show origin/main:CHANGELOG.md > /tmp/main-changelog.md
+          CHANGELOG_FILE=/tmp/main-changelog.md node scripts/create-github-release.mjs "$STABLE" main
 
           git checkout beta
           git pull origin beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## v1.6
 
+### Changed
+- **Post-merge releases:** `feature/release-*` → `main` and manual `workflow_dispatch` bootstrap now create the stable **GitHub Release** from `CHANGELOG.md` (e.g. backfill `v1.5.3` if missing).
+
 ### Fixed
 - **Map layer transparency:** Restored `transparencyScale` on forecast map fill/stroke opacity after the main sync dropped the multiplier (fixes CI on `beta`).
 - **GFC-WEB-4 (monitor startup):** Break circular import between `monitor/types` and `monitorSettingsNormalize` that crashed the hosted app at load (`Gv is not iterable` / `MONITOR_OUTLOOK_LAYER_TYPES` before initialization when spreading outlook layer types).

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -44,11 +44,12 @@ Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from
 
 ### `feature/release-*` → main (release infrastructure)
 
+- Creates a **GitHub Release** for the stable version on `main` (from `CHANGELOG.md`) if it does not exist yet.
 - Merges **main** into **beta** so beta gets workflows/scripts.
 - Sets **beta** to the next development line (e.g. main `1.5.3` → beta `1.6.0-beta.1`).
 - Does **not** change `main` again (the PR already set the stable version).
 
-If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**).
+If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**) to backfill the GitHub Release and beta sync.
 
 ## Branch rules (enforced in CI)
 

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -31,6 +31,11 @@ if (headRef.startsWith('port/')) {
   process.exit(0);
 }
 
+if (headRef.startsWith('dependabot/')) {
+  console.log('Skipping changelog check for Dependabot version PR.');
+  process.exit(0);
+}
+
 const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
 
 const result = changelogTouchesPr(changedFiles, prBody);

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -21,7 +21,8 @@ if (
   branchPolicy.ok &&
   branchPolicy.kind !== 'beta-promotion' &&
   branchPolicy.kind !== 'release-infrastructure' &&
-  !headRef.startsWith('port/')
+  !headRef.startsWith('port/') &&
+  !headRef.startsWith('dependabot/')
 ) {
   const changelogResult = changelogTouchesPr(changedFiles, prBody);
   changelogOk = changelogResult.ok;

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -10,7 +10,8 @@ if (!stableVersion) {
   process.exit(1);
 }
 
-const changelog = readFileSync('CHANGELOG.md', 'utf8');
+const changelogPath = process.env.CHANGELOG_FILE ?? 'CHANGELOG.md';
+const changelog = readFileSync(changelogPath, 'utf8');
 const section = extractChangelogSection(changelog, stableVersion);
 
 if (!section) {


### PR DESCRIPTION
## Summary

When release infrastructure merged to `main` (#329) or bootstrap ran via `workflow_dispatch`, post-merge synced `beta` but never created the stable **GitHub Release** (e.g. missing `v1.5.3`).

This runs `create-github-release.mjs` during that bootstrap path, reading `CHANGELOG.md` from `origin/main`.

## Changelog

- **Post-merge releases:** Bootstrap from `main` now creates the stable GitHub Release from `CHANGELOG.md`.
- Dependabot PRs skip the changelog file gate (version-only updates).

## Test plan

- [x] `node --test scripts/lib/*.test.mjs`
- [ ] CI green on this PR
- [ ] After merge: run **Post-merge automation** on `main` with **sync beta from main** once to backfill `v1.5.3` if still missing