### PR TITLE
Publish GitHub Releases on every version bump

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,7 @@ Every user-facing change must be recorded in [CHANGELOG.md](../CHANGELOG.md) und
 *   `Removed`: For now-removed features.
 *   `Fixed`: For any bug fixes.
 *   `Security`: In case of vulnerabilities.
+*   `Dependencies`: For dependency version bumps (Dependabot PRs auto-update this subsection).
 
 ### 2. Update Notes
 When structural changes (schema migrations, API changes, new store slices) occur:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
-        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs
 
       - name: Validate package version for target branch
         env:

--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -1,0 +1,44 @@
+name: Dependabot changelog
+
+# Commits ### Dependencies bullets to Dependabot PRs so CI changelog policy passes.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  update-changelog:
+    if: >-
+      github.event_name == 'pull_request' &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout head branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Fetch base branch
+        run: git fetch origin "${{ github.base_ref }}"
+
+      - name: Update CHANGELOG dependencies
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: node scripts/update-dependabot-changelog.mjs
+
+      - name: Commit and push
+        run: |
+          if git diff --quiet CHANGELOG.md; then
+            echo "No CHANGELOG changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore: update CHANGELOG dependencies for Dependabot bump"
+          git push

--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: dependabot-changelog-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -2,10 +2,12 @@ name: Post-merge automation
 
 # Runs after a PR merges. No manual workflow dispatch needed for normal releases.
 #
-# beta → main: strip stable version on main, GitHub Release from CHANGELOG, start next beta line.
-# release/* → main: GitHub Release from CHANGELOG, start next beta line (optional prepare workflow).
-# feature/*|fix/*|other → beta: bump -beta.N on beta (hotfix/* is the only blocked target).
-# hotfix/* → main: bump patch on main and create GitHub Release.
+# Every package.json version bump creates a GitHub Release (stable or --prerelease for -beta.N).
+# beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
+# release/* → main: stable release + next beta line + prerelease.
+# feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.
+# hotfix/* → main: patch bump on main + stable release.
+# feature/release-*|workflow_dispatch: sync main→beta, stable release for main, prerelease for new beta.
 #
 # Required secret: GH_PAT (repo scope)
 on:
@@ -66,7 +68,12 @@ jobs:
           set -euo pipefail
           git fetch origin main beta
           git show origin/main:package.json > /tmp/main-package.json
+          git show origin/main:CHANGELOG.md > /tmp/main-changelog.md
           STABLE=$(node scripts/read-package-version.mjs /tmp/main-package.json)
+
+          export CHANGELOG_FILE=/tmp/main-changelog.md
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$STABLE" main
 
           git checkout beta
           git pull origin beta
@@ -80,6 +87,10 @@ jobs:
             git commit -m "chore: start beta cycle at $NEXT after main release v$STABLE"
           fi
           git push origin beta
+
+          export CHANGELOG_FILE=CHANGELOG.md
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$NEXT" beta
 
       - name: Beta promotion merged into main
         if: >-
@@ -115,6 +126,10 @@ jobs:
             git push origin beta
           fi
 
+          NEXT=$(node scripts/read-package-version.mjs)
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$NEXT" beta
+
       - name: Release branch merged into main
         if: >-
           github.event_name == 'pull_request' &&
@@ -140,6 +155,10 @@ jobs:
             git commit -m "chore: start next beta cycle after v$STABLE main release (was $BETA_VERSION)"
             git push origin beta
           fi
+
+          NEXT=$(node scripts/read-package-version.mjs)
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$NEXT" beta
 
       - name: Hotfix merged into main
         if: >-
@@ -169,6 +188,8 @@ jobs:
           github.event.pull_request.head.ref != 'beta' &&
           !startsWith(github.event.pull_request.head.ref, 'port/') &&
           !startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5; do
@@ -184,6 +205,9 @@ jobs:
             git add package.json
             git commit -m "chore: bump beta prerelease after merge (was $PREVIOUS)"
             if git push origin beta; then
+              NEW=$(node scripts/read-package-version.mjs)
+              export NOTES_FILE=$(mktemp)
+              node scripts/create-github-release.mjs "$NEW" beta
               exit 0
             fi
             echo "Push failed (attempt $attempt), retrying..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **GitHub Releases on every version bump:** Post-merge automation now publishes a release whenever `package.json` changes — stable tags on `main` (promotion, hotfix, release branch, bootstrap backfill) and prerelease tags on `beta` after each `-beta.N` integration merge.
 - **Release automation:** Beta → main stays a normal PR; merge triggers stable versioning on `main`, GitHub Releases from CHANGELOG (including hotfixes), and beta prerelease bumps. CI enforces branch routing (preferred `feature/*`/`fix/*` → beta; only `hotfix/*` blocked on beta), changelog checks, and automated PR labels. Workflow definitions ship on `main` so GitHub can run them for repository pull requests.
-- **Post-merge bootstrap:** `feature/release-*` → `main` syncs automation to `beta` and starts the next `-beta.N` line; manual `workflow_dispatch` recovery when bootstrap was missed.
+- **Post-merge bootstrap:** `feature/release-*` → `main` syncs automation to `beta`, backfills the stable GitHub Release for `main`, starts the next `-beta.N` line, and publishes the first prerelease; manual `workflow_dispatch` recovery when bootstrap was missed.
 - **Dependabot:** Version update PRs for root and `server/` npm ecosystems target `beta` (not `main`). Urgent production dependency fixes use `hotfix/*` → `main` or a beta promotion.
 
 ## v1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Dependencies
+<!-- dependabot-automation -->
+
 ### Changed
 - **GitHub Releases on every version bump:** Post-merge automation now publishes a release whenever `package.json` changes — stable tags on `main` (promotion, hotfix, release branch, bootstrap backfill) and prerelease tags on `beta` after each `-beta.N` integration merge.
 - **Release automation:** Beta → main stays a normal PR; merge triggers stable versioning on `main`, GitHub Releases from CHANGELOG (including hotfixes), and beta prerelease bumps. CI enforces branch routing (preferred `feature/*`/`fix/*` → beta; only `hotfix/*` blocked on beta), changelog checks, and automated PR labels. Workflow definitions ship on `main` so GitHub can run them for repository pull requests.
 - **Post-merge bootstrap:** `feature/release-*` → `main` syncs automation to `beta`, backfills the stable GitHub Release for `main`, starts the next `-beta.N` line, and publishes the first prerelease; manual `workflow_dispatch` recovery when bootstrap was missed.
