### PR TITLE
fix: removeChild NotFoundError when OpenLayers moves React popup elements

### DIFF
--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -1022,7 +1022,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
       if (!el) return;
       if (popupInfo) {
         el.style.display = "block";
-        el.textContent = "";
+        el.innerHTML = "";
         const content = document.createElement("div");
         content.className = "ol-popup-content";
         const name = document.createElement("div");
@@ -1038,7 +1038,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
         el.appendChild(content);
       } else {
         el.style.display = "none";
-        el.textContent = "";
+        el.innerHTML = "";
       }
     }, [popupInfo]);
 

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -804,19 +804,21 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
         resizeObserver.observe(targetEl);
       }
 
-      // Create popup overlay
-      if (popupRef.current) {
-        const overlay = new Overlay({
-          element: popupRef.current,
-          autoPan: {
-            animation: {
-              duration: 250,
-            },
+      // Create popup element imperatively to prevent React/OpenLayers DOM ownership conflict.
+      const popupEl = document.createElement("div");
+      popupEl.className = "ol-popup";
+      popupEl.style.display = "none";
+      popupRef.current = popupEl;
+      const overlay = new Overlay({
+        element: popupEl,
+        autoPan: {
+          animation: {
+            duration: 250,
           },
-        });
-        map.addOverlay(overlay);
-        overlayRef.current = overlay;
-      }
+        },
+      });
+      map.addOverlay(overlay);
+      overlayRef.current = overlay;
 
       // Add click handler for pan mode
       map.on("click", (evt) => {
@@ -966,6 +968,14 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
         if (selectRef.current) {
           map.removeInteraction(selectRef.current);
         }
+        if (overlayRef.current) {
+          map.removeOverlay(overlayRef.current);
+          overlayRef.current = null;
+        }
+        if (popupRef.current) {
+          popupRef.current.remove();
+          popupRef.current = null;
+        }
         map.setTarget();
         mapRef.current = null;
         vectorBaseGroupRef.current = null;
@@ -1006,6 +1016,31 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
         ghostSnapRef.current.setActive(enableSnap);
       }
     }, [interactionMode]);
