### PR TITLE
[Port] fix: signed-in home primary CTA text in light mode to feature/alert-banner-scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - **Alert banner:** Optional `linkUrl` / `linkLabel`, `startsAt` / `expiresAt` scheduling, and `id` on `public/alert-banner.json`; client normalizes config in `alertBannerConfig.ts`. See `docs/alert-banner.md`.
 
 ### Fixed
+- **Signed-in home (light mode):** Primary gradient “Resume Forecast” buttons use white text instead of `#067aff` on the concept home layout (`.home-concept-top-primary`, `.home-concept-action-primary`).
 - **Analytics server tests:** Share `configureApp` with production so `/collect` stays rate-limited in server smoke tests (fixes CodeQL `js/missing-rate-limiting` on `beta`).
 - **Analytics server (beta):** Restored a broken partial merge in `server/analytics.js` so the hosted collector starts again before Express 5 / Stripe 22 land.
 - **Stripe subscription webhooks:** Read `current_period_end` from subscription items for Stripe API 2025-03-31+ (stripe-node v22) with fallback for older payloads.

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -858,7 +858,7 @@
 .home-concept-action-primary {
     border: 1px solid var(--button-bg);
     background: linear-gradient(135deg, #7b61ff, var(--button-bg));
-    color: #067aff;
+    color: #fff;
     box-shadow: 0 1.15rem 2rem
         rgba(0, 123, 255, 0.18);
 }
@@ -958,7 +958,7 @@
 .home-concept-action.home-concept-action-primary {
     border-color: var(--button-bg);
     background: linear-gradient(135deg, #7b61ff, var(--button-bg));
-    color: #067aff;
+    color: #fff;
     box-shadow: 0 1.15rem 2rem
         rgba(0, 123, 255, 0.18);
 }

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1332,6 +1332,7 @@
 
 .dark-mode .home-concept-top-primary,
 .dark-mode .home-concept-action.home-concept-action-primary {
+    /* Explicit dark-mode label color; light-mode gradient rule below uses #fff. */
     border-color: rgba(159, 178, 200, 0.28);
     background: linear-gradient(
         180deg,


### PR DESCRIPTION
Automated port of the original commits from PR #365 into `feature/alert-banner-scheduling` after merge into `beta`.