### PR TITLE
[Port][Conflicts] hotfix: resolve removeChild NotFoundError on OpenLayers maps → beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 
 All notable changes to this project will be documented in this file.
 
-<<<<<<< HEAD
 ## Unreleased
 ### Dependencies
 <!-- dependabot-automation -->
@@ -21,12 +20,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Added Google Analytics entry to deployment
-=======
-## v1.6.4
 
 ### Fixed
 - **OpenLayers map stability (GFC-WEB-5, GFC-WEB-9, GFC-WEB-C):** Completed the Monitor map popup fix by rendering NWS alert overlays imperatively instead of portaling React into OpenLayers-moved DOM nodes. Hardened map teardown order and marked map shells `notranslate` so Chrome auto-translate is less likely to trigger `removeChild` errors on forecast, verification, and monitor maps.
->>>>>>> 426a8b7 (chore: bump to v1.6.4 and document OpenLayers map hotfix)
 
 ## v1.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 All notable changes to this project will be documented in this file.
 
+<<<<<<< HEAD
 ## Unreleased
 ### Dependencies
 <!-- dependabot-automation -->
@@ -20,6 +21,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Added Google Analytics entry to deployment
+=======
+## v1.6.4
+
+### Fixed
+- **OpenLayers map stability (GFC-WEB-5, GFC-WEB-9, GFC-WEB-C):** Completed the Monitor map popup fix by rendering NWS alert overlays imperatively instead of portaling React into OpenLayers-moved DOM nodes. Hardened map teardown order and marked map shells `notranslate` so Chrome auto-translate is less likely to trigger `removeChild` errors on forecast, verification, and monitor maps.
+>>>>>>> 426a8b7 (chore: bump to v1.6.4 and document OpenLayers map hotfix)
 
 ## v1.6.1
 

