### PR TITLE
feat: link What's New in navbar Resources menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ All notable changes to this project will be documented in this file.
 - **Monitor — NWS alerts & storm reports:** `useMonitorNwsAlerts` and `useMonitorStormReports` integrations, panel toggles, and map rendering for alert polygons and report markers.
 - **Monitor — outlook on map:** `buildMonitorOutlookOptions`, cloud outlook fetch hook, and OpenLayers outlook layer styling aligned with forecast outlook types.
 - **What's New page:** Public `/updates` route with v1.6 copy in `src/content/updates/v1.6.ts` and screenshot directory `public/updates/v1.6/` (images optional until marketing adds them).
+- **What's New navigation:** Navbar Resources overflow menu links to `/updates` so the release page is discoverable without typing the URL.
 
 ### Changed
 - **Analytics server:** Land Express 5 and Stripe Node 22 on beta (`server/analytics.js` / `configureApp`) and shared smoke-test app wiring for CodeQL rate-limit coverage on `/collect`.
 - **Alert banner:** Optional `linkUrl` / `linkLabel`, `startsAt` / `expiresAt` scheduling, and `id` on `public/alert-banner.json`; client normalizes config in `alertBannerConfig.ts`. See `docs/alert-banner.md`.
-- **What's New navigation:** Resources overflow menu links to `/updates` so the v1.6 release page is discoverable without typing the URL.
 
 ### Dependencies
 <!-- dependabot-automation -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - **Analytics server:** Land Express 5 and Stripe Node 22 on beta (`server/analytics.js` / `configureApp`) and shared smoke-test app wiring for CodeQL rate-limit coverage on `/collect`.
 - **Alert banner:** Optional `linkUrl` / `linkLabel`, `startsAt` / `expiresAt` scheduling, and `id` on `public/alert-banner.json`; client normalizes config in `alertBannerConfig.ts`. See `docs/alert-banner.md`.
+- **What's New navigation:** Resources overflow menu links to `/updates` so the v1.6 release page is discoverable without typing the URL.
 
 ### Dependencies
 <!-- dependabot-automation -->

--- a/src/components/Layout/NavbarSections.test.tsx
+++ b/src/components/Layout/NavbarSections.test.tsx
@@ -66,6 +66,7 @@ describe('NavbarSections', () => {
     expect(screen.getByLabelText(/Account \(user@example.com\)/i)).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText(/Switch to dark mode/i));
     expect(onToggleDarkMode).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("What's New")).toBeInTheDocument();
     fireEvent.click(screen.getByText('Documentation'));
     expect(onToggleDocumentation).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByText('Terms of Service'));

--- a/src/components/Layout/NavbarSections.test.tsx
+++ b/src/components/Layout/NavbarSections.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { BrandSection, MainTabs, RightActions } from './NavbarSections';
 
 const mockUseAuth = jest.fn();
@@ -17,9 +17,15 @@ jest.mock('../ui/tooltip', () => ({
 jest.mock('../ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({ children, onSelect }: { children: React.ReactNode; onSelect?: () => void }) => (
-    <button onClick={onSelect}>{children}</button>
-  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    asChild,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+    asChild?: boolean;
+  }) => (asChild ? <div>{children}</div> : <button type="button" onClick={onSelect}>{children}</button>),
   DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuSeparator: () => <hr />,
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
@@ -52,21 +58,28 @@ describe('NavbarSections', () => {
     const onViewPrivacyPolicy = jest.fn();
 
     render(
-      <MemoryRouter>
-        <RightActions
-          darkMode={false}
-          onToggleDarkMode={onToggleDarkMode}
-          onToggleDocumentation={onToggleDocumentation}
-          onViewTerms={onViewTerms}
-          onViewPrivacyPolicy={onViewPrivacyPolicy}
-        />
-      </MemoryRouter>
+      <MemoryRouter initialEntries={['/forecast']}>
+        <Routes>
+          <Route
+            path="/forecast"
+            element={
+              <RightActions
+                darkMode={false}
+                onToggleDarkMode={onToggleDarkMode}
+                onToggleDocumentation={onToggleDocumentation}
+                onViewTerms={onViewTerms}
+                onViewPrivacyPolicy={onViewPrivacyPolicy}
+              />
+            }
+          />
+          <Route path="/updates" element={<div>Updates destination</div>} />
+        </Routes>
+      </MemoryRouter>,
     );
 
     expect(screen.getByLabelText(/Account \(user@example.com\)/i)).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText(/Switch to dark mode/i));
     expect(onToggleDarkMode).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("What's New")).toBeInTheDocument();
     fireEvent.click(screen.getByText('Documentation'));
     expect(onToggleDocumentation).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByText('Terms of Service'));
@@ -79,6 +92,10 @@ describe('NavbarSections', () => {
       '_blank',
       'noopener,noreferrer'
     );
+    const whatsNewLink = screen.getByRole('link', { name: /What's New/i });
+    expect(whatsNewLink).toHaveAttribute('href', '/updates');
+    fireEvent.click(whatsNewLink);
+    expect(screen.getByText('Updates destination')).toBeInTheDocument();
   });
 
   test('renders signed-out and dark-mode labels', () => {

--- a/src/components/Layout/NavbarSections.tsx
+++ b/src/components/Layout/NavbarSections.tsx
@@ -16,6 +16,7 @@ import {
   CircleUserRound,
   MoreHorizontal,
   Crown,
+  Sparkles,
 } from 'lucide-react';
 import { Button } from '../ui/button';
 import {
@@ -212,6 +213,12 @@ const MoreActionsMenu: FC<{
         <DropdownMenuItem onSelect={onToggleDocumentation}>
           <HelpCircle className="h-4 w-4" />
           Documentation
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <NavLink to="/updates">
+            <Sparkles className="h-4 w-4" />
+            What&apos;s New
+          </NavLink>
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onViewTerms}>
           <FileText className="h-4 w-4" />


### PR DESCRIPTION
## Summary

- Adds **What's New** under the navbar **⋯ → Resources** menu, linking to `/updates`.
- The page shipped in #367 but had no in-app entry point.

## Test plan

- [x] Navbar section tests
- [ ] On beta: open ⋯ menu → What's New → `/updates` loads
- [ ] Direct URL still works: `/updates`