### PR TITLE
fix: DeepSource follow-up after #402

### DIFF
--- a/src/monitor/useRadarSiteOptions.ts
+++ b/src/monitor/useRadarSiteOptions.ts
@@ -14,7 +14,6 @@ export const useRadarSiteOptions = () => {
       .then((options) => {
         if (active) {
           setSites(options);
-          setError(undefined);
         }
       })
       .catch(() => {

--- a/src/monitor/useWmsLayerPlayback.ts
+++ b/src/monitor/useWmsLayerPlayback.ts
@@ -1,7 +1,6 @@
 import { useEffect, type Dispatch, type SetStateAction } from 'react';
 import type { AddToastFn } from '../components/Layout';
-import * as wms from './wms';
-import type { WmsLayerConfig } from './wms';
+import { fetchLayerTimeValues, selectAnimationFrameTimes, type WmsLayerConfig } from './wms';
 
 export interface LayerPlaybackState {
   frameTimes: string[];
@@ -63,13 +62,13 @@ export const useLoadWmsLayerFrames = ({
     setPlayback(emptyPlayback());
 
     if (config) {
-      wms.fetchLayerTimeValues(config)
+      fetchLayerTimeValues(config)
         .then((timeValues) => {
           if (!active) {
             return undefined;
           }
 
-          const frameTimes = wms.selectAnimationFrameTimes(timeValues);
+          const frameTimes = selectAnimationFrameTimes(timeValues);
           setPlayback({
             frameTimes,
             frameIndex: Math.max(0, frameTimes.length - 1),

--- a/src/pages/MonitorPage.tsx
+++ b/src/pages/MonitorPage.tsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useOutletContext } from 'react-router-dom';
 import type { RootState, AppDispatch } from '../store';
 import {
-  applyMonitorSettings,
   setAnimationEnabled,
   setAnimationSpeedMs,
   setMonitorOutlookSource,


### PR DESCRIPTION
## Summary

Follow-up to #402: three small DeepSource fixes on the monitor path.

- Remove redundant `setError(undefined)` in `useRadarSiteOptions` (success path only runs on initial mount).
- Import `fetchLayerTimeValues` and `selectAnimationFrameTimes` directly in `useWmsLayerPlayback` instead of namespace import.
- Drop unused `applyMonitorSettings` import from `MonitorPage` (hydration stays in `useLocalMonitorSettings`).

## Changelog

- Minor DeepSource cleanup on monitor hooks and Monitor page imports after v1.6 DeepSource batch merge.

## Test plan

- [x] `useLiveWmsLayers` and `MonitorPage` unit tests
- [ ] DeepSource green on this PR