### PR TITLE
Fix post-merge: sync main into beta after release/* merges

### DIFF
--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -148,8 +148,8 @@ jobs:
 
           git checkout beta
           git pull --ff-only origin beta
-          git merge origin/main -X theirs -m "chore: sync main into beta after release branch merge"
           BETA_VERSION=$(node scripts/read-package-version.mjs)
+          git merge origin/main -X theirs -m "chore: sync main into beta after release branch merge"
           node scripts/bump-beta-after-main-release.mjs "$STABLE"
           git add package.json
           if ! git diff --cached --quiet; then

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -4,7 +4,7 @@ name: Post-merge automation
 #
 # Every package.json version bump creates a GitHub Release (stable or --prerelease for -beta.N).
 # beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
-# release/* → main: stable release + next beta line + prerelease.
+# release/* → main: merge main into beta, stable release + next beta line + prerelease.
 # feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.
 # hotfix/* → main: patch bump on main + stable release.
 # feature/release-*|workflow_dispatch: sync main→beta, stable release for main, prerelease for new beta.
@@ -148,13 +148,14 @@ jobs:
 
           git checkout beta
           git pull --ff-only origin beta
+          git merge origin/main -X theirs -m "chore: sync main into beta after release branch merge"
           BETA_VERSION=$(node scripts/read-package-version.mjs)
           node scripts/bump-beta-after-main-release.mjs "$STABLE"
-          if ! git diff --quiet package.json; then
-            git add package.json
+          git add package.json
+          if ! git diff --cached --quiet; then
             git commit -m "chore: start next beta cycle after v$STABLE main release (was $BETA_VERSION)"
-            git push origin beta
           fi
+          git push origin beta
 
           NEXT=$(node scripts/read-package-version.mjs)
           export NOTES_FILE=$(mktemp)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 <!-- dependabot-automation -->
 
 ### Changed
+- **Post-merge `release/*` → main:** Automation now merges `main` into `beta` after every `release/*` merge (same as `feature/release-*`), not only when `package.json` changes — prevents beta from drifting behind main.
 - **Porting vs post-merge:** PR porting no longer opens `port/* → beta` when post-merge automation already syncs `main` into `beta` (beta promotion, `release/*`, and `feature/release-*` merges). CI fails redundant `port/* → beta` PRs so duplicate port work cannot merge.
 - **GitHub Releases on every version bump:** Post-merge automation now publishes a release whenever `package.json` changes — stable tags on `main` (promotion, hotfix, release branch, bootstrap backfill) and prerelease tags on `beta` after each `-beta.N` integration merge.
 - **Release automation:** Beta → main stays a normal PR; merge triggers stable versioning on `main`, GitHub Releases from CHANGELOG (including hotfixes), and beta prerelease bumps. CI enforces branch routing (preferred `feature/*`/`fix/*` → beta; only `hotfix/*` blocked on beta), changelog checks, and automated PR labels. Workflow definitions ship on `main` so GitHub can run them for repository pull requests.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -41,7 +41,9 @@ If both tried to port the same merge into `beta`, you would get a port PR and a 
 Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from **Prepare Beta → Main Release PR**:
 
 1. Merge the release PR to `main`.
-2. **Post-merge automation** creates the **stable GitHub Release**, bumps **beta** to the next line, and publishes a **prerelease** for the new beta version.
+2. **Post-merge automation** merges **main** into **beta** (so beta always has the same code), creates the **stable GitHub Release**, bumps **beta** to the next line, and publishes a **prerelease** for the new beta version.
+
+Infrastructure fixes that land via `release/*` → `main` (not only `feature/release-*`) use the same **main → beta** merge; version-only bumps are not enough.
 
 ### Integrations → beta
 


### PR DESCRIPTION
## Summary
- After \elease/*\ → \main\, post-merge now **merges main into beta** (matching \eature/release-*\ behavior), not only bumps \package.json\ when it changes.
- Prevents beta from staying on an old commit while main has new infrastructure (e.g. #354 porting dedup).

## Immediate recovery
Beta was backfilled via \workflow_dispatch\ (sync beta from main); \main\ is now an ancestor of \eta\ at \3c96d36\.

## Test plan
- [ ] Merge to main and confirm post-merge pushes a beta merge commit even when version is already \1.6.0-beta.N\


Made with [Cursor](https://cursor.com)