### PR TITLE
feat: lightbox for What's New release screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - **Monitor — outlook on map:** `buildMonitorOutlookOptions`, cloud outlook fetch hook, and OpenLayers outlook layer styling aligned with forecast outlook types.
 - **What's New page:** Public `/updates` route with v1.6 copy in `src/content/updates/v1.6.ts` and screenshot directory `public/updates/v1.6/` (hero promo image and section screenshots as assets are added).
 - **What's New navigation:** Navbar Resources overflow menu links to `/updates` so the release page is discoverable without typing the URL.
+- **What's New images:** Release screenshots open in a full-size lightbox when clicked so promo and section images remain readable on narrow layouts.
 
 ### Changed
 - **Analytics server:** Land Express 5 and Stripe Node 22 on beta (`server/analytics.js` / `configureApp`) and shared smoke-test app wiring for CodeQL rate-limit coverage on `/collect`.

--- a/src/pages/UpdatesPage.css
+++ b/src/pages/UpdatesPage.css
@@ -82,10 +82,94 @@
   box-shadow: var(--shadow-sm);
 }
 
-.updates-page__figure img {
+.updates-page__figure-button {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: zoom-in;
+  text-align: left;
+}
+
+.updates-page__figure-button:focus-visible {
+  outline: 2px solid var(--button-bg);
+  outline-offset: 2px;
+}
+
+.updates-page__figure-button img {
   display: block;
   width: 100%;
   height: auto;
+}
+
+.updates-page__figure-hint {
+  position: absolute;
+  right: 0.65rem;
+  bottom: 0.65rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 0.35rem;
+  background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.updates-page__lightbox {
+  width: min(96vw, 72rem);
+  max-width: none;
+  max-height: 96vh;
+  padding: 0;
+  border: none;
+  border-radius: 0.75rem;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-lg);
+}
+
+.updates-page__lightbox::backdrop {
+  background: rgba(8, 12, 20, 0.78);
+}
+
+.updates-page__lightbox-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 1rem 1rem 1.15rem;
+}
+
+.updates-page__lightbox-close {
+  align-self: flex-end;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.45rem;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.updates-page__lightbox-close:hover {
+  border-color: var(--button-bg);
+  color: var(--button-bg);
+}
+
+.updates-page__lightbox-image {
+  display: block;
+  width: 100%;
+  max-height: min(78vh, 52rem);
+  object-fit: contain;
+}
+
+.updates-page__lightbox-caption {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
 .updates-page__figure figcaption {

--- a/src/pages/UpdatesPage.css
+++ b/src/pages/UpdatesPage.css
@@ -158,6 +158,12 @@
   color: var(--button-bg);
 }
 
+.updates-page__lightbox-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
 .updates-page__lightbox-image {
   display: block;
   width: 100%;

--- a/src/pages/UpdatesPage.css
+++ b/src/pages/UpdatesPage.css
@@ -121,6 +121,7 @@
   width: min(96vw, 72rem);
   max-width: none;
   max-height: 96vh;
+  overflow-y: auto;
   padding: 0;
   border: none;
   border-radius: 0.75rem;

--- a/src/pages/UpdatesPage.test.tsx
+++ b/src/pages/UpdatesPage.test.tsx
@@ -1,6 +1,16 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import UpdatesPage from './UpdatesPage';
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = jest.fn(function showModal(this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = jest.fn(function close(this: HTMLDialogElement) {
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  });
+});
 
 describe('UpdatesPage', () => {
   test('renders v1.6 headline and improvement list', () => {
@@ -12,16 +22,29 @@ describe('UpdatesPage', () => {
 
     expect(screen.getByRole('heading', { level: 1, name: /Monitor/i })).toBeInTheDocument();
     expect(screen.getByText(/What's new · v1\.6/i)).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /light mode with MRMS reflectivity and GOES visible satellite/i })).toHaveAttribute(
-      'src',
-      '/updates/v1.6/v1.6-promo-image-light-mrms-visible.png',
-    );
-    expect(screen.getByRole('img', { name: /dark mode with single-site reflectivity and GOES shortwave IR satellite/i })).toHaveAttribute(
-      'src',
-      '/updates/v1.6/v1.6-promo-image-dark-single-site-shortwave-ir.png',
-    );
+    expect(screen.getByRole('button', { name: /View larger: Monitor in light mode/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /View larger: Monitor in dark mode/i })).toBeInTheDocument();
+    expect(document.querySelector('img[src="/updates/v1.6/v1.6-promo-image-light-mrms-visible.png"]')).toBeTruthy();
+    expect(document.querySelector('img[src="/updates/v1.6/v1.6-promo-image-dark-single-site-shortwave-ir.png"]')).toBeTruthy();
     expect(screen.getByRole('heading', { name: /Monitor workspace/i })).toBeInTheDocument();
     expect(screen.getByText(/Signed-in home page primary buttons are easier to read/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Back to home/i })).toHaveAttribute('href', '/');
+  });
+
+  test('opens an enlarged preview when a promo image is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <UpdatesPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /View larger:.*light mode/i }));
+
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /light mode with MRMS reflectivity/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Close enlarged image/i }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 });

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { v16Update, type UpdateScreenshot } from '../content/updates/v1.6';
 import './UpdatesPage.css';
@@ -11,6 +11,8 @@ interface UpdateImageLightboxProps {
 /** Full-screen preview for a release screenshot. */
 function UpdateImageLightbox({ shot, onClose }: UpdateImageLightboxProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -23,7 +25,8 @@ function UpdateImageLightbox({ shot, onClose }: UpdateImageLightboxProps) {
     } else {
       dialog.setAttribute('open', '');
     }
-    const handleClose = () => onClose();
+    /** Sync parent state when the native dialog closes. */
+    const handleClose = () => onCloseRef.current();
     dialog.addEventListener('close', handleClose);
 
     return () => {
@@ -32,13 +35,14 @@ function UpdateImageLightbox({ shot, onClose }: UpdateImageLightboxProps) {
         dialog.close();
       }
     };
-  }, [onClose, shot]);
+  }, []);
 
   return (
     <dialog
       ref={dialogRef}
       className="updates-page__lightbox"
-      aria-labelledby="updates-lightbox-caption"
+      aria-labelledby="updates-lightbox-title"
+      aria-describedby="updates-lightbox-caption"
       onClick={(event) => {
         if (event.target === dialogRef.current) {
           dialogRef.current?.close();
@@ -54,12 +58,10 @@ function UpdateImageLightbox({ shot, onClose }: UpdateImageLightboxProps) {
         >
           Close
         </button>
-        <img
-          id="updates-lightbox-image"
-          className="updates-page__lightbox-image"
-          src={shot.src}
-          alt={shot.alt}
-        />
+        <h2 id="updates-lightbox-title" className="updates-page__lightbox-title">
+          Enlarged preview
+        </h2>
+        <img className="updates-page__lightbox-image" src={shot.src} alt={shot.alt} />
         <p id="updates-lightbox-caption" className="updates-page__lightbox-caption">
           {shot.caption ?? shot.alt}
         </p>
@@ -102,6 +104,7 @@ function UpdateScreenshotFigure({ shot, onExpand }: UpdateScreenshotFigureProps)
 /** Public What's New page for the current major release. */
 export const UpdatesPage: React.FC = () => {
   const [expandedShot, setExpandedShot] = useState<UpdateScreenshot | null>(null);
+  const closeLightbox = useCallback(() => setExpandedShot(null), []);
 
   return (
     <div className="updates-page">
@@ -147,7 +150,7 @@ export const UpdatesPage: React.FC = () => {
       </div>
 
       {expandedShot ? (
-        <UpdateImageLightbox shot={expandedShot} onClose={() => setExpandedShot(null)} />
+        <UpdateImageLightbox shot={expandedShot} onClose={closeLightbox} />
       ) : null}
     </div>
   );

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -61,7 +61,14 @@ function UpdateImageLightbox({ shot, onClose }: UpdateImageLightboxProps) {
         <h2 id="updates-lightbox-title" className="updates-page__lightbox-title">
           Enlarged preview
         </h2>
-        <img className="updates-page__lightbox-image" src={shot.src} alt={shot.alt} />
+        <img
+          className="updates-page__lightbox-image"
+          src={shot.src}
+          alt={shot.alt}
+          onError={(event) => {
+            event.currentTarget.style.display = 'none';
+          }}
+        />
         <p id="updates-lightbox-caption" className="updates-page__lightbox-caption">
           {shot.caption ?? shot.alt}
         </p>

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -1,10 +1,80 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { v16Update, type UpdateScreenshot } from '../content/updates/v1.6';
 import './UpdatesPage.css';
 
+interface UpdateImageLightboxProps {
+  shot: UpdateScreenshot;
+  onClose: () => void;
+}
+
+/** Full-screen preview for a release screenshot. */
+function UpdateImageLightbox({ shot, onClose }: UpdateImageLightboxProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return undefined;
+    }
+
+    if (typeof dialog.showModal === 'function') {
+      dialog.showModal();
+    } else {
+      dialog.setAttribute('open', '');
+    }
+    const handleClose = () => onClose();
+    dialog.addEventListener('close', handleClose);
+
+    return () => {
+      dialog.removeEventListener('close', handleClose);
+      if (dialog.open) {
+        dialog.close();
+      }
+    };
+  }, [onClose, shot]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="updates-page__lightbox"
+      aria-labelledby="updates-lightbox-caption"
+      onClick={(event) => {
+        if (event.target === dialogRef.current) {
+          dialogRef.current?.close();
+        }
+      }}
+    >
+      <div className="updates-page__lightbox-panel">
+        <button
+          type="button"
+          className="updates-page__lightbox-close"
+          aria-label="Close enlarged image"
+          onClick={() => dialogRef.current?.close()}
+        >
+          Close
+        </button>
+        <img
+          id="updates-lightbox-image"
+          className="updates-page__lightbox-image"
+          src={shot.src}
+          alt={shot.alt}
+        />
+        <p id="updates-lightbox-caption" className="updates-page__lightbox-caption">
+          {shot.caption ?? shot.alt}
+        </p>
+      </div>
+    </dialog>
+  );
+}
+
+interface UpdateScreenshotFigureProps {
+  shot: UpdateScreenshot;
+  onExpand: (shot: UpdateScreenshot) => void;
+}
+
 /** Renders a release screenshot when the asset exists under public/updates. */
-function UpdateScreenshotFigure({ shot }: { shot: UpdateScreenshot }) {
+function UpdateScreenshotFigure({ shot, onExpand }: UpdateScreenshotFigureProps) {
   const [visible, setVisible] = useState(true);
 
   if (!visible) {
@@ -13,56 +83,74 @@ function UpdateScreenshotFigure({ shot }: { shot: UpdateScreenshot }) {
 
   return (
     <figure className="updates-page__figure">
-      <img src={shot.src} alt={shot.alt} loading="lazy" onError={() => setVisible(false)} />
+      <button
+        type="button"
+        className="updates-page__figure-button"
+        onClick={() => onExpand(shot)}
+        aria-label={`View larger: ${shot.alt}`}
+      >
+        <img src={shot.src} alt="" loading="lazy" onError={() => setVisible(false)} />
+        <span className="updates-page__figure-hint" aria-hidden="true">
+          Click to enlarge
+        </span>
+      </button>
       {shot.caption ? <figcaption>{shot.caption}</figcaption> : null}
     </figure>
   );
 }
 
 /** Public What's New page for the current major release. */
-export const UpdatesPage: React.FC = () => (
-  <div className="updates-page">
-    <div className="updates-page__inner">
-      <p className="updates-page__eyebrow">What&apos;s new · v{v16Update.version}</p>
-      <h1>{v16Update.title}</h1>
-      <p className="updates-page__summary">{v16Update.summary}</p>
+export const UpdatesPage: React.FC = () => {
+  const [expandedShot, setExpandedShot] = useState<UpdateScreenshot | null>(null);
 
-      {v16Update.promoImages?.length ? (
-        <div className="updates-page__promo">
-          {v16Update.promoImages.map((shot) => (
-            <UpdateScreenshotFigure key={shot.src} shot={shot} />
-          ))}
-        </div>
-      ) : null}
+  return (
+    <div className="updates-page">
+      <div className="updates-page__inner">
+        <p className="updates-page__eyebrow">What&apos;s new · v{v16Update.version}</p>
+        <h1>{v16Update.title}</h1>
+        <p className="updates-page__summary">{v16Update.summary}</p>
 
-      {v16Update.sections.map((section) => (
-        <section key={section.title} className="updates-page__section">
-          <h2>{section.title}</h2>
-          <p>{section.body}</p>
-          {section.screenshots?.length ? (
-            <div className="updates-page__shots">
-              {section.screenshots.map((shot) => (
-                <UpdateScreenshotFigure key={shot.src} shot={shot} />
-              ))}
-            </div>
-          ) : null}
+        {v16Update.promoImages?.length ? (
+          <div className="updates-page__promo">
+            {v16Update.promoImages.map((shot) => (
+              <UpdateScreenshotFigure key={shot.src} shot={shot} onExpand={setExpandedShot} />
+            ))}
+          </div>
+        ) : null}
+
+        {v16Update.sections.map((section) => (
+          <section key={section.title} className="updates-page__section">
+            <h2>{section.title}</h2>
+            <p>{section.body}</p>
+            {section.screenshots?.length ? (
+              <div className="updates-page__shots">
+                {section.screenshots.map((shot) => (
+                  <UpdateScreenshotFigure key={shot.src} shot={shot} onExpand={setExpandedShot} />
+                ))}
+              </div>
+            ) : null}
+          </section>
+        ))}
+
+        <section className="updates-page__improvements" aria-labelledby="updates-improvements-heading">
+          <h2 id="updates-improvements-heading">Also improved</h2>
+          <ul>
+            {v16Update.improvements.map((item) => (
+              <li key={item.id}>{item.text}</li>
+            ))}
+          </ul>
         </section>
-      ))}
 
-      <section className="updates-page__improvements" aria-labelledby="updates-improvements-heading">
-        <h2 id="updates-improvements-heading">Also improved</h2>
-        <ul>
-          {v16Update.improvements.map((item) => (
-            <li key={item.id}>{item.text}</li>
-          ))}
-        </ul>
-      </section>
+        <Link className="updates-page__back" to="/">
+          Back to home
+        </Link>
+      </div>
 
-      <Link className="updates-page__back" to="/">
-        Back to home
-      </Link>
+      {expandedShot ? (
+        <UpdateImageLightbox shot={expandedShot} onClose={() => setExpandedShot(null)} />
+      ) : null}
     </div>
-  </div>
-);
+  );
+};
 
 export default UpdatesPage;


### PR DESCRIPTION
## Summary

- Promo and section screenshots on `/updates` are clickable with a "Click to enlarge" hint.
- Opens a native `<dialog>` lightbox with full-size image, caption, Close button, backdrop click, and Escape to dismiss.
- Tests cover open/close flow with jsdom dialog polyfill.

## Test plan

- [ ] Visit `/updates` on beta deploy
- [ ] Click each promo image; verify large preview and caption
- [ ] Close via Close button, backdrop click, and Escape
- [ ] Confirm layout on mobile (portrait) — lightbox fits viewport without horizontal scroll
- [x] `pnpm test -- --runTestsByPath src/pages/UpdatesPage.test.tsx`