### PR TITLE
[Port][Conflicts] feat: alert banner links and schedule windows → feature/updates-page-v1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,13 @@ All notable changes to this project will be documented in this file.
 - **ts-jest:** ^29.4.9 → ^29.4.11
 - **vite:** ^8.0.13 → ^8.0.14
 
+<<<<<<< HEAD
 ### Added
 - **What's New page:** Public `/updates` route with v1.6 copy in `src/content/updates/v1.6.ts` and screenshot directory `public/updates/v1.6/` (images optional until marketing adds them).
+=======
+### Changed
+- **Alert banner:** Optional `linkUrl` / `linkLabel`, `startsAt` / `expiresAt` scheduling, and `id` on `public/alert-banner.json`; client normalizes config in `alertBannerConfig.ts`. See `docs/alert-banner.md`.
+>>>>>>> 3c75066 (feat: alert banner links and schedule windows)
 
 ### Fixed
 - **Analytics server tests:** Share `configureApp` with production so `/collect` stays rate-limited in server smoke tests (fixes CodeQL `js/missing-rate-limiting` on `beta`).

--- a/docs/alert-banner.md
+++ b/docs/alert-banner.md
@@ -1,0 +1,45 @@
+# Alert banner
+
+Site-wide banner loaded from `public/alert-banner.json` at runtime (deploy updates copy without rebuilding app logic).
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enabled` | boolean | yes | Master switch |
+| `message` | string | yes | Banner text |
+| `type` | `info` \| `warning` \| `error` | yes | Visual style |
+| `dismissible` | boolean | yes | Show close button |
+| `id` | string | no | Identifier for tracking |
+| `linkUrl` | string | no | CTA URL; paths starting with `/` use in-app routing |
+| `linkLabel` | string | no | CTA label (default: "Learn more") |
+| `startsAt` | string (ISO 8601) | no | Hide before this instant |
+| `expiresAt` | string (ISO 8601) | no | Hide at or after this instant |
+
+## v1.6 examples (production `hotfix/*` → `main`)
+
+**Pre-release maintenance**
+
+```json
+{
+  "enabled": true,
+  "id": "v1.6-maintenance",
+  "message": "v1.6 is deploying soon. You may see brief downtime while we update the site.",
+  "type": "warning",
+  "dismissible": true
+}
+```
+
+**Post-release**
+
+```json
+{
+  "enabled": true,
+  "id": "v1.6-released",
+  "message": "v1.6 is live — meet the new Monitor workspace.",
+  "type": "info",
+  "dismissible": true,
+  "linkUrl": "/updates",
+  "linkLabel": "What's new"
+}
+```

--- a/src/components/AlertBanner.css
+++ b/src/components/AlertBanner.css
@@ -24,8 +24,33 @@
   color: #ffffff;
 }
 
-.alert-banner__message {
+.alert-banner__content {
+  display: flex;
   flex: 1;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem 0.75rem;
+}
+
+.alert-banner__message {
+  flex: 0 1 auto;
+}
+
+.alert-banner__link {
+  color: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+}
+
+.alert-banner__link:hover {
+  opacity: 0.9;
+}
+
+.alert-banner--warning .alert-banner__link {
+  color: #1e3a8a;
 }
 
 .alert-banner__close {

--- a/src/components/AlertBanner.test.tsx
+++ b/src/components/AlertBanner.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import AlertBanner from './AlertBanner';
 
 describe('AlertBanner', () => {
@@ -12,23 +13,68 @@ describe('AlertBanner', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     global.fetch = jest.fn();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   test('renders alert when enabled', async () => {
-    const mockConfig = {
+    mockBannerFetch({
       enabled: true,
       message: 'Test Alert',
       type: 'warning',
       dismissible: true,
-    };
-    mockBannerFetch(mockConfig);
+    });
 
-    render(<AlertBanner />);
+    render(
+      <MemoryRouter>
+        <AlertBanner />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => expect(screen.getByText('Test Alert')).toBeInTheDocument());
-
-    expect(screen.getByText('Test Alert')).toBeInTheDocument();
     expect(screen.getByRole('status')).toHaveClass('alert-banner--warning');
+  });
+
+  test('renders internal link CTA', async () => {
+    mockBannerFetch({
+      enabled: true,
+      message: 'v1.6 is live',
+      type: 'info',
+      dismissible: true,
+      linkUrl: '/updates',
+      linkLabel: "What's new",
+    });
+
+    render(
+      <MemoryRouter>
+        <AlertBanner />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByRole('link', { name: "What's new" })).toHaveAttribute('href', '/updates'));
+  });
+
+  test('hides banner before startsAt', async () => {
+    mockBannerFetch({
+      enabled: true,
+      message: 'Future alert',
+      type: 'info',
+      dismissible: true,
+      startsAt: '2099-01-01T00:00:00.000Z',
+    });
+
+    render(
+      <MemoryRouter>
+        <AlertBanner />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
   });
 
   it.each([
@@ -44,7 +90,11 @@ describe('AlertBanner', () => {
       mockBannerFetch(config, ok ?? true);
     }
 
-    render(<AlertBanner />);
+    render(
+      <MemoryRouter>
+        <AlertBanner />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
@@ -52,37 +102,41 @@ describe('AlertBanner', () => {
   });
 
   test('can be dismissed', async () => {
-    const mockConfig = {
+    mockBannerFetch({
       enabled: true,
       message: 'Dismiss me',
       type: 'error',
       dismissible: true,
-    };
-    mockBannerFetch(mockConfig);
+    });
 
-    render(<AlertBanner />);
+    render(
+      <MemoryRouter>
+        <AlertBanner />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => expect(screen.getByText('Dismiss me')).toBeInTheDocument());
 
-    const closeButton = screen.getByLabelText('Dismiss alert');
-    fireEvent.click(closeButton);
+    fireEvent.click(screen.getByLabelText('Dismiss alert'));
 
     expect(screen.queryByText('Dismiss me')).not.toBeInTheDocument();
   });
 
   test('is not dismissible when dismissible is false', async () => {
-    const mockConfig = {
+    mockBannerFetch({
       enabled: true,
       message: 'Permanent',
       type: 'info',
       dismissible: false,
-    };
-    mockBannerFetch(mockConfig);
+    });
 
-    render(<AlertBanner />);
+    render(
+      <MemoryRouter>
+        <AlertBanner />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => expect(screen.getByText('Permanent')).toBeInTheDocument());
-
     expect(screen.queryByLabelText('Dismiss alert')).not.toBeInTheDocument();
   });
 });

--- a/src/components/AlertBanner.tsx
+++ b/src/components/AlertBanner.tsx
@@ -1,28 +1,22 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  DEFAULT_ALERT_BANNER_CONFIG,
+  isAlertBannerScheduleActive,
+  normalizeAlertBannerConfig,
+  type AlertBannerConfig,
+} from './alertBannerConfig';
 import './AlertBanner.css';
-
-export interface AlertConfig {
-  enabled: boolean;
-  message: string;
-  type: 'info' | 'warning' | 'error';
-  dismissible: boolean;
-}
-
-const DEFAULT_CONFIG: AlertConfig = {
-  enabled: false,
-  message: '',
-  type: 'info',
-  dismissible: true,
-};
 
 interface AlertBannerProps {
   configPath?: string;
 }
 
-/** Loads a static JSON banner config and renders a site-wide alert when enabled. */
+/** Loads static JSON banner config and renders a site-wide alert when enabled and in schedule. */
 export function AlertBanner({ configPath = '/alert-banner.json' }: AlertBannerProps) {
-  const [config, setConfig] = useState<AlertConfig>(DEFAULT_CONFIG);
+  const [config, setConfig] = useState<AlertBannerConfig>(DEFAULT_ALERT_BANNER_CONFIG);
   const [dismissed, setDismissed] = useState(false);
+  const [scheduleActive, setScheduleActive] = useState(false);
 
   useEffect(() => {
     fetch(configPath)
@@ -32,31 +26,65 @@ export function AlertBanner({ configPath = '/alert-banner.json' }: AlertBannerPr
         }
         return response.json();
       })
-      .then((data: AlertConfig) => {
-        setConfig(data);
+      .then((data: unknown) => {
+        const next = normalizeAlertBannerConfig(data);
+        setConfig(next);
         setDismissed(false);
+        setScheduleActive(isAlertBannerScheduleActive(next));
       })
       .catch(() => {
         // Invalid or missing config should fail closed and keep the banner hidden.
       });
   }, [configPath]);
 
-  if (!config.enabled || dismissed) {
+  useEffect(() => {
+    if (!config.enabled) {
+      setScheduleActive(false);
+      return undefined;
+    }
+
+    const tick = () => {
+      setScheduleActive(isAlertBannerScheduleActive(config));
+    };
+
+    tick();
+    const intervalId = window.setInterval(tick, 60_000);
+    return () => window.clearInterval(intervalId);
+  }, [config]);
+
+  if (!scheduleActive || dismissed || !config.message.trim()) {
     return null;
   }
 
+  const isInternalLink = config.linkUrl?.startsWith('/');
+  const linkLabel = config.linkLabel?.trim() || 'Learn more';
+
   return (
     <div className={`alert-banner alert-banner--${config.type}`} role="status" aria-live="polite">
-      <span className="alert-banner__message">{config.message}</span>
-      {config.dismissible && (
+      <div className="alert-banner__content">
+        <span className="alert-banner__message">{config.message}</span>
+        {config.linkUrl ? (
+          isInternalLink ? (
+            <Link className="alert-banner__link" to={config.linkUrl}>
+              {linkLabel}
+            </Link>
+          ) : (
+            <a className="alert-banner__link" href={config.linkUrl} rel="noopener noreferrer">
+              {linkLabel}
+            </a>
+          )
+        ) : null}
+      </div>
+      {config.dismissible ? (
         <button
           className="alert-banner__close"
+          type="button"
           onClick={() => setDismissed(true)}
           aria-label="Dismiss alert"
         >
           &times;
         </button>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/components/alertBannerConfig.test.ts
+++ b/src/components/alertBannerConfig.test.ts
@@ -1,0 +1,73 @@
+import {
+  DEFAULT_ALERT_BANNER_CONFIG,
+  isAlertBannerScheduleActive,
+  normalizeAlertBannerConfig,
+} from './alertBannerConfig';
+
+describe('alertBannerConfig', () => {
+  const now = Date.parse('2026-06-01T12:00:00.000Z');
+
+  test('isAlertBannerScheduleActive respects enabled flag', () => {
+    expect(isAlertBannerScheduleActive({ enabled: false }, now)).toBe(false);
+    expect(isAlertBannerScheduleActive({ enabled: true }, now)).toBe(true);
+  });
+
+  test('isAlertBannerScheduleActive respects startsAt and expiresAt', () => {
+    expect(
+      isAlertBannerScheduleActive(
+        {
+          enabled: true,
+          startsAt: '2026-06-01T13:00:00.000Z',
+        },
+        now,
+      ),
+    ).toBe(false);
+
+    expect(
+      isAlertBannerScheduleActive(
+        {
+          enabled: true,
+          expiresAt: '2026-06-01T12:00:00.000Z',
+        },
+        now,
+      ),
+    ).toBe(false);
+
+    expect(
+      isAlertBannerScheduleActive(
+        {
+          enabled: true,
+          startsAt: '2026-06-01T11:00:00.000Z',
+          expiresAt: '2026-06-01T13:00:00.000Z',
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  test('normalizeAlertBannerConfig fills defaults and optional fields', () => {
+    expect(normalizeAlertBannerConfig(null)).toEqual(DEFAULT_ALERT_BANNER_CONFIG);
+
+    expect(
+      normalizeAlertBannerConfig({
+        enabled: true,
+        message: 'Hello',
+        type: 'warning',
+        dismissible: false,
+        linkUrl: '/updates',
+        linkLabel: 'Learn more',
+        startsAt: '2026-06-01T00:00:00.000Z',
+      }),
+    ).toEqual({
+      enabled: true,
+      message: 'Hello',
+      type: 'warning',
+      dismissible: false,
+      id: undefined,
+      linkUrl: '/updates',
+      linkLabel: 'Learn more',
+      startsAt: '2026-06-01T00:00:00.000Z',
+      expiresAt: undefined,
+    });
+  });
+});

--- a/src/components/alertBannerConfig.ts
+++ b/src/components/alertBannerConfig.ts
@@ -1,0 +1,74 @@
+export type AlertBannerType = 'info' | 'warning' | 'error';
+
+export interface AlertBannerConfig {
+  enabled: boolean;
+  message: string;
+  type: AlertBannerType;
+  dismissible: boolean;
+  id?: string;
+  linkUrl?: string;
+  linkLabel?: string;
+  startsAt?: string;
+  expiresAt?: string;
+}
+
+export const DEFAULT_ALERT_BANNER_CONFIG: AlertBannerConfig = {
+  enabled: false,
+  message: '',
+  type: 'info',
+  dismissible: true,
+};
+
+const parseInstant = (value: string | undefined): number | null => {
+  if (!value?.trim()) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+/** Returns false when enabled is off or the current time is outside startsAt/expiresAt. */
+export const isAlertBannerScheduleActive = (
+  config: Pick<AlertBannerConfig, 'enabled' | 'startsAt' | 'expiresAt'>,
+  nowMs: number = Date.now(),
+): boolean => {
+  if (!config.enabled) {
+    return false;
+  }
+
+  const startsAtMs = parseInstant(config.startsAt);
+  if (startsAtMs !== null && nowMs < startsAtMs) {
+    return false;
+  }
+
+  const expiresAtMs = parseInstant(config.expiresAt);
+  if (expiresAtMs !== null && nowMs >= expiresAtMs) {
+    return false;
+  }
+
+  return true;
+};
+
+/** Normalizes fetched JSON into a full config object. */
+export const normalizeAlertBannerConfig = (data: unknown): AlertBannerConfig => {
+  if (!data || typeof data !== 'object') {
+    return { ...DEFAULT_ALERT_BANNER_CONFIG };
+  }
+
+  const raw = data as Record<string, unknown>;
+  const type = raw.type;
+  const allowedType =
+    type === 'info' || type === 'warning' || type === 'error' ? type : DEFAULT_ALERT_BANNER_CONFIG.type;
+
+  return {
+    enabled: raw.enabled === true,
+    message: typeof raw.message === 'string' ? raw.message : '',
+    type: allowedType,
+    dismissible: raw.dismissible !== false,
+    id: typeof raw.id === 'string' ? raw.id : undefined,
+    linkUrl: typeof raw.linkUrl === 'string' ? raw.linkUrl : undefined,
+    linkLabel: typeof raw.linkLabel === 'string' ? raw.linkLabel : undefined,
+    startsAt: typeof raw.startsAt === 'string' ? raw.startsAt : undefined,
+    expiresAt: typeof raw.expiresAt === 'string' ? raw.expiresAt : undefined,
+  };
+};


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/updates-page-v1.6`.

| | |
| --- | --- |
| Original PR | #366 — feat: alert banner links and schedule windows |
| Source branch | `feature/alert-banner-scheduling` (merged into `beta`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `CHANGELOG.md`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/366-to-feature-updates-page-v1.6`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #366, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/updates-page-v1.6` drifting behind `beta`.