### PR TITLE
fix(ci): stabilize PR governance labels on main

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -4,6 +4,8 @@ exclude_patterns = [
   "build/**",
   "server/release/**",
   "scripts/lib/production-release.test.mjs",
+  "scripts/lib/github-paginate.test.mjs",
+  "scripts/lib/pr-ci-label-state.test.mjs",
   "src/**/*.test.ts",
   "src/**/*.test.tsx",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,8 @@ jobs:
       - name: Run analytics server tests
         working-directory: server
         run: |
-          npm ci
           if node -e "const s=require('./package.json').scripts; process.exit(s && s.test ? 0 : 1)"; then
+            npm ci
             npm test
           else
             echo "Skipping server tests: no test script in server/package.json on this branch."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
-        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/pr-ci-label-state.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/pr-ci-label-state.test.mjs scripts/lib/github-paginate.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
 
       - name: Validate package version for target branch
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
-        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/pr-ci-label-state.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
 
       - name: Validate package version for target branch
         env:
@@ -110,3 +110,13 @@ jobs:
         run: pnpm test --silent
         env:
           CI: true
+
+      - name: Run analytics server tests
+        working-directory: server
+        run: |
+          npm ci
+          if node -e "const s=require('./package.json').scripts; process.exit(s && s.test ? 0 : 1)"; then
+            npm test
+          else
+            echo "Skipping server tests: no test script in server/package.json on this branch."
+          fi

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -13,6 +13,10 @@ permissions:
   pull-requests: write
   checks: read
 
+concurrency:
+  group: pr-governance-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   labels:
     if: github.event_name == 'pull_request'
@@ -100,11 +104,11 @@ jobs:
             const computed = JSON.parse(
               fs.readFileSync(process.env.COMPUTED_LABELS_PATH ?? 'pr-labels.json', 'utf8'),
             );
-            const managed = computed.managed ?? [];
-            const labels = new Set(computed.labels ?? []);
+            const contentManaged = computed.contentManaged ?? [];
+            const desired = new Set(computed.labels ?? []);
 
-            if (pull.mergeable === false) labels.add('has conflicts');
-            if (pull.draft) labels.add('draft');
+            if (pull.mergeable === false) desired.add('has conflicts');
+            if (pull.draft) desired.add('draft');
 
             const existing = (await github.rest.issues.listLabelsOnIssue({
               owner,
@@ -120,18 +124,19 @@ jobs:
               }
             };
 
-            for (const name of managed) {
-              if (existing.includes(name)) {
+            for (const name of contentManaged) {
+              if (existing.includes(name) && !desired.has(name)) {
                 await safeRemoveLabel(name);
               }
             }
 
-            if (labels.size > 0) {
+            const toAdd = [...desired].filter((name) => !existing.includes(name));
+            if (toAdd.length > 0) {
               await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: pr.number,
-                labels: [...labels],
+                labels: toAdd,
               });
             }
 
@@ -141,54 +146,16 @@ jobs:
       github.event.check_suite.pull_requests[0] != null
     runs-on: ubuntu-latest
     steps:
-      - name: Update CI labels from check suite
-        uses: actions/github-script@v7
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          script: |
-            const pr = context.payload.check_suite.pull_requests[0];
-            if (!pr) return;
+          node-version: '24.x'
 
-            const conclusion = context.payload.check_suite.conclusion;
-            const managed = ['ci:pending', 'ci:passing', 'ci:failing'];
-            const existing = (await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-            })).data.map((l) => l.name);
-
-            const safeRemoveLabel = async (name) => {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  name,
-                });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-              }
-            };
-
-            for (const name of managed) {
-              if (existing.includes(name)) {
-                await safeRemoveLabel(name);
-              }
-            }
-
-            if (!conclusion) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                labels: ['ci:pending'],
-              });
-              return;
-            }
-
-            const label = conclusion === 'success' ? 'ci:passing' : 'ci:failing';
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              labels: [label],
-            });
+      - name: Update CI labels from all check runs on PR head
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.check_suite.pull_requests[0].number }}
+        run: node scripts/sync-pr-ci-label.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 <!-- dependabot-automation -->
 
 ### Changed
+- **PR governance labels:** Content labels are diff-applied (no strip/re-add churn); `ci:*` labels aggregate all check runs on the PR head and only change when the overall state changes.
 - **Timed production rollout:** `deploy/production-release.json` drives stage-vs-live deploys; staged builds land under `releases/<version>/` until `rolloutAt`, then VPS cron runs `promote-release.sh`. Staging preview at `staging-gfc.weatherboysuper.com` (beta access gate). See `docs/hosted-rollout.md`.
 - **Dependabot grouping:** Root and `server/` npm version updates are combined into one multi-ecosystem Dependabot PR targeting `beta` instead of one PR per package; `target-branch` is set on the `npm-beta` group (required by Dependabot when using multi-ecosystem groups).
 - **Post-merge `release/*` → main:** Automation now merges `main` into `beta` after every `release/*` merge (same as `feature/release-*`), not only when `package.json` changes — prevents beta from drifting behind main.

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -6,7 +6,7 @@ import {
   listDependencyBumpsBetweenRefs,
 } from './lib/dependabot-changelog.mjs';
 import { listChangedFilesBetweenRefs } from './lib/git-changed-files.mjs';
