### PR TITLE
Fix Dependabot: target-branch on multi-ecosystem group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,19 @@ version: 2
 
 multi-ecosystem-groups:
   npm-beta:
+    target-branch: beta
     schedule:
       interval: weekly
 
 updates:
   - package-ecosystem: npm
     directory: /
-    target-branch: beta
     patterns:
       - "*"
     multi-ecosystem-group: npm-beta
 
   - package-ecosystem: npm
     directory: /server
-    target-branch: beta
     patterns:
       - "*"
     multi-ecosystem-group: npm-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 <!-- dependabot-automation -->
 
 ### Changed
-- **Dependabot grouping:** Root and `server/` npm version updates are combined into one multi-ecosystem Dependabot PR targeting `beta` instead of one PR per package.
+- **Dependabot grouping:** Root and `server/` npm version updates are combined into one multi-ecosystem Dependabot PR targeting `beta` instead of one PR per package; `target-branch` is set on the `npm-beta` group (required by Dependabot when using multi-ecosystem groups).
 - **Post-merge `release/*` → main:** Automation now merges `main` into `beta` after every `release/*` merge (same as `feature/release-*`), not only when `package.json` changes — prevents beta from drifting behind main.
 - **Porting vs post-merge:** PR porting no longer opens `port/* → beta` when post-merge automation already syncs `main` into `beta` (beta promotion, `release/*`, and `feature/release-*` merges). CI fails redundant `port/* → beta` PRs so duplicate port work cannot merge.
 - **GitHub Releases on every version bump:** Post-merge automation now publishes a release whenever `package.json` changes — stable tags on `main` (promotion, hotfix, release branch, bootstrap backfill) and prerelease tags on `beta` after each `-beta.N` integration merge.


### PR DESCRIPTION
## Summary

Moves `target-branch: beta` from individual `updates` entries to `multi-ecosystem-groups.npm-beta`, which Dependabot requires when using multi-ecosystem grouping.

## Test plan

- [ ] Merge to `main`
- [ ] Confirm Dependabot config validates (Insights → Dependency graph → Dependabot)
- [ ] Trigger **Check for updates** and expect one grouped PR to `beta`