### PR TITLE
[Port][Conflicts] Publish GitHub Releases on every version bump → feature/dependabot-changelog-automation

### DIFF
--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -2,10 +2,12 @@ name: Post-merge automation
 
 # Runs after a PR merges. No manual workflow dispatch needed for normal releases.
 #
-# beta → main: strip stable version on main, GitHub Release from CHANGELOG, start next beta line.
-# release/* → main: GitHub Release from CHANGELOG, start next beta line (optional prepare workflow).
-# feature/*|fix/*|other → beta: bump -beta.N on beta (hotfix/* is the only blocked target).
-# hotfix/* → main: bump patch on main and create GitHub Release.
+# Every package.json version bump creates a GitHub Release (stable or --prerelease for -beta.N).
+# beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
+# release/* → main: stable release + next beta line + prerelease.
+# feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.
+# hotfix/* → main: patch bump on main + stable release.
+# feature/release-*|workflow_dispatch: sync main→beta, stable release for main, prerelease for new beta.
 #
 # Required secret: GH_PAT (repo scope)
 on:
@@ -66,7 +68,12 @@ jobs:
           set -euo pipefail
           git fetch origin main beta
           git show origin/main:package.json > /tmp/main-package.json
+          git show origin/main:CHANGELOG.md > /tmp/main-changelog.md
           STABLE=$(node scripts/read-package-version.mjs /tmp/main-package.json)
+
+          export CHANGELOG_FILE=/tmp/main-changelog.md
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$STABLE" main
 
           git checkout beta
           git pull origin beta
@@ -80,6 +87,10 @@ jobs:
             git commit -m "chore: start beta cycle at $NEXT after main release v$STABLE"
           fi
           git push origin beta
+
+          export CHANGELOG_FILE=CHANGELOG.md
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$NEXT" beta
 
       - name: Beta promotion merged into main
         if: >-
@@ -115,6 +126,10 @@ jobs:
             git push origin beta
           fi
 
+          NEXT=$(node scripts/read-package-version.mjs)
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$NEXT" beta
+
       - name: Release branch merged into main
         if: >-
           github.event_name == 'pull_request' &&
@@ -140,6 +155,10 @@ jobs:
             git commit -m "chore: start next beta cycle after v$STABLE main release (was $BETA_VERSION)"
             git push origin beta
           fi
+
+          NEXT=$(node scripts/read-package-version.mjs)
+          export NOTES_FILE=$(mktemp)
+          node scripts/create-github-release.mjs "$NEXT" beta
 
       - name: Hotfix merged into main
         if: >-
@@ -169,6 +188,8 @@ jobs:
           github.event.pull_request.head.ref != 'beta' &&
           !startsWith(github.event.pull_request.head.ref, 'port/') &&
           !startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5; do
@@ -184,6 +205,9 @@ jobs:
             git add package.json
             git commit -m "chore: bump beta prerelease after merge (was $PREVIOUS)"
             if git push origin beta; then
+              NEW=$(node scripts/read-package-version.mjs)
+              export NOTES_FILE=$(mktemp)
+              node scripts/create-github-release.mjs "$NEW" beta
               exit 0
             fi
             echo "Push failed (attempt $attempt), retrying..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,9 @@ All notable changes to this project will be documented in this file.
 ## v1.5.0
 
 ### Changed
+- **GitHub Releases on every version bump:** Post-merge automation now publishes a release whenever `package.json` changes — stable tags on `main` (promotion, hotfix, release branch, bootstrap backfill) and prerelease tags on `beta` after each `-beta.N` integration merge.
 - **Release automation:** Beta → main stays a normal PR; merge triggers stable versioning on `main`, GitHub Releases from CHANGELOG (including hotfixes), and beta prerelease bumps. CI enforces branch routing (preferred `feature/*`/`fix/*` → beta; only `hotfix/*` blocked on beta), changelog checks, and automated PR labels. Workflow definitions ship on `main` so GitHub can run them for repository pull requests.
-- **Post-merge bootstrap:** `feature/release-*` → `main` syncs automation to `beta` and starts the next `-beta.N` line; manual `workflow_dispatch` recovery when bootstrap was missed.
+- **Post-merge bootstrap:** `feature/release-*` → `main` syncs automation to `beta`, backfills the stable GitHub Release for `main`, starts the next `-beta.N` line, and publishes the first prerelease; manual `workflow_dispatch` recovery when bootstrap was missed.
 - **Dependabot:** Version update PRs for root and `server/` npm ecosystems target `beta` (not `main`). Urgent production dependency fixes use `hotfix/*` → `main` or a beta promotion.
 
 ## v1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,14 @@ All notable changes to this project will be documented in this file.
 
 ## v1.5.0
 