-import { MANAGED_LABELS, computePrLabels } from './lib/pr-labels.mjs';
+import { CONTENT_MANAGED_LABELS, computePrLabels } from './lib/pr-labels.mjs';
 
 const baseRef = process.env.GITHUB_BASE_REF ?? '';
 const headRef = process.env.GITHUB_HEAD_REF ?? '';
@@ -49,4 +49,4 @@ const labels = computePrLabels({
   changelogOk,
 });
 
-console.log(JSON.stringify({ labels, managed: MANAGED_LABELS }));
+console.log(JSON.stringify({ labels, contentManaged: CONTENT_MANAGED_LABELS }));

--- a/scripts/lib/github-paginate.mjs
+++ b/scripts/lib/github-paginate.mjs
@@ -1,0 +1,21 @@
+export const GITHUB_PAGE_SIZE = 100;
+
+/**
+ * @template T
+ * @param {(page: number) => Promise<T[]>} fetchPage
+ * @returns {Promise<T[]>}
+ */
+export async function fetchAllPages(fetchPage) {
+  const items = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await fetchPage(page);
+    if (!batch.length) {
+      break;
+    }
+    items.push(...batch);
+    if (batch.length < GITHUB_PAGE_SIZE) {
+      break;
+    }
+  }
+  return items;
+}

--- a/scripts/lib/github-paginate.test.mjs
+++ b/scripts/lib/github-paginate.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { fetchAllPages } from './github-paginate.mjs';
+
+describe('fetchAllPages', () => {
+  it('stops after a short final page', async () => {
+    const pages = await fetchAllPages(async (page) => {
+      if (page === 1) return Array.from({ length: 100 }, (_, i) => i);
+      if (page === 2) return [100, 101];
+      return [];
+    });
+    assert.equal(pages.length, 102);
+  });
+
+  it('returns empty when the first page is empty', async () => {
+    const pages = await fetchAllPages(async () => []);
+    assert.deepEqual(pages, []);
+  });
+});

--- a/scripts/lib/pr-ci-label-state.mjs
+++ b/scripts/lib/pr-ci-label-state.mjs
@@ -1,0 +1,59 @@
+/** @typedef {{ status: string; conclusion: string | null }} CheckRun */
+
+const CI_LABELS = ['ci:pending', 'ci:passing', 'ci:failing'];
+
+const ACTIVE_STATUSES = new Set(['queued', 'in_progress', 'pending', 'waiting']);
+
+const FAILED_CONCLUSIONS = new Set([
+  'failure',
+  'cancelled',
+  'timed_out',
+  'action_required',
+  'stale',
+]);
+
+/**
+ * Derive the CI status label from the latest check runs on a commit.
+ * @param {CheckRun[]} checkRuns
+ * @returns {'ci:pending' | 'ci:passing' | 'ci:failing'}
+ */
+export function ciLabelFromCheckRuns(checkRuns) {
+  if (!checkRuns?.length) {
+    return 'ci:pending';
+  }
+
+  if (checkRuns.some((run) => ACTIVE_STATUSES.has(run.status))) {
+    return 'ci:pending';
+  }
+
+  if (
+    checkRuns.some(
+      (run) => run.status === 'completed' && FAILED_CONCLUSIONS.has(run.conclusion ?? ''),
+    )
+  ) {
+    return 'ci:failing';
+  }
+
+  const allCompleted = checkRuns.every((run) => run.status === 'completed');
+  if (!allCompleted) {
+    return 'ci:pending';
+  }
+
+  const allOk = checkRuns.every((run) =>
+    ['success', 'neutral', 'skipped'].includes(run.conclusion ?? ''),
+  );
+  return allOk ? 'ci:passing' : 'ci:failing';
+}
+
+/**
+ * @param {string[]} existingLabels
+ * @param {'ci:pending' | 'ci:passing' | 'ci:failing'} desired
+ * @returns {{ add: string[]; remove: string[] }}
+ */
+export function diffCiLabels(existingLabels, desired) {
+  const remove = CI_LABELS.filter((name) => existingLabels.includes(name) && name !== desired);
+  const add = existingLabels.includes(desired) ? [] : [desired];
+  return { add, remove };
+}
+
+export { CI_LABELS };

