### PR TITLE
[Port][Conflicts] fix: make hotfix deploys go live on main → beta

### DIFF
--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -6,7 +6,7 @@ name: Post-merge automation
 # beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
 # release/* → main: merge main into beta, stable release + next beta line + prerelease.
 # feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.
-# hotfix/*|fix/* → main: patch bump on main + stable release.
+# hotfix/* → main: patch bump on main + stable release.
 # feature/release-*|workflow_dispatch: sync main→beta, stable release for main, prerelease for new beta.
 #
 # Required secret: GH_PAT (repo scope)
@@ -176,8 +176,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
-          (startsWith(github.event.pull_request.head.ref, 'hotfix/') ||
-            startsWith(github.event.pull_request.head.ref, 'fix/'))
+          startsWith(github.event.pull_request.head.ref, 'hotfix/')
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -186,7 +186,27 @@ jobs:
           PREVIOUS=$(node scripts/read-package-version.mjs)
           node scripts/apply-version-bump.mjs main
           STABLE=$(node scripts/read-package-version.mjs)
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const manifestPath = 'deploy/production-release.json';
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+          const version = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+
+          const liveManifest = {
+            ...manifest,
+            releaseId: `v${version}`,
+            version,
+            action: 'live',
+            status: 'live',
+          };
+
+          delete liveManifest.rolloutAt;
+          delete liveManifest.banner;
+
+          fs.writeFileSync(manifestPath, `${JSON.stringify(liveManifest, null, 2)}\n`);
+          NODE
           git add package.json
+          git add deploy/production-release.json
           git commit -m "chore: bump patch version after hotfix merge (was $PREVIOUS)"
           git push origin main
 

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -6,7 +6,7 @@ name: Post-merge automation
 # beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
 # release/* → main: merge main into beta, stable release + next beta line + prerelease.
 # feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.
-# hotfix/* → main: patch bump on main + stable release.
+# hotfix/*|fix/* → main: patch bump on main + stable release.
 # feature/release-*|workflow_dispatch: sync main→beta, stable release for main, prerelease for new beta.
 #
 # Required secret: GH_PAT (repo scope)
@@ -176,7 +176,8 @@ jobs:
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'main' &&
-          startsWith(github.event.pull_request.head.ref, 'hotfix/')
+          (startsWith(github.event.pull_request.head.ref, 'hotfix/') ||
+            startsWith(github.event.pull_request.head.ref, 'fix/'))
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "graphical-forecast-creator",
+<<<<<<< HEAD
   "version": "1.7.0-beta.1",
+=======
+  "version": "1.6.1",
+>>>>>>> 5a8a0d3 (fix: make hotfix deploys go live on main)
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #410 — fix: make hotfix deploys go live on main |
| Source branch | `hotfix/post-merge-automation-live` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `package.json`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/410-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #410, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.