### PR TITLE
fix(deploy): staging analytics releases directory missing on stage deploy

### DIFF
--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -257,6 +257,7 @@ jobs:
             /var/www/gfc-staging/releases \
             /opt/gfc-analytics/releases \
             /opt/gfc-analytics/config \
+            /opt/gfc-staging-analytics/releases \
             /opt/gfc-staging-analytics/config \
             /opt/gfc-staging-analytics/logs"
 

--- a/scripts/setup-vps.sh
+++ b/scripts/setup-vps.sh
@@ -14,6 +14,7 @@ mkdir -p /var/www/gfc-staging/releases
 mkdir -p /opt/gfc-analytics/releases
 mkdir -p /opt/gfc-analytics/config
 mkdir -p /opt/gfc-analytics/logs
+mkdir -p /opt/gfc-staging-analytics/releases
 mkdir -p /opt/gfc-staging-analytics/config
 mkdir -p /opt/gfc-staging-analytics/logs
 


### PR DESCRIPTION
## Summary

Fixes production deploy failure on v1.6 stage rollout: rsync could not create `/opt/gfc-staging-analytics/releases/<version>` because the parent `releases` directory was never created in the stage job's pre-flight `mkdir -p` (only `config` and `logs` were).

## Changelog

- Fix staged VPS deploy by creating `/opt/gfc-staging-analytics/releases` before server rsync; align `setup-vps.sh`.

## Test plan

- [ ] Merge to `main`
- [ ] On VPS (one-time if needed before workflow re-run): `mkdir -p /opt/gfc-staging-analytics/releases`
- [ ] Re-run failed **Deploy Production to VPS** workflow (push or workflow_dispatch, `deploy_action=auto`)
- [ ] Confirm stage step completes and `gfc-staging-analytics` pm2 starts