### PR TITLE
Fix GFC-WEB-7: legacy outlook maps break auto-categorical

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Agents should act like senior collaborators, not script runners. Prefer concrete
 
 - Make code changes on a branch based on `beta` unless the user specifies another base or the workspace is already on a fresh task branch.
 - If the current branch is not suitable for the requested change, create a new branch from `beta` before editing.
+- Do not implement on `beta` (or `main`) in place when the work is a discrete fix or feature—check out a new task branch first (for example `fix/sentry-gfc-web-7-short-description`).
+- For production bug fixes, Sentry investigations, and other shippable repairs: use a dedicated branch, commit there, push, and open a pull request targeting `beta` when the fix is complete and verified—unless the user explicitly asks to stay local-only.
 - Do not commit unless the user asks.
 - Do not push unless the user asks.
 - Do not open a pull request unless the user asks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - **Forecast keyboard shortcuts (GFC-WEB-3):** Ignore `keydown` events where the browser omits `KeyboardEvent.key` (Sentry on `/forecast`) instead of throwing when normalizing the key for shortcuts. Centralized the guard in `keyboardShortcutKey` and applied it to forecast, navbar, and day-selector shortcuts.
 - **Safari overnight IndexedDB disconnects:** Switched hosted Firestore to an in-memory local cache so Safari/macOS sleep no longer hits WebKit’s “Connection to Indexed Database server lost” error from Firestore’s default IndexedDB persistence. Pauses Firestore network sync while the tab is hidden and resumes it on wake to reduce failures on long-lived forecast editor tabs.
 - **GFC-WEB-6 (auto-save/export crash):** Added runtime guards in `mapToArray` and `arrayToMap` so `serializeForecast`/`deserializeForecast` return fallback values instead of crashing when `OutlookData` Map fields are plain objects at runtime.
+- **GFC-WEB-7 (auto-categorical crash):** Coerce legacy plain-object probability maps to `Map` before auto-categorical iteration so `/forecast` no longer throws `forEach is not a function` when loading old saved cycles from localStorage.
 ## v1.5.3
 
 ### Changed

--- a/src/hooks/__tests__/useAutoCategorical.test.ts
+++ b/src/hooks/__tests__/useAutoCategorical.test.ts
@@ -125,29 +125,30 @@ describe('processOutlooksToCategorical', () => {
     expect(result[0].properties?.outlookType).toBe('categorical');
   });
 
