### PR TITLE
Dependabot changelog automation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,7 @@ Every user-facing change must be recorded in [CHANGELOG.md](../CHANGELOG.md) und
 *   `Removed`: For now-removed features.
 *   `Fixed`: For any bug fixes.
 *   `Security`: In case of vulnerabilities.
+*   `Dependencies`: For dependency version bumps (Dependabot PRs auto-update this subsection).
 
 ### 2. Update Notes
 When structural changes (schema migrations, API changes, new store slices) occur:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
-        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs
 
       - name: Validate package version for target branch
         env:

--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -1,0 +1,44 @@
+name: Dependabot changelog
+
+# Commits ### Dependencies bullets to Dependabot PRs so CI changelog policy passes.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  update-changelog:
+    if: >-
+      github.event_name == 'pull_request' &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout head branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Fetch base branch
+        run: git fetch origin "${{ github.base_ref }}"
+
+      - name: Update CHANGELOG dependencies
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: node scripts/update-dependabot-changelog.mjs
+
+      - name: Commit and push
+        run: |
+          if git diff --quiet CHANGELOG.md; then
+            echo "No CHANGELOG changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore: update CHANGELOG dependencies for Dependabot bump"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## v1.6
 
+### Dependencies
+<!-- dependabot-automation -->
+
 ### Fixed
 - **Map layer transparency:** Restored `transparencyScale` on forecast map fill/stroke opacity after the main sync dropped the multiplier (fixes CI on `beta`).
 - **GFC-WEB-4 (monitor startup):** Break circular import between `monitor/types` and `monitorSettingsNormalize` that crashed the hosted app at load (`Gv is not iterable` / `MONITOR_OUTLOOK_LAYER_TYPES` before initialization when spreading outlook layer types).

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -1,4 +1,9 @@
+import { execFileSync } from 'node:child_process';
 import { changelogTouchesPr } from './lib/changelog.mjs';
+import {
+  dependabotChangelogTouchesPr,
+  listDependencyBumpsBetweenRefs,
+} from './lib/dependabot-changelog.mjs';
 import { evaluateBranchPolicy } from './lib/branch-policy.mjs';
 import { listChangedFilesBetweenRefs } from './lib/git-changed-files.mjs';
 
@@ -32,6 +37,20 @@ if (headRef.startsWith('port/')) {
 }
 
 const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
