### PR TITLE
feat: public What's New page for v1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - **What's New page:** Public `/updates` route with v1.6 copy in `src/content/updates/v1.6.ts` and screenshot directory `public/updates/v1.6/` (images optional until marketing adds them).
 
 ### Fixed
+- **Signed-in home (light mode):** Primary gradient “Resume Forecast” buttons use white text instead of `#067aff` on the concept home layout (`.home-concept-top-primary`, `.home-concept-action-primary`).
 - **Analytics server tests:** Share `configureApp` with production so `/collect` stays rate-limited in server smoke tests (fixes CodeQL `js/missing-rate-limiting` on `beta`).
 - **Analytics server (beta):** Restored a broken partial merge in `server/analytics.js` so the hosted collector starts again before Express 5 / Stripe 22 land.
 - **Stripe subscription webhooks:** Read `current_period_end` from subscription items for Stripe API 2025-03-31+ (stripe-node v22) with fallback for older payloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - **ts-jest:** ^29.4.9 → ^29.4.11
 - **vite:** ^8.0.13 → ^8.0.14
 
+### Added
+- **What's New page:** Public `/updates` route with v1.6 copy in `src/content/updates/v1.6.ts` and screenshot directory `public/updates/v1.6/` (images optional until marketing adds them).
 
 ### Fixed
 - **Analytics server tests:** Share `configureApp` with production so `/collect` stays rate-limited in server smoke tests (fixes CodeQL `js/missing-rate-limiting` on `beta`).

