### PR TITLE
[Port][Conflicts] fix(release): preserve beta line on post-merge automation (main) → beta

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,6 +5,11 @@ exclude_patterns = [
   "server/release/**",
   "scripts/lib/production-release.test.mjs",
   "scripts/lib/bump-beta-after-main-release.test.mjs",
+<<<<<<< HEAD
+=======
+  "scripts/lib/github-paginate.test.mjs",
+  "scripts/lib/pr-ci-label-state.test.mjs",
+>>>>>>> 8f39310 (fix(release): preserve beta line when main stable is behind beta)
   "src/**/*.test.ts",
   "src/**/*.test.tsx",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,11 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
+<<<<<<< HEAD
         run: node --test scripts/lib/package-version.test.mjs scripts/lib/bump-beta-after-main-release.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
+=======
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/bump-beta-after-main-release.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/pr-ci-label-state.test.mjs scripts/lib/github-paginate.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
+>>>>>>> 8f39310 (fix(release): preserve beta line when main stable is behind beta)
 
       - name: Validate package version for target branch
         env:

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -80,7 +80,12 @@ jobs:
           BETA_BEFORE=$(node scripts/read-package-version.mjs)
           git merge origin/main -X theirs -m "chore: sync release automation from main"
 
+<<<<<<< HEAD
           node scripts/bump-beta-after-main-release.mjs "$STABLE" "$BETA_BEFORE"
+=======
+          BETA_BEFORE=$(node scripts/read-package-version.mjs)
+          node scripts/bump-beta-after-main-release.mjs "$STABLE"
+>>>>>>> 8f39310 (fix(release): preserve beta line when main stable is behind beta)
           NEXT=$(node scripts/read-package-version.mjs)
 
           git add package.json

--- a/scripts/bump-beta-after-main-release.mjs
+++ b/scripts/bump-beta-after-main-release.mjs
@@ -13,7 +13,11 @@ if (!stable) {
 }
 
 const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+<<<<<<< HEAD
 const previous = currentBetaInput.trim() || pkg.version;
+=======
+const previous = pkg.version;
+>>>>>>> 8f39310 (fix(release): preserve beta line when main stable is behind beta)
 const result = computeBetaVersionAfterMainRelease(stable, previous);
 
 const outputPath = process.env.GITHUB_OUTPUT;
@@ -26,6 +30,7 @@ if (outputPath) {
 }
 
 if (!result.changed) {
+<<<<<<< HEAD
   if (pkg.version !== previous) {
     pkg.version = previous;
     writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
@@ -37,6 +42,11 @@ if (!result.changed) {
       `Keeping beta package.json at ${previous} (main stable ${stable}; ${result.reason})`,
     );
   }
+=======
+  console.log(
+    `Keeping beta package.json at ${previous} (main stable ${stable}; ${result.reason})`,
+  );
+>>>>>>> 8f39310 (fix(release): preserve beta line when main stable is behind beta)
   process.exit(0);
 }
 


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #382 — fix(release): preserve beta line on post-merge automation (main) |
| Source branch | `hotfix/post-merge-beta-bump` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `.deepsource.toml`
- `.github/workflows/ci.yml`
- `.github/workflows/post-merge-automation.yml`
- `scripts/bump-beta-after-main-release.mjs`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/382-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #382, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.