### PR TITLE
Fix CodeQL: rate-limited /collect in server smoke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - **stripe:** ^18.4.0 → ^22.1.1 (`server`)
 
 ### Fixed
+- **Analytics server tests:** Share `configureApp` with production so `/collect` stays rate-limited in server smoke tests (fixes CodeQL `js/missing-rate-limiting` on `beta`).
 - **Analytics server (beta):** Restored a broken partial merge in `server/analytics.js` so the hosted collector starts again before Express 5 / Stripe 22 land.
 - **Stripe subscription webhooks:** Read `current_period_end` from subscription items for Stripe API 2025-03-31+ (stripe-node v22) with fallback for older payloads.
 - **Map layer transparency:** Restored `transparencyScale` on forecast map fill/stroke opacity after the main sync dropped the multiplier (fixes CI on `beta`).

--- a/server/analytics-app.js
+++ b/server/analytics-app.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { setupExpressErrorHandler } = require('./sentry');
+
+/** Returns the POST /collect handler that appends sanitized entries to the log file. */
+function createCollectHandler(fs, LOG_FILE) {
+  return (req, res) => {
+    // Sanitise and cap all user-controlled fields
+    const page = (typeof req.body?.page === 'string' ? req.body.page : '/').slice(0, 200);
+    const referrer = (typeof req.body?.referrer === 'string' ? req.body.referrer : '').slice(0, 500);
+
+    const entry = {
+      ts: new Date().toISOString(),
+      ua: (req.headers['user-agent'] || '').slice(0, 300),
+      page,
+      ref: referrer,
+    };
+
+    try {
+      fs.appendFileSync(LOG_FILE, `${JSON.stringify(entry)}\n`);
+      res.status(204).end();
+    } catch (err) {
+      console.error('[analytics] failed to write log:', err);
+      res.status(500).end();
+    }
+  };
+}
+
+/** Registers middleware, billing/metrics/beta routes, and the collect endpoint. */
+function configureApp(app, express, fs, LOG_FILE) {
+  const rateLimit = require('express-rate-limit');
+  const { registerBetaRoutes } = require('./beta');
+  const { registerBillingRoutes } = require('./billing');
+  const { registerMetricsRoutes } = require('./metrics');
+  const { registerSentryTunnelRoutes } = require('./sentry-tunnel');
+
+  app.set('trust proxy', 'loopback');
+
+  const collectRateLimit = rateLimit({
+    windowMs: 60 * 1000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  registerSentryTunnelRoutes(app, express, rateLimit);
+  registerBillingRoutes(app, express);
+  registerMetricsRoutes(app, express);
+  registerBetaRoutes(app, express);
+
+  app.post('/collect', express.json({ limit: '1kb' }), collectRateLimit, createCollectHandler(fs, LOG_FILE));
+
+  setupExpressErrorHandler(app);
+
+  // Reject everything else quietly
+  app.use((_req, res) => res.status(404).end());
+}
+
+module.exports = {
+  configureApp,
+  createCollectHandler,
+};

--- a/server/analytics-app.js
+++ b/server/analytics-app.js
@@ -58,5 +58,4 @@ function configureApp(app, express, fs, LOG_FILE) {
 
 module.exports = {
   configureApp,
-  createCollectHandler,
 };

--- a/server/analytics.js
+++ b/server/analytics.js
@@ -1,60 +1,7 @@
 'use strict';
 
-const { initSentry, setupExpressErrorHandler } = require('./sentry');
-
-/** Returns the POST /collect handler that appends sanitized entries to the log file. */
-function createCollectHandler(fs, LOG_FILE) {
-  return (req, res) => {
-    // Sanitise and cap all user-controlled fields
-    const page = (typeof req.body?.page === 'string' ? req.body.page : '/').slice(0, 200);
-    const referrer = (typeof req.body?.referrer === 'string' ? req.body.referrer : '').slice(0, 500);
-
-    const entry = {
-      ts: new Date().toISOString(),
-      ua: (req.headers['user-agent'] || '').slice(0, 300),
-      page,
-      ref: referrer,
-    };
-
-    try {
-      fs.appendFileSync(LOG_FILE, `${JSON.stringify(entry)}\n`);
-      res.status(204).end();
-    } catch (err) {
-      console.error('[analytics] failed to write log:', err);
-      res.status(500).end();
-    }
-  };
-}
-
-/** Registers middleware, billing/metrics/beta routes, and the collect endpoint. */
-function configureApp(app, express, fs, LOG_FILE) {
-  const rateLimit = require('express-rate-limit');
-  const { registerBetaRoutes } = require('./beta');
-  const { registerBillingRoutes } = require('./billing');
-  const { registerMetricsRoutes } = require('./metrics');
-  const { registerSentryTunnelRoutes } = require('./sentry-tunnel');
-
-  app.set('trust proxy', 'loopback');
-
-  const collectRateLimit = rateLimit({
-    windowMs: 60 * 1000,
-    max: 60,
-    standardHeaders: true,
-    legacyHeaders: false,
-  });
-
-  registerSentryTunnelRoutes(app, express, rateLimit);
-  registerBillingRoutes(app, express);
-  registerMetricsRoutes(app, express);
-  registerBetaRoutes(app, express);
-
-  app.post('/collect', express.json({ limit: '1kb' }), collectRateLimit, createCollectHandler(fs, LOG_FILE));
-
-  setupExpressErrorHandler(app);
-
-  // Reject everything else quietly
-  app.use((_req, res) => res.status(404).end());
-}
+const { initSentry } = require('./sentry');
+const { configureApp } = require('./analytics-app');
 
 /** Loads env vars, creates the Express app, and binds the analytics server. */
 async function start() {

--- a/server/server-stack.test.js
+++ b/server/server-stack.test.js
@@ -2,6 +2,7 @@
 
 const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert/strict');
+const { configureApp } = require('./analytics-app');
 
 /** @param {import('node:http').Server} server */
 const getServerPort = (server) => {
@@ -14,36 +15,18 @@ const getServerPort = (server) => {
 
 describe('analytics server stack (express 5)', () => {
   /** @type {import('node:http').Server | undefined} */
-  let server = undefined;
+  let server;
 
   before(async () => {
     const express = require('express');
     const fs = require('node:fs');
     const os = require('node:os');
     const path = require('node:path');
-    const { registerBillingRoutes } = require('./billing');
-    const { registerBetaRoutes } = require('./beta');
-    const { registerMetricsRoutes } = require('./metrics');
-    const { registerSentryTunnelRoutes } = require('./sentry-tunnel');
-    const rateLimit = require('express-rate-limit');
 
     const logFile = path.join(os.tmpdir(), `gfc-analytics-test-${process.pid}.log`);
 
     const app = express();
-    app.set('trust proxy', 'loopback');
-
-    registerSentryTunnelRoutes(app, express, rateLimit);
-    registerBillingRoutes(app, express);
-    registerMetricsRoutes(app, express);
-    registerBetaRoutes(app, express);
-
-    app.post('/collect', express.json({ limit: '1kb' }), (req, res) => {
-      const page = (typeof req.body?.page === 'string' ? req.body.page : '/').slice(0, 200);
-      fs.appendFileSync(logFile, `${JSON.stringify({ page })}\n`);
-      res.status(204).end();
-    });
-
-    app.use((_req, res) => res.status(404).end());
+    configureApp(app, express, fs, logFile);
 
     server = await new Promise((resolve, reject) => {
       const instance = app.listen(0, '127.0.0.1', () => resolve(instance));


### PR DESCRIPTION
## Summary

Resolves the open CodeQL alert on `beta` (**js/missing-rate-limiting** in `server/server-stack.test.js`).

The smoke test duplicated `/collect` without `express-rate-limit`, while production already rate-limits. This extracts `configureApp` into `server/analytics-app.js` and uses it from both `analytics.js` and `server-stack.test.js`.

## Test plan

- [x] `cd server && npm test` (5 tests pass)
- [ ] After merge: confirm CodeQL alert #22 closes on `beta`

**You merge manually** — no admin merge from the agent.