### PR TITLE
[Port][Conflicts] [TSTM-01] Add hidden Auto-TSTM forecast foundations → feature/auto-generate-tstm-lines

### DIFF
--- a/src/types/tstmGeneration.ts
+++ b/src/types/tstmGeneration.ts
@@ -4,6 +4,7 @@ import type { DayType } from './outlooks';
 export interface TstmGenerationRequest {
   day: DayType;
   cycleDate: string;
+<<<<<<< HEAD
   issueDate?: string;
   validDate?: string;
   issuanceTime?: string;
@@ -20,18 +21,32 @@ export interface TstmGenerationThresholds {
   capeJkg: number;
   cinJkg: number;
   reflectivityDbz: number;
+=======
+}
+
+export interface TstmGenerationThresholds {
+  calibratedThunderProbability: number;
+>>>>>>> d2114fe (feat: add gated Auto-TSTM forecast foundations)
   minAreaSqKm: number;
 }
 
 export interface TstmGenerationResponse {
   features: Feature[];
   run: string;
+<<<<<<< HEAD
   domain: string;
   forecastHours: number[];
+=======
+  source: 'spc-href-calibrated-thunder';
+  threshold: number;
+>>>>>>> d2114fe (feat: add gated Auto-TSTM forecast foundations)
   effectiveStart: string;
   effectiveEnd: string;
   thresholds: TstmGenerationThresholds;
   warnings: string[];
+<<<<<<< HEAD
   sources?: Record<string, { product: string; search: string; run?: string; period?: string; forecastHours?: string; url?: string } | null>;
+=======
+>>>>>>> d2114fe (feat: add gated Auto-TSTM forecast foundations)
   generatedAt: string;
 }

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -15,7 +15,11 @@ describe('tstmGeneration utilities', () => {
           type: 'Polygon',
           coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
         },
+<<<<<<< HEAD
         properties: { source: 'href' },
+=======
+        properties: { source: 'spc-href' },
+>>>>>>> d2114fe (feat: add gated Auto-TSTM forecast foundations)
       },
     ]);
 
@@ -23,8 +27,44 @@ describe('tstmGeneration utilities', () => {
       outlookType: 'categorical',
       probability: 'TSTM',
       isSignificant: false,
+<<<<<<< HEAD
       derivedFrom: 'spc-calibrated-thunder',
     });
     expect(feature.id).toBe('generated-tstm-0');
   });
+=======
+      derivedFrom: 'spc-href-calibrated-thunder',
+    });
+    expect(feature.id).toBe('generated-tstm-0');
+  });
+
+  test('keeps existing feature ids and accepts multipolygons', () => {
+    const [feature] = normalizeGeneratedTstmFeatures([
+      {
+        type: 'Feature',
+        id: 'cached-guidance-1',
+        geometry: {
+          type: 'MultiPolygon',
+          coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
+        },
+        properties: {},
+      },
+    ]);
+
+    expect(feature.id).toBe('cached-guidance-1');
+    expect(feature.geometry.type).toBe('MultiPolygon');
+  });
+
+  test('drops non-polygon guidance instead of placing it in forecast state', () => {
+    const features = normalizeGeneratedTstmFeatures([
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      },
+    ]);
+
+    expect(features).toEqual([]);
+  });
+>>>>>>> d2114fe (feat: add gated Auto-TSTM forecast foundations)
 });

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -1,13 +1,17 @@
 import type { Feature } from 'geojson';
+<<<<<<< HEAD
 import type { TstmGenerationRequest, TstmGenerationResponse } from '../types/tstmGeneration';
 
 const TSTM_GENERATION_ENDPOINT = '/api/tstm/generate';
+=======
+>>>>>>> d2114fe (feat: add gated Auto-TSTM forecast foundations)
 
 /** Returns true when SPC calibrated thunder can cover the given outlook day. */
 export const canGenerateTstmForDay = (day: number): boolean => day === 1 || day === 2;
 
 /** Normalizes generated polygons so they can enter the existing editable categorical/TSTM flow. */
 export const normalizeGeneratedTstmFeatures = (features: Feature[]): Feature[] =>
+<<<<<<< HEAD
   features.map((feature, index) => ({
     ...feature,
     id: feature.id ?? `generated-tstm-${index}`,
@@ -45,3 +49,23 @@ export const generateTstmLines = async (
     features: normalizeGeneratedTstmFeatures(Array.isArray(payload.features) ? payload.features : []),
   } as TstmGenerationResponse;
 };
+=======
+  features
+    .filter(
+      (feature) =>
+        feature.type === 'Feature' &&
+        (feature.geometry?.type === 'Polygon' || feature.geometry?.type === 'MultiPolygon')
+    )
+    .map((feature, index) => ({
+      ...feature,
+      id: feature.id ?? `generated-tstm-${index}`,
+      properties: {
+        ...feature.properties,
+        outlookType: 'categorical',
+        probability: 'TSTM',
+        isSignificant: false,
+        derivedFrom: 'spc-href-calibrated-thunder',
+        originalProbability: 'TSTM',
+      },
+    }));
+>>>>>>> d2114fe (feat: add gated Auto-TSTM forecast foundations)


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/auto-generate-tstm-lines`.

| | |
| --- | --- |
| Original PR | #503 — [TSTM-01] Add hidden Auto-TSTM forecast foundations |
| Source branch | `feature/v1.7-auto-tstm-foundation` (merged into `beta`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `src/types/tstmGeneration.ts`
- `src/utils/tstmGeneration.test.ts`
- `src/utils/tstmGeneration.ts`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/503-to-feature-auto-generate-tstm-lines`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #503, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/auto-generate-tstm-lines` drifting behind `beta`.