-- **Dependabot:** Version update PRs for root and `server/` npm ecosystems target `beta` (not `main`). Urgent production dependency fixes use `hotfix/*` → `main` or a beta promotion.
+- **Dependabot:** Version update PRs for root and `server/` npm ecosystems target `beta` (not `main`). **Dependabot changelog** workflow maintains `### Dependencies` under `[Unreleased]`; CI validates those bullets instead of skipping changelog checks.
 
 ## v1.6
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -79,6 +79,12 @@ If you merged release automation before this step existed, run **Post-merge auto
 
 Version update PRs from `.github/dependabot.yml` open against **beta** (root and `server/`). They ride the normal integration and **beta → main** promotion path. For an urgent CVE on production before the next promotion, use **hotfix/* → main** (or merge the dependency fix to `main` manually) instead of waiting on Dependabot alone.
 
+### Dependabot changelog automation
+
+- **Dependabot changelog** workflow (`dependabot-changelog.yml`) runs on each Dependabot PR and commits bullets under **`### Dependencies`** in the active changelog section (`## [Unreleased]` on `main`, or the top `## vX.Y` line on `beta`).
+- CI requires `CHANGELOG.md` to include those entries (not a generic changelog skip). Entries use the form `- **package:** old → new` with `(\`server\`)` when the bump is under `server/package.json`.
+- Dependency notes accumulate under **Dependencies** until the next **beta → main** promotion ships them in the stable GitHub Release for that line.
+
 ## Changelog
 
 For PRs into **beta** (feature/fix) and **hotfix → main**:

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -81,7 +81,7 @@ Version update PRs from `.github/dependabot.yml` open against **beta** (root and
 
 ### Dependabot changelog automation
 
-- **Dependabot changelog** workflow (`dependabot-changelog.yml`) runs on each Dependabot PR and commits bullets under **`### Dependencies`** in the active changelog section (`## [Unreleased]` on `main`, or the top `## vX.Y` line on `beta`).
+- **Dependabot changelog** workflow (`dependabot-changelog.yml`) lives on **`main`** (required for GitHub Actions to run it). After it ships, it runs on each Dependabot PR targeting `beta` and commits bullets under **`### Dependencies`** in the active changelog section (`## [Unreleased]` on `main`, or the top `## vX.Y` line on `beta` once synced).
 - CI requires `CHANGELOG.md` to include those entries (not a generic changelog skip). Entries use the form `- **package:** old → new` with `(\`server\`)` when the bump is under `server/package.json`.
 - Dependency notes accumulate under **Dependencies** until the next **beta → main** promotion ships them in the stable GitHub Release for that line.
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,6 +1,6 @@
 # Release workflow
 
-Your normal flow stays simple: **open a PR, review it, click merge**. Automation handles versions, changelog gates, labels, GitHub Releases, and beta prerelease bumps.
+Your normal flow stays simple: **open a PR, review it, click merge**. Automation handles versions, changelog gates, labels, and **GitHub Releases for every `package.json` version change** (stable tags on `main`, prerelease tags on `beta`).
 
 ## Your day-to-day (short answer)
 
@@ -20,7 +20,7 @@ After merge, **Post-merge automation** runs on its own (no Actions button).
 2. **Post-merge automation** (`post-merge-automation.yml`):
    - Strips `-beta` from `package.json` on `main` (e.g. `1.6.0-beta.3` → `1.6.0`) and pushes.
    - Creates a **GitHub Release** `v1.6.0` using the matching section in `CHANGELOG.md`.
-   - Bumps **beta** to the next line (e.g. `1.7.0-beta.1`) for continued development.
+   - Bumps **beta** to the next line (e.g. `1.7.0-beta.1`) and creates a **prerelease** `v1.7.0-beta.1`.
 3. **Deploy Production to VPS** runs on the push to `main` (Sentry release uses the **stable** version even if the merge commit still had `-beta` briefly).
 
 ### release/* → main (optional prepare workflow)
@@ -28,13 +28,14 @@ After merge, **Post-merge automation** runs on its own (no Actions button).
 Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from **Prepare Beta → Main Release PR**:
 
 1. Merge the release PR to `main`.
-2. **Post-merge automation** creates the **GitHub Release** and bumps **beta** to the next line.
+2. **Post-merge automation** creates the **stable GitHub Release**, bumps **beta** to the next line, and publishes a **prerelease** for the new beta version.
 
 ### Integrations → beta
 
 - Preferred: `feature/*` and `fix/*` (labeled `integration:primary`).
 - Other branch names are allowed into beta except `hotfix/*` (labeled `integration:other`).
 - Automation increments the beta prerelease on each merge: `1.6.0-beta.1` → `1.6.0-beta.2`, etc.
+- Each bump creates a **GitHub prerelease** (`v1.6.0-beta.2`) from the matching `CHANGELOG.md` line section, or from **\[Unreleased\]** when no line section exists yet.
 - Port branches (`port/*`) skip the version bump.
 
 ### hotfix/* → main
@@ -45,10 +46,11 @@ Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from
 ### `feature/release-*` → main (release infrastructure)
 
 - Merges **main** into **beta** so beta gets workflows/scripts.
-- Sets **beta** to the next development line (e.g. main `1.5.3` → beta `1.6.0-beta.1`).
+- Creates the **stable GitHub Release** for the version on `main` (e.g. `v1.5.3`) if it is missing.
+- Sets **beta** to the next development line (e.g. main `1.5.3` → beta `1.6.0-beta.1`) and creates the matching **prerelease**.
 - Does **not** change `main` again (the PR already set the stable version).
 
-If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**).
+If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**) to backfill the stable release and start the beta line.
 
 ## Branch rules (enforced in CI)
 

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -31,6 +31,11 @@ if (headRef.startsWith('port/')) {
   process.exit(0);
 }
 
+if (headRef.startsWith('dependabot/')) {
+  console.log('Skipping changelog check for Dependabot version updates.');
+  process.exit(0);
+}
+
 const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
 
 const result = changelogTouchesPr(changedFiles, prBody);

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -1,4 +1,9 @@
+import { execFileSync } from 'node:child_process';
 import { changelogTouchesPr } from './lib/changelog.mjs';
+import {
+  dependabotChangelogTouchesPr,
+  listDependencyBumpsBetweenRefs,
+} from './lib/dependabot-changelog.mjs';
 import { evaluateBranchPolicy } from './lib/branch-policy.mjs';
 import { listChangedFilesBetweenRefs } from './lib/git-changed-files.mjs';
 
@@ -31,12 +36,21 @@ if (headRef.startsWith('port/')) {
   process.exit(0);
 }
 
+const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
+
 if (headRef.startsWith('dependabot/')) {
-  console.log('Skipping changelog check for Dependabot version updates.');
+  const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
+  const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:CHANGELOG.md`], {
+    encoding: 'utf8',
+  });
+  const result = dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps);
+  if (!result.ok) {
+    console.error(result.reason);
+    process.exit(1);
+  }
+  console.log(result.reason);
   process.exit(0);
 }
-
-const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
 
 const result = changelogTouchesPr(changedFiles, prBody);
 

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -21,7 +21,8 @@ if (
   branchPolicy.ok &&
   branchPolicy.kind !== 'beta-promotion' &&
   branchPolicy.kind !== 'release-infrastructure' &&
-  !headRef.startsWith('port/')
+  !headRef.startsWith('port/') &&
+  !headRef.startsWith('dependabot/')
 ) {
   const changelogResult = changelogTouchesPr(changedFiles, prBody);
   changelogOk = changelogResult.ok;

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -1,5 +1,10 @@
+import { execFileSync } from 'node:child_process';
 import { evaluateBranchPolicy } from './lib/branch-policy.mjs';
 import { changelogTouchesPr } from './lib/changelog.mjs';
+import {
+  dependabotChangelogTouchesPr,
+  listDependencyBumpsBetweenRefs,
+} from './lib/dependabot-changelog.mjs';
 import { listChangedFilesBetweenRefs } from './lib/git-changed-files.mjs';
 import { MANAGED_LABELS, computePrLabels } from './lib/pr-labels.mjs';
 
@@ -21,11 +26,18 @@ if (
   branchPolicy.ok &&
   branchPolicy.kind !== 'beta-promotion' &&
   branchPolicy.kind !== 'release-infrastructure' &&
-  !headRef.startsWith('port/') &&
-  !headRef.startsWith('dependabot/')
+  !headRef.startsWith('port/')
 ) {
-  const changelogResult = changelogTouchesPr(changedFiles, prBody);
-  changelogOk = changelogResult.ok;
+  if (headRef.startsWith('dependabot/')) {
+    const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
+    const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:CHANGELOG.md`], {
+      encoding: 'utf8',
+    });
+    changelogOk = dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps).ok;
+  } else {
+    const changelogResult = changelogTouchesPr(changedFiles, prBody);
+    changelogOk = changelogResult.ok;
+  }
 }
 
 const labels = computePrLabels({

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -1,34 +1,36 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { extractChangelogSection } from './lib/changelog.mjs';
+import { extractReleaseNotes } from './lib/changelog.mjs';
+import { hasBetaPrerelease } from './lib/package-version.mjs';
 
-const stableVersion = process.argv[2];
+const version = process.argv[2];
 const targetBranch = process.argv[3] ?? 'main';
 
-if (!stableVersion) {
-  console.error('Usage: node scripts/create-github-release.mjs <stable-version> [target-branch]');
+if (!version) {
+  console.error('Usage: node scripts/create-github-release.mjs <version> [target-branch]');
   process.exit(1);
 }
 
-const changelog = readFileSync('CHANGELOG.md', 'utf8');
-const section = extractChangelogSection(changelog, stableVersion);
-
-if (!section) {
-  console.error(`No CHANGELOG section found for v${stableVersion}.`);
-  process.exit(1);
-}
+const changelogPath = process.env.CHANGELOG_FILE ?? 'CHANGELOG.md';
+const changelog = readFileSync(changelogPath, 'utf8');
+const section =
+  extractReleaseNotes(changelog, version) ??
+  `## v${version}\n\nRelease for package version ${version}.`;
 
 const notesFile = process.env.NOTES_FILE ?? 'release-notes.md';
 writeFileSync(notesFile, `${section}\n`);
 
-const tag = `v${stableVersion}`;
+const tag = `v${version}`;
+const prereleaseFlag = hasBetaPrerelease(version) ? '--prerelease' : '';
+
 try {
   execSync(`gh release view "${tag}"`, { stdio: 'ignore' });
   console.log(`GitHub release ${tag} already exists.`);
 } catch {
+  const prereleaseSuffix = prereleaseFlag ? ` ${prereleaseFlag}` : '';
   execSync(
-    `gh release create "${tag}" --title "${tag}" --notes-file "${notesFile}" --target "${targetBranch}"`,
+    `gh release create "${tag}" --title "${tag}" --notes-file "${notesFile}" --target "${targetBranch}"${prereleaseSuffix}`,
     { stdio: 'inherit' },
   );
-  console.log(`Created GitHub release ${tag}.`);
+  console.log(`Created GitHub release ${tag}${prereleaseFlag ? ' (prerelease)' : ''}.`);
 }

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -1,13 +1,21 @@
 import { readFileSync, writeFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { extractReleaseNotes } from './lib/changelog.mjs';
 import { hasBetaPrerelease } from './lib/package-version.mjs';
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-beta\.\d+)?$/;
+const BRANCH_PATTERN = /^[\w./-]+$/;
 
 const version = process.argv[2];
 const targetBranch = process.argv[3] ?? 'main';
 
-if (!version) {
-  console.error('Usage: node scripts/create-github-release.mjs <version> [target-branch]');
+if (!version || !VERSION_PATTERN.test(version)) {
+  console.error('Usage: node scripts/create-github-release.mjs <semver-version> [target-branch]');
+  process.exit(1);
+}
+
+if (!BRANCH_PATTERN.test(targetBranch)) {
+  console.error(`Invalid target branch: ${targetBranch}`);
   process.exit(1);
 }
 
@@ -21,16 +29,36 @@ const notesFile = process.env.NOTES_FILE ?? 'release-notes.md';
 writeFileSync(notesFile, `${section}\n`);
 
 const tag = `v${version}`;
-const prereleaseFlag = hasBetaPrerelease(version) ? '--prerelease' : '';
+const prerelease = hasBetaPrerelease(version);
 
-try {
-  execSync(`gh release view "${tag}"`, { stdio: 'ignore' });
+const ghReleaseExists = () => {
+  try {
+    execFileSync('gh', ['release', 'view', tag], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const createGhRelease = () => {
+  const args = [
+    'release',
+    'create',
+    tag,
+    '--title',
+    tag,
+    '--notes-file',
+    notesFile,
+    '--target',
+    targetBranch,
+  ];
+  if (prerelease) args.push('--prerelease');
+  execFileSync('gh', args, { stdio: 'inherit' });
+};
+
+if (ghReleaseExists()) {
   console.log(`GitHub release ${tag} already exists.`);
-} catch {
-  const prereleaseSuffix = prereleaseFlag ? ` ${prereleaseFlag}` : '';
-  execSync(
-    `gh release create "${tag}" --title "${tag}" --notes-file "${notesFile}" --target "${targetBranch}"${prereleaseSuffix}`,
-    { stdio: 'inherit' },
-  );
-  console.log(`Created GitHub release ${tag}${prereleaseFlag ? ' (prerelease)' : ''}.`);
+} else {
+  createGhRelease();
+  console.log(`Created GitHub release ${tag}${prerelease ? ' (prerelease)' : ''}.`);
 }

--- a/scripts/lib/changelog.mjs
+++ b/scripts/lib/changelog.mjs
@@ -1,3 +1,23 @@
+import { deriveStableVersion, hasBetaPrerelease } from './package-version.mjs';
+
+/**
+ * @param {string} changelog
+ * @returns {string | null}
+ */
+export const extractUnreleasedSection = (changelog) => {
+  const heading = '## [Unreleased]';
+  const start = changelog.indexOf(heading);
+  if (start === -1) return null;
+
+  const afterHeading = start + heading.length;
+  const rest = changelog.slice(afterHeading);
+  const nextSection = rest.search(/\n## /);
+  const body = (nextSection === -1 ? rest : rest.slice(0, nextSection)).trim();
+  if (!body) return null;
+
+  return `${heading}\n\n${body}`.trim();
+};
+
 /**
  * @param {string} changelog
  * @param {string} stableVersion e.g. 1.6.0
@@ -21,6 +41,28 @@ export const extractChangelogSection = (changelog, stableVersion) => {
     const body = (nextSection === -1 ? rest : rest.slice(0, nextSection)).trim();
     if (body) {
       return `${heading}\n\n${body}`.trim();
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Notes body for a GitHub Release tag (stable or beta prerelease).
+ * @param {string} changelog
+ * @param {string} version e.g. 1.6.0 or 1.6.0-beta.2
+ * @returns {string | null}
+ */
+export const extractReleaseNotes = (changelog, version) => {
+  const stable = deriveStableVersion(version) ?? version;
+  const section = extractChangelogSection(changelog, stable);
+  if (section) return section;
+
+  if (hasBetaPrerelease(version)) {
+    const unreleased = extractUnreleasedSection(changelog);
+    if (unreleased) {
+      const body = unreleased.replace(/^## \[Unreleased\]\s*\n*/i, '').trim();
+      return `## v${version}\n\n${body}`.trim();
     }
   }
 

--- a/scripts/lib/changelog.test.mjs
+++ b/scripts/lib/changelog.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractChangelogSection,
+  extractReleaseNotes,
+  extractUnreleasedSection,
+} from './changelog.mjs';
+
+const sample = `# Changelog
+
+## [Unreleased]
+
+### Added
+- WIP feature
+
+## v1.6
+
+### Fixed
+- Bug fix
+
+## v1.5.3
+
+### Changed
+- Stable ship
+`;
+
+test('extractUnreleasedSection returns body under Unreleased', () => {
+  const section = extractUnreleasedSection(sample);
+  assert.match(section ?? '', /WIP feature/);
+  assert.match(section ?? '', /\[Unreleased\]/);
+});
+
+test('extractChangelogSection matches minor line heading', () => {
+  const section = extractChangelogSection(sample, '1.6.0');
+  assert.match(section ?? '', /Bug fix/);
+});
+
+test('extractReleaseNotes uses line section for stable version', () => {
+  const notes = extractReleaseNotes(sample, '1.5.3');
+  assert.match(notes ?? '', /Stable ship/);
+});
+
+test('extractReleaseNotes uses line section for beta when minor line exists', () => {
+  const notes = extractReleaseNotes(sample, '1.6.0-beta.4');
+  assert.match(notes ?? '', /Bug fix/);
+});
+
+test('extractReleaseNotes falls back to Unreleased for beta without line section', () => {
+  const changelog = `# Changelog\n\n## [Unreleased]\n\n### Added\n- WIP only\n`;
+  const notes = extractReleaseNotes(changelog, '2.0.0-beta.1');
+  assert.match(notes ?? '', /v2\.0\.0-beta\.1/);
+  assert.match(notes ?? '', /WIP only/);
+});

--- a/scripts/lib/dependabot-changelog.mjs
+++ b/scripts/lib/dependabot-changelog.mjs
@@ -70,8 +70,8 @@ export const extractDependenciesSubsection = (changelog, section) => {
  */
 export const formatDependencyChangelogBullet = ({ name, from, to, directory }) => {
   const label = packageDirectoryLabel(directory);
-  const scope = label === 'root' ? '' : ' (`' + label + '`)';
-  return '- **' + name + ':** ' + from + ' → ' + to + scope;
+  const scope = label === 'root' ? '' : ` (\`${label}\`)`;
+  return `- **${name}:** ${from} → ${to}${scope}`;
 };
 
 /**
@@ -99,14 +99,10 @@ const readPackageJsonPairAtRefs = (baseRef, headRef, packagePath) => {
   try {
     return {
       basePackage: JSON.parse(
-        execFileSync('git', ['show', 'origin/' + baseRef + ':' + packagePath], {
-          encoding: 'utf8',
-        }),
+        execFileSync('git', ['show', `origin/${baseRef}:${packagePath}`], { encoding: 'utf8' }),
       ),
       headPackage: JSON.parse(
-        execFileSync('git', ['show', 'origin/' + headRef + ':' + packagePath], {
-          encoding: 'utf8',
-        }),
+        execFileSync('git', ['show', `origin/${headRef}:${packagePath}`], { encoding: 'utf8' }),
       ),
       directory: packagePath === 'package.json' ? 'root' : 'server',
     };

--- a/scripts/lib/dependabot-changelog.mjs
+++ b/scripts/lib/dependabot-changelog.mjs
@@ -1,0 +1,221 @@
+import { execFileSync } from 'node:child_process';
+
+export const DEPENDENCIES_HEADING = '### Dependencies';
+export const DEPENDENCIES_MARKER = '<!-- dependabot-automation -->';
+
+const PACKAGE_JSON_PATHS = ['package.json', 'server/package.json'];
+
+/**
+ * @param {string} directory
+ */
+export const packageDirectoryLabel = (directory) => {
+  if (directory === 'root' || directory === '.' || directory === '') return 'root';
+  return directory.replace(/\/$/, '');
+};
+
+/**
+ * @param {string} changelog
+ * @returns {{ heading: string; start: number; end: number } | null}
+ */
+export const findDependabotChangelogSection = (changelog) => {
+  const unreleased = changelog.indexOf('## [Unreleased]');
+  if (unreleased !== -1) {
+    const afterStart = unreleased + '## [Unreleased]'.length;
+    const rest = changelog.slice(afterStart);
+    const next = rest.search(/\n## /);
+    const end = next === -1 ? changelog.length : afterStart + next;
+    return { heading: '## [Unreleased]', start: unreleased, end };
+  }
+
+  const match = changelog.match(/^## v[\d.]+/m);
+  if (!match || match.index === undefined) return null;
+
+  const afterStart = match.index + match[0].length;
+  const rest = changelog.slice(afterStart);
+  const next = rest.search(/\n## /);
+  const end = next === -1 ? changelog.length : afterStart + next;
+  return { heading: match[0], start: match.index, end };
+};
+
+/**
+ * @param {string} changelog
+ * @param {{ heading: string; start: number; end: number }} section
+ * @returns {string | null}
+ */
+export const extractDependenciesSubsection = (changelog, section) => {
+  const body = changelog.slice(section.start, section.end);
+  const escapedHeading = DEPENDENCIES_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = body.match(new RegExp(`${escapedHeading}[\\s\\S]*?(?=\\n### |\\n## |$)`));
+  if (!match) return null;
+
+  return match[0].slice(DEPENDENCIES_HEADING.length).replace(DEPENDENCIES_MARKER, '').trim();
+};
+
+/**
+ * @param {{ name: string; from: string; to: string; directory: string }} bump
+ */
+export const formatDependencyChangelogBullet = ({ name, from, to, directory }) => {
+  const scope =
+    packageDirectoryLabel(directory) === 'root' ? '' : ` (\`${packageDirectoryLabel(directory)}\`)`;
+  return `- **${name}:** ${from} → ${to}${scope}`;
+};
+
+/**
+ * @param {string} line
+ * @param {string} packageName
+ */
+export const dependencyBulletCoversPackage = (line, packageName) =>
+  new RegExp(`\\*\\*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\*\\*:`).test(line);
+
+/**
+ * @param {{ name: string; from: string; to: string; directory: string }} bump
+ * @param {string} dependenciesBody
+ */
+export const dependencyBumpDocumented = (bump, dependenciesBody) => {
+  if (!dependenciesBody.includes(`**${bump.name}:**`)) return false;
+  return dependenciesBody.includes(bump.from) && dependenciesBody.includes(bump.to);
+};
+
+/**
+ * @param {string} baseRef
+ * @param {string} headRef
+ * @returns {Array<{ name: string; from: string; to: string; directory: string; depType: string }>}
+ */
+export const listDependencyBumpsBetweenRefs = (baseRef, headRef) => {
+  /** @type {Array<{ name: string; from: string; to: string; directory: string; depType: string }>} */
+  const bumps = [];
+
+  for (const packagePath of PACKAGE_JSON_PATHS) {
+    let basePkg;
+    let headPkg;
+    try {
+      basePkg = JSON.parse(
+        execFileSync('git', ['show', `origin/${baseRef}:${packagePath}`], { encoding: 'utf8' }),
+      );
+      headPkg = JSON.parse(
+        execFileSync('git', ['show', `origin/${headRef}:${packagePath}`], { encoding: 'utf8' }),
+      );
+    } catch {
+      continue;
+    }
+
+    const directory = packagePath === 'package.json' ? 'root' : 'server';
+
+    for (const depType of ['dependencies', 'devDependencies']) {
+      const baseDeps = basePkg[depType] ?? {};
+      const headDeps = headPkg[depType] ?? {};
+      for (const [name, to] of Object.entries(headDeps)) {
+        const from = baseDeps[name];
+        if (from !== undefined && from !== to) {
+          bumps.push({ name, from, to, directory, depType });
+        }
+      }
+    }
+  }
+
+  return bumps;
+};
+
+/**
+ * @param {string} changelog
+ * @param {Array<{ name: string; from: string; to: string; directory: string }>} bumps
+ */
+export const applyDependencyBumpsToChangelog = (changelog, bumps) => {
+  if (bumps.length === 0) return changelog;
+
+  const section = findDependabotChangelogSection(changelog);
+  if (!section) {
+    throw new Error(
+      'CHANGELOG.md must include ## [Unreleased] or a top ## vX.Y section for dependency entries.',
+    );
+  }
+
+  const existingDepsBody = extractDependenciesSubsection(changelog, section);
+  if (existingDepsBody && bumps.every((bump) => dependencyBumpDocumented(bump, existingDepsBody))) {
+    return changelog;
+  }
+
+  const depsBody = existingDepsBody ?? '';
+  const lines = depsBody
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.startsWith('- **') && line.includes(':**'));
+
+  for (const bump of bumps) {
+    const bullet = formatDependencyChangelogBullet(bump);
+    const existingIndex = lines.findIndex((line) => dependencyBulletCoversPackage(line, bump.name));
+    if (existingIndex === -1) {
+      lines.push(bullet);
+    } else if (!lines[existingIndex].includes(bump.to)) {
+      lines[existingIndex] = bullet;
+    }
+  }
+
+  const dependenciesBlock = [
+    DEPENDENCIES_HEADING,
+    DEPENDENCIES_MARKER,
+    '',
+    ...lines,
+    '',
+  ].join('\n');
+
+  let sectionBody = changelog.slice(section.start, section.end);
+  const escapedHeading = DEPENDENCIES_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const depsPattern = new RegExp(`${escapedHeading}[\\s\\S]*?(?=\\n### |\\n## |$)`);
+  sectionBody = sectionBody.replace(depsPattern, '').trimEnd();
+
+  const headingEnd = sectionBody.indexOf('\n');
+  const insertPos = headingEnd === -1 ? sectionBody.length : headingEnd + 1;
+  sectionBody = `${sectionBody.slice(0, insertPos)}\n${dependenciesBlock}${sectionBody.slice(insertPos)}`;
+
+  return changelog.slice(0, section.start) + sectionBody + changelog.slice(section.end);
+};
+
+/**
+ * @param {string[]} changedFiles
+ * @param {string} changelogAtHead
+ * @param {Array<{ name: string; from: string; to: string; directory: string }>} bumps
+ */
+export const dependabotChangelogTouchesPr = (changedFiles, changelogAtHead, bumps) => {
+  const touchesChangelog = changedFiles.some(
+    (file) => file === 'CHANGELOG.md' || file.endsWith('/CHANGELOG.md'),
+  );
+
+  if (!touchesChangelog) {
+    return {
+      ok: false,
+      reason:
+        'Dependabot PRs must update CHANGELOG.md (the dependabot-changelog workflow commits ### Dependencies entries).',
+    };
+  }
+
+  const section = findDependabotChangelogSection(changelogAtHead);
+  if (!section) {
+    return {
+      ok: false,
+      reason: 'CHANGELOG.md needs ## [Unreleased] or a top ## vX.Y section for ### Dependencies.',
+    };
+  }
+
+  const depsBody = extractDependenciesSubsection(changelogAtHead, section);
+  if (!depsBody || !/^-\s/m.test(depsBody)) {
+    return {
+      ok: false,
+      reason: 'CHANGELOG.md ### Dependencies must list at least one dependency bump bullet.',
+    };
+  }
+
+  const missing = bumps.filter((bump) => !dependencyBumpDocumented(bump, depsBody));
+  if (missing.length > 0) {
+    const names = missing.map((bump) => bump.name).join(', ');
+    return {
+      ok: false,
+      reason: `CHANGELOG.md ### Dependencies is missing entries for: ${names}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: 'CHANGELOG.md ### Dependencies documents this dependency bump.',
+  };
+};

--- a/scripts/lib/dependabot-changelog.mjs
+++ b/scripts/lib/dependabot-changelog.mjs
@@ -4,6 +4,7 @@ export const DEPENDENCIES_HEADING = '### Dependencies';
 export const DEPENDENCIES_MARKER = '<!-- dependabot-automation -->';
 
 const PACKAGE_JSON_PATHS = ['package.json', 'server/package.json'];
+const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies'];
 
 /**
  * @param {string} directory
@@ -20,21 +21,27 @@ export const packageDirectoryLabel = (directory) => {
 export const findDependabotChangelogSection = (changelog) => {
   const unreleased = changelog.indexOf('## [Unreleased]');
   if (unreleased !== -1) {
-    const afterStart = unreleased + '## [Unreleased]'.length;
-    const rest = changelog.slice(afterStart);
-    const next = rest.search(/\n## /);
-    const end = next === -1 ? changelog.length : afterStart + next;
-    return { heading: '## [Unreleased]', start: unreleased, end };
+    return sliceSectionBounds(changelog, unreleased, '## [Unreleased]'.length);
   }
 
   const match = changelog.match(/^## v[\d.]+/m);
   if (!match || match.index === undefined) return null;
 
-  const afterStart = match.index + match[0].length;
+  return sliceSectionBounds(changelog, match.index, match[0].length, match[0]);
+};
+
+/**
+ * @param {string} changelog
+ * @param {number} start
+ * @param {number} headingLength
+ * @param {string} [heading]
+ */
+const sliceSectionBounds = (changelog, start, headingLength, heading = '## [Unreleased]') => {
+  const afterStart = start + headingLength;
   const rest = changelog.slice(afterStart);
   const next = rest.search(/\n## /);
   const end = next === -1 ? changelog.length : afterStart + next;
-  return { heading: match[0], start: match.index, end };
+  return { heading, start, end };
 };
 
 /**
@@ -79,41 +86,102 @@ export const dependencyBumpDocumented = (bump, dependenciesBody) => {
 /**
  * @param {string} baseRef
  * @param {string} headRef
- * @returns {Array<{ name: string; from: string; to: string; directory: string; depType: string }>}
+ * @param {string} packagePath
  */
-export const listDependencyBumpsBetweenRefs = (baseRef, headRef) => {
-  /** @type {Array<{ name: string; from: string; to: string; directory: string; depType: string }>} */
-  const bumps = [];
-
-  for (const packagePath of PACKAGE_JSON_PATHS) {
-    let basePkg;
-    let headPkg;
-    try {
-      basePkg = JSON.parse(
+const readPackageJsonPairAtRefs = (baseRef, headRef, packagePath) => {
+  try {
+    return {
+      base: JSON.parse(
         execFileSync('git', ['show', `origin/${baseRef}:${packagePath}`], { encoding: 'utf8' }),
-      );
-      headPkg = JSON.parse(
+      ),
+      head: JSON.parse(
         execFileSync('git', ['show', `origin/${headRef}:${packagePath}`], { encoding: 'utf8' }),
-      );
-    } catch {
-      continue;
-    }
+      ),
+      directory: packagePath === 'package.json' ? 'root' : 'server',
+    };
+  } catch {
+    return null;
+  }
+};
 
-    const directory = packagePath === 'package.json' ? 'root' : 'server';
-
-    for (const depType of ['dependencies', 'devDependencies']) {
-      const baseDeps = basePkg[depType] ?? {};
-      const headDeps = headPkg[depType] ?? {};
-      for (const [name, to] of Object.entries(headDeps)) {
-        const from = baseDeps[name];
-        if (from !== undefined && from !== to) {
-          bumps.push({ name, from, to, directory, depType });
-        }
-      }
+/**
+ * @param {Record<string, string>} baseDeps
+ * @param {Record<string, string>} headDeps
+ * @param {string} directory
+ * @param {string} depType
+ */
+const bumpsForDependencyField = (baseDeps, headDeps, directory, depType) => {
+  const bumps = [];
+  for (const [name, to] of Object.entries(headDeps)) {
+    const from = baseDeps[name];
+    if (from !== undefined && from !== to) {
+      bumps.push({ name, from, to, directory, depType });
     }
   }
-
   return bumps;
+};
+
+/**
+ * @param {object} basePkg
+ * @param {object} headPkg
+ * @param {string} directory
+ */
+const collectBumpsFromPackagePair = (basePkg, headPkg, directory) =>
+  DEPENDENCY_FIELDS.flatMap((depType) =>
+    bumpsForDependencyField(basePkg[depType] ?? {}, headPkg[depType] ?? {}, directory, depType),
+  );
+
+/**
+ * @param {string} baseRef
+ * @param {string} headRef
+ */
+export const listDependencyBumpsBetweenRefs = (baseRef, headRef) =>
+  PACKAGE_JSON_PATHS.flatMap((packagePath) => {
+    const pair = readPackageJsonPairAtRefs(baseRef, headRef, packagePath);
+    return pair ? collectBumpsFromPackagePair(pair.base, pair.head, pair.directory) : [];
+  });
+
+/**
+ * @param {string} depsBody
+ */
+const parseDependencyLines = (depsBody) =>
+  depsBody
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.startsWith('- **') && line.includes(':**'));
+
+/**
+ * @param {string[]} lines
+ * @param {Array<{ name: string; from: string; to: string; directory: string }>} bumps
+ */
+const mergeDependencyLines = (lines, bumps) => {
+  const merged = [...lines];
+  for (const bump of bumps) {
+    const bullet = formatDependencyChangelogBullet(bump);
+    const existingIndex = merged.findIndex((line) => dependencyBulletCoversPackage(line, bump.name));
+    if (existingIndex === -1) merged.push(bullet);
+    else if (!merged[existingIndex].includes(bump.to)) merged[existingIndex] = bullet;
+  }
+  return merged;
+};
+
+/**
+ * @param {string[]} lines
+ */
+const formatDependenciesBlock = (lines) =>
+  [DEPENDENCIES_HEADING, DEPENDENCIES_MARKER, '', ...lines, ''].join('\n');
+
+/**
+ * @param {string} sectionBody
+ * @param {string} dependenciesBlock
+ */
+const replaceDependenciesBlock = (sectionBody, dependenciesBlock) => {
+  const escapedHeading = DEPENDENCIES_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const depsPattern = new RegExp(`${escapedHeading}[\\s\\S]*?(?=\\n### |\\n## |$)`);
+  const stripped = sectionBody.replace(depsPattern, '').trimEnd();
+  const headingEnd = stripped.indexOf('\n');
+  const insertPos = headingEnd === -1 ? stripped.length : headingEnd + 1;
+  return `${stripped.slice(0, insertPos)}\n${dependenciesBlock}${stripped.slice(insertPos)}`;
 };
 
 /**
@@ -135,38 +203,11 @@ export const applyDependencyBumpsToChangelog = (changelog, bumps) => {
     return changelog;
   }
 
-  const depsBody = existingDepsBody ?? '';
-  const lines = depsBody
-    .split('\n')
-    .map((line) => line.trimEnd())
-    .filter((line) => line.startsWith('- **') && line.includes(':**'));
-
-  for (const bump of bumps) {
-    const bullet = formatDependencyChangelogBullet(bump);
-    const existingIndex = lines.findIndex((line) => dependencyBulletCoversPackage(line, bump.name));
-    if (existingIndex === -1) {
-      lines.push(bullet);
-    } else if (!lines[existingIndex].includes(bump.to)) {
-      lines[existingIndex] = bullet;
-    }
-  }
-
-  const dependenciesBlock = [
-    DEPENDENCIES_HEADING,
-    DEPENDENCIES_MARKER,
-    '',
-    ...lines,
-    '',
-  ].join('\n');
-
-  let sectionBody = changelog.slice(section.start, section.end);
-  const escapedHeading = DEPENDENCIES_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const depsPattern = new RegExp(`${escapedHeading}[\\s\\S]*?(?=\\n### |\\n## |$)`);
-  sectionBody = sectionBody.replace(depsPattern, '').trimEnd();
-
-  const headingEnd = sectionBody.indexOf('\n');
-  const insertPos = headingEnd === -1 ? sectionBody.length : headingEnd + 1;
-  sectionBody = `${sectionBody.slice(0, insertPos)}\n${dependenciesBlock}${sectionBody.slice(insertPos)}`;
+  const lines = mergeDependencyLines(parseDependencyLines(existingDepsBody ?? ''), bumps);
+  const sectionBody = replaceDependenciesBlock(
+    changelog.slice(section.start, section.end),
+    formatDependenciesBlock(lines),
+  );
 
   return changelog.slice(0, section.start) + sectionBody + changelog.slice(section.end);
 };

--- a/scripts/lib/dependabot-changelog.mjs
+++ b/scripts/lib/dependabot-changelog.mjs
@@ -75,20 +75,45 @@ export const formatDependencyChangelogBullet = ({ name, from, to, directory }) =
 };
 
 /**
+ * @param {string} value
+ */
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
  * @param {string} line
  * @param {string} packageName
  */
 export const dependencyBulletCoversPackage = (line, packageName) =>
-  new RegExp(`\\*\\*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\*\\*:`).test(line);
+  new RegExp(`\\*\\*${escapeRegExp(packageName)}:\\*\\*`).test(line);
+
+/**
+ * @param {string} line
+ * @param {{ name: string; directory: string }} bump
+ */
+export const dependencyBulletMatchesBump = (line, bump) => {
+  if (!dependencyBulletCoversPackage(line, bump.name)) return false;
+
+  const label = packageDirectoryLabel(bump.directory);
+  if (label === 'root') return !/\s\(`/.test(line);
+
+  return line.includes(`(\`${label}\`)`);
+};
 
 /**
  * @param {{ name: string; from: string; to: string; directory: string }} bump
  * @param {string} dependenciesBody
  */
-export const dependencyBumpDocumented = (bump, dependenciesBody) => {
-  if (!dependenciesBody.includes(`**${bump.name}:**`)) return false;
-  return dependenciesBody.includes(bump.from) && dependenciesBody.includes(bump.to);
-};
+export const dependencyBumpDocumented = (bump, dependenciesBody) =>
+  dependenciesBody
+    .split('\n')
+    .some((line) => {
+      const trimmed = line.trim();
+      return (
+        dependencyBulletMatchesBump(trimmed, bump) &&
+        trimmed.includes(bump.from) &&
+        trimmed.includes(bump.to)
+      );
+    });
 
 /**
  * @param {string} baseRef
@@ -167,7 +192,7 @@ const mergeDependencyLines = (lines, bumps) => {
   const merged = [...lines];
   for (const bump of bumps) {
     const bullet = formatDependencyChangelogBullet(bump);
-    const existingIndex = merged.findIndex((line) => dependencyBulletCoversPackage(line, bump.name));
+    const existingIndex = merged.findIndex((line) => dependencyBulletMatchesBump(line, bump));
     if (existingIndex === -1) merged.push(bullet);
     else if (!merged[existingIndex].includes(bump.to)) merged[existingIndex] = bullet;
   }

--- a/scripts/lib/dependabot-changelog.mjs
+++ b/scripts/lib/dependabot-changelog.mjs
@@ -5,13 +5,25 @@ export const DEPENDENCIES_MARKER = '<!-- dependabot-automation -->';
 
 const PACKAGE_JSON_PATHS = ['package.json', 'server/package.json'];
 const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies'];
+const ROOT_DIRECTORY_LABELS = new Set(['root', '.', '']);
 
 /**
  * @param {string} directory
  */
 export const packageDirectoryLabel = (directory) => {
-  if (directory === 'root' || directory === '.' || directory === '') return 'root';
-  return directory.replace(/\/$/, '');
+  const normalized = String(directory ?? '').trim();
+  if (ROOT_DIRECTORY_LABELS.has(normalized)) return 'root';
+  return normalized.replace(/\/$/, '');
+};
+
+/**
+ * @param {string} changelog
+ * @param {number} afterStart
+ */
+const sectionEndIndex = (changelog, afterStart) => {
+  const rest = changelog.slice(afterStart);
+  const next = rest.search(/\n## /);
+  return next === -1 ? changelog.length : afterStart + next;
 };
 
 /**
@@ -21,27 +33,22 @@ export const packageDirectoryLabel = (directory) => {
 export const findDependabotChangelogSection = (changelog) => {
   const unreleased = changelog.indexOf('## [Unreleased]');
   if (unreleased !== -1) {
-    return sliceSectionBounds(changelog, unreleased, '## [Unreleased]'.length);
+    const heading = '## [Unreleased]';
+    return {
+      heading,
+      start: unreleased,
+      end: sectionEndIndex(changelog, unreleased + heading.length),
+    };
   }
 
   const match = changelog.match(/^## v[\d.]+/m);
   if (!match || match.index === undefined) return null;
 
-  return sliceSectionBounds(changelog, match.index, match[0].length, match[0]);
-};
-
-/**
- * @param {string} changelog
- * @param {number} start
- * @param {number} headingLength
- * @param {string} [heading]
- */
-const sliceSectionBounds = (changelog, start, headingLength, heading = '## [Unreleased]') => {
-  const afterStart = start + headingLength;
-  const rest = changelog.slice(afterStart);
-  const next = rest.search(/\n## /);
-  const end = next === -1 ? changelog.length : afterStart + next;
-  return { heading, start, end };
+  return {
+    heading: match[0],
+    start: match.index,
+    end: sectionEndIndex(changelog, match.index + match[0].length),
+  };
 };
 
 /**
@@ -62,9 +69,9 @@ export const extractDependenciesSubsection = (changelog, section) => {
  * @param {{ name: string; from: string; to: string; directory: string }} bump
  */
 export const formatDependencyChangelogBullet = ({ name, from, to, directory }) => {
-  const scope =
-    packageDirectoryLabel(directory) === 'root' ? '' : ` (\`${packageDirectoryLabel(directory)}\`)`;
-  return `- **${name}:** ${from} → ${to}${scope}`;
+  const label = packageDirectoryLabel(directory);
+  const scope = label === 'root' ? '' : ' (`' + label + '`)';
+  return '- **' + name + ':** ' + from + ' → ' + to + scope;
 };
 
 /**
@@ -91,11 +98,15 @@ export const dependencyBumpDocumented = (bump, dependenciesBody) => {
 const readPackageJsonPairAtRefs = (baseRef, headRef, packagePath) => {
   try {
     return {
-      base: JSON.parse(
-        execFileSync('git', ['show', `origin/${baseRef}:${packagePath}`], { encoding: 'utf8' }),
+      basePackage: JSON.parse(
+        execFileSync('git', ['show', 'origin/' + baseRef + ':' + packagePath], {
+          encoding: 'utf8',
+        }),
       ),
-      head: JSON.parse(
-        execFileSync('git', ['show', `origin/${headRef}:${packagePath}`], { encoding: 'utf8' }),
+      headPackage: JSON.parse(
+        execFileSync('git', ['show', 'origin/' + headRef + ':' + packagePath], {
+          encoding: 'utf8',
+        }),
       ),
       directory: packagePath === 'package.json' ? 'root' : 'server',
     };
@@ -138,7 +149,9 @@ const collectBumpsFromPackagePair = (basePkg, headPkg, directory) =>
 export const listDependencyBumpsBetweenRefs = (baseRef, headRef) =>
   PACKAGE_JSON_PATHS.flatMap((packagePath) => {
     const pair = readPackageJsonPairAtRefs(baseRef, headRef, packagePath);
-    return pair ? collectBumpsFromPackagePair(pair.base, pair.head, pair.directory) : [];
+    return pair
+      ? collectBumpsFromPackagePair(pair.basePackage, pair.headPackage, pair.directory)
+      : [];
   });
 
 /**

--- a/scripts/lib/dependabot-changelog.test.mjs
+++ b/scripts/lib/dependabot-changelog.test.mjs
@@ -54,6 +54,33 @@ describe('dependabot changelog', () => {
     assert.equal(result.ok, true);
   });
 
+  it('keeps separate bullets when the same package bumps in root and server', () => {
+    const bumps = [
+      { name: 'axios', from: '^1.7.0', to: '^1.7.9', directory: 'root' },
+      { name: 'axios', from: '^1.7.0', to: '^1.7.9', directory: 'server' },
+    ];
+    const updated = applyDependencyBumpsToChangelog(sampleChangelog, bumps);
+    const section = findDependabotChangelogSection(updated);
+    const deps = extractDependenciesSubsection(updated, section);
+    assert.match(deps ?? '', /- \*\*axios:\*\* \^1\.7\.0 → \^1\.7\.9\n/);
+    assert.match(deps ?? '', /- \*\*axios:\*\* \^1\.7\.0 → \^1\.7\.9 \(`server`\)/);
+    assert.equal(dependabotChangelogTouchesPr(['CHANGELOG.md'], updated, bumps).ok, true);
+  });
+
+  it('does not treat another package line as documenting a different bump', () => {
+    const changelog = applyDependencyBumpsToChangelog(sampleChangelog, [
+      { name: 'postcss', from: '8.5.14', to: '8.5.15', directory: 'root' },
+    ]);
+    const undocumented = {
+      name: 'express-rate-limit',
+      from: '^8.5.1',
+      to: '^8.5.2',
+      directory: 'server',
+    };
+    const result = dependabotChangelogTouchesPr(['CHANGELOG.md'], changelog, [undocumented]);
+    assert.equal(result.ok, false);
+  });
+
   it('formats bullets with optional directory scope', () => {
     assert.equal(
       formatDependencyChangelogBullet({

--- a/scripts/lib/dependabot-changelog.test.mjs
+++ b/scripts/lib/dependabot-changelog.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  applyDependencyBumpsToChangelog,
+  dependabotChangelogTouchesPr,
+  extractDependenciesSubsection,
+  findDependabotChangelogSection,
+  formatDependencyChangelogBullet,
+} from './dependabot-changelog.mjs';
+
+const sampleChangelog = `# Changelog
+
+## [Unreleased]
+
+### Changed
+- Something
+
+## v1.5.3
+`;
+
+describe('dependabot changelog', () => {
+  it('finds Unreleased as the active section', () => {
+    const section = findDependabotChangelogSection(sampleChangelog);
+    assert.equal(section?.heading, '## [Unreleased]');
+  });
+
+  it('inserts and updates dependency bullets', () => {
+    const bump = {
+      name: 'express-rate-limit',
+      from: '^8.5.1',
+      to: '^8.5.2',
+      directory: 'server',
+    };
+    const updated = applyDependencyBumpsToChangelog(sampleChangelog, [bump]);
+    const section = findDependabotChangelogSection(updated);
+    assert.ok(section);
+    const deps = extractDependenciesSubsection(updated, section);
+    assert.match(deps ?? '', /express-rate-limit/);
+    assert.match(deps ?? '', /\^8\.5\.2/);
+
+    const updatedAgain = applyDependencyBumpsToChangelog(updated, [bump]);
+    assert.equal(updatedAgain, updated);
+  });
+
+  it('validates dependabot changelog policy', () => {
+    const bump = {
+      name: 'postcss',
+      from: '8.5.14',
+      to: '8.5.15',
+      directory: 'root',
+    };
+    const changelog = applyDependencyBumpsToChangelog(sampleChangelog, [bump]);
+    const result = dependabotChangelogTouchesPr(['CHANGELOG.md'], changelog, [bump]);
+    assert.equal(result.ok, true);
+  });
+
+  it('formats bullets with optional directory scope', () => {
+    assert.equal(
+      formatDependencyChangelogBullet({
+        name: 'postcss',
+        from: '8.5.14',
+        to: '8.5.15',
+        directory: 'root',
+      }),
+      '- **postcss:** 8.5.14 → 8.5.15',
+    );
+    assert.match(
+      formatDependencyChangelogBullet({
+        name: 'express-rate-limit',
+        from: '^8.5.1',
+        to: '^8.5.2',
+        directory: 'server',
+      }),
+      /`server`/,
+    );
+  });
+});

--- a/scripts/update-dependabot-changelog.mjs
+++ b/scripts/update-dependabot-changelog.mjs
@@ -1,0 +1,38 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  applyDependencyBumpsToChangelog,
+  listDependencyBumpsBetweenRefs,
+} from './lib/dependabot-changelog.mjs';
+
+const baseRef = process.env.GITHUB_BASE_REF ?? '';
+const headRef = process.env.GITHUB_HEAD_REF ?? '';
+const changelogPath = process.env.CHANGELOG_FILE ?? 'CHANGELOG.md';
+
+if (!baseRef || !headRef) {
+  console.error('Set GITHUB_BASE_REF and GITHUB_HEAD_REF.');
+  process.exit(1);
+}
+
+if (!headRef.startsWith('dependabot/')) {
+  console.log('Not a Dependabot branch; skipping changelog update.');
+  process.exit(0);
+}
+
+const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
+if (bumps.length === 0) {
+  console.log('No dependency version changes detected in package.json files.');
+  process.exit(0);
+}
+
+const changelog = readFileSync(changelogPath, 'utf8');
+const next = applyDependencyBumpsToChangelog(changelog, bumps);
+
+if (next === changelog) {
+  console.log('CHANGELOG.md already up to date for dependency bumps.');
+  process.exit(0);
+}
+
+writeFileSync(changelogPath, next);
+console.log(
+  `Updated CHANGELOG.md ### Dependencies for: ${bumps.map((b) => b.name).join(', ')}`,
+);


### PR DESCRIPTION
## Summary
- Post-merge automation creates a GitHub Release whenever \package.json\ changes (stable on \main\, prerelease on \eta\).
- **Dependabot changelog** workflow + \### Dependencies\ section (no changelog skip): automation commits bullets; CI validates them.
- Bootstrap path backfills stable releases and publishes the first beta prerelease.

## Related
- Merge **#348** to \eta\ first so open Dependabot PRs can pass changelog CI.
- After this merges to \main\, run **Post-merge automation** (\workflow_dispatch\, sync beta from main) once to backfill \1.5.3\.

## Test plan
- [ ] \
ode --test scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs\
- [ ] Merge #348 → beta, then merge safe Dependabot PRs
- [ ] Merge this PR → main, run workflow_dispatch bootstrap