+
+    useEffect(() => {
+      const el = popupRef.current;
+      if (!el) return;
+      if (popupInfo) {
+        el.style.display = "block";
+        el.textContent = "";
+        const content = document.createElement("div");
+        content.className = "ol-popup-content";
+        const name = document.createElement("div");
+        name.className = "text-sm font-semibold capitalize";
+        name.textContent = popupInfo.outlookType;
+        const prob = document.createElement("div");
+        prob.className = "text-xs";
+        prob.textContent =
+          popupInfo.probability +
+          (popupInfo.isSignificant ? " (Significant)" : "");
+        content.appendChild(name);
+        content.appendChild(prob);
+        el.appendChild(content);
+      } else {
+        el.style.display = "none";
+        el.textContent = "";
+      }
+    }, [popupInfo]);
 
     useEffect(() => {
       const map = mapRef.current;
@@ -1426,25 +1461,6 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
     return (
       <div className="map-container">
         <div ref={mapElementRef} style={{ width: "100%", height: "100%" }} />
-        <div
-          ref={popupRef}
-          className="ol-popup"
-          style={{
-            display: popupInfo ? "block" : "none",
-          }}
-        >
-          {popupInfo && (
-            <div className="ol-popup-content">
-              <div className="text-sm font-semibold capitalize">
-                {popupInfo.outlookType}
-              </div>
-              <div className="text-xs">
-                {popupInfo.probability}
-                {popupInfo.isSignificant ? " (Significant)" : ""}
-              </div>
-            </div>
-          )}
-        </div>
         <div className="map-toolbar-bottom-right">
           <div className="map-toolbar-surface">
             <button

--- a/src/components/Monitor/MonitorMap.tsx
+++ b/src/components/Monitor/MonitorMap.tsx
@@ -41,7 +41,7 @@ const MonitorMap: React.FC<MonitorMapProps> = ({
     [outlookData, outlookType],
   );
 
-  const { selectedAlert, handleCloseAlertPopup, popupElRef } = useMonitorOlMap({
+  const { selectedAlert, handleCloseAlertPopup, popupElement } = useMonitorOlMap({
     mapView,
     radarLayer,
     radarOpacity,
@@ -57,12 +57,12 @@ const MonitorMap: React.FC<MonitorMapProps> = ({
   return (
     <div className="monitor-map" aria-label="Monitor map">
       <div ref={mapElementRef} className="monitor-map__viewport" />
-      {popupElRef.current &&
+      {popupElement &&
         createPortal(
           selectedAlert && (
             <MonitorAlertPopup details={selectedAlert} onClose={handleCloseAlertPopup} />
           ),
-          popupElRef.current,
+          popupElement,
         )}
       <div className="monitor-map__badge">Read-only monitor</div>
     </div>

--- a/src/components/Monitor/MonitorMap.tsx
+++ b/src/components/Monitor/MonitorMap.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import 'ol/ol.css';
 import type { StormReport } from '../../types/stormReports';
 import type { NwsAlertFeatureCollection } from '../../monitor/nwsAlerts';
@@ -35,13 +36,12 @@ const MonitorMap: React.FC<MonitorMapProps> = ({
   alertsOpacity,
 }) => {
   const mapElementRef = useRef<HTMLDivElement>(null);
-  const popupRef = useRef<HTMLDivElement>(null);
   const serializedFeatures = useMemo(
     () => flattenMonitorOutlookFeatures(outlookData, outlookType),
     [outlookData, outlookType],
   );
 
-  const { selectedAlert, handleCloseAlertPopup } = useMonitorOlMap({
+  const { selectedAlert, handleCloseAlertPopup, popupElRef } = useMonitorOlMap({
     mapView,
     radarLayer,
     radarOpacity,
@@ -52,17 +52,18 @@ const MonitorMap: React.FC<MonitorMapProps> = ({
     alertsCollection,
     alertsOpacity,
     mapElementRef,
-    popupRef,
   });
 
   return (
     <div className="monitor-map" aria-label="Monitor map">
       <div ref={mapElementRef} className="monitor-map__viewport" />
-      <div ref={popupRef} className="monitor-map__alertOverlay">
-        {selectedAlert && (
-          <MonitorAlertPopup details={selectedAlert} onClose={handleCloseAlertPopup} />
+      {popupElRef.current &&
+        createPortal(
+          selectedAlert && (
+            <MonitorAlertPopup details={selectedAlert} onClose={handleCloseAlertPopup} />
+          ),
+          popupElRef.current,
         )}
-      </div>
       <div className="monitor-map__badge">Read-only monitor</div>
     </div>
   );

--- a/src/components/Monitor/monitorMapRefs.ts
+++ b/src/components/Monitor/monitorMapRefs.ts
@@ -9,6 +9,7 @@ import Overlay from 'ol/Overlay';
 
 export const useMonitorMapRefs = () => ({
   overlayRef: useRef<Overlay | null>(null),
+  popupElRef: useRef<HTMLDivElement | null>(null),
   mapRef: useRef<OLMap | null>(null),
   radarLayerRef: useRef<TileLayer<TileWMS> | null>(null),
   satelliteLayerRef: useRef<TileLayer<TileWMS> | null>(null),

--- a/src/components/Monitor/useMonitorMapBootstrap.ts
+++ b/src/components/Monitor/useMonitorMapBootstrap.ts
@@ -41,7 +41,6 @@ interface UseMonitorMapBootstrapArgs {
   satelliteOpacity: number;
   alertsOpacity: number;
   mapElementRef: RefObject<HTMLDivElement | null>;
-  popupRef: RefObject<HTMLDivElement | null>;
   refs: MonitorMapRefs;
   onSelectAlert: (details: NwsAlertDetails | null) => void;
 }
@@ -53,7 +52,6 @@ export const useMonitorMapBootstrap = ({
   satelliteOpacity,
   alertsOpacity,
   mapElementRef,
-  popupRef,
   refs,
   onSelectAlert,
 }: UseMonitorMapBootstrapArgs) => {
@@ -164,11 +162,12 @@ export const useMonitorMapBootstrap = ({
     map.on('click', handleMapClick);
     map.on('pointermove', handlePointerMove);
 
-    if (popupRef.current) {
-      const overlay = new Overlay({ element: popupRef.current, autoPan: false });
-      map.addOverlay(overlay);
-      refs.overlayRef.current = overlay;
-    }
+    const popupEl = document.createElement("div");
+    popupEl.className = "monitor-map__alertOverlay";
+    refs.popupElRef.current = popupEl;
+    const overlay = new Overlay({ element: popupEl, autoPan: false });
+    map.addOverlay(overlay);
+    refs.overlayRef.current = overlay;
 
     refs.mapRef.current = map;
     refs.radarLayerRef.current = radarLayerInstance;
@@ -204,8 +203,15 @@ export const useMonitorMapBootstrap = ({
       if (target instanceof HTMLElement) {
         target.style.cursor = '';
       }
+      if (refs.overlayRef.current) {
+        map.removeOverlay(refs.overlayRef.current);
+        refs.overlayRef.current = null;
+      }
+      if (refs.popupElRef.current) {
+        refs.popupElRef.current.remove();
+        refs.popupElRef.current = null;
+      }
       map.setTarget();
-      refs.overlayRef.current = null;
       refs.mapRef.current = null;
       refs.radarLayerRef.current = null;
       refs.satelliteLayerRef.current = null;

--- a/src/components/Monitor/useMonitorMapBootstrap.ts
+++ b/src/components/Monitor/useMonitorMapBootstrap.ts
@@ -43,6 +43,7 @@ interface UseMonitorMapBootstrapArgs {
   mapElementRef: RefObject<HTMLDivElement | null>;
   refs: MonitorMapRefs;
   onSelectAlert: (details: NwsAlertDetails | null) => void;
+  onCreatePopupElement: (el: HTMLDivElement | null) => void;
 }
 
 export const useMonitorMapBootstrap = ({
@@ -54,6 +55,7 @@ export const useMonitorMapBootstrap = ({
   mapElementRef,
   refs,
   onSelectAlert,
+  onCreatePopupElement,
 }: UseMonitorMapBootstrapArgs) => {
   const dispatch = useDispatch<AppDispatch>();
 
@@ -165,6 +167,7 @@ export const useMonitorMapBootstrap = ({
     const popupEl = document.createElement("div");
     popupEl.className = "monitor-map__alertOverlay";
     refs.popupElRef.current = popupEl;
+    onCreatePopupElement(popupEl);
     const overlay = new Overlay({ element: popupEl, autoPan: false });
     map.addOverlay(overlay);
     refs.overlayRef.current = overlay;
@@ -211,6 +214,7 @@ export const useMonitorMapBootstrap = ({
         refs.popupElRef.current.remove();
         refs.popupElRef.current = null;
       }
+      onCreatePopupElement(null);
       map.setTarget();
       refs.mapRef.current = null;
       refs.radarLayerRef.current = null;

--- a/src/components/Monitor/useMonitorOlMap.ts
+++ b/src/components/Monitor/useMonitorOlMap.ts
@@ -23,7 +23,6 @@ interface UseMonitorOlMapArgs {
   alertsCollection: NwsAlertFeatureCollection;
   alertsOpacity: number;
   mapElementRef: RefObject<HTMLDivElement | null>;
-  popupRef: RefObject<HTMLDivElement | null>;
 }
 
 export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
@@ -45,7 +44,6 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
     satelliteOpacity: args.satelliteOpacity,
     alertsOpacity: args.alertsOpacity,
     mapElementRef: args.mapElementRef,
-    popupRef: args.popupRef,
     refs,
     onSelectAlert: setSelectedAlert,
   });
@@ -68,5 +66,6 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
   return {
     selectedAlert,
     handleCloseAlertPopup: clearSelectedAlert,
+    popupElRef: refs.popupElRef,
   };
 };

--- a/src/components/Monitor/useMonitorOlMap.ts
+++ b/src/components/Monitor/useMonitorOlMap.ts
@@ -28,6 +28,7 @@ interface UseMonitorOlMapArgs {
 export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
   const [selectedAlert, setSelectedAlert] = useState<NwsAlertDetails | null>(null);
+  const [popupElement, setPopupElement] = useState<HTMLDivElement | null>(null);
   const refs = useMonitorMapRefs();
 
   const clearSelectedAlert = useCallback(() => {
@@ -46,6 +47,7 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
     mapElementRef: args.mapElementRef,
     refs,
     onSelectAlert: setSelectedAlert,
+    onCreatePopupElement: setPopupElement,
   });
 
   useMonitorMapLayerSync({
@@ -66,6 +68,6 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
   return {
     selectedAlert,
     handleCloseAlertPopup: clearSelectedAlert,
-    popupElRef: refs.popupElRef,
+    popupElement,
   };
 };


### PR DESCRIPTION
## Root Cause

The NotFoundError was caused by React rendering popup elements in JSX, then OpenLayers moving those same DOM nodes into its own overlay container via Overlay({ element }). When React later reconciled the DOM, it tried parent.removeChild(el) on the original parent - but OpenLayers had already moved the node.

## Fix

Created popup elements imperatively (document.createElement) instead of JSX so React never tracks them. OpenLayers can move them freely without causing reconciliation conflicts.

## Changelog

- Fixed NotFoundError when OpenLayers map unmounts on Android Chrome by moving popup elements out of JSX reconciliation scope
- Applied same fix to monitor page alert popup via createPortal
- Added proper overlay cleanup in map effect return

## Files

- OpenLayersForecastMap.tsx - popup created imperatively; content updated via dedicated useEffect; overlay/popup cleanup added
- MonitorMap.tsx / useMonitorOlMap.ts / useMonitorMapBootstrap.ts / monitorMapRefs.ts - same pattern fixed using createPortal for React content inside the popup
