### PR TITLE
fix: GFC-WEB-8 outlet context + v1.6 changelog merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to this project will be documented in this file.
 - **Monitor (`/monitor`):** Live weather workspace with radar and satellite WMS layers (site and composite modes, opacity, animation speed), read-only overlay of the active forecast cycle / saved local cycles / premium cloud library outlooks, NWS watches-warnings-advisories layer, and storm reports with hazard filters plus optional outlook-type matching. Redux `monitorSlice`, `MonitorControls` / `MonitorMap`, premium settings sync via `usePremiumMonitorSettingsSync`, and navbar route with shortcut.
 - **Monitor — NWS alerts & storm reports:** `useMonitorNwsAlerts` and `useMonitorStormReports` integrations, panel toggles, and map rendering for alert polygons and report markers.
 - **Monitor — outlook on map:** `buildMonitorOutlookOptions`, cloud outlook fetch hook, and OpenLayers outlook layer styling aligned with forecast outlook types.
+- **What's New page:** Public `/updates` route with v1.6 copy in `src/content/updates/v1.6.ts` and screenshot directory `public/updates/v1.6/` (images optional until marketing adds them).
 
 ### Changed
 - **Analytics server:** Land Express 5 and Stripe Node 22 on beta (`server/analytics.js` / `configureApp`) and shared smoke-test app wiring for CodeQL rate-limit coverage on `/collect`.
+- **Alert banner:** Optional `linkUrl` / `linkLabel`, `startsAt` / `expiresAt` scheduling, and `id` on `public/alert-banner.json`; client normalizes config in `alertBannerConfig.ts`. See `docs/alert-banner.md`.
 
 ### Dependencies
 <!-- dependabot-automation -->
@@ -32,13 +34,8 @@ All notable changes to this project will be documented in this file.
 - **ts-jest:** ^29.4.9 → ^29.4.11
 - **vite:** ^8.0.13 → ^8.0.14
 
-### Added
-- **What's New page:** Public `/updates` route with v1.6 copy in `src/content/updates/v1.6.ts` and screenshot directory `public/updates/v1.6/` (images optional until marketing adds them).
-
-### Changed
-- **Alert banner:** Optional `linkUrl` / `linkLabel`, `startsAt` / `expiresAt` scheduling, and `id` on `public/alert-banner.json`; client normalizes config in `alertBannerConfig.ts`. See `docs/alert-banner.md`.
-
 ### Fixed
+- **GFC-WEB-8 (beta routes after `/updates` split):** `BetaAccessGuard` forwards `AppLayout` outlet context so home, forecast, and other guarded routes can destructure `addToast` again.
 - **Signed-in home (light mode):** Primary gradient “Resume Forecast” buttons use white text instead of `#067aff` on the concept home layout (`.home-concept-top-primary`, `.home-concept-action-primary`).
 - **Analytics server tests:** Share `configureApp` with production so `/collect` stays rate-limited in server smoke tests (fixes CodeQL `js/missing-rate-limiting` on `beta`).
 - **Analytics server (beta):** Restored a broken partial merge in `server/analytics.js` so the hosted collector starts again before Express 5 / Stripe 22 land.

--- a/src/components/Beta/BetaAccessGuard.test.tsx
+++ b/src/components/Beta/BetaAccessGuard.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, Outlet, useOutletContext } from 'react-router-dom';
 import BetaAccessGuard from './BetaAccessGuard';
 import { useAuth } from '../../auth/AuthProvider';
 import { isBetaModeEnabled, isLocalBetaBypassEnabled } from '../../lib/betaAccess';
@@ -96,6 +97,37 @@ describe('BetaAccessGuard', () => {
 
     renderGuard();
     expect(screen.getByText('Beta Page')).toBeInTheDocument();
+  });
+
+  it('forwards parent outlet context to nested routes', async () => {
+    const user = userEvent.setup();
+    const addToast = jest.fn();
+
+    const ContextConsumer = () => {
+      const { addToast: toast } = useOutletContext<{ addToast: typeof addToast }>();
+      return (
+        <button type="button" onClick={() => toast('hello')}>
+          Trigger toast
+        </button>
+      );
+    };
+
+    (isBetaModeEnabled as jest.Mock).mockReturnValue(false);
+
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route element={<Outlet context={{ addToast }} />}>
+            <Route element={<BetaAccessGuard />}>
+              <Route path="/protected" element={<ContextConsumer />} />
+            </Route>
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Trigger toast' }));
+    expect(addToast).toHaveBeenCalledWith('hello');
   });
 
   it.each([

--- a/src/components/Beta/BetaAccessGuard.test.tsx
+++ b/src/components/Beta/BetaAccessGuard.test.tsx
@@ -113,6 +113,13 @@ describe('BetaAccessGuard', () => {
     };
 
     (isBetaModeEnabled as jest.Mock).mockReturnValue(false);
+    (isLocalBetaBypassEnabled as jest.Mock).mockReturnValue(false);
+    (useAuth as jest.Mock).mockReturnValue({
+      hostedAuthEnabled: true,
+      status: 'signed_out',
+      betaAccessLoading: false,
+      betaAccess: false,
+    });
 
     render(
       <MemoryRouter initialEntries={['/protected']}>

--- a/src/components/Beta/BetaAccessGuard.tsx
+++ b/src/components/Beta/BetaAccessGuard.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
-import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useOutletContext } from 'react-router-dom';
+import type { AddToastFn } from '../Layout/AppLayout';
 import { useAuth } from '../../auth/AuthProvider';
 import { isBetaModeEnabled, isLocalBetaBypassEnabled } from '../../lib/betaAccess';
 import { BetaStatusPanel } from './BetaPageLayout';
+
+type AppLayoutOutletContext = { addToast: AddToastFn };
+
+/** Forwards `AppLayout` outlet context through the guard so nested routes keep `addToast`. */
+const GuardedOutlet: React.FC = () => {
+  const layoutContext = useOutletContext<AppLayoutOutletContext>();
+  return <Outlet context={layoutContext} />;
+};
 
 /** True when the beta gate should show an access-check loading state. */
 const isCheckingBetaAccess = (
@@ -22,11 +31,11 @@ const BetaAccessGuard: React.FC = () => {
   const { betaAccess, betaAccessLoading, hostedAuthEnabled, status } = useAuth();
 
   if (!isBetaModeEnabled()) {
-    return <Outlet />;
+    return <GuardedOutlet />;
   }
 
   if (isLocalBetaBypassEnabled(location.search)) {
-    return <Outlet />;
+    return <GuardedOutlet />;
   }
 
   if (!hostedAuthEnabled) {
@@ -43,7 +52,7 @@ const BetaAccessGuard: React.FC = () => {
   }
 
   if (status === 'signed_in' && betaAccess) {
-    return <Outlet />;
+    return <GuardedOutlet />;
   }
 
   return <Navigate to="/beta" replace />;


### PR DESCRIPTION
## Summary

- Fixes GFC-WEB-8: `BetaAccessGuard` forwards `AppLayout` outlet context so guarded routes can use `addToast` from `useOutletContext` again after the `/updates` route split (PR #367).
- Consolidates duplicate v1.6 `CHANGELOG.md` headings (`### Added` / `### Changed`) from the multi-PR merge into single sections.

## Test plan

- [x] `pnpm test -- --runTestsByPath src/components/Beta/BetaAccessGuard.test.tsx src/pages/home/useHomePageLogic.test.tsx`
- [x] CI green on PR
- [x] Verify beta deploy: navigate home, forecast, admin without `addToast` destructuring error

Fixes GFC-WEB-8