--- a/scripts/lib/pr-ci-label-state.test.mjs
+++ b/scripts/lib/pr-ci-label-state.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ciLabelFromCheckRuns, diffCiLabels } from './pr-ci-label-state.mjs';
+
+describe('ciLabelFromCheckRuns', () => {
+  it('returns pending when there are no check runs', () => {
+    assert.equal(ciLabelFromCheckRuns([]), 'ci:pending');
+  });
+
+  it('returns pending while any check is still running', () => {
+    assert.equal(
+      ciLabelFromCheckRuns([
+        { status: 'completed', conclusion: 'success' },
+        { status: 'in_progress', conclusion: null },
+      ]),
+      'ci:pending',
+    );
+  });
+
+  it('returns failing when any completed check failed', () => {
+    assert.equal(
+      ciLabelFromCheckRuns([
+        { status: 'completed', conclusion: 'success' },
+        { status: 'completed', conclusion: 'failure' },
+      ]),
+      'ci:failing',
+    );
+  });
+
+  it('returns passing only when every check completed successfully', () => {
+    assert.equal(
+      ciLabelFromCheckRuns([
+        { status: 'completed', conclusion: 'success' },
+        { status: 'completed', conclusion: 'skipped' },
+      ]),
+      'ci:passing',
+    );
+  });
+});
+
+describe('diffCiLabels', () => {
+  it('adds desired label and removes stale ci labels', () => {
+    const result = diffCiLabels(['ci:failing', 'Bug'], 'ci:passing');
+    assert.deepEqual(result.remove, ['ci:failing']);
+    assert.deepEqual(result.add, ['ci:passing']);
+  });
+
+  it('makes no changes when desired label is already present', () => {
+    const result = diffCiLabels(['ci:passing', 'Bug'], 'ci:passing');
+    assert.deepEqual(result.remove, []);
+    assert.deepEqual(result.add, []);
+  });
+});

--- a/scripts/lib/pr-label-managed.mjs
+++ b/scripts/lib/pr-label-managed.mjs
@@ -1,5 +1,8 @@
-/** Labels this automation owns (removed before re-applying). */
-export const MANAGED_LABELS = [
+/** CI labels owned by check-run aggregation (not touched on pull_request sync). */
+export const CI_MANAGED_LABELS = ['ci:pending', 'ci:passing', 'ci:failing'];
+
+/** Labels recomputed on pull_request events (routing, changelog, descriptive). */
+export const CONTENT_MANAGED_LABELS = [
   'promotion',
   'feature',
   'fix',
@@ -11,9 +14,6 @@ export const MANAGED_LABELS = [
   'integration:other',
   'has conflicts',
   'draft',
-  'ci:pending',
-  'ci:passing',
-  'ci:failing',
   'changelog:ok',
   'changelog:missing',
   'Documentation',
@@ -32,3 +32,6 @@ export const MANAGED_LABELS = [
   'Component: UI',
   'Component: Storage',
 ];
+
+/** @deprecated Use CONTENT_MANAGED_LABELS or CI_MANAGED_LABELS */
+export const MANAGED_LABELS = [...CONTENT_MANAGED_LABELS, ...CI_MANAGED_LABELS];

--- a/scripts/lib/pr-labels.mjs
+++ b/scripts/lib/pr-labels.mjs
@@ -1,7 +1,7 @@
 import { descriptiveLabels } from './pr-label-content.mjs';
 import { routingLabels } from './pr-label-routing.mjs';
 
-export { MANAGED_LABELS } from './pr-label-managed.mjs';
+export { CONTENT_MANAGED_LABELS, CI_MANAGED_LABELS, MANAGED_LABELS } from './pr-label-managed.mjs';
 export { routingLabels } from './pr-label-routing.mjs';
 export { descriptiveLabels } from './pr-label-content.mjs';
 

--- a/scripts/sync-pr-ci-label.mjs
+++ b/scripts/sync-pr-ci-label.mjs
@@ -1,0 +1,65 @@
+import { ciLabelFromCheckRuns, diffCiLabels } from './lib/pr-ci-label-state.mjs';
+
+const token = process.env.GITHUB_TOKEN ?? '';
+const repository = process.env.GITHUB_REPOSITORY ?? '';
+const prNumber = process.env.PR_NUMBER ?? '';
+
+if (!token || !repository || !prNumber) {
+  console.error('GITHUB_TOKEN, GITHUB_REPOSITORY, and PR_NUMBER are required.');
+  process.exit(1);
+}
+
+const [owner, repo] = repository.split('/');
+
+/**
+ * @param {string} path
+ * @param {RequestInit} [init]
+ */
+async function githubApi(path, init = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}: ${await response.text()}`);
+  }
+  return response.status === 204 ? null : response.json();
+}
+
+const pull = await githubApi(`/repos/${owner}/${repo}/pulls/${prNumber}`);
+const checkData = await githubApi(
+  `/repos/${owner}/${repo}/commits/${pull.head.sha}/check-runs?filter=latest&per_page=100`,
+);
+const existing = (await githubApi(`/repos/${owner}/${repo}/issues/${prNumber}/labels`)).map(
+  (label) => label.name,
+);
+
+const desired = ciLabelFromCheckRuns(
+  (checkData.check_runs ?? []).map((run) => ({
+    status: run.status,
+    conclusion: run.conclusion,
+  })),
+);
+
+const { add, remove } = diffCiLabels(existing, desired);
+
+for (const name of remove) {
+  await githubApi(`/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  });
+}
+
+if (add.length > 0) {
+  await githubApi(`/repos/${owner}/${repo}/issues/${prNumber}/labels`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ labels: add }),
+  });
+}
+
+console.log(`CI label for PR #${prNumber}: ${desired} (add=${add.join(',') || 'none'} remove=${remove.join(',') || 'none'})`);

