### PR TITLE
[TSTM-01] Add hidden Auto-TSTM forecast foundations

### DIFF
--- a/src/store/forecastSlice.test.ts
+++ b/src/store/forecastSlice.test.ts
@@ -65,6 +65,25 @@ const createTstmFeature = (id: string, offset: number): Feature =>
     probability: 'TSTM',
   });
 
+const createStateWithCategoricalFeatures = () => {
+  let state = reducer(undefined, setForecastDay(1));
+  state = reducer(
+    state,
+    applyAutoCategoricalSync({
+      map: new Map([
+        ['TSTM', [createTstmFeature('old-tstm', 0)]],
+        ['ENH', [createCategoricalFeature('enh', 2)]],
+      ]),
+    })
+  );
+  return state;
+};
+
+const getCategoricalFeatureId = (
+  state: ReturnType<typeof reducer>,
+  probability: string
+) => state.forecastCycle.days[1]?.data.categorical?.get(probability)?.[0].id;
+
 const createOutlookFeature = (
   id: string,
   offset: number,
@@ -327,26 +346,26 @@ describe('forecastSlice undo/redo', () => {
   });
 
   test('replaces only TSTM features and keeps generated categorical risks', () => {
-    let state = reducer(undefined, setForecastDay(1));
-    state = reducer(
-      state,
-      applyAutoCategoricalSync({
-        map: new Map([
-          ['TSTM', [createTstmFeature('old-tstm', 0)]],
-          ['ENH', [createCategoricalFeature('enh', 2)]],
-        ]),
-      })
+    const state = reducer(
+      createStateWithCategoricalFeatures(),
+      replaceTstmFeatures({ features: [createTstmFeature('new-tstm', 4)] })
     );
 
-    state = reducer(state, replaceTstmFeatures({ features: [createTstmFeature('new-tstm', 4)] }));
+    expect(getCategoricalFeatureId(state, 'TSTM')).toBe('new-tstm');
+    expect(getCategoricalFeatureId(state, 'ENH')).toBe('enh');
+  });
 
-    expect(state.forecastCycle.days[1]?.data.categorical?.get('TSTM')?.[0].id).toBe('new-tstm');
-    expect(state.forecastCycle.days[1]?.data.categorical?.get('ENH')?.[0].id).toBe('enh');
-    expect(selectCanUndo({ forecast: state } as never)).toBe(true);
+  test('records generated TSTM replacement as one undoable edit', () => {
+    const replacedState = reducer(
+      createStateWithCategoricalFeatures(),
+      replaceTstmFeatures({ features: [createTstmFeature('new-tstm', 4)] })
+    );
 
-    state = reducer(state, undoLastEdit());
-    expect(state.forecastCycle.days[1]?.data.categorical?.get('TSTM')?.[0].id).toBe('old-tstm');
-    expect(state.forecastCycle.days[1]?.data.categorical?.get('ENH')?.[0].id).toBe('enh');
+    expect(selectCanUndo({ forecast: replacedState } as never)).toBe(true);
+
+    const restoredState = reducer(replacedState, undoLastEdit());
+    expect(getCategoricalFeatureId(restoredState, 'TSTM')).toBe('old-tstm');
+    expect(getCategoricalFeatureId(restoredState, 'ENH')).toBe('enh');
   });
 
   test('importing and resetting clear all per-day history', () => {

--- a/src/store/forecastSlice.test.ts
+++ b/src/store/forecastSlice.test.ts
@@ -368,6 +368,28 @@ describe('forecastSlice undo/redo', () => {
     expect(getCategoricalFeatureId(restoredState, 'ENH')).toBe('enh');
   });
 
+  test('does not add an undo entry for logically identical TSTM features', () => {
+    const firstFeature = createTstmFeature('generated-tstm', 0);
+    const secondFeature = createTstmFeature('generated-tstm', 0);
+    secondFeature.properties = {
+      originalProbability: 'TSTM',
+      derivedFrom: 'categorical',
+      probability: 'TSTM',
+      outlookType: 'categorical',
+      isSignificant: false,
+    };
+
+    let state = reducer(
+      reducer(undefined, setForecastDay(1)),
+      replaceTstmFeatures({ features: [firstFeature] })
+    );
+    state = reducer(state, replaceTstmFeatures({ features: [secondFeature] }));
+
+    state = reducer(state, undoLastEdit());
+    expect(selectCanUndo({ forecast: state } as never)).toBe(false);
+    expect(getCategoricalFeatureId(state, 'TSTM')).toBeUndefined();
+  });
+
   test('importing and resetting clear all per-day history', () => {
     let state = reducer(undefined, addFeature({ feature: createFeature('feature-1', 0) }));
     state = reducer(state, setForecastDay(2));

--- a/src/store/forecastSlice.test.ts
+++ b/src/store/forecastSlice.test.ts
@@ -6,6 +6,7 @@ import reducer, {
   copyFeaturesFromPrevious,
   importForecastCycle,
   redoLastEdit,
+  replaceTstmFeatures,
   resetForecasts,
   selectCanRedo,
   selectCanUndo,
@@ -56,6 +57,12 @@ const createCategoricalFeature = (id: string, offset: number): Feature =>
     outlookType: 'categorical',
     probability: 'ENH',
     extras: { derivedFrom: 'auto-generated' },
+  });
+
+const createTstmFeature = (id: string, offset: number): Feature =>
+  createBaseFeature(id, offset, {
+    outlookType: 'categorical',
+    probability: 'TSTM',
   });
 
 const createOutlookFeature = (
@@ -317,6 +324,29 @@ describe('forecastSlice undo/redo', () => {
 
     expect(getTornadoFeatures(state)).toHaveLength(0);
     expect(state.forecastCycle.days[1]?.data.categorical?.size ?? 0).toBe(0);
+  });
+
+  test('replaces only TSTM features and keeps generated categorical risks', () => {
+    let state = reducer(undefined, setForecastDay(1));
+    state = reducer(
+      state,
+      applyAutoCategoricalSync({
+        map: new Map([
+          ['TSTM', [createTstmFeature('old-tstm', 0)]],
+          ['ENH', [createCategoricalFeature('enh', 2)]],
+        ]),
+      })
+    );
+
+    state = reducer(state, replaceTstmFeatures({ features: [createTstmFeature('new-tstm', 4)] }));
+
+    expect(state.forecastCycle.days[1]?.data.categorical?.get('TSTM')?.[0].id).toBe('new-tstm');
+    expect(state.forecastCycle.days[1]?.data.categorical?.get('ENH')?.[0].id).toBe('enh');
+    expect(selectCanUndo({ forecast: state } as never)).toBe(true);
+
+    state = reducer(state, undoLastEdit());
+    expect(state.forecastCycle.days[1]?.data.categorical?.get('TSTM')?.[0].id).toBe('old-tstm');
+    expect(state.forecastCycle.days[1]?.data.categorical?.get('ENH')?.[0].id).toBe('enh');
   });
 
   test('importing and resetting clear all per-day history', () => {

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -622,6 +622,32 @@ export const forecastSlice = createSlice({
       state.isSaved = false;
     },
 
+    replaceTstmFeatures: (state, action: PayloadAction<{ features: Feature[] }>) => {
+      const outlookData = getCurrentOutlook(state);
+      if (!outlookData.categorical) {
+        return;
+      }
+
+      const normalizedFeatures = action.payload.features.map((feature) =>
+        buildFeatureWithProps(feature, 'categorical', 'TSTM', false)
+      );
+      const existingTstm = outlookData.categorical.get('TSTM') || [];
+
+      if (JSON.stringify(existingTstm) === JSON.stringify(normalizedFeatures)) {
+        return;
+      }
+
+      pushUndoSnapshot(state);
+
+      if (normalizedFeatures.length > 0) {
+        outlookData.categorical.set('TSTM', normalizedFeatures);
+      } else {
+        outlookData.categorical.delete('TSTM');
+      }
+
+      state.isSaved = false;
+    },
+
     setMapView: (state, action: PayloadAction<{ center: [number, number], zoom: number }>) => {
       state.currentMapView = action.payload;
     },
@@ -818,6 +844,7 @@ export const {
   resetCategorical,
   setOutlookMap,
   applyAutoCategoricalSync,
+  replaceTstmFeatures,
   setMapView,
   resetForecasts,
   markAsSaved,

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -7,6 +7,7 @@ import { RootState } from './index'; // Need RootState for selectors
 import { cloneForecastCycle } from '../utils/fileUtils';
 import { countForecastMetrics } from '../utils/forecastMetrics';
 import { getLocalCalendarDate } from '../utils/localDate';
+import { areTstmFeaturesEqual } from '../utils/tstmGeneration';
 
 export interface SavedCycleStats {
   forecastDays: number;
@@ -633,7 +634,7 @@ export const forecastSlice = createSlice({
       );
       const existingTstm = outlookData.categorical.get('TSTM') || [];
 
-      if (JSON.stringify(existingTstm) === JSON.stringify(normalizedFeatures)) {
+      if (areTstmFeaturesEqual(existingTstm, normalizedFeatures)) {
         return;
       }
 

--- a/src/types/tstmGeneration.ts
+++ b/src/types/tstmGeneration.ts
@@ -1,0 +1,24 @@
+import type { Feature } from 'geojson';
+import type { DayType } from './outlooks';
+
+export interface TstmGenerationRequest {
+  day: DayType;
+  cycleDate: string;
+}
+
+export interface TstmGenerationThresholds {
+  calibratedThunderProbability: number;
+  minAreaSqKm: number;
+}
+
+export interface TstmGenerationResponse {
+  features: Feature[];
+  run: string;
+  source: 'spc-href-calibrated-thunder';
+  threshold: number;
+  effectiveStart: string;
+  effectiveEnd: string;
+  thresholds: TstmGenerationThresholds;
+  warnings: string[];
+  generatedAt: string;
+}

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -1,0 +1,59 @@
+import { canGenerateTstmForDay, normalizeGeneratedTstmFeatures } from './tstmGeneration';
+
+describe('tstmGeneration utilities', () => {
+  test('limits SPC calibrated thunder generation to day 1 and day 2', () => {
+    expect(canGenerateTstmForDay(1)).toBe(true);
+    expect(canGenerateTstmForDay(2)).toBe(true);
+    expect(canGenerateTstmForDay(3)).toBe(false);
+  });
+
+  test('normalizes generated polygons into editable categorical TSTM features', () => {
+    const [feature] = normalizeGeneratedTstmFeatures([
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+        },
+        properties: { source: 'spc-href' },
+      },
+    ]);
+
+    expect(feature.properties).toMatchObject({
+      outlookType: 'categorical',
+      probability: 'TSTM',
+      isSignificant: false,
+      derivedFrom: 'spc-href-calibrated-thunder',
+    });
+    expect(feature.id).toBe('generated-tstm-0');
+  });
+
+  test('keeps existing feature ids and accepts multipolygons', () => {
+    const [feature] = normalizeGeneratedTstmFeatures([
+      {
+        type: 'Feature',
+        id: 'cached-guidance-1',
+        geometry: {
+          type: 'MultiPolygon',
+          coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
+        },
+        properties: {},
+      },
+    ]);
+
+    expect(feature.id).toBe('cached-guidance-1');
+    expect(feature.geometry.type).toBe('MultiPolygon');
+  });
+
+  test('drops non-polygon guidance instead of placing it in forecast state', () => {
+    const features = normalizeGeneratedTstmFeatures([
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      },
+    ]);
+
+    expect(features).toEqual([]);
+  });
+});

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -1,4 +1,8 @@
-import { canGenerateTstmForDay, normalizeGeneratedTstmFeatures } from './tstmGeneration';
+import {
+  areTstmFeaturesEqual,
+  canGenerateTstmForDay,
+  normalizeGeneratedTstmFeatures,
+} from './tstmGeneration';
 
 describe('tstmGeneration utilities', () => {
   test('limits SPC calibrated thunder generation to day 1 and day 2', () => {
@@ -55,5 +59,16 @@ describe('tstmGeneration utilities', () => {
     ]);
 
     expect(features).toEqual([]);
+  });
+
+  test('compares equivalent features without depending on property key order', () => {
+    const geometry = {
+      type: 'Polygon' as const,
+      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+    };
+    const left = [{ type: 'Feature' as const, geometry, properties: { source: 'spc', probability: 'TSTM' } }];
+    const right = [{ type: 'Feature' as const, geometry, properties: { probability: 'TSTM', source: 'spc' } }];
+
+    expect(areTstmFeaturesEqual(left, right)).toBe(true);
   });
 });

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -1,0 +1,25 @@
+import type { Feature } from 'geojson';
+
+/** Returns true when SPC calibrated thunder can cover the given outlook day. */
+export const canGenerateTstmForDay = (day: number): boolean => day === 1 || day === 2;
+
+/** Normalizes generated polygons so they can enter the existing editable categorical/TSTM flow. */
+export const normalizeGeneratedTstmFeatures = (features: Feature[]): Feature[] =>
+  features
+    .filter(
+      (feature) =>
+        feature.type === 'Feature' &&
+        (feature.geometry?.type === 'Polygon' || feature.geometry?.type === 'MultiPolygon')
+    )
+    .map((feature, index) => ({
+      ...feature,
+      id: feature.id ?? `generated-tstm-${index}`,
+      properties: {
+        ...feature.properties,
+        outlookType: 'categorical',
+        probability: 'TSTM',
+        isSignificant: false,
+        derivedFrom: 'spc-href-calibrated-thunder',
+        originalProbability: 'TSTM',
+      },
+    }));

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -1,7 +1,27 @@
 import type { Feature } from 'geojson';
+import type { DayType } from '../types/outlooks';
 
 /** Returns true when SPC calibrated thunder can cover the given outlook day. */
-export const canGenerateTstmForDay = (day: number): boolean => day === 1 || day === 2;
+export const canGenerateTstmForDay = (day: DayType): boolean => day === 1 || day === 2;
+
+/** Produces a stable JSON-like value so object key insertion order does not affect equality. */
+const sortJsonKeys = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonKeys);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, sortJsonKeys(entry)])
+    );
+  }
+  return value;
+};
+
+/** Compares generated feature arrays without depending on object key insertion order. */
+export const areTstmFeaturesEqual = (left: Feature[], right: Feature[]): boolean =>
+  JSON.stringify(sortJsonKeys(left)) === JSON.stringify(sortJsonKeys(right));
 
 /** Normalizes generated polygons so they can enter the existing editable categorical/TSTM flow. */
 export const normalizeGeneratedTstmFeatures = (features: Feature[]): Feature[] =>


### PR DESCRIPTION
## Summary

Begins the Auto-TSTM integration as a deliberately hidden foundation slice rebuilt from current `beta`.

This PR adds:

- typed contracts for cached SPC HREF calibrated-thunder guidance;
- Day 1/Day 2 capability and generated-geometry normalization helpers;
- an undoable reducer that replaces only categorical TSTM features;
- focused tests for normalization, invalid geometry, categorical preservation, and undo.

## Exposure

This PR exposes **no user-facing or server behavior**:

- no toolbar control;
- no modal;
- no API call;
- no server route;
- no Python runtime;
- no scheduled worker.

The unfinished feature cannot mount, execute, or generate Sentry traffic after this slice merges.

## Source branch handling

`feature/auto-generate-tstm-lines` remains unchanged as reference material. It should not be merged directly because it is based on an older beta point and combines the feature with unrelated local-auth, analytics-server, and development-runner changes.

None of those unrelated changes are included here.

## Verification

- `pnpm test -- --runInBand --watch=false --runTestsByPath src/store/forecastSlice.test.ts src/utils/tstmGeneration.test.ts`
  - 2 suites passed
  - 18 tests passed
- `pnpm run build`
  - passed
- `git diff --check`
  - passed

## Continuation

After review, follow-up PRs should implement the remaining tracker slices independently:

1. audit and simplify the SPC calibrated-thunder product logic;
2. scheduled latest-complete-run ingestion and cache;
3. disabled cached API with operational controls;
4. gated preview/apply UI with stale-result protection;
5. meteorological validation and deployment documentation.

Closes #472 when merged.

## Changelog

- Add hidden Auto-TSTM forecast contracts, geometry normalization, and undoable categorical TSTM replacement foundations.
