### PR TITLE
fix: guard mapToArray against non-Map values (GFC-WEB-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - **GFC-WEB-4 (monitor startup):** Break circular import between `monitor/types` and `monitorSettingsNormalize` that crashed the hosted app at load (`Gv is not iterable` / `MONITOR_OUTLOOK_LAYER_TYPES` before initialization when spreading outlook layer types).
 - **Forecast keyboard shortcuts (GFC-WEB-3):** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts. Centralized the guard in `keyboardShortcutKey` and applied it to forecast, navbar, and day-selector shortcuts.
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
+- **GFC-WEB-6 (auto-save/export crash):** Added runtime guards in `mapToArray` and `arrayToMap` so `serializeForecast`/`deserializeForecast` return fallback values instead of crashing when `OutlookData` Map fields are plain objects at runtime.
 ## v1.5.3
 
 ### Changed

--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -50,7 +50,7 @@ describe('fileUtils', () => {
 
     let ser: ReturnType<typeof serializeForecast>;
     expect(() => { ser = serializeForecast(corruptedCycle, { center: [0,0], zoom: 0 }); }).not.toThrow();
-    expect(ser!.forecastCycle?.days?.[1]?.data?.categorical).toEqual([]);
+    expect(ser?.forecastCycle?.days?.[1]?.data?.categorical).toEqual([]);
   });
 
   test('deserializeForecast handles non-Array data without throwing', () => {

--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -48,9 +48,9 @@ describe('fileUtils', () => {
       cycleDate: '2026-04-21'
     } as unknown as ForecastCycle;
 
-    expect(() => serializeForecast(corruptedCycle, { center: [0,0], zoom: 0 })).not.toThrow();
-    const ser = serializeForecast(corruptedCycle, { center: [0,0], zoom: 0 });
-    expect(ser.forecastCycle?.days?.[1]?.data?.categorical).toEqual([]);
+    let ser: ReturnType<typeof serializeForecast>;
+    expect(() => { ser = serializeForecast(corruptedCycle, { center: [0,0], zoom: 0 }); }).not.toThrow();
+    expect(ser!.forecastCycle?.days?.[1]?.data?.categorical).toEqual([]);
   });
 
   test('deserializeForecast handles non-Array data without throwing', () => {
@@ -73,5 +73,7 @@ describe('fileUtils', () => {
     };
 
     expect(() => deserializeForecast(corruptedData as never)).not.toThrow();
+    const result = deserializeForecast(corruptedData as never);
+    expect(result.days[1]?.data.tornado instanceof Map).toBe(true);
   });
 });

--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -34,4 +34,44 @@ describe('fileUtils', () => {
     const des = deserializeForecast(ser);
     expect(des.days[1].data.categorical instanceof Map).toBe(true);
   });
+
+  test('serializeForecast handles non-Map data without throwing', () => {
+    const corruptedCycle = {
+      days: {
+        1: {
+          day: 1,
+          metadata: { issueDate: 'x', validDate: 'y', issuanceTime: '0600', createdAt:'', lastModified:'', lowProbabilityOutlooks:[] },
+          data: { categorical: {} }
+        }
+      },
+      currentDay: 1,
+      cycleDate: '2026-04-21'
+    } as unknown as ForecastCycle;
+
+    expect(() => serializeForecast(corruptedCycle, { center: [0,0], zoom: 0 })).not.toThrow();
+    const ser = serializeForecast(corruptedCycle, { center: [0,0], zoom: 0 });
+    expect(ser.forecastCycle?.days?.[1]?.data?.categorical).toEqual([]);
+  });
+
+  test('deserializeForecast handles non-Array data without throwing', () => {
+    const corruptedData = {
+      version: '0.5.0',
+      type: 'forecast-cycle',
+      timestamp: '2026-05-26',
+      forecastCycle: {
+        days: {
+          1: {
+            day: 1,
+            metadata: { issueDate: 'x', validDate: 'y', issuanceTime: '0600', lowProbabilityOutlooks:[] },
+            data: { tornado: 'not-an-array' }
+          }
+        },
+        currentDay: 1,
+        cycleDate: '2026-05-26'
+      },
+      mapView: { center: [0,0], zoom: 4 }
+    };
+
+    expect(() => deserializeForecast(corruptedData as never)).not.toThrow();
+  });
 });

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -5,10 +5,12 @@ import { compileDiscussionToText } from './discussionUtils';
 const CURRENT_VERSION = '0.5.0';
 
 // Helper to convert Map to Array for JSON serialization
-const mapToArray = <K, V>(m: Map<K, V>): [K, V][] => Array.from(m.entries());
+const mapToArray = <K, V>(m: Map<K, V>): [K, V][] =>
+  m instanceof Map ? Array.from(m.entries()) : [];
 
 // Helper to convert serializable Array back to Map
-const arrayToMap = <K, V>(arr: [K, V][]): Map<K, V> => new Map(arr);
+const arrayToMap = <K, V>(arr: [K, V][]): Map<K, V> =>
+  Array.isArray(arr) ? new Map(arr) : new Map();
 
 // Types for serialization helper
 type SerializedDay = {


### PR DESCRIPTION
Sentry GFC-WEB-6: TypeError: e.entries is not a function at src/utils/fileUtils.ts:8