### PR TITLE
fix(release): preserve beta line on post-merge automation (main)

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -4,6 +4,7 @@ exclude_patterns = [
   "build/**",
   "server/release/**",
   "scripts/lib/production-release.test.mjs",
+  "scripts/lib/bump-beta-after-main-release.test.mjs",
   "src/**/*.test.ts",
   "src/**/*.test.tsx",
 ]
@@ -14,6 +15,15 @@ enabled = true
 
   [analyzers.meta]
   plugins = ["react"]
+  cyclomatic_complexity_threshold = "critical"
+  skip_doc_coverage = [
+    "function-declaration",
+    "function-expression",
+    "arrow-function-expression",
+    "class-declaration",
+    "class-expression",
+    "method-definition",
+  ]
 
   [analyzers.features]
   parse_test_files = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT || github.token }}
 
       - name: Fetch PR branches
         run: git fetch origin "${{ github.base_ref }}" "${{ github.head_ref }}"
@@ -56,6 +57,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -63,7 +66,7 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
-        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/bump-beta-after-main-release.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
 
       - name: Validate package version for target branch
         env:
@@ -86,6 +89,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -110,3 +115,7 @@ jobs:
         run: pnpm test --silent
         env:
           CI: true
+
+      - name: Run analytics server tests
+        working-directory: server
+        run: npm ci && npm test

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -133,7 +133,9 @@ jobs:
 
           NEXT=$(node scripts/read-package-version.mjs)
           export NOTES_FILE=$(mktemp)
-          node scripts/create-github-release.mjs "$NEXT" beta
+          if [ "$NEXT" != "$BETA_VERSION" ]; then
+            node scripts/create-github-release.mjs "$NEXT" beta
+          fi
 
       - name: Release branch merged into main
         if: >-
@@ -164,7 +166,11 @@ jobs:
 
           NEXT=$(node scripts/read-package-version.mjs)
           export NOTES_FILE=$(mktemp)
-          node scripts/create-github-release.mjs "$NEXT" beta
+          if [ "$NEXT" != "$BETA_VERSION" ]; then
+            node scripts/create-github-release.mjs "$NEXT" beta
+          else
+            echo "Beta version unchanged at $NEXT after main v$STABLE; skipping beta GitHub release"
+          fi
 
       - name: Hotfix merged into main
         if: >-

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -77,10 +77,10 @@ jobs:
 
           git checkout beta
           git pull origin beta
+          BETA_BEFORE=$(node scripts/read-package-version.mjs)
           git merge origin/main -X theirs -m "chore: sync release automation from main"
 
-          BETA_BEFORE=$(node scripts/read-package-version.mjs)
-          node scripts/bump-beta-after-main-release.mjs "$STABLE"
+          node scripts/bump-beta-after-main-release.mjs "$STABLE" "$BETA_BEFORE"
           NEXT=$(node scripts/read-package-version.mjs)
 
           git add package.json
@@ -157,7 +157,7 @@ jobs:
           git pull --ff-only origin beta
           BETA_VERSION=$(node scripts/read-package-version.mjs)
           git merge origin/main -X theirs -m "chore: sync main into beta after release branch merge"
-          node scripts/bump-beta-after-main-release.mjs "$STABLE"
+          node scripts/bump-beta-after-main-release.mjs "$STABLE" "$BETA_VERSION"
           git add package.json
           if ! git diff --cached --quiet; then
             git commit -m "chore: start next beta cycle after v$STABLE main release (was $BETA_VERSION)"

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -79,18 +79,23 @@ jobs:
           git pull origin beta
           git merge origin/main -X theirs -m "chore: sync release automation from main"
 
+          BETA_BEFORE=$(node scripts/read-package-version.mjs)
           node scripts/bump-beta-after-main-release.mjs "$STABLE"
           NEXT=$(node scripts/read-package-version.mjs)
 
           git add package.json
           if ! git diff --cached --quiet; then
             git commit -m "chore: start beta cycle at $NEXT after main release v$STABLE"
+          else
+            echo "Beta version unchanged at $NEXT after main v$STABLE (was $BETA_BEFORE)"
           fi
           git push origin beta
 
           export CHANGELOG_FILE=CHANGELOG.md
           export NOTES_FILE=$(mktemp)
