### PR TITLE
Fix porting overlap with post-merge and block redundant port PRs in CI

### DIFF
--- a/.github/scripts/port-changes.sh
+++ b/.github/scripts/port-changes.sh
@@ -34,8 +34,24 @@ fi
 
 TARGETS=()
 
+# post-merge-automation.yml owns main→beta for promotion and release infrastructure
+# (version strip/bump, merge main into beta, GitHub releases). Porting the same merge
+# here would race or duplicate that work with a second port PR.
+post_merge_owns_beta_sync() {
+  [[ "${BASE_BRANCH}" == "main" ]] || return 1
+  [[ "${SOURCE_BRANCH}" == "beta" ]] && return 0
+  [[ "${SOURCE_BRANCH}" == release/* ]] && return 0
+  [[ "${SOURCE_BRANCH}" == feature/release-* ]] && return 0
+  return 1
+}
+
 if [[ "${BASE_BRANCH}" == "main" ]]; then
-  TARGETS+=("beta")
+  if post_merge_owns_beta_sync; then
+    echo "Skipping beta: post-merge-automation handles main→beta for ${SOURCE_BRANCH}."
+    append_summary "_Beta sync is handled by **Post-merge automation** (not a port PR)._"
+  else
+    TARGETS+=("beta")
+  fi
 
   HOTFIX_BRANCHES=$(jq -r '.[].name | select(startswith("hotfix/"))' "${WORK_DIR}/branches.json")
   for b in $HOTFIX_BRANCHES; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   pr-governance:
@@ -27,6 +28,15 @@ jobs:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: node scripts/validate-branch-policy.mjs
 
+      - name: Port PR policy
+        if: startsWith(github.head_ref, 'port/')
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/validate-port-pr-policy.mjs
+
       - name: Changelog policy
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
@@ -46,7 +56,7 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
-        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs
 
       - name: Validate package version for target branch
         env:

--- a/.github/workflows/pr-porting.yml
+++ b/.github/workflows/pr-porting.yml
@@ -2,9 +2,13 @@ name: PR Porting System
 
 # Automates porting changes across the branch hierarchy via Pull Requests.
 #
+# main → beta is NOT ported here when post-merge-automation.yml already syncs beta
+# (beta promotion, release/*, feature/release-*). Those use direct CI pushes with version bumps.
+# hotfix/* → main still opens port PRs into beta (post-merge only bumps main).
+#
 # Flows:
-# 1. hotfix/* → main (broadcasts to beta, other hotfix/*, and all feature/*)
-# 2. feature/* → beta (broadcasts to all other feature/*)
+# 1. hotfix/* → main (port PRs to beta, other hotfix/*, and all feature/*)
+# 2. feature/* → beta (port PRs to all other feature/*)
 #
 # On conflicts: opens draft port PRs with conflict markers, files a tracking issue,
 # and annotates the workflow run so ports are not silently dropped.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -12,6 +12,19 @@ Your normal flow stays simple: **open a PR, review it, click merge**. Automation
 
 After merge, **Post-merge automation** runs on its own (no Actions button).
 
+## Porting vs post-merge (do not double up)
+
+Two automations run on merged PRs; they are split on purpose:
+
+| Responsibility | Workflow | Mechanism |
+|----------------|----------|-----------|
+| **Versions and GitHub Releases** on `main` / `beta` | `post-merge-automation.yml` | Direct commits to `main` or `beta` |
+| **main → beta sync** after promotion, `release/*`, or `feature/release-*` | `post-merge-automation.yml` | Merge/bump on `beta` (no port PR) |
+| **hotfix → beta** (commits only) | `pr-porting.yml` | Port PR into `beta` |
+| **Fan-out to other `feature/*` / `hotfix/*`** | `pr-porting.yml` | Port PRs per target branch |
+
+If both tried to port the same merge into `beta`, you would get a port PR and a CI push fighting each other. **PR porting skips `beta`** when post-merge already owns that sync. CI **fails** new `port/* → beta` PRs that duplicate that path.
+
 ## What happens when you merge
 
 ### beta → main (promotion)

--- a/scripts/lib/port-pr-policy.mjs
+++ b/scripts/lib/port-pr-policy.mjs
@@ -1,0 +1,78 @@
+const PORT_HEAD_PATTERN = /^port\/(\d+)-to-(.+)$/;
+
+/**
+ * @param {string} headRef
+ * @returns {{ sourcePrNumber: number; targetSlug: string } | null}
+ */
+export const parsePortBranch = (headRef) => {
+  const match = headRef.match(PORT_HEAD_PATTERN);
+  if (!match) return null;
+  return { sourcePrNumber: Number(match[1]), targetSlug: match[2] };
+};
+
+/**
+ * Reverse port-changes.sh slugging: `feature/foo-bar` → `feature/foo/bar` only for known prefixes.
+ *
+ * @param {string} slug
+ */
+export const targetBranchFromSlug = (slug) => {
+  if (slug === 'beta' || slug === 'main') return slug;
+  for (const prefix of ['feature', 'hotfix', 'release']) {
+    const marker = `${prefix}-`;
+    if (slug.startsWith(marker)) {
+      return `${prefix}/${slug.slice(marker.length)}`;
+    }
+  }
+  return slug;
+};
+
+/**
+ * Merges into main that post-merge-automation.yml already syncs onto beta.
+ *
+ * @param {string} sourceHeadRef
+ */
+export const postMergeOwnsMainToBetaSync = (sourceHeadRef) => {
+  if (sourceHeadRef === 'beta') return true;
+  if (sourceHeadRef.startsWith('release/')) return true;
+  if (sourceHeadRef.startsWith('feature/release-')) return true;
+  return false;
+};
+
+/**
+ * @param {{
+ *   headRef: string;
+ *   baseRef: string;
+ *   targetBranch: string;
+ *   sourcePrHeadRef: string;
+ *   sourcePrBaseRef: string;
+ *   sourcePrNumber: number;
+ * }} context
+ */
+export const evaluatePortPrPolicy = ({
+  headRef,
+  baseRef,
+  targetBranch,
+  sourcePrHeadRef,
+  sourcePrBaseRef,
+  sourcePrNumber,
+}) => {
+  if (!parsePortBranch(headRef)) {
+    return { ok: true };
+  }
+
+  if (
+    targetBranch === 'beta' &&
+    baseRef === 'beta' &&
+    sourcePrBaseRef === 'main' &&
+    postMergeOwnsMainToBetaSync(sourcePrHeadRef)
+  ) {
+    return {
+      ok: false,
+      message:
+        `Port PR ${headRef} duplicates post-merge-automation: PR #${sourcePrNumber} ` +
+        `(${sourcePrHeadRef} → main) already synced beta via CI. Close this port PR.`,
+    };
+  }
+
+  return { ok: true };
+};

--- a/scripts/lib/port-pr-policy.test.mjs
+++ b/scripts/lib/port-pr-policy.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  evaluatePortPrPolicy,
+  parsePortBranch,
+  postMergeOwnsMainToBetaSync,
+  targetBranchFromSlug,
+} from './port-pr-policy.mjs';
+
+describe('port PR policy', () => {
+  it('parses port branch names', () => {
+    assert.deepEqual(parsePortBranch('port/346-to-beta'), {
+      sourcePrNumber: 346,
+      targetSlug: 'beta',
+    });
+    assert.deepEqual(parsePortBranch('port/346-to-feature-dependabot-changelog-skip'), {
+      sourcePrNumber: 346,
+      targetSlug: 'feature-dependabot-changelog-skip',
+    });
+  });
+
+  it('decodes target slugs', () => {
+    assert.equal(targetBranchFromSlug('beta'), 'beta');
+    assert.equal(
+      targetBranchFromSlug('feature-dependabot-changelog-skip'),
+      'feature/dependabot-changelog-skip',
+    );
+  });
+
+  it('knows which main merges post-merge syncs to beta', () => {
+    assert.equal(postMergeOwnsMainToBetaSync('beta'), true);
+    assert.equal(postMergeOwnsMainToBetaSync('feature/release-post-merge-github-release'), true);
+    assert.equal(postMergeOwnsMainToBetaSync('hotfix/urgent'), false);
+  });
+
+  it('blocks redundant port PR into beta after release infrastructure merge', () => {
+    const result = evaluatePortPrPolicy({
+      headRef: 'port/346-to-beta',
+      baseRef: 'beta',
+      targetBranch: 'beta',
+      sourcePrHeadRef: 'feature/release-post-merge-github-release',
+      sourcePrBaseRef: 'main',
+      sourcePrNumber: 346,
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('allows hotfix ports into beta', () => {
+    const result = evaluatePortPrPolicy({
+      headRef: 'port/99-to-beta',
+      baseRef: 'beta',
+      targetBranch: 'beta',
+      sourcePrHeadRef: 'hotfix/patch',
+      sourcePrBaseRef: 'main',
+      sourcePrNumber: 99,
+    });
+    assert.equal(result.ok, true);
+  });
+});

--- a/scripts/validate-port-pr-policy.mjs
+++ b/scripts/validate-port-pr-policy.mjs
@@ -1,0 +1,46 @@
+import { execFileSync } from 'node:child_process';
+import {
+  evaluatePortPrPolicy,
+  parsePortBranch,
+  targetBranchFromSlug,
+} from './lib/port-pr-policy.mjs';
+
+const headRef = process.env.GITHUB_HEAD_REF ?? '';
+const baseRef = process.env.GITHUB_BASE_REF ?? '';
+
+const parsed = parsePortBranch(headRef);
+if (!parsed) {
+  console.log('Not a port/* branch; skipping port PR policy.');
+  process.exit(0);
+}
+
+const sourcePrJson = execFileSync(
+  'gh',
+  [
+    'pr',
+    'view',
+    String(parsed.sourcePrNumber),
+    '--repo',
+    process.env.GITHUB_REPOSITORY ?? '',
+    '--json',
+    'headRefName,baseRefName',
+  ],
+  { encoding: 'utf8' },
+);
+
+const sourcePr = JSON.parse(sourcePrJson);
+const result = evaluatePortPrPolicy({
+  headRef,
+  baseRef,
+  targetBranch: targetBranchFromSlug(parsed.targetSlug),
+  sourcePrHeadRef: sourcePr.headRefName,
+  sourcePrBaseRef: sourcePr.baseRefName,
+  sourcePrNumber: parsed.sourcePrNumber,
+});
+
+if (!result.ok) {
+  console.error(result.message);
+  process.exit(1);
+}
+
+console.log(`Port PR policy OK: ${headRef} → ${baseRef}.`);


### PR DESCRIPTION
## Summary

- Stop pr-porting from opening port/* to beta when post-merge-automation already syncs beta.
- Add CI guard that fails redundant port/* to beta PRs.
- Document the split in release-workflow.md.

## Context

#346 merged; post-merge already synced beta. Closed redundant port PRs #349-351.

## Test plan

- [x] port-pr-policy unit tests
- [ ] CI

Made with [Cursor](https://cursor.com)