+### Dependencies
+<!-- dependabot-automation -->
+
 ### Changed
 - **GitHub Releases on every version bump:** Post-merge automation now publishes a release whenever `package.json` changes — stable tags on `main` (promotion, hotfix, release branch, bootstrap backfill) and prerelease tags on `beta` after each `-beta.N` integration merge.
 - **Release automation:** Beta → main stays a normal PR; merge triggers stable versioning on `main`, GitHub Releases from CHANGELOG (including hotfixes), and beta prerelease bumps. CI enforces branch routing (preferred `feature/*`/`fix/*` → beta; only `hotfix/*` blocked on beta), changelog checks, and automated PR labels. Workflow definitions ship on `main` so GitHub can run them for repository pull requests.
 - **Post-merge bootstrap:** `feature/release-*` → `main` syncs automation to `beta`, backfills the stable GitHub Release for `main`, starts the next `-beta.N` line, and publishes the first prerelease; manual `workflow_dispatch` recovery when bootstrap was missed.
-- **Dependabot:** Version update PRs for root and `server/` npm ecosystems target `beta` (not `main`). Urgent production dependency fixes use `hotfix/*` → `main` or a beta promotion.
+- **Dependabot:** Version update PRs for root and `server/` npm ecosystems target `beta` (not `main`). **Dependabot changelog** workflow maintains `### Dependencies` under `[Unreleased]`; CI validates those bullets instead of skipping changelog checks.
 
 ## v1.6
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -79,6 +79,12 @@ If you merged release automation before this step existed, run **Post-merge auto
 
 Version update PRs from `.github/dependabot.yml` open against **beta** (root and `server/`). They ride the normal integration and **beta → main** promotion path. For an urgent CVE on production before the next promotion, use **hotfix/* → main** (or merge the dependency fix to `main` manually) instead of waiting on Dependabot alone.
 
+### Dependabot changelog automation
+
+- **Dependabot changelog** workflow (`dependabot-changelog.yml`) runs on each Dependabot PR and commits bullets under **`### Dependencies`** in the active changelog section (`## [Unreleased]` on `main`, or the top `## vX.Y` line on `beta`).
+- CI requires `CHANGELOG.md` to include those entries (not a generic changelog skip). Entries use the form `- **package:** old → new` with `(\`server\`)` when the bump is under `server/package.json`.
+- Dependency notes accumulate under **Dependencies** until the next **beta → main** promotion ships them in the stable GitHub Release for that line.
+
 ## Changelog
 
 For PRs into **beta** (feature/fix) and **hotfix → main**:

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,6 +1,6 @@
 # Release workflow
 
-Your normal flow stays simple: **open a PR, review it, click merge**. Automation handles versions, changelog gates, labels, GitHub Releases, and beta prerelease bumps.
+Your normal flow stays simple: **open a PR, review it, click merge**. Automation handles versions, changelog gates, labels, and **GitHub Releases for every `package.json` version change** (stable tags on `main`, prerelease tags on `beta`).
 
 ## Your day-to-day (short answer)
 
@@ -20,7 +20,7 @@ After merge, **Post-merge automation** runs on its own (no Actions button).
 2. **Post-merge automation** (`post-merge-automation.yml`):
    - Strips `-beta` from `package.json` on `main` (e.g. `1.6.0-beta.3` → `1.6.0`) and pushes.
    - Creates a **GitHub Release** `v1.6.0` using the matching section in `CHANGELOG.md`.
-   - Bumps **beta** to the next line (e.g. `1.7.0-beta.1`) for continued development.
+   - Bumps **beta** to the next line (e.g. `1.7.0-beta.1`) and creates a **prerelease** `v1.7.0-beta.1`.
 3. **Deploy Production to VPS** runs on the push to `main` (Sentry release uses the **stable** version even if the merge commit still had `-beta` briefly).
 
 ### release/* → main (optional prepare workflow)
@@ -28,13 +28,14 @@ After merge, **Post-merge automation** runs on its own (no Actions button).
 Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from **Prepare Beta → Main Release PR**:
 
 1. Merge the release PR to `main`.
-2. **Post-merge automation** creates the **GitHub Release** and bumps **beta** to the next line.
+2. **Post-merge automation** creates the **stable GitHub Release**, bumps **beta** to the next line, and publishes a **prerelease** for the new beta version.
 
 ### Integrations → beta
 
 - Preferred: `feature/*` and `fix/*` (labeled `integration:primary`).
 - Other branch names are allowed into beta except `hotfix/*` (labeled `integration:other`).
 - Automation increments the beta prerelease on each merge: `1.6.0-beta.1` → `1.6.0-beta.2`, etc.
+- Each bump creates a **GitHub prerelease** (`v1.6.0-beta.2`) from the matching `CHANGELOG.md` line section, or from **\[Unreleased\]** when no line section exists yet.
 - Port branches (`port/*`) skip the version bump.
 
 ### hotfix/* → main
@@ -45,10 +46,11 @@ Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from
 ### `feature/release-*` → main (release infrastructure)
 
 - Merges **main** into **beta** so beta gets workflows/scripts.
-- Sets **beta** to the next development line (e.g. main `1.5.3` → beta `1.6.0-beta.1`).
+- Creates the **stable GitHub Release** for the version on `main` (e.g. `v1.5.3`) if it is missing.
+- Sets **beta** to the next development line (e.g. main `1.5.3` → beta `1.6.0-beta.1`) and creates the matching **prerelease**.
 - Does **not** change `main` again (the PR already set the stable version).
 
-If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**).
+If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**) to backfill the stable release and start the beta line.
 
 ## Branch rules (enforced in CI)
 

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -36,6 +36,11 @@ if (headRef.startsWith('port/')) {
   process.exit(0);
 }
 
+if (headRef.startsWith('dependabot/')) {
+  console.log('Skipping changelog check for Dependabot version updates.');
+  process.exit(0);
+}
+
 const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
 
 if (headRef.startsWith('dependabot/')) {

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -36,11 +36,6 @@ if (headRef.startsWith('port/')) {
   process.exit(0);
 }
 
-if (headRef.startsWith('dependabot/')) {
-  console.log('Skipping changelog check for Dependabot version updates.');
-  process.exit(0);
-}
-
 const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
 
 if (headRef.startsWith('dependabot/')) {
@@ -57,6 +52,25 @@ if (headRef.startsWith('dependabot/')) {
   process.exit(0);
 }
 
+<<<<<<< HEAD
+const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
+
+if (headRef.startsWith('dependabot/')) {
+  const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
+  const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:CHANGELOG.md`], {
+    encoding: 'utf8',
+  });
+  const result = dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps);
+  if (!result.ok) {
+    console.error(result.reason);
+    process.exit(1);
+  }
+  console.log(result.reason);
+  process.exit(0);
+}
+
+=======
+>>>>>>> f4aafc8 (Add Dependabot changelog automation with a Dependencies section.)
 const result = changelogTouchesPr(changedFiles, prBody);
 
 if (!result.ok) {

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -26,7 +26,8 @@ if (
   branchPolicy.ok &&
   branchPolicy.kind !== 'beta-promotion' &&
   branchPolicy.kind !== 'release-infrastructure' &&
-  !headRef.startsWith('port/')
+  !headRef.startsWith('port/') &&
+  !headRef.startsWith('dependabot/')
 ) {
   if (headRef.startsWith('dependabot/')) {
     const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -26,8 +26,7 @@ if (
   branchPolicy.ok &&
   branchPolicy.kind !== 'beta-promotion' &&
   branchPolicy.kind !== 'release-infrastructure' &&
-  !headRef.startsWith('port/') &&
-  !headRef.startsWith('dependabot/')
+  !headRef.startsWith('port/')
 ) {
   if (headRef.startsWith('dependabot/')) {
     const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -1,34 +1,36 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { extractChangelogSection } from './lib/changelog.mjs';
+import { extractReleaseNotes } from './lib/changelog.mjs';
+import { hasBetaPrerelease } from './lib/package-version.mjs';
 
-const stableVersion = process.argv[2];
+const version = process.argv[2];
 const targetBranch = process.argv[3] ?? 'main';
 
-if (!stableVersion) {
-  console.error('Usage: node scripts/create-github-release.mjs <stable-version> [target-branch]');
+if (!version) {
+  console.error('Usage: node scripts/create-github-release.mjs <version> [target-branch]');
   process.exit(1);
 }
 
-const changelog = readFileSync('CHANGELOG.md', 'utf8');
-const section = extractChangelogSection(changelog, stableVersion);
-
-if (!section) {
-  console.error(`No CHANGELOG section found for v${stableVersion}.`);
-  process.exit(1);
-}
+const changelogPath = process.env.CHANGELOG_FILE ?? 'CHANGELOG.md';
+const changelog = readFileSync(changelogPath, 'utf8');
+const section =
+  extractReleaseNotes(changelog, version) ??
+  `## v${version}\n\nRelease for package version ${version}.`;
 
 const notesFile = process.env.NOTES_FILE ?? 'release-notes.md';
 writeFileSync(notesFile, `${section}\n`);
 
-const tag = `v${stableVersion}`;
+const tag = `v${version}`;
+const prereleaseFlag = hasBetaPrerelease(version) ? '--prerelease' : '';
+
 try {
   execSync(`gh release view "${tag}"`, { stdio: 'ignore' });
   console.log(`GitHub release ${tag} already exists.`);
 } catch {
+  const prereleaseSuffix = prereleaseFlag ? ` ${prereleaseFlag}` : '';
   execSync(
-    `gh release create "${tag}" --title "${tag}" --notes-file "${notesFile}" --target "${targetBranch}"`,
+    `gh release create "${tag}" --title "${tag}" --notes-file "${notesFile}" --target "${targetBranch}"${prereleaseSuffix}`,
     { stdio: 'inherit' },
   );
-  console.log(`Created GitHub release ${tag}.`);
+  console.log(`Created GitHub release ${tag}${prereleaseFlag ? ' (prerelease)' : ''}.`);
 }

--- a/scripts/lib/changelog.mjs
+++ b/scripts/lib/changelog.mjs
@@ -1,3 +1,23 @@
+import { deriveStableVersion, hasBetaPrerelease } from './package-version.mjs';
+
+/**
+ * @param {string} changelog
+ * @returns {string | null}
+ */
+export const extractUnreleasedSection = (changelog) => {
+  const heading = '## [Unreleased]';
+  const start = changelog.indexOf(heading);
+  if (start === -1) return null;
+
+  const afterHeading = start + heading.length;
+  const rest = changelog.slice(afterHeading);
+  const nextSection = rest.search(/\n## /);
+  const body = (nextSection === -1 ? rest : rest.slice(0, nextSection)).trim();
+  if (!body) return null;
+
+  return `${heading}\n\n${body}`.trim();
+};
+
 /**
  * @param {string} changelog
  * @param {string} stableVersion e.g. 1.6.0
@@ -21,6 +41,28 @@ export const extractChangelogSection = (changelog, stableVersion) => {
     const body = (nextSection === -1 ? rest : rest.slice(0, nextSection)).trim();
     if (body) {
       return `${heading}\n\n${body}`.trim();
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Notes body for a GitHub Release tag (stable or beta prerelease).
+ * @param {string} changelog
+ * @param {string} version e.g. 1.6.0 or 1.6.0-beta.2
+ * @returns {string | null}
+ */
+export const extractReleaseNotes = (changelog, version) => {
+  const stable = deriveStableVersion(version) ?? version;
+  const section = extractChangelogSection(changelog, stable);
+  if (section) return section;
+
+  if (hasBetaPrerelease(version)) {
+    const unreleased = extractUnreleasedSection(changelog);
+    if (unreleased) {
+      const body = unreleased.replace(/^## \[Unreleased\]\s*\n*/i, '').trim();
+      return `## v${version}\n\n${body}`.trim();
     }
   }
 

--- a/scripts/lib/changelog.test.mjs
+++ b/scripts/lib/changelog.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractChangelogSection,
+  extractReleaseNotes,
+  extractUnreleasedSection,
+} from './changelog.mjs';
+
+const sample = `# Changelog
+
+## [Unreleased]
+
+### Added
+- WIP feature
+
+## v1.6
+
+### Fixed
+- Bug fix
+
+## v1.5.3
+
+### Changed
+- Stable ship
+`;
+
+test('extractUnreleasedSection returns body under Unreleased', () => {
+  const section = extractUnreleasedSection(sample);
+  assert.match(section ?? '', /WIP feature/);
+  assert.match(section ?? '', /\[Unreleased\]/);
+});
+
+test('extractChangelogSection matches minor line heading', () => {
+  const section = extractChangelogSection(sample, '1.6.0');
+  assert.match(section ?? '', /Bug fix/);
+});
+
+test('extractReleaseNotes uses line section for stable version', () => {
+  const notes = extractReleaseNotes(sample, '1.5.3');
+  assert.match(notes ?? '', /Stable ship/);
+});
+
+test('extractReleaseNotes uses line section for beta when minor line exists', () => {
+  const notes = extractReleaseNotes(sample, '1.6.0-beta.4');
+  assert.match(notes ?? '', /Bug fix/);
+});
+
+test('extractReleaseNotes falls back to Unreleased for beta without line section', () => {
+  const changelog = `# Changelog\n\n## [Unreleased]\n\n### Added\n- WIP only\n`;
+  const notes = extractReleaseNotes(changelog, '2.0.0-beta.1');
+  assert.match(notes ?? '', /v2\.0\.0-beta\.1/);
+  assert.match(notes ?? '', /WIP only/);
+});


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/dependabot-changelog-automation`.

| | |
| --- | --- |
| Original PR | #346 — Publish GitHub Releases on every version bump |
| Source branch | `feature/release-post-merge-github-release` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `scripts/check-changelog-pr.mjs`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/346-to-feature-dependabot-changelog-automation`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #346, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/dependabot-changelog-automation` drifting behind `main`.