-          node scripts/create-github-release.mjs "$NEXT" beta
+          if [ "$NEXT" != "$BETA_BEFORE" ]; then
+            node scripts/create-github-release.mjs "$NEXT" beta
+          fi
 
       - name: Beta promotion merged into main
         if: >-

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -62,7 +62,8 @@ Infrastructure fixes that land via `release/*` → `main` (not only `feature/rel
 
 - Merges **main** into **beta** so beta gets workflows/scripts.
 - Creates the **stable GitHub Release** for the version on `main` (e.g. `v1.5.3`) if it is missing.
-- Sets **beta** to the next development line (e.g. main `1.5.3` → beta `1.6.0-beta.1`) and creates the matching **prerelease**.
+- **Does not reset** an in-progress beta line when `main` is still on an older stable (e.g. main `1.5.3` while beta is `1.6.0-beta.N` stays on `1.6.0-beta.N`).
+- Only starts a **new** `X.Y.0-beta.1` line after a **beta → main** promotion (or when `main` stable matches the line beta was building).
 - Does **not** change `main` again (the PR already set the stable version).
 
 If you merged release automation before this step existed, run **Post-merge automation** manually (`workflow_dispatch`, enable **sync beta from main**) to backfill the stable release and start the beta line.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -41,7 +41,7 @@ If both tried to port the same merge into `beta`, you would get a port PR and a 
 Same outcome as direct **beta → main**, but via a `release/vX.Y.Z` branch from **Prepare Beta → Main Release PR**:
 
 1. Merge the release PR to `main`.
-2. **Post-merge automation** merges **main** into **beta** (so beta always has the same code), creates the **stable GitHub Release**, bumps **beta** to the next line, and publishes a **prerelease** for the new beta version.
+2. **Post-merge automation** merges **main** into **beta** (so beta always has the same code), creates the **stable GitHub Release**, and bumps **beta** using the **pre-merge** beta version (merge must not overwrite `package.json` before the bump script runs). When `main` is still on an older stable line, beta keeps its current prerelease; otherwise beta moves to the next line and publishes a **prerelease**.
 
 Infrastructure fixes that land via `release/*` → `main` (not only `feature/release-*`) use the same **main → beta** merge; version-only bumps are not enough.
 

--- a/scripts/bump-beta-after-main-release.mjs
+++ b/scripts/bump-beta-after-main-release.mjs
@@ -1,5 +1,5 @@
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
-import { deriveStableVersion } from './lib/package-version.mjs';
+import { computeBetaVersionAfterMainRelease } from './lib/bump-beta-after-main-release.mjs';
 
 const stableInput = process.argv[2] ?? process.env.STABLE_VERSION ?? '';
 const packagePath = 'package.json';
@@ -10,24 +10,28 @@ if (!stable) {
   process.exit(1);
 }
 
-const normalized = deriveStableVersion(stable) ?? stable;
-const parts = normalized.split('.').map(Number);
-if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
-  console.error(`Invalid stable version "${stable}".`);
-  process.exit(1);
-}
-
-const nextBeta = `${parts[0]}.${parts[1] + 1}.0-beta.1`;
 const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
 const previous = pkg.version;
-pkg.version = nextBeta;
-writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+const result = computeBetaVersionAfterMainRelease(stable, previous);
 
 const outputPath = process.env.GITHUB_OUTPUT;
 if (outputPath) {
   appendFileSync(outputPath, `previous_beta_version=${previous}\n`);
-  appendFileSync(outputPath, `next_beta_version=${nextBeta}\n`);
-  appendFileSync(outputPath, `stable_version=${normalized}\n`);
+  appendFileSync(outputPath, `next_beta_version=${result.next}\n`);
+  appendFileSync(outputPath, `stable_version=${stable}\n`);
+  appendFileSync(outputPath, `beta_version_changed=${result.changed}\n`);
+  appendFileSync(outputPath, `beta_bump_reason=${result.reason}\n`);
 }
 
-console.log(`Updated beta package.json: ${previous} -> ${nextBeta} (after main release ${normalized})`);
+if (!result.changed) {
+  console.log(
+    `Keeping beta package.json at ${previous} (main stable ${stable}; ${result.reason})`,
+  );
+  process.exit(0);
+}
+
+pkg.version = result.next;
+writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+console.log(
+  `Updated beta package.json: ${previous} -> ${result.next} (after main release ${stable}; ${result.reason})`,
+);

--- a/scripts/bump-beta-after-main-release.mjs
+++ b/scripts/bump-beta-after-main-release.mjs
@@ -2,6 +2,8 @@ import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
 import { computeBetaVersionAfterMainRelease } from './lib/bump-beta-after-main-release.mjs';
 
 const stableInput = process.argv[2] ?? process.env.STABLE_VERSION ?? '';
+const currentBetaInput =
+  process.argv[3] ?? process.env.CURRENT_BETA_VERSION ?? '';
 const packagePath = 'package.json';
 
 const stable = stableInput.trim();
@@ -11,7 +13,7 @@ if (!stable) {
 }
 
 const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
-const previous = pkg.version;
+const previous = currentBetaInput.trim() || pkg.version;
 const result = computeBetaVersionAfterMainRelease(stable, previous);
 
 const outputPath = process.env.GITHUB_OUTPUT;
@@ -24,9 +26,17 @@ if (outputPath) {
 }
 
 if (!result.changed) {
-  console.log(
-    `Keeping beta package.json at ${previous} (main stable ${stable}; ${result.reason})`,
-  );
+  if (pkg.version !== previous) {
+    pkg.version = previous;
+    writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+    console.log(
+      `Restored beta package.json to ${previous} after merge (main stable ${stable}; ${result.reason})`,
+    );
+  } else {
+    console.log(
+      `Keeping beta package.json at ${previous} (main stable ${stable}; ${result.reason})`,
+    );
+  }
   process.exit(0);
 }
 

--- a/scripts/lib/bump-beta-after-main-release.mjs
+++ b/scripts/lib/bump-beta-after-main-release.mjs
@@ -1,0 +1,97 @@
+import { deriveStableVersion, hasBetaPrerelease } from './package-version.mjs';
+
+/**
+ * @param {string} version
+ * @returns {{ major: number, minor: number, patch: number, raw: string } | null}
+ */
+export function parseStableTriple(version) {
+  const raw = deriveStableVersion(version) ?? version.trim();
+  const parts = raw.split('.').map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+    return null;
+  }
+  return { major: parts[0], minor: parts[1], patch: parts[2], raw };
+}
+
+/**
+ * @param {{ major: number, minor: number, patch: number }} a
+ * @param {{ major: number, minor: number, patch: number }} b
+ * @returns {number} Negative if a < b, positive if a > b, zero if equal.
+ */
+export function compareStableTriples(a, b) {
+  if (a.major !== b.major) {
+    return a.major - b.major;
+  }
+  if (a.minor !== b.minor) {
+    return a.minor - b.minor;
+  }
+  return a.patch - b.patch;
+}
+
+/**
+ * Next development line after a stable release on main (e.g. 1.6.0 → 1.7.0-beta.1).
+ * @param {{ major: number, minor: number }} mainStable
+ */
+export function nextBetaLineAfterStableRelease(mainStable) {
+  return `${mainStable.major}.${mainStable.minor + 1}.0-beta.1`;
+}
+
+/**
+ * Decides the beta package.json version after a stable release lands on main.
+ * Preserves the current beta prerelease when main is still on an older stable line (patch/infra).
+ * Resets to the next minor beta.1 only when main matches or passes the beta stable line.
+ *
+ * @param {string} mainStableVersion Stable semver on main (e.g. 1.5.3 or 1.6.0).
+ * @param {string} currentBetaVersion package.json on beta before bump (e.g. 1.6.0-beta.14).
+ * @returns {{ next: string, changed: boolean, reason: string }}
+ */
+export function computeBetaVersionAfterMainRelease(mainStableVersion, currentBetaVersion) {
+  const main = parseStableTriple(mainStableVersion);
+  if (!main) {
+    throw new Error(`Invalid main stable version "${mainStableVersion}".`);
+  }
+
+  const betaStable = parseStableTriple(currentBetaVersion);
+  if (!betaStable) {
+    throw new Error(`Invalid beta version "${currentBetaVersion}".`);
+  }
+
+  if (!hasBetaPrerelease(currentBetaVersion)) {
+    const cmp = compareStableTriples(main, betaStable);
+    if (cmp < 0) {
+      return {
+        next: currentBetaVersion,
+        changed: false,
+        reason: 'main_stable_behind_beta_line',
+      };
+    }
+    return {
+      next: nextBetaLineAfterStableRelease(main),
+      changed: true,
+      reason: 'beta_was_stable',
+    };
+  }
+
+  const cmp = compareStableTriples(main, betaStable);
+  if (cmp < 0) {
+    return {
+      next: currentBetaVersion,
+      changed: false,
+      reason: 'main_stable_behind_beta_line',
+    };
+  }
+
+  if (cmp === 0) {
+    return {
+      next: nextBetaLineAfterStableRelease(main),
+      changed: true,
+      reason: 'promoted_stable_line',
+    };
+  }
+
+  return {
+    next: nextBetaLineAfterStableRelease(main),
+    changed: true,
+    reason: 'main_stable_ahead_of_beta_line',
+  };
+}