-  test('GFC-WEB-7: processDay12OutlooksToCategorical does not throw on empty legacy plain-object maps', () => {
-    const outlooks = {
-      tornado: {},
-      wind: {},
-      hail: {},
-      categorical: {},
-    } as unknown as OutlookData;
-
-    expect(() => processDay12OutlooksToCategorical(outlooks)).not.toThrow();
-    expect(processDay12OutlooksToCategorical(outlooks)).toEqual([]);
-  });
-
-  test('processDay12OutlooksToCategorical tolerates legacy plain-object probability maps', () => {
-    const outlooks = {
-      tornado: {},
-      wind: { '30%': [makeFeature('wind')] },
-      hail: new Map(),
-      categorical: {},
-    } as unknown as OutlookData;
-
-    expect(() => processDay12OutlooksToCategorical(outlooks)).not.toThrow();
-    expect(processDay12OutlooksToCategorical(outlooks).length).toBeGreaterThan(0);
-  });
+  test.each([
+    [
+      'empty legacy plain-object maps',
+      { tornado: {}, wind: {}, hail: {}, categorical: {} },
+      0,
+    ],
+    [
+      'legacy plain-object wind probabilities',
+      { tornado: {}, wind: { '30%': [makeFeature('wind')] }, hail: new Map(), categorical: {} },
+      1,
+    ],
+  ] as const)(
+    'GFC-WEB-7: processDay12OutlooksToCategorical tolerates %s',
+    (_label, outlooks, minFeatures) => {
+      const typedOutlooks = outlooks as unknown as OutlookData;
+      expect(() => processDay12OutlooksToCategorical(typedOutlooks)).not.toThrow();
+      const result = processDay12OutlooksToCategorical(typedOutlooks);
+      if (minFeatures === 0) {
+        expect(result).toEqual([]);
+      } else {
+        expect(result.length).toBeGreaterThanOrEqual(minFeatures);
+      }
+    },
+  );
 
   test('handles hatching intersections and union fallbacks for day 1 and day 2', () => {
     const outlooks: OutlookData = {

--- a/src/hooks/__tests__/useAutoCategorical.test.ts
+++ b/src/hooks/__tests__/useAutoCategorical.test.ts
@@ -125,6 +125,30 @@ describe('processOutlooksToCategorical', () => {
     expect(result[0].properties?.outlookType).toBe('categorical');
   });
 
+  test('GFC-WEB-7: processDay12OutlooksToCategorical does not throw on empty legacy plain-object maps', () => {
+    const outlooks = {
+      tornado: {},
+      wind: {},
+      hail: {},
+      categorical: {},
+    } as unknown as OutlookData;
+
+    expect(() => processDay12OutlooksToCategorical(outlooks)).not.toThrow();
+    expect(processDay12OutlooksToCategorical(outlooks)).toEqual([]);
+  });
+
+  test('processDay12OutlooksToCategorical tolerates legacy plain-object probability maps', () => {
+    const outlooks = {
+      tornado: {},
+      wind: { '30%': [makeFeature('wind')] },
+      hail: new Map(),
+      categorical: {},
+    } as unknown as OutlookData;
+
+    expect(() => processDay12OutlooksToCategorical(outlooks)).not.toThrow();
+    expect(processDay12OutlooksToCategorical(outlooks).length).toBeGreaterThan(0);
+  });
+
   test('handles hatching intersections and union fallbacks for day 1 and day 2', () => {
     const outlooks: OutlookData = {
       tornado: new Map(),

--- a/src/hooks/useAutoCategorical.ts
+++ b/src/hooks/useAutoCategorical.ts
@@ -299,9 +299,11 @@ const buildCumulativeCategoricalFeatures = (
 
 type PolygonOutlookFeature = Feature<Polygon | MultiPolygon>;
 
+/** Narrows GeoJSON features to polygon geometries used in categorical generation. */
 const isPolygonOutlookFeature = (feature: GeoJSON.Feature): feature is PolygonOutlookFeature =>
   feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon';
 
+/** Separates probability keys from CIG hatching keys inside one outlook probability map. */
 const partitionProbabilityMap = (probMap: Map<string, GeoJSON.Feature[]>) => {
   const probabilityFeatures = new Map<string, PolygonOutlookFeature[]>();
   const hatchingFeatures = new Map<CIGLevel, PolygonOutlookFeature[]>();
@@ -322,6 +324,7 @@ const partitionProbabilityMap = (probMap: Map<string, GeoJSON.Feature[]>) => {
   return { probabilityFeatures, hatchingFeatures };
 };
 
+/** Unions hatching polygons per CIG level for intersection against probability areas. */
 const buildHatchingRegions = (
   hatchingFeatures: Map<CIGLevel, PolygonOutlookFeature[]>,
   cigLevels: CIGLevel[],
@@ -341,6 +344,7 @@ const buildHatchingRegions = (
   return hatchingRegions;
 };
 
+/** Splits each probability polygon by hatching layers and emits categorical pieces via callback. */
 const applyProbabilityFeaturesWithHatching = (
   probabilityFeatures: Map<string, PolygonOutlookFeature[]>,
   hatchingRegions: Map<CIGLevel, PolygonOutlookFeature>,
@@ -381,6 +385,7 @@ const applyProbabilityFeaturesWithHatching = (
   });
 };
 
+/** Appends one categorical risk polygon unless the mapped risk is manual TSTM. */
 const appendRiskPolygon = (
   riskMap: Map<CategoricalRiskLevel, PolygonOutlookFeature[]>,
   risk: CategoricalRiskLevel,

--- a/src/hooks/useAutoCategorical.ts
+++ b/src/hooks/useAutoCategorical.ts
@@ -297,79 +297,125 @@ const buildCumulativeCategoricalFeatures = (
   return generatedFeatures;
 };
 
-// Helper to convert Day 1/2 probability features to categorical pieces
-export function processDay12OutlooksToCategorical(outlooks: OutlookData): GeoJSON.Feature[] {
-  const riskPolygons = new Map<CategoricalRiskLevel, Feature<Polygon | MultiPolygon>[]>();
+type PolygonOutlookFeature = Feature<Polygon | MultiPolygon>;
 
-  // 2. Process each Probability Type
-  const types = ['tornado', 'wind', 'hail'] as const;
-  
-  types.forEach(type => {
-    const probMap = coerceOutlookProbabilityMap(outlooks[type]);
-    if (!probMap || probMap.size === 0) return;
-    
-    // Split into Probability Polygons and Hatching Polygons
-    const probabilityFeatures = new Map<string, Feature<Polygon | MultiPolygon>[]>();
-    const hatchingFeatures = new Map<CIGLevel, Feature<Polygon | MultiPolygon>[]>();
-    
-    probMap.forEach((features, key) => {
-      // Cast to Polygon/MultiPolygon
-      const validFeatures = features.filter(f => f.geometry.type === 'Polygon' || f.geometry.type === 'MultiPolygon') as Feature<Polygon | MultiPolygon>[];
-      if (validFeatures.length === 0) return;
+const isPolygonOutlookFeature = (feature: GeoJSON.Feature): feature is PolygonOutlookFeature =>
+  feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon';
 
-      if (key.startsWith('CIG')) {
-        hatchingFeatures.set(key as CIGLevel, validFeatures);
-      } else {
-        probabilityFeatures.set(key, validFeatures);
+const partitionProbabilityMap = (probMap: Map<string, GeoJSON.Feature[]>) => {
+  const probabilityFeatures = new Map<string, PolygonOutlookFeature[]>();
+  const hatchingFeatures = new Map<CIGLevel, PolygonOutlookFeature[]>();
+
+  probMap.forEach((features, key) => {
+    const validFeatures = features.filter(isPolygonOutlookFeature);
+    if (validFeatures.length === 0) {
+      return;
+    }
+
+    if (key.startsWith('CIG')) {
+      hatchingFeatures.set(key as CIGLevel, validFeatures);
+    } else {
+      probabilityFeatures.set(key, validFeatures);
+    }
+  });
+
+  return { probabilityFeatures, hatchingFeatures };
+};
+
+const buildHatchingRegions = (
+  hatchingFeatures: Map<CIGLevel, PolygonOutlookFeature[]>,
+  cigLevels: CIGLevel[],
+): Map<CIGLevel, PolygonOutlookFeature> => {
+  const hatchingRegions = new Map<CIGLevel, PolygonOutlookFeature>();
+
+  cigLevels.forEach((cig) => {
+    const features = hatchingFeatures.get(cig);
+    if (features) {
+      const unioned = safeUnion(features);
+      if (unioned) {
+        hatchingRegions.set(cig, unioned);
       }
-    });
+    }
+  });
 
-    // Create Unioned Hatching Regions for this type
-    const hatchingRegions = new Map<CIGLevel, Feature<Polygon | MultiPolygon>>();
-    const cigLevels: CIGLevel[] = ['CIG3', 'CIG2', 'CIG1'];
-    
-    cigLevels.forEach(cig => {
-      const features = hatchingFeatures.get(cig);
-      if (features) {
-        const unioned = safeUnion(features);
-        if (unioned) hatchingRegions.set(cig, unioned);
-      }
-    });
+  return hatchingRegions;
+};
 
-    // Process Probabilities against Hatching (of the same type)
-    probabilityFeatures.forEach((features, probStr) => {
-      features.forEach(poly => {
-        let remainingPoly: Feature<Polygon | MultiPolygon> | null = poly;
+const applyProbabilityFeaturesWithHatching = (
+  probabilityFeatures: Map<string, PolygonOutlookFeature[]>,
+  hatchingRegions: Map<CIGLevel, PolygonOutlookFeature>,
+  cigLevels: CIGLevel[],
+  onPiece: (probStr: string, cig: CIGLevel, piece: PolygonOutlookFeature) => void,
+): void => {
+  probabilityFeatures.forEach((features, probStr) => {
+    features.forEach((poly) => {
+      let remainingPoly: PolygonOutlookFeature | null = poly;
 
-        // Intersect with Hatching Layers
-        cigLevels.forEach(cig => {
-          if (!remainingPoly) return;
-          const hatchRegion = hatchingRegions.get(cig);
-          
-          if (hatchRegion) {
-            try {
-              // Turf v7: intersect takes FeatureCollection
-              const intersection = turf.intersect(turf.featureCollection([remainingPoly, hatchRegion]));
-              if (intersection) {
-                // We found a piece with this CIG level
-                addPieceToRiskMap(type, probStr, cig, intersection as Feature<Polygon | MultiPolygon>, riskPolygons);
-                
-                // Subtract this piece from the remaining polygon
-                // Turf v7: difference takes FeatureCollection
-                remainingPoly = turf.difference(turf.featureCollection([remainingPoly, intersection as Feature<Polygon | MultiPolygon>])) as Feature<Polygon | MultiPolygon> | null;
-              }
-            } catch {
-              // Ignore topology errors
-            }
+      cigLevels.forEach((cig) => {
+        if (!remainingPoly) {
+          return;
+        }
+
+        const hatchRegion = hatchingRegions.get(cig);
+        if (!hatchRegion) {
+          return;
+        }
+
+        try {
+          const intersection = turf.intersect(turf.featureCollection([remainingPoly, hatchRegion]));
+          if (intersection) {
+            onPiece(probStr, cig, intersection as PolygonOutlookFeature);
+            remainingPoly = turf.difference(
+              turf.featureCollection([remainingPoly, intersection as PolygonOutlookFeature]),
+            ) as PolygonOutlookFeature | null;
           }
-        });
-
-        // Any remaining part is CIG0
-        if (remainingPoly) {
-          addPieceToRiskMap(type, probStr, 'CIG0', remainingPoly, riskPolygons);
+        } catch {
+          // Ignore topology errors
         }
       });
+
+      if (remainingPoly) {
+        onPiece(probStr, 'CIG0', remainingPoly);
+      }
     });
+  });
+};
+
+const appendRiskPolygon = (
+  riskMap: Map<CategoricalRiskLevel, PolygonOutlookFeature[]>,
+  risk: CategoricalRiskLevel,
+  poly: PolygonOutlookFeature,
+): void => {
+  if (risk === 'TSTM') {
+    return;
+  }
+
+  const current = riskMap.get(risk) || [];
+  current.push(poly);
+  riskMap.set(risk, current);
+};
+
+// Helper to convert Day 1/2 probability features to categorical pieces
+export function processDay12OutlooksToCategorical(outlooks: OutlookData): GeoJSON.Feature[] {
+  const riskPolygons = new Map<CategoricalRiskLevel, PolygonOutlookFeature[]>();
+  const types = ['tornado', 'wind', 'hail'] as const;
+  const cigLevels: CIGLevel[] = ['CIG3', 'CIG2', 'CIG1'];
+
+  types.forEach((type) => {
+    const probMap = coerceOutlookProbabilityMap(outlooks[type]);
+    if (!probMap || probMap.size === 0) {
+      return;
+    }
+
+    const { probabilityFeatures, hatchingFeatures } = partitionProbabilityMap(probMap);
+    const hatchingRegions = buildHatchingRegions(hatchingFeatures, cigLevels);
+
+    applyProbabilityFeaturesWithHatching(
+      probabilityFeatures,
+      hatchingRegions,
+      cigLevels,
+      (probStr, cig, piece) => addPieceToRiskMap(type, probStr, cig, piece, riskPolygons),
+    );
   });
 
   return buildCumulativeCategoricalFeatures(riskPolygons);
@@ -380,101 +426,40 @@ export function processDay12OutlooksToCategorical(outlooks: OutlookData): GeoJSO
  * bucket and appends it unless it resolves to TSTM.
  */
 function addPieceToRiskMap(
-  type: 'tornado' | 'wind' | 'hail', 
-  prob: string, 
-  cig: CIGLevel, 
-  poly: Feature<Polygon | MultiPolygon>,
-  riskMap: Map<CategoricalRiskLevel, Feature<Polygon | MultiPolygon>[]>
+  type: 'tornado' | 'wind' | 'hail',
+  prob: string,
+  cig: CIGLevel,
+  poly: PolygonOutlookFeature,
+  riskMap: Map<CategoricalRiskLevel, PolygonOutlookFeature[]>,
 ) {
-    let risk: CategoricalRiskLevel = 'TSTM';
-    if (type === 'tornado') risk = tornadoToCategorical(prob, cig);
-    if (type === 'wind') risk = windToCategorical(prob, cig);
-    if (type === 'hail') risk = hailToCategorical(prob, cig);
+  let risk: CategoricalRiskLevel = 'TSTM';
+  if (type === 'tornado') risk = tornadoToCategorical(prob, cig);
+  if (type === 'wind') risk = windToCategorical(prob, cig);
+  if (type === 'hail') risk = hailToCategorical(prob, cig);
 
-    if (risk !== 'TSTM') {
-        const current = riskMap.get(risk) || [];
-        current.push(poly);
-        riskMap.set(risk, current);
-    }
+  appendRiskPolygon(riskMap, risk, poly);
 }
 
 // Helper to convert Day 3 Total Severe probability features to categorical pieces
 export function processDay3OutlooksToCategorical(outlooks: OutlookData): GeoJSON.Feature[] {
-  const riskPolygons = new Map<CategoricalRiskLevel, Feature<Polygon | MultiPolygon>[]>();
-
-  // Day 3 only has totalSevere
+  const riskPolygons = new Map<CategoricalRiskLevel, PolygonOutlookFeature[]>();
   const probMap = coerceOutlookProbabilityMap(outlooks.totalSevere);
-  if (!probMap || probMap.size === 0) return [];
-  
-  // Split into Probability Polygons and Hatching Polygons
-  const probabilityFeatures = new Map<string, Feature<Polygon | MultiPolygon>[]>();
-  const hatchingFeatures = new Map<CIGLevel, Feature<Polygon | MultiPolygon>[]>();
-  
-  probMap.forEach((features, key) => {
-    const validFeatures = features.filter(f => f.geometry.type === 'Polygon' || f.geometry.type === 'MultiPolygon') as Feature<Polygon | MultiPolygon>[];
-    if (validFeatures.length === 0) return;
+  if (!probMap || probMap.size === 0) {
+    return [];
+  }
 
-    if (key.startsWith('CIG')) {
-      hatchingFeatures.set(key as CIGLevel, validFeatures);
-    } else {
-      probabilityFeatures.set(key, validFeatures);
-    }
-  });
+  const cigLevels: CIGLevel[] = ['CIG2', 'CIG1'];
+  const { probabilityFeatures, hatchingFeatures } = partitionProbabilityMap(probMap);
+  const hatchingRegions = buildHatchingRegions(hatchingFeatures, cigLevels);
 
-  // Create Unioned Hatching Regions
-  const hatchingRegions = new Map<CIGLevel, Feature<Polygon | MultiPolygon>>();
-  const cigLevels: CIGLevel[] = ['CIG2', 'CIG1']; // Day 3 only has CIG0, 1, 2 (no CIG3)
-  
-  cigLevels.forEach(cig => {
-    const features = hatchingFeatures.get(cig);
-    if (features) {
-      const unioned = safeUnion(features);
-      if (unioned) hatchingRegions.set(cig, unioned);
-    }
-  });
-
-  // Process Probabilities against Hatching
-  probabilityFeatures.forEach((features, probStr) => {
-    features.forEach(poly => {
-      let remainingPoly: Feature<Polygon | MultiPolygon> | null = poly;
-
-      // Intersect with Hatching Layers
-      cigLevels.forEach(cig => {
-        if (!remainingPoly) return;
-        const hatchRegion = hatchingRegions.get(cig);
-        
-        if (hatchRegion) {
-          try {
-            const intersection = turf.intersect(turf.featureCollection([remainingPoly, hatchRegion]));
-            if (intersection) {
-              // We found a piece with this CIG level
-              const risk = totalSevereToCategorical(probStr, cig);
-              if (risk !== 'TSTM') {
-                const current = riskPolygons.get(risk) || [];
-                current.push(intersection as Feature<Polygon | MultiPolygon>);
-                riskPolygons.set(risk, current);
-              }
-              
-              // Subtract this piece from the remaining polygon
-              remainingPoly = turf.difference(turf.featureCollection([remainingPoly, intersection as Feature<Polygon | MultiPolygon>])) as Feature<Polygon | MultiPolygon> | null;
-            }
-          } catch (e) {
-            // Ignore topology errors
-          }
-        }
-      });
-
-      // Any remaining part is CIG0
-      if (remainingPoly) {
-        const risk = totalSevereToCategorical(probStr, 'CIG0');
-        if (risk !== 'TSTM') {
-          const current = riskPolygons.get(risk) || [];
-          current.push(remainingPoly);
-          riskPolygons.set(risk, current);
-        }
-      }
-    });
-  });
+  applyProbabilityFeaturesWithHatching(
+    probabilityFeatures,
+    hatchingRegions,
+    cigLevels,
+    (probStr, cig, piece) => {
+      appendRiskPolygon(riskPolygons, totalSevereToCategorical(probStr, cig), piece);
+    },
+  );
 
   return buildCumulativeCategoricalFeatures(riskPolygons);
 }

--- a/src/hooks/useAutoCategorical.ts
+++ b/src/hooks/useAutoCategorical.ts
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { applyAutoCategoricalSync, selectCurrentOutlooks, selectCurrentDay } from '../store/forecastSlice';
 import { tornadoToCategorical, windToCategorical, hailToCategorical, totalSevereToCategorical } from '../utils/outlookUtils';
 import { OutlookData, CIGLevel, CategoricalRiskLevel } from '../types/outlooks';
+import { coerceOutlookProbabilityMap } from '../utils/outlookMapCoercion';
 import { v4 as uuidv4 } from 'uuid';
 import * as turf from '@turf/turf';
 import { Feature, Polygon, MultiPolygon } from 'geojson';
@@ -304,8 +305,8 @@ export function processDay12OutlooksToCategorical(outlooks: OutlookData): GeoJSO
   const types = ['tornado', 'wind', 'hail'] as const;
   
   types.forEach(type => {
-    const probMap = outlooks[type];
-    if (!probMap) return; // Skip if outlook map doesn't exist for this day
+    const probMap = coerceOutlookProbabilityMap(outlooks[type]);
+    if (!probMap || probMap.size === 0) return;
     
     // Split into Probability Polygons and Hatching Polygons
     const probabilityFeatures = new Map<string, Feature<Polygon | MultiPolygon>[]>();
@@ -402,8 +403,8 @@ export function processDay3OutlooksToCategorical(outlooks: OutlookData): GeoJSON
   const riskPolygons = new Map<CategoricalRiskLevel, Feature<Polygon | MultiPolygon>[]>();
 
   // Day 3 only has totalSevere
-  const probMap = outlooks.totalSevere;
-  if (!probMap) return []; // No totalSevere data
+  const probMap = coerceOutlookProbabilityMap(outlooks.totalSevere);
+  if (!probMap || probMap.size === 0) return [];
   
   // Split into Probability Polygons and Hatching Polygons
   const probabilityFeatures = new Map<string, Feature<Polygon | MultiPolygon>[]>();

--- a/src/monitor/outlookLayers.ts
+++ b/src/monitor/outlookLayers.ts
@@ -1,31 +1,10 @@
 import type { Feature as GeoJsonFeature } from 'geojson';
 import type { MonitorOutlookLayerType } from './types';
 import type { OutlookData, OutlookType } from '../types/outlooks';
+import { coerceOutlookProbabilityMap } from '../utils/outlookMapCoercion';
 
 export { MONITOR_OUTLOOK_LAYER_TYPES } from './types';
-
-/** Accepts Map-backed outlook data and plain objects from legacy persisted cycles. */
-export const coerceOutlookProbabilityMap = (
-  map: Map<string, GeoJsonFeature[]> | Record<string, GeoJsonFeature[]> | undefined | unknown,
-): Map<string, GeoJsonFeature[]> | null => {
-  if (!map) {
-    return null;
-  }
-
-  if (map instanceof Map) {
-    return map;
-  }
-
-  if (typeof map === 'object' && !Array.isArray(map)) {
-    return new Map(
-      Object.entries(map as Record<string, GeoJsonFeature[]>).filter(
-        ([, features]) => Array.isArray(features),
-      ),
-    );
-  }
-
-  return null;
-};
+export { coerceOutlookProbabilityMap };
 
 export const MONITOR_OUTLOOK_LAYER_LABELS: Record<MonitorOutlookLayerType, string> = {
   tornado: 'Tornado',

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1,6 +1,7 @@
 import '../immerSetup';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { OutlookData, OutlookType, DrawingState, ForecastCycle, DayType, OutlookDay, DiscussionData, Probability } from '../types/outlooks';
+import { normalizeForecastCycle } from '../utils/outlookMapCoercion';
 import type { Feature } from 'geojson';
 import { RootState } from './index'; // Need RootState for selectors
 import { cloneForecastCycle } from '../utils/fileUtils';
@@ -729,7 +730,7 @@ export const forecastSlice = createSlice({
       const cycleId = action.payload;
       const savedCycle = state.savedCycles.find(c => c.id === cycleId);
       if (savedCycle) {
-        state.forecastCycle = cloneForecastCycle(savedCycle.forecastCycle);
+        state.forecastCycle = cloneForecastCycle(normalizeForecastCycle(savedCycle.forecastCycle));
         clearHistory(state);
         state.isSaved = true;
       }

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -51,6 +51,46 @@ describe('cycleHistoryPersistence', () => {
     expect(fileUtils.deserializeForecast).toHaveBeenCalled();
   });
 
+  test('GFC-WEB-7: legacy saved cycles with plain-object outlook maps normalize on load', async () => {
+    const legacy = [{
+      id: 'legacy-plain-maps',
+      timestamp: '2026-03-01T00:00:00.000Z',
+      cycleDate: '2026-03-01',
+      label: 'Legacy',
+      forecastCycle: {
+        currentDay: 1,
+        cycleDate: '2026-03-01',
+        days: {
+          1: {
+            day: 1,
+            metadata: {
+              issueDate: '2026-03-01',
+              validDate: '2026-03-01',
+              issuanceTime: '0600',
+              lowProbabilityOutlooks: [],
+            },
+            data: {
+              tornado: {},
+              wind: {},
+              hail: {},
+              categorical: {},
+            },
+          },
+        },
+      },
+      stats: {},
+    }];
+
+    localStorage.setItem('gfc-cycle-history', JSON.stringify(legacy));
+
+    const mod = await import('./cycleHistoryPersistence');
+    const loaded = mod.loadCycleHistoryFromStorage();
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].forecastCycle.days[1]?.data.tornado).toBeUndefined();
+    expect(loaded[0].forecastCycle.days[1]?.data.wind).toBeUndefined();
+  });
+
   test('loadCycleHistoryFromStorage handles legacy format and computes stats when missing', async () => {
     jest.doMock('./forecastMetrics', () => ({
       countForecastMetrics: jest.fn(() => ({ computed: 42 })),

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -71,7 +71,14 @@ describe('cycleHistoryPersistence', () => {
             },
             data: {
               tornado: {},
-              wind: {},
+              wind: {
+                '30%': [{
+                  type: 'Feature',
+                  id: 'legacy-wind',
+                  properties: {},
+                  geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+                }],
+              },
               hail: {},
               categorical: {},
             },
@@ -88,7 +95,8 @@ describe('cycleHistoryPersistence', () => {
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].forecastCycle.days[1]?.data.tornado).toBeUndefined();
-    expect(loaded[0].forecastCycle.days[1]?.data.wind).toBeUndefined();
+    expect(loaded[0].forecastCycle.days[1]?.data.wind).toBeInstanceOf(Map);
+    expect(loaded[0].forecastCycle.days[1]?.data.wind?.get('30%')).toHaveLength(1);
   });
 
   test('loadCycleHistoryFromStorage handles legacy format and computes stats when missing', async () => {

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -6,6 +6,7 @@ import { loadCycleHistory } from '../store/forecastSlice';
 import type { SavedCycle, SavedCycleStats } from '../store/forecastSlice';
 import { deserializeForecast, serializeForecast } from './fileUtils';
 import { countForecastMetrics } from './forecastMetrics';
+import { normalizeForecastCycle } from './outlookMapCoercion';
 import type { ForecastCycle, GFCForecastSaveData } from '../types/outlooks';
 
 const CYCLE_HISTORY_KEY = 'gfc-cycle-history';
@@ -52,14 +53,18 @@ const fromLegacySavedCycle = (cycle: {
   label?: string;
   forecastCycle: ForecastCycle;
   stats?: SavedCycleStats;
-}): SavedCycle => ({
-  id: cycle.id,
-  timestamp: cycle.timestamp,
-  cycleDate: cycle.cycleDate,
-  label: cycle.label,
-  forecastCycle: cycle.forecastCycle,
-  stats: cycle.stats ?? countForecastMetrics(cycle.forecastCycle),
-});
+}): SavedCycle => {
+  const forecastCycle = normalizeForecastCycle(cycle.forecastCycle);
+
+  return {
+    id: cycle.id,
+    timestamp: cycle.timestamp,
+    cycleDate: cycle.cycleDate,
+    label: cycle.label,
+    forecastCycle,
+    stats: cycle.stats ?? countForecastMetrics(forecastCycle),
+  };
+};
 
 /**
  * Save cycle history to localStorage

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -205,12 +205,10 @@ export const cloneForecastCycle = (forecastCycle: ForecastCycle): ForecastCycle 
  */
 export const validateForecastData = (data: unknown): data is GFCForecastSaveData => {
   if (typeof data !== 'object' || data === null) return false;
-  const d = data as Partial<GFCForecastSaveData>;
+  const candidate = data as Partial<GFCForecastSaveData>;
 
   // Check valid structure (either new or old)
-  if (!d.forecastCycle && !d.outlooks) return false;
-  
-  return true;
+  return Boolean(candidate.forecastCycle || candidate.outlooks);
 };
 
 /**

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,6 +1,7 @@
 import JSZip from 'jszip';
 import { OutlookData, GFCForecastSaveData, ForecastCycle, DayType, OutlookDay, DiscussionData, SerializedOutlookData, OutlookType } from '../types/outlooks';
 import { compileDiscussionToText } from './discussionUtils';
+import { coerceOutlookProbabilityMap } from './outlookMapCoercion';
 
 const CURRENT_VERSION = '0.5.0';
 
@@ -9,8 +10,16 @@ const mapToArray = <K, V>(m: Map<K, V>): [K, V][] =>
   m instanceof Map ? Array.from(m.entries()) : [];
 
 // Helper to convert serializable Array back to Map
-const arrayToMap = <K, V>(arr: [K, V][]): Map<K, V> =>
-  Array.isArray(arr) ? new Map(arr) : new Map();
+const deserializeOutlookMap = <K extends string, V>(
+  value: [K, V][] | Record<string, V> | Map<K, V> | undefined,
+): Map<K, V> | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const coerced = coerceOutlookProbabilityMap(value);
+  return coerced ?? new Map<K, V>();
+};
 
 // Types for serialization helper
 type SerializedDay = {
@@ -123,12 +132,12 @@ export const deserializeForecast = (data: GFCForecastSaveData): ForecastCycle =>
         const outlookData: OutlookData = {};
         
         // Only deserialize outlook maps that exist in the saved data
-        if (savedDay.data.tornado) outlookData.tornado = arrayToMap(savedDay.data.tornado);
-        if (savedDay.data.wind) outlookData.wind = arrayToMap(savedDay.data.wind);
-        if (savedDay.data.hail) outlookData.hail = arrayToMap(savedDay.data.hail);
-        if (savedDay.data.totalSevere) outlookData.totalSevere = arrayToMap(savedDay.data.totalSevere);
-        if (savedDay.data['day4-8']) outlookData['day4-8'] = arrayToMap(savedDay.data['day4-8']);
-        if (savedDay.data.categorical) outlookData.categorical = arrayToMap(savedDay.data.categorical);
+        if (savedDay.data.tornado) outlookData.tornado = deserializeOutlookMap(savedDay.data.tornado);
+        if (savedDay.data.wind) outlookData.wind = deserializeOutlookMap(savedDay.data.wind);
+        if (savedDay.data.hail) outlookData.hail = deserializeOutlookMap(savedDay.data.hail);
+        if (savedDay.data.totalSevere) outlookData.totalSevere = deserializeOutlookMap(savedDay.data.totalSevere);
+        if (savedDay.data['day4-8']) outlookData['day4-8'] = deserializeOutlookMap(savedDay.data['day4-8']);
+        if (savedDay.data.categorical) outlookData.categorical = deserializeOutlookMap(savedDay.data.categorical);
         
         days[day] = {
           day: savedDay.day,
@@ -168,10 +177,10 @@ export const deserializeForecast = (data: GFCForecastSaveData): ForecastCycle =>
   const day1 = createEmptyOutlook(1);
   if (data.outlooks) { // Old format used 'outlooks'
     const outlookData: OutlookData = {};
-    if (data.outlooks.tornado) outlookData.tornado = arrayToMap(data.outlooks.tornado);
-    if (data.outlooks.wind) outlookData.wind = arrayToMap(data.outlooks.wind);
-    if (data.outlooks.hail) outlookData.hail = arrayToMap(data.outlooks.hail);
-    if (data.outlooks.categorical) outlookData.categorical = arrayToMap(data.outlooks.categorical);
+    if (data.outlooks.tornado) outlookData.tornado = deserializeOutlookMap(data.outlooks.tornado);
+    if (data.outlooks.wind) outlookData.wind = deserializeOutlookMap(data.outlooks.wind);
+    if (data.outlooks.hail) outlookData.hail = deserializeOutlookMap(data.outlooks.hail);
+    if (data.outlooks.categorical) outlookData.categorical = deserializeOutlookMap(data.outlooks.categorical);
     day1.data = outlookData;
   }
 

--- a/src/utils/outlookMapCoercion.test.ts
+++ b/src/utils/outlookMapCoercion.test.ts
@@ -1,0 +1,72 @@
+import {
+  coerceOutlookProbabilityMap,
+  normalizeForecastCycle,
+  normalizeOutlookData,
+} from './outlookMapCoercion';
+import type { ForecastCycle, OutlookData } from '../types/outlooks';
+
+describe('outlookMapCoercion', () => {
+  test('GFC-WEB-7: plain empty objects coerce to Maps so forEach is safe', () => {
+    const legacyEmpty = {};
+    expect(typeof (legacyEmpty as { forEach?: unknown }).forEach).not.toBe('function');
+
+    const probMap = coerceOutlookProbabilityMap(legacyEmpty);
+    expect(probMap).toBeInstanceOf(Map);
+    expect(() => probMap?.forEach(() => undefined)).not.toThrow();
+  });
+
+  test('coerceOutlookProbabilityMap accepts plain objects from legacy persistence', () => {
+    const plain = {
+      '30%': [{ type: 'Feature', properties: {}, geometry: { type: 'Polygon', coordinates: [] } }],
+    };
+    const map = coerceOutlookProbabilityMap(plain);
+    expect(map?.get('30%')).toHaveLength(1);
+  });
+
+  test('coerceOutlookProbabilityMap accepts serialized map entry arrays', () => {
+    const serialized: [string, { type: 'Feature'; properties: object; geometry: { type: 'Polygon'; coordinates: [] } }][] = [
+      ['30%', [{ type: 'Feature', properties: {}, geometry: { type: 'Polygon', coordinates: [] } }]],
+    ];
+    const map = coerceOutlookProbabilityMap(serialized);
+    expect(map?.get('30%')).toHaveLength(1);
+  });
+
+  test('normalizeOutlookData coerces legacy plain-object maps', () => {
+    const data = {
+      tornado: {},
+      wind: { '10%': [{ type: 'Feature', properties: {}, geometry: { type: 'Polygon', coordinates: [] } }] },
+      hail: new Map(),
+    } as unknown as OutlookData;
+
+    const normalized = normalizeOutlookData(data);
+    expect(normalized.tornado).toBeUndefined();
+    expect(normalized.wind?.get('10%')).toHaveLength(1);
+    expect(normalized.hail).toBeUndefined();
+  });
+
+  test('normalizeForecastCycle normalizes every day', () => {
+    const cycle: ForecastCycle = {
+      currentDay: 1,
+      cycleDate: '2026-03-01',
+      days: {
+        1: {
+          day: 1,
+          metadata: {
+            issueDate: 'x',
+            validDate: 'x',
+            issuanceTime: '0600',
+            lowProbabilityOutlooks: [],
+          },
+          data: {
+            tornado: {},
+            categorical: {},
+          } as unknown as OutlookData,
+        },
+      },
+    };
+
+    const normalized = normalizeForecastCycle(cycle);
+    expect(normalized.days[1]?.data.tornado).toBeUndefined();
+    expect(normalized.days[1]?.data.categorical).toBeUndefined();
+  });
+});

--- a/src/utils/outlookMapCoercion.test.ts
+++ b/src/utils/outlookMapCoercion.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeForecastCycle,
   normalizeOutlookData,
 } from './outlookMapCoercion';
+import type { Feature as GeoJsonFeature } from 'geojson';
 import type { ForecastCycle, OutlookData } from '../types/outlooks';
 
 describe('outlookMapCoercion', () => {
@@ -41,7 +42,20 @@ describe('outlookMapCoercion', () => {
     const normalized = normalizeOutlookData(data);
     expect(normalized.tornado).toBeUndefined();
     expect(normalized.wind?.get('10%')).toHaveLength(1);
-    expect(normalized.hail).toBeUndefined();
+    expect(normalized.hail).toBeInstanceOf(Map);
+    expect(normalized.hail?.size).toBe(0);
+  });
+
+  test('normalizeOutlookData preserves empty Map instances', () => {
+    const emptyMap = new Map<string, GeoJsonFeature[]>();
+    const normalized = normalizeOutlookData({
+      tornado: emptyMap,
+      wind: [],
+    } as unknown as OutlookData);
+
+    expect(normalized.tornado).toBe(emptyMap);
+    expect(normalized.wind).toBeInstanceOf(Map);
+    expect(normalized.wind?.size).toBe(0);
   });
 
   test('normalizeForecastCycle normalizes every day', () => {

--- a/src/utils/outlookMapCoercion.ts
+++ b/src/utils/outlookMapCoercion.ts
@@ -46,7 +46,22 @@ export const normalizeOutlookData = (data: OutlookData): OutlookData => {
   const outlookKeys = ['tornado', 'wind', 'hail', 'totalSevere', 'categorical', 'day4-8'] as const;
 
   outlookKeys.forEach((key) => {
-    const coerced = coerceOutlookProbabilityMap(data[key]);
+    const raw = data[key];
+    if (raw === undefined || raw === null) {
+      return;
+    }
+
+    if (raw instanceof Map) {
+      normalized[key] = raw;
+      return;
+    }
+
+    if (Array.isArray(raw) && raw.length === 0) {
+      normalized[key] = new Map();
+      return;
+    }
+
+    const coerced = coerceOutlookProbabilityMap(raw);
     if (coerced && coerced.size > 0) {
       normalized[key] = coerced;
     }

--- a/src/utils/outlookMapCoercion.ts
+++ b/src/utils/outlookMapCoercion.ts
@@ -1,0 +1,82 @@
+import type { Feature as GeoJsonFeature } from 'geojson';
+import type { ForecastCycle, OutlookData } from '../types/outlooks';
+
+/** Accepts Map-backed outlook data, serialized entry arrays, and plain objects from legacy persistence. */
+export const coerceOutlookProbabilityMap = (
+  map:
+    | Map<string, GeoJsonFeature[]>
+    | Record<string, GeoJsonFeature[]>
+    | [string, GeoJsonFeature[]][]
+    | undefined
+    | unknown,
+): Map<string, GeoJsonFeature[]> | null => {
+  if (!map) {
+    return null;
+  }
+
+  if (map instanceof Map) {
+    return map;
+  }
+
+  if (Array.isArray(map)) {
+    const entries = map.filter(
+      (entry): entry is [string, GeoJsonFeature[]] =>
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === 'string' &&
+        Array.isArray(entry[1]),
+    );
+    return new Map(entries);
+  }
+
+  if (typeof map === 'object') {
+    return new Map(
+      Object.entries(map as Record<string, GeoJsonFeature[]>).filter(
+        ([, features]) => Array.isArray(features),
+      ),
+    );
+  }
+
+  return null;
+};
+
+/** Ensures every outlook probability map on a day is a Map instance. */
+export const normalizeOutlookData = (data: OutlookData): OutlookData => {
+  const normalized: OutlookData = {};
+  const outlookKeys = ['tornado', 'wind', 'hail', 'totalSevere', 'categorical', 'day4-8'] as const;
+
+  outlookKeys.forEach((key) => {
+    const coerced = coerceOutlookProbabilityMap(data[key]);
+    if (coerced && coerced.size > 0) {
+      normalized[key] = coerced;
+    }
+  });
+
+  return normalized;
+};
+
+/** Normalizes all day outlook maps on a forecast cycle (e.g. after legacy localStorage hydration). */
+export const normalizeForecastCycle = (forecastCycle: ForecastCycle): ForecastCycle => {
+  if (!forecastCycle?.days || typeof forecastCycle.days !== 'object') {
+    return forecastCycle;
+  }
+
+  const days = { ...forecastCycle.days };
+
+  (Object.keys(days) as unknown as Array<keyof typeof days>).forEach((dayKey) => {
+    const dayData = days[dayKey];
+    if (!dayData) {
+      return;
+    }
+
+    days[dayKey] = {
+      ...dayData,
+      data: normalizeOutlookData(dayData.data),
+    };
+  });
+
+  return {
+    ...forecastCycle,
+    days,
+  };
+};


### PR DESCRIPTION
## Summary
- Fixes Sentry **GFC-WEB-7** (\TypeError: r.forEach is not a function\ on \/forecast\) when probability outlook data was a plain object from legacy localStorage cycles instead of a \Map\.
- Adds \coerceOutlookProbabilityMap\ / normalization in \outlookMapCoercion.ts\ and uses it in auto-categorical, file deserialize, and cycle history load.
- Adds GFC-WEB-7 regression tests and updates **AGENTS.md** so shippable fixes use a task branch and PR.

## Test plan
- [x] \pnpm test -- --runTestsByPath src/utils/outlookMapCoercion.test.ts src/hooks/__tests__/useAutoCategorical.test.ts src/utils/cycleHistoryPersistence.extra.test.ts src/utils/fileUtils.test.ts\
- [ ] Load an old saved cycle from cycle history on \/forecast\ and confirm no console error
- [ ] Confirm Sentry issue GFC-WEB-7 resolves after deploy (commit message includes \Fixes GFC-WEB-7\)


Made with [Cursor](https://cursor.com)