### PR TITLE
Dependabot: group root and server npm into one PR to beta

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,24 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot version updates target beta. Group root + server npm into one PR via multi-ecosystem-groups.
+# https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/configuring-multi-ecosystem-updates
 
 version: 2
+
+multi-ecosystem-groups:
+  npm-beta:
+    schedule:
+      interval: weekly
+
 updates:
   - package-ecosystem: npm
     directory: /
     target-branch: beta
-    schedule:
-      interval: weekly
+    patterns:
+      - "*"
+    multi-ecosystem-group: npm-beta
 
   - package-ecosystem: npm
     directory: /server
     target-branch: beta
-    schedule:
-      interval: weekly
+    patterns:
+      - "*"
+    multi-ecosystem-group: npm-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 <!-- dependabot-automation -->
 
 ### Changed
+- **Dependabot grouping:** Root and `server/` npm version updates are combined into one multi-ecosystem Dependabot PR targeting `beta` instead of one PR per package.
 - **Post-merge `release/*` → main:** Automation now merges `main` into `beta` after every `release/*` merge (same as `feature/release-*`), not only when `package.json` changes — prevents beta from drifting behind main.
 - **Porting vs post-merge:** PR porting no longer opens `port/* → beta` when post-merge automation already syncs `main` into `beta` (beta promotion, `release/*`, and `feature/release-*` merges). CI fails redundant `port/* → beta` PRs so duplicate port work cannot merge.
 - **GitHub Releases on every version bump:** Post-merge automation now publishes a release whenever `package.json` changes — stable tags on `main` (promotion, hotfix, release branch, bootstrap backfill) and prerelease tags on `beta` after each `-beta.N` integration merge.


### PR DESCRIPTION
## Summary
- Adds \multi-ecosystem-groups.npm-beta\ so root \/\ and \/server\ npm updates land in **one** Dependabot PR targeting \eta\.
- Replaces per-dependency PRs after the grouped config is on \main\ (Dependabot reads the default branch).

## After merge
1. Individual Dependabot PRs (#333, #339–#343) are already closed.
2. Go to **Insights → Dependency graph → Dependabot → Recent update jobs → Check for updates** (or wait for the push to trigger a run).
3. Expect a single grouped version-update PR into \eta\.

## Test plan
- [ ] Merged to \main\
- [ ] Grouped Dependabot PR appears targeting \eta\


Made with [Cursor](https://cursor.com)