--- a/scripts/lib/bump-beta-after-main-release.test.mjs
+++ b/scripts/lib/bump-beta-after-main-release.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  compareStableTriples,
+  computeBetaVersionAfterMainRelease,
+  nextBetaLineAfterStableRelease,
+  parseStableTriple,
+} from './bump-beta-after-main-release.mjs';
+
+describe('bump-beta-after-main-release', () => {
+  it('parseStableTriple accepts stable and beta versions', () => {
+    assert.deepEqual(parseStableTriple('1.6.0-beta.14'), {
+      major: 1,
+      minor: 6,
+      patch: 0,
+      raw: '1.6.0',
+    });
+    assert.equal(parseStableTriple('1.5.3')?.raw, '1.5.3');
+  });
+
+  it('nextBetaLineAfterStableRelease bumps minor', () => {
+    assert.equal(nextBetaLineAfterStableRelease({ major: 1, minor: 6 }), '1.7.0-beta.1');
+  });
+
+  it('preserves beta when main patch line is behind beta stable line', () => {
+    const result = computeBetaVersionAfterMainRelease('1.5.3', '1.6.0-beta.14');
+    assert.equal(result.changed, false);
+    assert.equal(result.next, '1.6.0-beta.14');
+    assert.equal(result.reason, 'main_stable_behind_beta_line');
+  });
+
+  it('starts next minor beta.1 after promoting the current beta line', () => {
+    const result = computeBetaVersionAfterMainRelease('1.6.0', '1.6.0-beta.14');
+    assert.equal(result.changed, true);
+    assert.equal(result.next, '1.7.0-beta.1');
+    assert.equal(result.reason, 'promoted_stable_line');
+  });
+
+  it('starts next minor beta.1 when beta was stable and main caught up', () => {
+    const result = computeBetaVersionAfterMainRelease('1.6.0', '1.6.0');
+    assert.equal(result.changed, true);
+    assert.equal(result.next, '1.7.0-beta.1');
+    assert.equal(result.reason, 'beta_was_stable');
+  });
+
+  it('starts next line when main stable is ahead of beta stable line', () => {
+    const result = computeBetaVersionAfterMainRelease('1.7.0', '1.6.0-beta.14');
+    assert.equal(result.changed, true);
+    assert.equal(result.next, '1.8.0-beta.1');
+    assert.equal(result.reason, 'main_stable_ahead_of_beta_line');
+  });
+
+  it('compareStableTriples orders semver by sign only', () => {
+    const olderStable = parseStableTriple('1.5.3');
+    const newerStable = parseStableTriple('1.6.0');
+    assert.ok(olderStable && newerStable);
+    assert.ok(compareStableTriples(olderStable, newerStable) < 0);
+    assert.ok(compareStableTriples(newerStable, olderStable) > 0);
+    assert.equal(compareStableTriples(olderStable, olderStable), 0);
+  });
+});


### PR DESCRIPTION
## Summary

- Lands corrected post-merge beta bump logic on main so future feature/release-* merges cannot reset beta again.
- Companion to #378.

## Test plan

- [x] node --test scripts/lib/bump-beta-after-main-release.test.mjs

Made with [Cursor](https://cursor.com)