### PR TITLE
hotfix: pre-release maintenance banner

### DIFF
--- a/public/alert-banner.json
+++ b/public/alert-banner.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "message": "Intermittent maintenance may occur through tomorrow (June 5) at 3:00 PM Central while we prepare the site. Brief interruptions are possible.",
+  "message": "Intermittent maintenance may occur through 3:00 PM Central today (June 3). Brief interruptions are possible.",
   "type": "warning",
   "dismissible": true
 }

--- a/public/alert-banner.json
+++ b/public/alert-banner.json
@@ -1,6 +1,6 @@
 {
-  "enabled": false,
-  "message": "",
-  "type": "info",
+  "enabled": true,
+  "message": "Intermittent maintenance may occur through tomorrow (June 5) at 3:00 PM Central while we prepare the site. Brief interruptions are possible.",
+  "type": "warning",
   "dismissible": true
 }


### PR DESCRIPTION
## Summary

- Enables a production warning banner: intermittent maintenance through **3:00 PM Central today (June 3)**.
- No version tease or social link.

## Changelog

- **PR record only (not added to CHANGELOG.md):** Enabled production alert-banner.json maintenance warning for intermittent work through 3:00 PM Central on June 3. Ops/comms hotfix; no user-facing product release note.

## Deploy

Merge triggers Deploy Production to VPS and updates live alert-banner.json.

## v1.6 promote (separate beta→main PR)

- If go-live stays **tomorrow June 4 at 3:00 PM Central**: rolloutAt `2026-06-04T20:00:00.000Z`