### PR TITLE
Skip changelog gate for Dependabot PRs

### DIFF
--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -31,6 +31,11 @@ if (headRef.startsWith('port/')) {
   process.exit(0);
 }
 
+if (headRef.startsWith('dependabot/')) {
+  console.log('Skipping changelog check for Dependabot version updates.');
+  process.exit(0);
+}
+
 const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
 
 const result = changelogTouchesPr(changedFiles, prBody);

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -21,7 +21,8 @@ if (
   branchPolicy.ok &&
   branchPolicy.kind !== 'beta-promotion' &&
   branchPolicy.kind !== 'release-infrastructure' &&
-  !headRef.startsWith('port/')
+  !headRef.startsWith('port/') &&
+  !headRef.startsWith('dependabot/')
 ) {
   const changelogResult = changelogTouchesPr(changedFiles, prBody);
   changelogOk = changelogResult.ok;


### PR DESCRIPTION
## Summary

- Lets Dependabot version PRs merge to \eta\ without a CHANGELOG file or PR-body section.
- Same change ships to \main\ in #346.

## Test plan

- [ ] Merge, then re-run / merge open Dependabot PRs (#336, #339–#343).

Made with [Cursor](https://cursor.com)