+
+if (headRef.startsWith('dependabot/')) {
+  const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
+  const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:CHANGELOG.md`], {
+    encoding: 'utf8',
+  });
+  const result = dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps);
+  if (!result.ok) {
+    console.error(result.reason);
+    process.exit(1);
+  }
+  console.log(result.reason);
+  process.exit(0);
+}
 
 const result = changelogTouchesPr(changedFiles, prBody);
 

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -1,5 +1,10 @@
+import { execFileSync } from 'node:child_process';
 import { evaluateBranchPolicy } from './lib/branch-policy.mjs';
 import { changelogTouchesPr } from './lib/changelog.mjs';
+import {
+  dependabotChangelogTouchesPr,
+  listDependencyBumpsBetweenRefs,
+} from './lib/dependabot-changelog.mjs';
 import { listChangedFilesBetweenRefs } from './lib/git-changed-files.mjs';
 import { MANAGED_LABELS, computePrLabels } from './lib/pr-labels.mjs';
 
@@ -23,8 +28,16 @@ if (
   branchPolicy.kind !== 'release-infrastructure' &&
   !headRef.startsWith('port/')
 ) {
-  const changelogResult = changelogTouchesPr(changedFiles, prBody);
-  changelogOk = changelogResult.ok;
+  if (headRef.startsWith('dependabot/')) {
+    const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
+    const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:CHANGELOG.md`], {
+      encoding: 'utf8',
+    });
+    changelogOk = dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps).ok;
+  } else {
+    const changelogResult = changelogTouchesPr(changedFiles, prBody);
+    changelogOk = changelogResult.ok;
+  }
 }
 
 const labels = computePrLabels({

--- a/scripts/lib/dependabot-changelog.mjs
+++ b/scripts/lib/dependabot-changelog.mjs
@@ -1,0 +1,221 @@
+import { execFileSync } from 'node:child_process';
+
+export const DEPENDENCIES_HEADING = '### Dependencies';
+export const DEPENDENCIES_MARKER = '<!-- dependabot-automation -->';
+
+const PACKAGE_JSON_PATHS = ['package.json', 'server/package.json'];
+
+/**
+ * @param {string} directory
+ */
+export const packageDirectoryLabel = (directory) => {
+  if (directory === 'root' || directory === '.' || directory === '') return 'root';
+  return directory.replace(/\/$/, '');
+};
+
+/**
+ * @param {string} changelog
+ * @returns {{ heading: string; start: number; end: number } | null}
+ */
+export const findDependabotChangelogSection = (changelog) => {
+  const unreleased = changelog.indexOf('## [Unreleased]');
+  if (unreleased !== -1) {
+    const afterStart = unreleased + '## [Unreleased]'.length;
+    const rest = changelog.slice(afterStart);
+    const next = rest.search(/\n## /);
+    const end = next === -1 ? changelog.length : afterStart + next;
+    return { heading: '## [Unreleased]', start: unreleased, end };
+  }
+
+  const match = changelog.match(/^## v[\d.]+/m);
+  if (!match || match.index === undefined) return null;
+
+  const afterStart = match.index + match[0].length;
+  const rest = changelog.slice(afterStart);
+  const next = rest.search(/\n## /);
+  const end = next === -1 ? changelog.length : afterStart + next;
+  return { heading: match[0], start: match.index, end };
+};
+
+/**
+ * @param {string} changelog
+ * @param {{ heading: string; start: number; end: number }} section
+ * @returns {string | null}
+ */
+export const extractDependenciesSubsection = (changelog, section) => {
+  const body = changelog.slice(section.start, section.end);
+  const escapedHeading = DEPENDENCIES_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = body.match(new RegExp(`${escapedHeading}[\\s\\S]*?(?=\\n### |\\n## |$)`));
+  if (!match) return null;
+
+  return match[0].slice(DEPENDENCIES_HEADING.length).replace(DEPENDENCIES_MARKER, '').trim();
+};
+
+/**
+ * @param {{ name: string; from: string; to: string; directory: string }} bump
+ */
+export const formatDependencyChangelogBullet = ({ name, from, to, directory }) => {
+  const scope =
+    packageDirectoryLabel(directory) === 'root' ? '' : ` (\`${packageDirectoryLabel(directory)}\`)`;
+  return `- **${name}:** ${from} → ${to}${scope}`;
+};
+
+/**
+ * @param {string} line
+ * @param {string} packageName
+ */
+export const dependencyBulletCoversPackage = (line, packageName) =>
+  new RegExp(`\\*\\*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\*\\*:`).test(line);
+
+/**
+ * @param {{ name: string; from: string; to: string; directory: string }} bump
+ * @param {string} dependenciesBody
+ */
+export const dependencyBumpDocumented = (bump, dependenciesBody) => {
+  if (!dependenciesBody.includes(`**${bump.name}:**`)) return false;
+  return dependenciesBody.includes(bump.from) && dependenciesBody.includes(bump.to);
+};
+
+/**
+ * @param {string} baseRef
+ * @param {string} headRef
+ * @returns {Array<{ name: string; from: string; to: string; directory: string; depType: string }>}
+ */
+export const listDependencyBumpsBetweenRefs = (baseRef, headRef) => {
+  /** @type {Array<{ name: string; from: string; to: string; directory: string; depType: string }>} */
+  const bumps = [];
+
+  for (const packagePath of PACKAGE_JSON_PATHS) {
+    let basePkg;
+    let headPkg;
+    try {
+      basePkg = JSON.parse(
+        execFileSync('git', ['show', `origin/${baseRef}:${packagePath}`], { encoding: 'utf8' }),
+      );
+      headPkg = JSON.parse(
+        execFileSync('git', ['show', `origin/${headRef}:${packagePath}`], { encoding: 'utf8' }),
+      );
+    } catch {
+      continue;
+    }
+
+    const directory = packagePath === 'package.json' ? 'root' : 'server';
+
+    for (const depType of ['dependencies', 'devDependencies']) {
+      const baseDeps = basePkg[depType] ?? {};
+      const headDeps = headPkg[depType] ?? {};
+      for (const [name, to] of Object.entries(headDeps)) {
+        const from = baseDeps[name];
+        if (from !== undefined && from !== to) {
+          bumps.push({ name, from, to, directory, depType });
+        }
+      }
+    }
+  }
+
+  return bumps;
+};
+
+/**
+ * @param {string} changelog
+ * @param {Array<{ name: string; from: string; to: string; directory: string }>} bumps
+ */
+export const applyDependencyBumpsToChangelog = (changelog, bumps) => {
+  if (bumps.length === 0) return changelog;
+
+  const section = findDependabotChangelogSection(changelog);
+  if (!section) {
+    throw new Error(
+      'CHANGELOG.md must include ## [Unreleased] or a top ## vX.Y section for dependency entries.',
+    );
+  }
+
+  const existingDepsBody = extractDependenciesSubsection(changelog, section);
+  if (existingDepsBody && bumps.every((bump) => dependencyBumpDocumented(bump, existingDepsBody))) {
+    return changelog;
+  }
+
+  const depsBody = existingDepsBody ?? '';
+  const lines = depsBody
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.startsWith('- **') && line.includes(':**'));
+
+  for (const bump of bumps) {
+    const bullet = formatDependencyChangelogBullet(bump);
+    const existingIndex = lines.findIndex((line) => dependencyBulletCoversPackage(line, bump.name));
+    if (existingIndex === -1) {
+      lines.push(bullet);
+    } else if (!lines[existingIndex].includes(bump.to)) {
+      lines[existingIndex] = bullet;
+    }
+  }
+
+  const dependenciesBlock = [
+    DEPENDENCIES_HEADING,
+    DEPENDENCIES_MARKER,
+    '',
+    ...lines,
+    '',
+  ].join('\n');
+
+  let sectionBody = changelog.slice(section.start, section.end);
+  const escapedHeading = DEPENDENCIES_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const depsPattern = new RegExp(`${escapedHeading}[\\s\\S]*?(?=\\n### |\\n## |$)`);
+  sectionBody = sectionBody.replace(depsPattern, '').trimEnd();
+
+  const headingEnd = sectionBody.indexOf('\n');
+  const insertPos = headingEnd === -1 ? sectionBody.length : headingEnd + 1;
+  sectionBody = `${sectionBody.slice(0, insertPos)}\n${dependenciesBlock}${sectionBody.slice(insertPos)}`;
+
+  return changelog.slice(0, section.start) + sectionBody + changelog.slice(section.end);
+};
+
+/**
+ * @param {string[]} changedFiles
+ * @param {string} changelogAtHead
+ * @param {Array<{ name: string; from: string; to: string; directory: string }>} bumps
+ */
+export const dependabotChangelogTouchesPr = (changedFiles, changelogAtHead, bumps) => {
+  const touchesChangelog = changedFiles.some(
+    (file) => file === 'CHANGELOG.md' || file.endsWith('/CHANGELOG.md'),
+  );
+
+  if (!touchesChangelog) {
+    return {
+      ok: false,
+      reason:
+        'Dependabot PRs must update CHANGELOG.md (the dependabot-changelog workflow commits ### Dependencies entries).',
+    };
+  }
+
+  const section = findDependabotChangelogSection(changelogAtHead);
+  if (!section) {
+    return {
+      ok: false,
+      reason: 'CHANGELOG.md needs ## [Unreleased] or a top ## vX.Y section for ### Dependencies.',
+    };
+  }
+
+  const depsBody = extractDependenciesSubsection(changelogAtHead, section);
+  if (!depsBody || !/^-\s/m.test(depsBody)) {
+    return {
+      ok: false,
+      reason: 'CHANGELOG.md ### Dependencies must list at least one dependency bump bullet.',
+    };
+  }
+
+  const missing = bumps.filter((bump) => !dependencyBumpDocumented(bump, depsBody));
+  if (missing.length > 0) {
+    const names = missing.map((bump) => bump.name).join(', ');
+    return {
+      ok: false,
+      reason: `CHANGELOG.md ### Dependencies is missing entries for: ${names}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: 'CHANGELOG.md ### Dependencies documents this dependency bump.',
+  };
+};

--- a/scripts/lib/dependabot-changelog.test.mjs
+++ b/scripts/lib/dependabot-changelog.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  applyDependencyBumpsToChangelog,
+  dependabotChangelogTouchesPr,
+  extractDependenciesSubsection,
+  findDependabotChangelogSection,
+  formatDependencyChangelogBullet,
+} from './dependabot-changelog.mjs';
+
+const sampleChangelog = `# Changelog
+
+## [Unreleased]
+
+### Changed
+- Something
+
+## v1.5.3
+`;
+
+describe('dependabot changelog', () => {
+  it('finds Unreleased as the active section', () => {
+    const section = findDependabotChangelogSection(sampleChangelog);
+    assert.equal(section?.heading, '## [Unreleased]');
+  });
+
+  it('inserts and updates dependency bullets', () => {
+    const bump = {
+      name: 'express-rate-limit',
+      from: '^8.5.1',
+      to: '^8.5.2',
+      directory: 'server',
+    };
+    const updated = applyDependencyBumpsToChangelog(sampleChangelog, [bump]);
+    const section = findDependabotChangelogSection(updated);
+    assert.ok(section);
+    const deps = extractDependenciesSubsection(updated, section);
+    assert.match(deps ?? '', /express-rate-limit/);
+    assert.match(deps ?? '', /\^8\.5\.2/);
+
+    const updatedAgain = applyDependencyBumpsToChangelog(updated, [bump]);
+    assert.equal(updatedAgain, updated);
+  });
+
+  it('validates dependabot changelog policy', () => {
+    const bump = {
+      name: 'postcss',
+      from: '8.5.14',
+      to: '8.5.15',
+      directory: 'root',
+    };
+    const changelog = applyDependencyBumpsToChangelog(sampleChangelog, [bump]);
+    const result = dependabotChangelogTouchesPr(['CHANGELOG.md'], changelog, [bump]);
+    assert.equal(result.ok, true);
+  });
+
+  it('formats bullets with optional directory scope', () => {
+    assert.equal(
+      formatDependencyChangelogBullet({
+        name: 'postcss',
+        from: '8.5.14',
+        to: '8.5.15',
+        directory: 'root',
+      }),
+      '- **postcss:** 8.5.14 → 8.5.15',
+    );
+    assert.match(
+      formatDependencyChangelogBullet({
+        name: 'express-rate-limit',
+        from: '^8.5.1',
+        to: '^8.5.2',
+        directory: 'server',
+      }),
+      /`server`/,
+    );
+  });
+});

--- a/scripts/update-dependabot-changelog.mjs
+++ b/scripts/update-dependabot-changelog.mjs
@@ -1,0 +1,38 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  applyDependencyBumpsToChangelog,
+  listDependencyBumpsBetweenRefs,
+} from './lib/dependabot-changelog.mjs';
+
+const baseRef = process.env.GITHUB_BASE_REF ?? '';
+const headRef = process.env.GITHUB_HEAD_REF ?? '';
+const changelogPath = process.env.CHANGELOG_FILE ?? 'CHANGELOG.md';
+
+if (!baseRef || !headRef) {
+  console.error('Set GITHUB_BASE_REF and GITHUB_HEAD_REF.');
+  process.exit(1);
+}
+
+if (!headRef.startsWith('dependabot/')) {
+  console.log('Not a Dependabot branch; skipping changelog update.');
+  process.exit(0);
+}
+
+const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
+if (bumps.length === 0) {
+  console.log('No dependency version changes detected in package.json files.');
+  process.exit(0);
+}
+
+const changelog = readFileSync(changelogPath, 'utf8');
+const next = applyDependencyBumpsToChangelog(changelog, bumps);
+
+if (next === changelog) {
+  console.log('CHANGELOG.md already up to date for dependency bumps.');
+  process.exit(0);
+}
+
+writeFileSync(changelogPath, next);
+console.log(
+  `Updated CHANGELOG.md ### Dependencies for: ${bumps.map((b) => b.name).join(', ')}`,
+);


### PR DESCRIPTION
## Summary
- Adds **Dependabot changelog** workflow: commits \### Dependencies\ bullets on each Dependabot PR.
- CI validates those entries (package name + version range) instead of skipping changelog checks.
- Adds empty \### Dependencies\ under \## v1.6\ for automation to fill.

## Test plan
- [ ] Merge, then re-run failing Dependabot PRs (#336, #339–#343) so the workflow can commit changelog updates.
- [ ] Leave #337 and #338 closed (breaking majors).

Made with [Cursor](https://cursor.com)