### PR TITLE
fix: make hotfix deploys go live on main

### DIFF
--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -6,7 +6,7 @@ name: Post-merge automation
 # beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
 # release/* → main: merge main into beta, stable release + next beta line + prerelease.
 # feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.
-# hotfix/*|fix/* → main: patch bump on main + stable release.
+# hotfix/* → main: patch bump on main + stable release.
 # feature/release-*|workflow_dispatch: sync main→beta, stable release for main, prerelease for new beta.
 #
 # Required secret: GH_PAT (repo scope)
@@ -176,8 +176,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
-          (startsWith(github.event.pull_request.head.ref, 'hotfix/') ||
-            startsWith(github.event.pull_request.head.ref, 'fix/'))
+          startsWith(github.event.pull_request.head.ref, 'hotfix/')
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -186,7 +186,27 @@ jobs:
           PREVIOUS=$(node scripts/read-package-version.mjs)
           node scripts/apply-version-bump.mjs main
           STABLE=$(node scripts/read-package-version.mjs)
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const manifestPath = 'deploy/production-release.json';
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+          const version = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+
+          const liveManifest = {
+            ...manifest,
+            releaseId: `v${version}`,
+            version,
+            action: 'live',
+            status: 'live',
+          };
+
+          delete liveManifest.rolloutAt;
+          delete liveManifest.banner;
+
+          fs.writeFileSync(manifestPath, `${JSON.stringify(liveManifest, null, 2)}\n`);
+          NODE
           git add package.json
+          git add deploy/production-release.json
           git commit -m "chore: bump patch version after hotfix merge (was $PREVIOUS)"
           git push origin main
 

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -180,6 +180,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
+          set -euo pipefail
           git fetch origin main
           git checkout main
           git pull --ff-only origin main
@@ -207,7 +208,7 @@ jobs:
           NODE
           git add package.json
           git add deploy/production-release.json
-          git commit -m "chore: bump patch version after hotfix merge (was $PREVIOUS)"
+          git commit -m "chore: bump patch version and go live after hotfix merge (was $PREVIOUS)"
           git push origin main
 
           export NOTES_FILE=$(mktemp)

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -6,7 +6,7 @@ name: Post-merge automation
 # beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
 # release/* → main: merge main into beta, stable release + next beta line + prerelease.
 # feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.
-# hotfix/* → main: patch bump on main + stable release.
+# hotfix/*|fix/* → main: patch bump on main + stable release.
 # feature/release-*|workflow_dispatch: sync main→beta, stable release for main, prerelease for new beta.
 #
 # Required secret: GH_PAT (repo scope)
@@ -176,7 +176,8 @@ jobs:
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
-          startsWith(github.event.pull_request.head.ref, 'hotfix/')
+          (startsWith(github.event.pull_request.head.ref, 'hotfix/') ||
+            startsWith(github.event.pull_request.head.ref, 'fix/'))
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphical-forecast-creator",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"


### PR DESCRIPTION
Hotfix branch for the deploy automation fix. This makes hotfix merges update the live manifest so the VPS swaps the live current symlink to the new release instead of leaving the site on the previous staged version.

## Changelog

- Hotfix merges to main now write a live production-release manifest before pushing the patch bump.
- The workflow now fails fast if the live-manifest write step errors.
- The commit message now reflects both the version bump and the live deploy flip.