--- a/deploy/production-release.json
+++ b/deploy/production-release.json
@@ -1,6 +1,6 @@
 {
-  "releaseId": "v1.6.3",
-  "version": "1.6.3",
+  "releaseId": "v1.6.4",
+  "version": "1.6.4",
   "action": "live",
   "status": "live",
   "strategy": "instant"

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/png" href="/cloud.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#1a237e" />
+    <meta name="google" content="notranslate" />
     <meta
       name="description"
       content="Graphical Forecast Creator — Create, save, and verify SPC-style severe weather outlooks with multi-day cycle management, storm report verification, and forecast discussion tools."

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "graphical-forecast-creator",
-<<<<<<< HEAD
   "version": "1.7.0-beta.4",
-=======
-  "version": "1.6.4",
->>>>>>> 426a8b7 (chore: bump to v1.6.4 and document OpenLayers map hotfix)
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "graphical-forecast-creator",
+<<<<<<< HEAD
   "version": "1.7.0-beta.4",
+=======
+  "version": "1.6.4",
+>>>>>>> 426a8b7 (chore: bump to v1.6.4 and document OpenLayers map hotfix)
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"

--- a/scripts/lib/port-pr-policy.mjs
+++ b/scripts/lib/port-pr-policy.mjs
@@ -43,6 +43,7 @@ export const postMergeOwnsMainToBetaSync = (sourceHeadRef) =>
  *   baseRef: string;
  *   sourcePrBaseRef: string;
  *   sourcePrHeadRef: string;
+ *   betaContainsMain?: boolean;
  * }} context
  */
 export const isRedundantBetaPortPr = ({
@@ -50,11 +51,13 @@ export const isRedundantBetaPortPr = ({
   baseRef,
   sourcePrBaseRef,
   sourcePrHeadRef,
+  betaContainsMain = true,
 }) =>
   targetBranch === 'beta' &&
   baseRef === 'beta' &&
   sourcePrBaseRef === 'main' &&
-  postMergeOwnsMainToBetaSync(sourcePrHeadRef);
+  postMergeOwnsMainToBetaSync(sourcePrHeadRef) &&
+  betaContainsMain;
 
 /**
  * @param {{
@@ -64,6 +67,7 @@ export const isRedundantBetaPortPr = ({
  *   sourcePrHeadRef: string;
  *   sourcePrBaseRef: string;
  *   sourcePrNumber: number;
+ *   betaContainsMain?: boolean;
  * }} context
  */
 export const evaluatePortPrPolicy = ({
@@ -73,6 +77,7 @@ export const evaluatePortPrPolicy = ({
   sourcePrHeadRef,
   sourcePrBaseRef,
   sourcePrNumber,
+  betaContainsMain = true,
 }) => {
   if (!parsePortBranch(headRef)) {
     return { ok: true };
@@ -84,6 +89,7 @@ export const evaluatePortPrPolicy = ({
       baseRef,
       sourcePrBaseRef,
       sourcePrHeadRef,
+      betaContainsMain,
     })
   ) {
     return {

--- a/scripts/lib/port-pr-policy.test.mjs
+++ b/scripts/lib/port-pr-policy.test.mjs
@@ -68,29 +68,23 @@ describe('port PR policy', () => {
     assert.equal(result.ok, false);
   });
 
-  it('blocks hotfix ports into beta when main is already on beta', () => {
-    const result = evaluatePortPrPolicy({
+  it('evaluates hotfix ports into beta based on whether main is on beta', () => {
+    const hotfixPort = {
       headRef: 'port/99-to-beta',
       baseRef: 'beta',
       targetBranch: 'beta',
       sourcePrHeadRef: 'hotfix/patch',
       sourcePrBaseRef: 'main',
       sourcePrNumber: 99,
-      betaContainsMain: true,
-    });
-    assert.equal(result.ok, false);
-  });
+    };
 
-  it('allows hotfix ports into beta when post-merge sync has not landed', () => {
-    const result = evaluatePortPrPolicy({
-      headRef: 'port/421-to-beta',
-      baseRef: 'beta',
-      targetBranch: 'beta',
-      sourcePrHeadRef: 'hotfix/sentry-gfc-web-5-removechild-regression',
-      sourcePrBaseRef: 'main',
-      sourcePrNumber: 421,
-      betaContainsMain: false,
-    });
-    assert.equal(result.ok, true);
+    assert.equal(
+      evaluatePortPrPolicy({ ...hotfixPort, betaContainsMain: true }).ok,
+      false,
+    );
+    assert.equal(
+      evaluatePortPrPolicy({ ...hotfixPort, betaContainsMain: false }).ok,
+      true,
+    );
   });
 });

--- a/scripts/lib/port-pr-policy.test.mjs
+++ b/scripts/lib/port-pr-policy.test.mjs
@@ -68,7 +68,7 @@ describe('port PR policy', () => {
     assert.equal(result.ok, false);
   });
 
-  it('blocks hotfix ports into beta', () => {
+  it('blocks hotfix ports into beta when main is already on beta', () => {
     const result = evaluatePortPrPolicy({
       headRef: 'port/99-to-beta',
       baseRef: 'beta',
@@ -76,7 +76,21 @@ describe('port PR policy', () => {
       sourcePrHeadRef: 'hotfix/patch',
       sourcePrBaseRef: 'main',
       sourcePrNumber: 99,
+      betaContainsMain: true,
     });
     assert.equal(result.ok, false);
+  });
+
+  it('allows hotfix ports into beta when post-merge sync has not landed', () => {
+    const result = evaluatePortPrPolicy({
+      headRef: 'port/421-to-beta',
+      baseRef: 'beta',
+      targetBranch: 'beta',
+      sourcePrHeadRef: 'hotfix/sentry-gfc-web-5-removechild-regression',
+      sourcePrBaseRef: 'main',
+      sourcePrNumber: 421,
+      betaContainsMain: false,
+    });
+    assert.equal(result.ok, true);
   });
 });

--- a/scripts/validate-port-pr-policy.mjs
+++ b/scripts/validate-port-pr-policy.mjs
@@ -39,9 +39,16 @@ try {
 
 const sourcePr = JSON.parse(sourcePrJson);
 
-let betaContainsMain = true;
 try {
   execFileSync('git', ['fetch', 'origin', 'beta', 'main'], { stdio: 'ignore' });
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Port PR policy: could not fetch origin/beta and origin/main — ${message}`);
+  process.exit(1);
+}
+
+let betaContainsMain = true;
+try {
   execFileSync('git', ['merge-base', '--is-ancestor', 'origin/main', 'origin/beta']);
 } catch {
   betaContainsMain = false;

--- a/scripts/validate-port-pr-policy.mjs
+++ b/scripts/validate-port-pr-policy.mjs
@@ -38,6 +38,15 @@ try {
 }
 
 const sourcePr = JSON.parse(sourcePrJson);
+
+let betaContainsMain = true;
+try {
+  execFileSync('git', ['fetch', 'origin', 'beta', 'main'], { stdio: 'ignore' });
+  execFileSync('git', ['merge-base', '--is-ancestor', 'origin/main', 'origin/beta']);
+} catch {
+  betaContainsMain = false;
+}
+
 const result = evaluatePortPrPolicy({
   headRef,
   baseRef,
@@ -45,6 +54,7 @@ const result = evaluatePortPrPolicy({
   sourcePrHeadRef: sourcePr.headRefName,
   sourcePrBaseRef: sourcePr.baseRefName,
   sourcePrNumber: parsed.sourcePrNumber,
+  betaContainsMain,
 });
 
 if (!result.ok) {

--- a/src/components/Map/Legend.tsx
+++ b/src/components/Map/Legend.tsx
@@ -141,6 +141,7 @@ const Legend: React.FC<LegendProps> = React.memo(({
       className={`map-legend ${desktopOpen ? '' : 'map-legend--desktop-hidden'} ${mobileOpen ? 'map-legend--mobile-open' : ''}`}
       role="complementary"
       aria-label="Map Legend"
+      translate="no"
     >
       {activeOutlookType === 'categorical' ? renderCategoricalLegend() : renderProbabilisticLegend()}
     </div>

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -807,6 +807,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
       // Create popup element imperatively to prevent React/OpenLayers DOM ownership conflict.
       const popupEl = document.createElement("div");
       popupEl.className = "ol-popup";
+      popupEl.setAttribute("translate", "no");
       popupEl.style.display = "none";
       popupRef.current = popupEl;
       const overlay = new Overlay({
@@ -1459,7 +1460,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
     };
 
     return (
-      <div className="map-container">
+      <div className="map-container" translate="no">
         <div ref={mapElementRef} style={{ width: "100%", height: "100%" }} />
         <div className="map-toolbar-bottom-right">
           <div className="map-toolbar-surface">

--- a/src/components/Map/OpenLayersVerificationMap.tsx
+++ b/src/components/Map/OpenLayersVerificationMap.tsx
@@ -924,7 +924,7 @@ const OpenLayersVerificationMap = forwardRef<
   };
 
   return (
-    <div className="forecast-map-container">
+    <div className="forecast-map-container" translate="no">
       <div ref={mapElementRef} style={{ width: "100%", height: "100%" }} />
       <div className="map-toolbar-bottom-right">
         <div className="flex items-center gap-1 rounded-md bg-white dark:bg-gray-800 p-1 shadow-md border border-gray-300 dark:border-gray-600">

--- a/src/components/Monitor/MonitorAlertPopup.tsx
+++ b/src/components/Monitor/MonitorAlertPopup.tsx
@@ -26,7 +26,12 @@ const MonitorAlertPopup: React.FC<MonitorAlertPopupProps> = ({ details, onClose 
   const expires = formatNwsAlertTime(details.expires);
 
   return (
-    <div className="monitor-alert-popup" role="dialog" aria-label={`${details.event} details`}>
+    <div
+      className="monitor-alert-popup"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${details.event} details`}
+    >
       <div className="monitor-alert-popup__header">
         <h3 className="monitor-alert-popup__title">{details.event}</h3>
         <button

--- a/src/components/Monitor/MonitorMap.tsx
+++ b/src/components/Monitor/MonitorMap.tsx
@@ -1,9 +1,7 @@
 import React, { useMemo, useRef } from 'react';
-import { createPortal } from 'react-dom';
 import 'ol/ol.css';
 import type { StormReport } from '../../types/stormReports';
 import type { NwsAlertFeatureCollection } from '../../monitor/nwsAlerts';
-import MonitorAlertPopup from './MonitorAlertPopup';
 import type { OutlookData } from '../../types/outlooks';
 import type { MonitorMapView, MonitorOutlookLayerType } from '../../monitor/types';
 import { flattenMonitorOutlookFeatures } from '../../monitor/outlookLayers';
@@ -41,7 +39,7 @@ const MonitorMap: React.FC<MonitorMapProps> = ({
     [outlookData, outlookType],
   );
 
-  const { selectedAlert, handleCloseAlertPopup, popupElement } = useMonitorOlMap({
+  useMonitorOlMap({
     mapView,
     radarLayer,
     radarOpacity,
@@ -55,15 +53,8 @@ const MonitorMap: React.FC<MonitorMapProps> = ({
   });
 
   return (
-    <div className="monitor-map" aria-label="Monitor map">
+    <div className="monitor-map" aria-label="Monitor map" translate="no">
       <div ref={mapElementRef} className="monitor-map__viewport" />
-      {popupElement &&
-        createPortal(
-          selectedAlert && (
-            <MonitorAlertPopup details={selectedAlert} onClose={handleCloseAlertPopup} />
-          ),
-          popupElement,
-        )}
       <div className="monitor-map__badge">Read-only monitor</div>
     </div>
   );

--- a/src/components/Monitor/MonitorMap.tsx
+++ b/src/components/Monitor/MonitorMap.tsx
@@ -21,6 +21,7 @@ interface MonitorMapProps {
   alertsOpacity: number;
 }
 
+/** Monitor workspace map shell hosting radar, satellite, outlook, and alert layers. */
 const MonitorMap: React.FC<MonitorMapProps> = ({
   mapView,
   radarLayer,

--- a/src/components/Monitor/renderMonitorAlertPopup.test.ts
+++ b/src/components/Monitor/renderMonitorAlertPopup.test.ts
@@ -1,0 +1,43 @@
+import { renderMonitorAlertPopup, clearMonitorAlertPopup } from './renderMonitorAlertPopup';
+import type { NwsAlertDetails } from '../../monitor/nwsAlertDetails';
+
+const sampleDetails: NwsAlertDetails = {
+  event: 'Tornado Warning',
+  headline: null,
+  areaDesc: 'Oklahoma County',
+  severity: 'Extreme',
+  certainty: 'Observed',
+  urgency: 'Immediate',
+  effective: '2026-04-20T18:00:00-05:00',
+  expires: '2026-04-20T19:00:00-05:00',
+  description: 'Take shelter now.',
+  instruction: 'Move to basement.',
+  senderName: 'NWS Norman OK',
+  detailUrl: 'https://api.weather.gov/alerts/1',
+};
+
+describe('renderMonitorAlertPopup', () => {
+  test('renders alert fields and invokes onClose from the close button', () => {
+    const container = document.createElement('div');
+    const onClose = jest.fn();
+
+    const cleanup = renderMonitorAlertPopup(container, sampleDetails, onClose);
+
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).toHaveAttribute('aria-label', 'Tornado Warning details');
+    expect(container.textContent).toContain('Oklahoma County');
+    expect(container.textContent).toContain('Take shelter now.');
+
+    const link = container.querySelector('a.monitor-alert-popup__link');
+    expect(link).toHaveAttribute('href', 'https://api.weather.gov/alerts/1');
+
+    const closeButton = container.querySelector('button[aria-label="Close alert details"]');
+    expect(closeButton).not.toBeNull();
+    closeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    clearMonitorAlertPopup(container);
+    expect(container.childElementCount).toBe(0);
+  });
+});

--- a/src/components/Monitor/renderMonitorAlertPopup.ts
+++ b/src/components/Monitor/renderMonitorAlertPopup.ts
@@ -6,6 +6,7 @@ export const clearMonitorAlertPopup = (container: HTMLElement): void => {
   container.replaceChildren();
 };
 
+/** Appends a labeled metadata row when `value` is present. */
 const appendMetaRow = (
   parent: HTMLElement,
   label: string,
@@ -31,6 +32,7 @@ const appendMetaRow = (
   parent.appendChild(row);
 };
 
+/** Appends a titled description or instruction block to the popup. */
 const appendSection = (
   parent: HTMLElement,
   title: string,
@@ -66,6 +68,7 @@ export const renderMonitorAlertPopup = (
   const dialog = document.createElement('div');
   dialog.className = 'monitor-alert-popup';
   dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
   dialog.setAttribute('aria-label', `${details.event} details`);
 
   const header = document.createElement('div');
@@ -81,10 +84,7 @@ export const renderMonitorAlertPopup = (
   closeButton.setAttribute('aria-label', 'Close alert details');
   closeButton.textContent = '×';
 
-  const handleClose = () => {
-    onClose();
-  };
-  closeButton.addEventListener('click', handleClose);
+  closeButton.addEventListener('click', onClose);
 
   header.appendChild(title);
   header.appendChild(closeButton);
@@ -129,6 +129,6 @@ export const renderMonitorAlertPopup = (
   container.appendChild(dialog);
 
   return () => {
-    closeButton.removeEventListener('click', handleClose);
+    closeButton.removeEventListener('click', onClose);
   };
 };

--- a/src/components/Monitor/renderMonitorAlertPopup.ts
+++ b/src/components/Monitor/renderMonitorAlertPopup.ts
@@ -1,0 +1,134 @@
+import type { NwsAlertDetails } from '../../monitor/nwsAlertDetails';
+import { formatNwsAlertTime } from '../../monitor/nwsAlertDetails';
+
+/** Clears imperative alert popup content from an OpenLayers overlay container. */
+export const clearMonitorAlertPopup = (container: HTMLElement): void => {
+  container.replaceChildren();
+};
+
+const appendMetaRow = (
+  parent: HTMLElement,
+  label: string,
+  value: string | null,
+): void => {
+  if (!value) {
+    return;
+  }
+
+  const row = document.createElement('div');
+  row.className = 'monitor-alert-popup__metaRow';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'monitor-alert-popup__metaLabel';
+  labelEl.textContent = label;
+
+  const valueEl = document.createElement('span');
+  valueEl.className = 'monitor-alert-popup__metaValue';
+  valueEl.textContent = value;
+
+  row.appendChild(labelEl);
+  row.appendChild(valueEl);
+  parent.appendChild(row);
+};
+
+const appendSection = (
+  parent: HTMLElement,
+  title: string,
+  body: string,
+): void => {
+  const section = document.createElement('section');
+  section.className = 'monitor-alert-popup__section';
+
+  const heading = document.createElement('h4');
+  heading.className = 'monitor-alert-popup__sectionTitle';
+  heading.textContent = title;
+
+  const paragraph = document.createElement('p');
+  paragraph.className = 'monitor-alert-popup__body';
+  paragraph.textContent = body;
+
+  section.appendChild(heading);
+  section.appendChild(paragraph);
+  parent.appendChild(section);
+};
+
+/**
+ * Renders NWS alert details into an OpenLayers overlay element without React.
+ * Returns a cleanup function that removes the close-button listener.
+ */
+export const renderMonitorAlertPopup = (
+  container: HTMLElement,
+  details: NwsAlertDetails,
+  onClose: () => void,
+): (() => void) => {
+  clearMonitorAlertPopup(container);
+
+  const dialog = document.createElement('div');
+  dialog.className = 'monitor-alert-popup';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-label', `${details.event} details`);
+
+  const header = document.createElement('div');
+  header.className = 'monitor-alert-popup__header';
+
+  const title = document.createElement('h3');
+  title.className = 'monitor-alert-popup__title';
+  title.textContent = details.event;
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'monitor-alert-popup__close';
+  closeButton.setAttribute('aria-label', 'Close alert details');
+  closeButton.textContent = '×';
+
+  const handleClose = () => {
+    onClose();
+  };
+  closeButton.addEventListener('click', handleClose);
+
+  header.appendChild(title);
+  header.appendChild(closeButton);
+  dialog.appendChild(header);
+
+  if (details.headline) {
+    const headline = document.createElement('p');
+    headline.className = 'monitor-alert-popup__headline';
+    headline.textContent = details.headline;
+    dialog.appendChild(headline);
+  }
+
+  const meta = document.createElement('div');
+  meta.className = 'monitor-alert-popup__meta';
+  appendMetaRow(meta, 'Area', details.areaDesc);
+  appendMetaRow(meta, 'Severity', details.severity);
+  appendMetaRow(meta, 'Certainty', details.certainty);
+  appendMetaRow(meta, 'Urgency', details.urgency);
+  appendMetaRow(meta, 'Effective', formatNwsAlertTime(details.effective));
+  appendMetaRow(meta, 'Expires', formatNwsAlertTime(details.expires));
+  appendMetaRow(meta, 'Issued by', details.senderName);
+  dialog.appendChild(meta);
+
+  if (details.description) {
+    appendSection(dialog, 'Description', details.description);
+  }
+
+  if (details.instruction) {
+    appendSection(dialog, 'Instructions', details.instruction);
+  }
+
+  if (details.detailUrl) {
+    const link = document.createElement('a');
+    link.className = 'monitor-alert-popup__link';
+    link.href = details.detailUrl;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = 'View full alert on weather.gov';
+    dialog.appendChild(link);
+  }
+
+  container.appendChild(dialog);
+
+  return () => {
+    closeButton.removeEventListener('click', handleClose);
+  };
+};

--- a/src/components/Monitor/useMonitorMapBootstrap.ts
+++ b/src/components/Monitor/useMonitorMapBootstrap.ts
@@ -107,6 +107,7 @@ export const useMonitorMapBootstrap = ({
       }),
     });
 
+    /** Persists user pan/zoom into monitor map view state. */
     const handleMoveEnd = () => {
       if (refs.applyingExternalViewRef.current) {
         return;
@@ -122,6 +123,7 @@ export const useMonitorMapBootstrap = ({
       dispatch(setMonitorMapView({ center: [latitude, longitude], zoom }));
     };
 
+    /** Opens or dismisses the NWS alert popup for the clicked feature. */
     const handleMapClick = (evt: { pixel: number[]; coordinate: number[] }) => {
       const feature = map.forEachFeatureAtPixel(
         evt.pixel,
@@ -149,6 +151,7 @@ export const useMonitorMapBootstrap = ({
       onSelectAlert(null);
     };
 
+    /** Toggles the pointer cursor when hovering clickable alert features. */
     const handlePointerMove = (evt: { pixel: number[] }) => {
       const target = map.getTargetElement();
       if (!(target instanceof HTMLElement)) {

--- a/src/components/Monitor/useMonitorMapBootstrap.ts
+++ b/src/components/Monitor/useMonitorMapBootstrap.ts
@@ -12,6 +12,7 @@ import { buildNwsAlertStyle } from '../../monitor/nwsAlerts';
 import { parseNwsAlertFromOlProperties } from '../../monitor/nwsAlertDetails';
 import type { NwsAlertDetails } from '../../monitor/nwsAlertDetails';
 import { hideOverlay } from '../Map/OpenLayersForecastMap';
+import { clearMonitorAlertPopup } from './renderMonitorAlertPopup';
 import { useDispatch } from 'react-redux';
 import type { AppDispatch } from '../../store';
 import { setMonitorMapView } from '../../store/monitorSlice';
@@ -43,7 +44,6 @@ interface UseMonitorMapBootstrapArgs {
   mapElementRef: RefObject<HTMLDivElement | null>;
   refs: MonitorMapRefs;
   onSelectAlert: (details: NwsAlertDetails | null) => void;
-  onCreatePopupElement: (el: HTMLDivElement | null) => void;
 }
 
 export const useMonitorMapBootstrap = ({
@@ -55,7 +55,6 @@ export const useMonitorMapBootstrap = ({
   mapElementRef,
   refs,
   onSelectAlert,
-  onCreatePopupElement,
 }: UseMonitorMapBootstrapArgs) => {
   const dispatch = useDispatch<AppDispatch>();
 
@@ -168,8 +167,8 @@ export const useMonitorMapBootstrap = ({
 
     const popupEl = document.createElement("div");
     popupEl.className = "monitor-map__alertOverlay";
+    popupEl.setAttribute("translate", "no");
     refs.popupElRef.current = popupEl;
-    onCreatePopupElement(popupEl);
     const overlay = new Overlay({ element: popupEl, autoPan: false });
     map.addOverlay(overlay);
     refs.overlayRef.current = overlay;
@@ -210,6 +209,10 @@ export const useMonitorMapBootstrap = ({
       if (target instanceof HTMLElement) {
         target.style.cursor = '';
       }
+      onSelectAlert(null);
+      if (refs.popupElRef.current) {
+        clearMonitorAlertPopup(refs.popupElRef.current);
+      }
       if (refs.overlayRef.current) {
         map.removeOverlay(refs.overlayRef.current);
         refs.overlayRef.current = null;
@@ -218,7 +221,6 @@ export const useMonitorMapBootstrap = ({
         refs.popupElRef.current.remove();
         refs.popupElRef.current = null;
       }
-      onCreatePopupElement(null);
       map.setTarget();
       refs.mapRef.current = null;
       refs.baseLayerRef.current = null;

--- a/src/components/Monitor/useMonitorOlMap.ts
+++ b/src/components/Monitor/useMonitorOlMap.ts
@@ -29,6 +29,7 @@ interface UseMonitorOlMapArgs {
   mapElementRef: RefObject<HTMLDivElement | null>;
 }
 
+/** Wires Monitor OpenLayers map bootstrap, layers, and imperative alert popups. */
 export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
   const [selectedAlert, setSelectedAlert] = useState<NwsAlertDetails | null>(null);
@@ -39,7 +40,9 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
       hideOverlay(refs.overlayRef.current);
     }
     setSelectedAlert(null);
-  }, [refs]);
+    // refs omitted: wrapper object from useMonitorMapRefs() is new each render,
+    // but all inner refs are stable across renders.
+  }, []);
 
   useMonitorMapBootstrap({
     mapView: args.mapView,
@@ -82,8 +85,4 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
     onClearSelectedAlert: clearSelectedAlert,
   });
 
-  return {
-    selectedAlert,
-    handleCloseAlertPopup: clearSelectedAlert,
-  };
 };

--- a/src/components/Monitor/useMonitorOlMap.ts
+++ b/src/components/Monitor/useMonitorOlMap.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useState, type RefObject } from 'react';
 import { useSelector } from 'react-redux';
 import type { StormReport } from '../../types/stormReports';
 import type { NwsAlertFeatureCollection } from '../../monitor/nwsAlerts';
@@ -11,6 +11,10 @@ import type { SerializedMonitorOutlookFeature } from './monitorMapFeatureSync';
 import { useMonitorMapBootstrap } from './useMonitorMapBootstrap';
 import { useMonitorMapLayerSync } from './useMonitorMapLayerSync';
 import { useMonitorMapRefs } from './monitorMapRefs';
+import {
+  clearMonitorAlertPopup,
+  renderMonitorAlertPopup,
+} from './renderMonitorAlertPopup';
 
 interface UseMonitorOlMapArgs {
   mapView: MonitorMapView;
@@ -28,7 +32,6 @@ interface UseMonitorOlMapArgs {
 export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
   const [selectedAlert, setSelectedAlert] = useState<NwsAlertDetails | null>(null);
-  const [popupElement, setPopupElement] = useState<HTMLDivElement | null>(null);
   const refs = useMonitorMapRefs();
 
   const clearSelectedAlert = useCallback(() => {
@@ -47,8 +50,22 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
     mapElementRef: args.mapElementRef,
     refs,
     onSelectAlert: setSelectedAlert,
-    onCreatePopupElement: setPopupElement,
   });
+
+  useEffect(() => {
+    const container = refs.popupElRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    if (!selectedAlert) {
+      clearMonitorAlertPopup(container);
+      return undefined;
+    }
+
+    return renderMonitorAlertPopup(container, selectedAlert, clearSelectedAlert);
+    // refs omitted: wrapper object from useMonitorMapRefs() is new each render.
+  }, [clearSelectedAlert, selectedAlert]);
 
   useMonitorMapLayerSync({
     mapView: args.mapView,
@@ -68,6 +85,5 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
   return {
     selectedAlert,
     handleCloseAlertPopup: clearSelectedAlert,
-    popupElement,
   };
 };

--- a/src/content/updates/v1.6.ts
+++ b/src/content/updates/v1.6.ts
@@ -15,6 +15,12 @@ export interface ReleaseImprovement {
   text: string;
 }
 
+export interface ReleaseHotfixes {
+  title: string;
+  body: string;
+  items: ReleaseImprovement[];
+}
+
 export interface ReleaseUpdate {
   version: string;
   title: string;
@@ -22,6 +28,7 @@ export interface ReleaseUpdate {
   /** Optional hero graphics under `public/updates/v{version}/`. */
   promoImages?: UpdateScreenshot[];
   sections: UpdateSection[];
+  hotfixes?: ReleaseHotfixes;
   improvements: ReleaseImprovement[];
 }
 
@@ -79,6 +86,21 @@ export const v16Update: ReleaseUpdate = {
       ],
     },
   ],
+  hotfixes: {
+    title: 'v1.6 Hotfixes',
+    body:
+      'Stability fixes shipped after the v1.6 release for map-heavy workflows on forecast, verification, and monitor.',
+    items: [
+      {
+        id: 'openlayers-removechild',
+        text: 'Fixed a map error that could surface as a blank or unstable editor when OpenLayers and React disagreed about popup DOM ownership — especially on Monitor alert popups and when switching outlook types or routes.',
+      },
+      {
+        id: 'map-translation-guard',
+        text: 'Map shells and legends are now marked notranslate so Chrome auto-translate is less likely to rewrite map UI text and trigger React DOM errors on mobile browsers.',
+      },
+    ],
+  },
   improvements: [
     {
       id: 'safari-hosted-sleep',

--- a/src/pages/UpdatesPage.css
+++ b/src/pages/UpdatesPage.css
@@ -185,6 +185,7 @@
   font-size: 0.875rem;
 }
 
+.updates-page__hotfixes,
 .updates-page__improvements {
   margin: 2.5rem 0 0;
   padding: 1.25rem 1.35rem;
@@ -193,11 +194,19 @@
   background: var(--bg-secondary);
 }
 
+.updates-page__hotfixes p {
+  margin: 0 0 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.updates-page__hotfixes h2,
 .updates-page__improvements h2 {
   margin: 0 0 0.75rem;
   font-size: 1.2rem;
 }
 
+.updates-page__hotfixes ul,
 .updates-page__improvements ul {
   margin: 0;
   padding-left: 1.2rem;
@@ -205,6 +214,7 @@
   line-height: 1.65;
 }
 
+.updates-page__hotfixes li + li,
 .updates-page__improvements li + li {
   margin-top: 0.45rem;
 }

--- a/src/pages/UpdatesPage.test.tsx
+++ b/src/pages/UpdatesPage.test.tsx
@@ -27,6 +27,8 @@ describe('UpdatesPage', () => {
     expect(document.querySelector('img[src="/updates/v1.6/v1.6-promo-image-light-mrms-visible.png"]')).toBeTruthy();
     expect(document.querySelector('img[src="/updates/v1.6/v1.6-promo-image-dark-single-site-shortwave-ir.png"]')).toBeTruthy();
     expect(screen.getByRole('heading', { name: /Monitor workspace/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /v1\.6 Hotfixes/i })).toBeInTheDocument();
+    expect(screen.getByText(/OpenLayers and React disagreed about popup DOM ownership/i)).toBeInTheDocument();
     expect(screen.getByText(/Signed-in home page primary buttons are easier to read/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Back to home/i })).toHaveAttribute('href', '/');
   });

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -142,6 +142,18 @@ export const UpdatesPage: React.FC = () => {
           </section>
         ))}
 
+        {v16Update.hotfixes ? (
+          <section className="updates-page__hotfixes" aria-labelledby="updates-hotfixes-heading">
+            <h2 id="updates-hotfixes-heading">{v16Update.hotfixes.title}</h2>
+            <p>{v16Update.hotfixes.body}</p>
+            <ul>
+              {v16Update.hotfixes.items.map((item) => (
+                <li key={item.id}>{item.text}</li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
         <section className="updates-page__improvements" aria-labelledby="updates-improvements-heading">
           <h2 id="updates-improvements-heading">Also improved</h2>
           <ul>


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #420 — hotfix: resolve removeChild NotFoundError on OpenLayers maps |
| Source branch | `hotfix/sentry-gfc-web-5-removechild-regression` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `CHANGELOG.md`
- `package.json`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/420-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #420, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.