--- a/public/updates/v1.6/README.md
+++ b/public/updates/v1.6/README.md
@@ -1,0 +1,12 @@
+# v1.6 update screenshots
+
+Place release screenshots in this folder only.
+
+Suggested filenames (referenced by `/updates` when present):
+
+- `monitor-overview.png`
+- `monitor-radar-outlook.png`
+- `monitor-alerts.png`
+- `monitor-storm-reports.png`
+
+The page hides missing images until files are added.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -12,6 +12,7 @@ jest.mock('./pages', () => ({
   ComingSoonPage: () => <div>ComingSoonPage Mock</div>,
   AccountPage: () => <div>AccountPage Mock</div>,
   PricingPage: () => <div>PricingPage Mock</div>,
+  UpdatesPage: () => <div>UpdatesPage Mock</div>,
   AdminPage: () => <div>AdminPage Mock</div>,
   BetaLandingPage: () => <div>BetaLandingPage Mock</div>,
   BetaInvitePage: () => <div>BetaInvitePage Mock</div>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { EntitlementProvider } from './billing/EntitlementProvider';
 
 // New UI components
 import { AppLayout } from './components/Layout';
-import { HomePage, ForecastPage, DiscussionPage, VerificationPage, MonitorPage, ComingSoonPage, AccountPage, PricingPage, AdminPage, BetaLandingPage, BetaInvitePage } from './pages';
+import { HomePage, ForecastPage, DiscussionPage, VerificationPage, MonitorPage, ComingSoonPage, AccountPage, PricingPage, UpdatesPage, AdminPage, BetaLandingPage, BetaInvitePage } from './pages';
 import CloudLibraryPage from './pages/CloudLibraryPage';
 import BetaAccessGuard from './components/Beta/BetaAccessGuard';
 import ToSModal, { hasAcceptedToS } from './components/ToS/ToSModal';
@@ -141,6 +141,7 @@ const AppRoutes: React.FC<AppRoutesProps> = ({ showComingSoon }) => {
         <Route index element={<HomePage />} />
         <Route path="account" element={<AccountPage />} />
         <Route path="pricing" element={<PricingPage />} />
+        <Route path="updates" element={<UpdatesPage />} />
         <Route path="admin" element={<AdminPage />} />
         <Route path="cloud" element={<CloudLibraryPage />} />
         <Route path="forecast" element={<ForecastPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,19 +136,19 @@ const AppRoutes: React.FC<AppRoutesProps> = ({ showComingSoon }) => {
     <Routes>
       <Route path="beta" element={<BetaLandingPage />} />
       <Route path="beta-access/:invitePath?" element={<BetaInvitePage />} />
-      <Route element={<BetaAccessGuard />}>
       <Route element={<AppLayout />}>
+        <Route path="updates" element={<UpdatesPage />} />
+        <Route element={<BetaAccessGuard />}>
         <Route index element={<HomePage />} />
         <Route path="account" element={<AccountPage />} />
         <Route path="pricing" element={<PricingPage />} />
-        <Route path="updates" element={<UpdatesPage />} />
         <Route path="admin" element={<AdminPage />} />
         <Route path="cloud" element={<CloudLibraryPage />} />
         <Route path="forecast" element={<ForecastPage />} />
         <Route path="discussion" element={<DiscussionPage />} />
         <Route path="verification" element={<VerificationPage />} />
         <Route path="monitor" element={<MonitorPage />} />
-      </Route>
+        </Route>
       </Route>
       <Route path="*" element={<Navigate to={BETA_MODE ? '/beta' : '/'} replace />} />
     </Routes>

--- a/src/App.updates-route.test.tsx
+++ b/src/App.updates-route.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import BetaAccessGuard from './components/Beta/BetaAccessGuard';
+import UpdatesPage from './pages/UpdatesPage';
+
+jest.mock('./lib/betaAccess', () => ({
+  isBetaModeEnabled: () => true,
+  isLocalBetaBypassEnabled: () => false,
+}));
+
+jest.mock('./auth/AuthProvider', () => ({
+  useAuth: () => ({
+    status: 'signed_out',
+    betaAccess: false,
+    betaAccessLoading: false,
+    hostedAuthEnabled: true,
+  }),
+}));
+
+describe('Updates route access', () => {
+  test('renders /updates without passing BetaAccessGuard', () => {
+    render(
+      <MemoryRouter initialEntries={['/updates']}>
+        <Routes>
+          <Route path="updates" element={<UpdatesPage />} />
+          <Route element={<BetaAccessGuard />}>
+            <Route path="*" element={<div>Blocked</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { level: 1, name: /Monitor/i })).toBeInTheDocument();
+    expect(screen.queryByText('Blocked')).not.toBeInTheDocument();
+  });
+});

--- a/src/content/updates/v1.6.ts
+++ b/src/content/updates/v1.6.ts
@@ -10,12 +10,17 @@ export interface UpdateSection {
   screenshots?: UpdateScreenshot[];
 }
 
+export interface ReleaseImprovement {
+  id: string;
+  text: string;
+}
+
 export interface ReleaseUpdate {
   version: string;
   title: string;
   summary: string;
   sections: UpdateSection[];
-  improvements: string[];
+  improvements: ReleaseImprovement[];
 }
 
 /** Builds a screenshot descriptor under public/updates/v1.6/. */
@@ -61,10 +66,25 @@ export const v16Update: ReleaseUpdate = {
     },
   ],
   improvements: [
-    'Hosted accounts on Safari and macOS are less likely to lose connection after the computer sleeps overnight.',
-    'Forecast keyboard shortcuts no longer break when the browser sends an unusual key event.',
-    'Map layer transparency controls behave consistently again on the forecast editor.',
-    'Saving, loading, and exporting forecasts is more resilient when outlook data was stored in an unexpected shape.',
-    'Signed-in home page primary buttons are easier to read in light mode.',
+    {
+      id: 'safari-hosted-sleep',
+      text: 'Hosted accounts on Safari and macOS are less likely to lose connection after the computer sleeps overnight.',
+    },
+    {
+      id: 'forecast-shortcuts',
+      text: 'Forecast keyboard shortcuts no longer break when the browser sends an unusual key event.',
+    },
+    {
+      id: 'map-transparency',
+      text: 'Map layer transparency controls behave consistently again on the forecast editor.',
+    },
+    {
+      id: 'forecast-persistence',
+      text: 'Saving, loading, and exporting forecasts is more resilient when outlook data was stored in an unexpected shape.',
+    },
+    {
+      id: 'home-primary-cta',
+      text: 'Signed-in home page primary buttons are easier to read in light mode.',
+    },
   ],
 };

--- a/src/content/updates/v1.6.ts
+++ b/src/content/updates/v1.6.ts
@@ -18,11 +18,14 @@ export interface ReleaseUpdate {
   improvements: string[];
 }
 
-const image = (fileName: string, alt: string, caption?: string): UpdateScreenshot => ({
+/** Builds a screenshot descriptor under public/updates/v1.6/. */
+function buildUpdateImage(fileName: string, alt: string, caption?: string): UpdateScreenshot {
+  return {
   src: `/updates/v1.6/${fileName}`,
   alt,
   caption,
-});
+  };
+}
 
 export const v16Update: ReleaseUpdate = {
   version: '1.6',
@@ -35,12 +38,12 @@ export const v16Update: ReleaseUpdate = {
       body:
         'Open Monitor from the main navigation to see radar and satellite imagery, animate recent frames, and keep your active or saved outlook on the map for context. Premium users can also pull outlooks from the cloud library.',
       screenshots: [
-        image(
+        buildUpdateImage(
           'monitor-overview.png',
           'Monitor page showing the map and control sidebar',
           'Monitor layout with map and controls',
         ),
-        image(
+        buildUpdateImage(
           'monitor-radar-outlook.png',
           'Radar imagery with a semi-transparent outlook overlay',
           'Radar plus your outlook overlay',
@@ -52,8 +55,8 @@ export const v16Update: ReleaseUpdate = {
       body:
         'Toggle NWS watches, warnings, and advisories with adjustable opacity. Layer storm reports and filter by hazard type, optionally matching your outlook type for faster verification.',
       screenshots: [
-        image('monitor-alerts.png', 'NWS alerts displayed on the Monitor map'),
-        image('monitor-storm-reports.png', 'Storm reports plotted on the Monitor map'),
+        buildUpdateImage('monitor-alerts.png', 'NWS alerts displayed on the Monitor map'),
+        buildUpdateImage('monitor-storm-reports.png', 'Storm reports plotted on the Monitor map'),
       ],
     },
   ],

--- a/src/content/updates/v1.6.ts
+++ b/src/content/updates/v1.6.ts
@@ -1,0 +1,67 @@
+export interface UpdateScreenshot {
+  src: string;
+  alt: string;
+  caption?: string;
+}
+
+export interface UpdateSection {
+  title: string;
+  body: string;
+  screenshots?: UpdateScreenshot[];
+}
+
+export interface ReleaseUpdate {
+  version: string;
+  title: string;
+  summary: string;
+  sections: UpdateSection[];
+  improvements: string[];
+}
+
+const image = (fileName: string, alt: string, caption?: string): UpdateScreenshot => ({
+  src: `/updates/v1.6/${fileName}`,
+  alt,
+  caption,
+});
+
+export const v16Update: ReleaseUpdate = {
+  version: '1.6',
+  title: 'Monitor — live weather at a glance',
+  summary:
+    'Version 1.6 introduces Monitor: a dedicated workspace for live radar, satellite, your forecast outlook, NWS alerts, and storm reports — built for quick situational awareness while you work.',
+  sections: [
+    {
+      title: 'Monitor workspace',
+      body:
+        'Open Monitor from the main navigation to see radar and satellite imagery, animate recent frames, and keep your active or saved outlook on the map for context. Premium users can also pull outlooks from the cloud library.',
+      screenshots: [
+        image(
+          'monitor-overview.png',
+          'Monitor page showing the map and control sidebar',
+          'Monitor layout with map and controls',
+        ),
+        image(
+          'monitor-radar-outlook.png',
+          'Radar imagery with a semi-transparent outlook overlay',
+          'Radar plus your outlook overlay',
+        ),
+      ],
+    },
+    {
+      title: 'Alerts and storm reports',
+      body:
+        'Toggle NWS watches, warnings, and advisories with adjustable opacity. Layer storm reports and filter by hazard type, optionally matching your outlook type for faster verification.',
+      screenshots: [
+        image('monitor-alerts.png', 'NWS alerts displayed on the Monitor map'),
+        image('monitor-storm-reports.png', 'Storm reports plotted on the Monitor map'),
+      ],
+    },
+  ],
+  improvements: [
+    'Hosted accounts on Safari and macOS are less likely to lose connection after the computer sleeps overnight.',
+    'Forecast keyboard shortcuts no longer break when the browser sends an unusual key event.',
+    'Map layer transparency controls behave consistently again on the forecast editor.',
+    'Saving, loading, and exporting forecasts is more resilient when outlook data was stored in an unexpected shape.',
+    'Signed-in home page primary buttons are easier to read in light mode.',
+  ],
+};

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -858,7 +858,7 @@
 .home-concept-action-primary {
     border: 1px solid var(--button-bg);
     background: linear-gradient(135deg, #7b61ff, var(--button-bg));
-    color: #067aff;
+    color: #fff;
     box-shadow: 0 1.15rem 2rem
         rgba(0, 123, 255, 0.18);
 }
@@ -958,7 +958,7 @@
 .home-concept-action.home-concept-action-primary {
     border-color: var(--button-bg);
     background: linear-gradient(135deg, #7b61ff, var(--button-bg));
-    color: #067aff;
+    color: #fff;
     box-shadow: 0 1.15rem 2rem
         rgba(0, 123, 255, 0.18);
 }

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1332,6 +1332,7 @@
 
 .dark-mode .home-concept-top-primary,
 .dark-mode .home-concept-action.home-concept-action-primary {
+    /* Explicit dark-mode label color; light-mode gradient rule below uses #fff. */
     border-color: rgba(159, 178, 200, 0.28);
     background: linear-gradient(
         180deg,

--- a/src/pages/UpdatesPage.css
+++ b/src/pages/UpdatesPage.css
@@ -1,0 +1,115 @@
+.updates-page {
+  min-height: 100%;
+  overflow: auto;
+  background: linear-gradient(180deg, var(--bg-primary) 0%, color-mix(in srgb, var(--muted) 35%, var(--bg-primary)) 100%);
+}
+
+.updates-page__inner {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 3.5rem) clamp(1.25rem, 4vw, 2rem) 4rem;
+}
+
+.updates-page__eyebrow {
+  margin: 0 0 0.5rem;
+  color: var(--button-bg);
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.updates-page h1 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 850;
+  line-height: 1.1;
+}
+
+.updates-page__summary {
+  margin: 1rem 0 0;
+  color: var(--text-secondary);
+  font-size: 1.125rem;
+  line-height: 1.6;
+}
+
+.updates-page__section {
+  margin-top: 2.5rem;
+}
+
+.updates-page__section h2 {
+  margin: 0 0 0.75rem;
+  color: var(--text-primary);
+  font-size: 1.35rem;
+  font-weight: 800;
+}
+
+.updates-page__section p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.updates-page__shots {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+}
+
+.updates-page__figure {
+  margin: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.updates-page__figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.updates-page__figure figcaption {
+  padding: 0.65rem 0.9rem;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.updates-page__improvements {
+  margin: 2.5rem 0 0;
+  padding: 1.25rem 1.35rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  background: var(--bg-secondary);
+}
+
+.updates-page__improvements h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.2rem;
+}
+
+.updates-page__improvements ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.updates-page__improvements li + li {
+  margin-top: 0.45rem;
+}
+
+.updates-page__back {
+  display: inline-flex;
+  margin-top: 2.5rem;
+  color: var(--button-bg);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.updates-page__back:hover {
+  text-decoration: underline;
+}

--- a/src/pages/UpdatesPage.test.tsx
+++ b/src/pages/UpdatesPage.test.tsx
@@ -13,7 +13,7 @@ describe('UpdatesPage', () => {
     expect(screen.getByRole('heading', { level: 1, name: /Monitor/i })).toBeInTheDocument();
     expect(screen.getByText(/What's new · v1\.6/i)).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /Monitor workspace/i })).toBeInTheDocument();
-    expect(screen.getByText(/Signed-in home page primary buttons/i)).toBeInTheDocument();
+    expect(screen.getByText(/Signed-in home page primary buttons are easier to read/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Back to home/i })).toHaveAttribute('href', '/');
   });
 });

--- a/src/pages/UpdatesPage.test.tsx
+++ b/src/pages/UpdatesPage.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UpdatesPage from './UpdatesPage';
+
+describe('UpdatesPage', () => {
+  test('renders v1.6 headline and improvement list', () => {
+    render(
+      <MemoryRouter>
+        <UpdatesPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { level: 1, name: /Monitor/i })).toBeInTheDocument();
+    expect(screen.getByText(/What's new · v1\.6/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Monitor workspace/i })).toBeInTheDocument();
+    expect(screen.getByText(/Signed-in home page primary buttons/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to home/i })).toHaveAttribute('href', '/');
+  });
+});

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -44,8 +44,8 @@ export const UpdatesPage: React.FC = () => (
       <section className="updates-page__improvements" aria-labelledby="updates-improvements-heading">
         <h2 id="updates-improvements-heading">Also improved</h2>
         <ul>
-          {v16Update.improvements.map((item, index) => (
-            <li key={`v16-improvement-${index}`}>{item}</li>
+          {v16Update.improvements.map((item) => (
+            <li key={item.id}>{item.text}</li>
           ))}
         </ul>
       </section>

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -3,7 +3,8 @@ import { Link } from 'react-router-dom';
 import { v16Update, type UpdateScreenshot } from '../content/updates/v1.6';
 import './UpdatesPage.css';
 
-const UpdateScreenshotFigure: React.FC<{ shot: UpdateScreenshot }> = ({ shot }) => {
+/** Renders a release screenshot when the asset exists under public/updates. */
+function UpdateScreenshotFigure({ shot }: { shot: UpdateScreenshot }) {
   const [visible, setVisible] = useState(true);
 
   if (!visible) {
@@ -16,7 +17,7 @@ const UpdateScreenshotFigure: React.FC<{ shot: UpdateScreenshot }> = ({ shot }) 
       {shot.caption ? <figcaption>{shot.caption}</figcaption> : null}
     </figure>
   );
-};
+}
 
 /** Public What's New page for the current major release. */
 export const UpdatesPage: React.FC = () => (
@@ -43,8 +44,8 @@ export const UpdatesPage: React.FC = () => (
       <section className="updates-page__improvements" aria-labelledby="updates-improvements-heading">
         <h2 id="updates-improvements-heading">Also improved</h2>
         <ul>
-          {v16Update.improvements.map((item) => (
-            <li key={item}>{item}</li>
+          {v16Update.improvements.map((item, index) => (
+            <li key={`v16-improvement-${index}`}>{item}</li>
           ))}
         </ul>
       </section>

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { v16Update, type UpdateScreenshot } from '../content/updates/v1.6';
+import './UpdatesPage.css';
+
+const UpdateScreenshotFigure: React.FC<{ shot: UpdateScreenshot }> = ({ shot }) => {
+  const [visible, setVisible] = useState(true);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <figure className="updates-page__figure">
+      <img src={shot.src} alt={shot.alt} loading="lazy" onError={() => setVisible(false)} />
+      {shot.caption ? <figcaption>{shot.caption}</figcaption> : null}
+    </figure>
+  );
+};
+
+/** Public What's New page for the current major release. */
+export const UpdatesPage: React.FC = () => (
+  <div className="updates-page">
+    <div className="updates-page__inner">
+      <p className="updates-page__eyebrow">What&apos;s new · v{v16Update.version}</p>
+      <h1>{v16Update.title}</h1>
+      <p className="updates-page__summary">{v16Update.summary}</p>
+
+      {v16Update.sections.map((section) => (
+        <section key={section.title} className="updates-page__section">
+          <h2>{section.title}</h2>
+          <p>{section.body}</p>
+          {section.screenshots?.length ? (
+            <div className="updates-page__shots">
+              {section.screenshots.map((shot) => (
+                <UpdateScreenshotFigure key={shot.src} shot={shot} />
+              ))}
+            </div>
+          ) : null}
+        </section>
+      ))}
+
+      <section className="updates-page__improvements" aria-labelledby="updates-improvements-heading">
+        <h2 id="updates-improvements-heading">Also improved</h2>
+        <ul>
+          {v16Update.improvements.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <Link className="updates-page__back" to="/">
+        Back to home
+      </Link>
+    </div>
+  </div>
+);
+
+export default UpdatesPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -6,6 +6,7 @@ export { MonitorPage } from './MonitorPage';
 export { ComingSoonPage } from './ComingSoonPage';
 export { AccountPage } from './AccountPage';
 export { PricingPage } from './PricingPage';
+export { UpdatesPage } from './UpdatesPage';
 export { AdminPage } from './AdminPage';
 export { default as BetaLandingPage } from './BetaLandingPage';
 export { default as BetaInvitePage } from './BetaInvitePage';


### PR DESCRIPTION
## Summary

- Adds public `/updates` What's New page (content in `src/content/updates/v1.6.ts`, not generated from CHANGELOG).
- Screenshot directory: `public/updates/v1.6/` (place monitor PNGs per README; page hides missing images).

## Test plan

- [x] `pnpm test -- --runTestsByPath src/pages/UpdatesPage.test.tsx`
- [ ] Manual: visit `/updates` on beta deploy after merge