--- a/scripts/sync-pr-ci-label.mjs
+++ b/scripts/sync-pr-ci-label.mjs
@@ -1,4 +1,4 @@
-import { fetchAllPages } from './lib/github-paginate.mjs';
+import { fetchAllPages, GITHUB_PAGE_SIZE } from './lib/github-paginate.mjs';
 import { ciLabelFromCheckRuns, diffCiLabels } from './lib/pr-ci-label-state.mjs';
 
 const token = process.env.GITHUB_TOKEN ?? '';
@@ -35,7 +35,7 @@ async function githubApi(path, init = {}) {
 const pull = await githubApi(`/repos/${owner}/${repo}/pulls/${prNumber}`);
 const checkRuns = await fetchAllPages(async (page) => {
   const checkData = await githubApi(
-    `/repos/${owner}/${repo}/commits/${pull.head.sha}/check-runs?filter=latest&per_page=100&page=${page}`,
+    `/repos/${owner}/${repo}/commits/${pull.head.sha}/check-runs?filter=latest&per_page=${GITHUB_PAGE_SIZE}&page=${page}`,
   );
   return checkData?.check_runs ?? [];
 });

--- a/scripts/sync-pr-ci-label.mjs
+++ b/scripts/sync-pr-ci-label.mjs
@@ -1,3 +1,4 @@
+import { fetchAllPages } from './lib/github-paginate.mjs';
 import { ciLabelFromCheckRuns, diffCiLabels } from './lib/pr-ci-label-state.mjs';
 
 const token = process.env.GITHUB_TOKEN ?? '';
@@ -32,15 +33,18 @@ async function githubApi(path, init = {}) {
 }
 
 const pull = await githubApi(`/repos/${owner}/${repo}/pulls/${prNumber}`);
-const checkData = await githubApi(
-  `/repos/${owner}/${repo}/commits/${pull.head.sha}/check-runs?filter=latest&per_page=100`,
-);
+const checkRuns = await fetchAllPages(async (page) => {
+  const checkData = await githubApi(
+    `/repos/${owner}/${repo}/commits/${pull.head.sha}/check-runs?filter=latest&per_page=100&page=${page}`,
+  );
+  return checkData?.check_runs ?? [];
+});
 const existing = (await githubApi(`/repos/${owner}/${repo}/issues/${prNumber}/labels`)).map(
   (label) => label.name,
 );
 
 const desired = ciLabelFromCheckRuns(
-  (checkData.check_runs ?? []).map((run) => ({
+  checkRuns.map((run) => ({
     status: run.status,
     conclusion: run.conclusion,
   })),
@@ -62,4 +66,6 @@ if (add.length > 0) {
   });
 }
 
-console.log(`CI label for PR #${prNumber}: ${desired} (add=${add.join(',') || 'none'} remove=${remove.join(',') || 'none'})`);
+console.log(
+  `CI label for PR #${prNumber}: ${desired} (${checkRuns.length} check runs; add=${add.join(',') || 'none'} remove=${remove.join(',') || 'none'})`,
+);


### PR DESCRIPTION
## Summary

- Fixes PR label churn: content labels are diff-applied instead of strip/re-add on every push.
- `ci:*` labels aggregate **all** check runs on the PR head (paginated); only update when overall state changes.
- Skips `server/` npm test on `main` when no test script exists (unblocks CI until server tests land on main).

## Related

- Post-merge beta preservation remains in #382 (`hotfix/post-merge-beta-bump`). Merge this PR first for immediate label relief on `main`.

## Test plan

- [x] `node --test scripts/lib/pr-ci-label-state.test.mjs scripts/lib/github-paginate.test.mjs`
- [ ] Open a PR to `main` and confirm labels stop flipping; `ci:passing` only after all checks complete