### PR TITLE
[Port][Conflicts] [Security Hotfix] Install patched esbuild 0.28.1 → feature/auto-generate-tstm-lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **OpenLayers map stability (GFC-WEB-5, GFC-WEB-9, GFC-WEB-C):** Completed the Monitor map popup fix by rendering NWS alert overlays imperatively instead of portaling React into OpenLayers-moved DOM nodes. Hardened map teardown order and marked map shells `notranslate` so Chrome auto-translate is less likely to trigger `removeChild` errors on forecast, verification, and monitor maps.
-- **Build dependency security (Dependabot #128 and #129):** Forced the transitive `esbuild` toolchain to `0.28.1` or newer to add binary integrity verification and close the Windows development-server path traversal advisory.
+- **Build dependency security (Dependabot #128 and #129):** Replaced the transitive `esbuild` 0.27.x installation with an explicit patched `esbuild` 0.28.1 development dependency and added a `pnpm.overrides` guard to prevent the vulnerable resolution from returning.
 
 ## v1.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.6.4
+
+### Fixed
+- **OpenLayers map stability (GFC-WEB-5, GFC-WEB-9, GFC-WEB-C):** Completed the Monitor map popup fix by rendering NWS alert overlays imperatively instead of portaling React into OpenLayers-moved DOM nodes. Hardened map teardown order and marked map shells `notranslate` so Chrome auto-translate is less likely to trigger `removeChild` errors on forecast, verification, and monitor maps.
+
 ## v1.6.1
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **OpenLayers map stability (GFC-WEB-5, GFC-WEB-9, GFC-WEB-C):** Completed the Monitor map popup fix by rendering NWS alert overlays imperatively instead of portaling React into OpenLayers-moved DOM nodes. Hardened map teardown order and marked map shells `notranslate` so Chrome auto-translate is less likely to trigger `removeChild` errors on forecast, verification, and monitor maps.
+- **Build dependency security (Dependabot #128 and #129):** Forced the transitive `esbuild` toolchain to `0.28.1` or newer to add binary integrity verification and close the Windows development-server path traversal advisory.
 
 ## v1.6.1
 

--- a/deploy/production-release.json
+++ b/deploy/production-release.json
@@ -1,6 +1,6 @@
 {
-  "releaseId": "v1.6.4",
-  "version": "1.6.4",
+  "releaseId": "v1.6.3",
+  "version": "1.6.3",
   "action": "live",
   "status": "live",
   "strategy": "instant"

--- a/deploy/production-release.json
+++ b/deploy/production-release.json
@@ -1,6 +1,6 @@
 {
-  "releaseId": "v1.6.3",
-  "version": "1.6.3",
+  "releaseId": "v1.6.4",
+  "version": "1.6.4",
   "action": "live",
   "status": "live",
   "strategy": "instant"

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/png" href="/cloud.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#1a237e" />
+    <meta name="google" content="notranslate" />
     <meta
       name="description"
       content="Graphical Forecast Creator — Create, save, and verify SPC-style severe weather outlooks with multi-day cycle management, storm report verification, and forecast discussion tools."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphical-forecast-creator",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "autoprefixer": "^10.4.27",
     "babel-jest": "^30.2.0",
     "babel-plugin-istanbul": "^8.0.0",
+    "esbuild": "^0.28.1",
     "gh-pages": "^6.3.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphical-forecast-creator",
-  "version": "1.6.4",
+  "version": "1.6.3",
   "private": true,
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
       "svgo": "2.8.1",
       "@tootallnate/once": "3.0.1",
       "@ungap/structured-clone": "1.3.1",
-      "ws": "^8.20.1"
+      "ws": "^8.20.1",
+      "esbuild": "^0.28.1"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   brace-expansion: ^2.0.3
   '@ungap/structured-clone': 1.3.1
   ws: ^8.20.1
+  esbuild: ^0.28.1
 
 importers:
 
@@ -188,7 +189,7 @@ importers:
         version: 11.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.5.0(postcss@8.5.15)
@@ -218,10 +219,10 @@ importers:
         version: 4.3.0
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)
+        version: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0)
 
 packages:
 
@@ -921,162 +922,6 @@ packages:
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
-
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@firebase/ai@2.13.0':
     resolution: {integrity: sha512-nJJDQKqjAcbkZdZGT/5WTVLrGZ+pYhWbwKC90nNzmvtoRTtnOJaNS34fhKSHQeB9SALgD2kxuWT5I4AkytdZ/Q==}
@@ -3270,11 +3115,6 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -4727,7 +4567,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: ^0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -5764,84 +5604,6 @@ snapshots:
     optional: true
 
   '@epic-web/invariant@1.0.0': {}
-
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
-    optional: true
 
   '@firebase/ai@2.13.0(@firebase/app-types@0.9.5)(@firebase/app@0.14.13)':
     dependencies:
@@ -8498,10 +8260,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0)
 
   '@zarrita/storage@0.2.0':
     dependencies:
@@ -8864,36 +8626,6 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-errors@1.3.0: {}
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
-    optional: true
 
   escalade@3.2.0: {}
 
@@ -10396,7 +10128,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -10414,7 +10146,6 @@ snapshots:
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       babel-jest: 30.4.1(@babel/core@7.29.7)
-      esbuild: 0.27.7
       jest-util: 30.4.1
 
   tslib@2.8.1: {}
@@ -10510,7 +10241,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0):
+  vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10519,7 +10250,6 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
-      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.46.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ importers:
         version: 11.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.5.0(postcss@8.5.15)
@@ -199,6 +199,9 @@ importers:
       babel-plugin-istanbul:
         specifier: ^8.0.0
         version: 8.0.0
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       gh-pages:
         specifier: ^6.3.0
         version: 6.3.0
@@ -219,10 +222,10 @@ importers:
         version: 4.3.0
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
 
 packages:
 
@@ -922,6 +925,162 @@ packages:
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@firebase/ai@2.13.0':
     resolution: {integrity: sha512-nJJDQKqjAcbkZdZGT/5WTVLrGZ+pYhWbwKC90nNzmvtoRTtnOJaNS34fhKSHQeB9SALgD2kxuWT5I4AkytdZ/Q==}
@@ -3114,6 +3273,11 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -5604,6 +5768,84 @@ snapshots:
     optional: true
 
   '@epic-web/invariant@1.0.0': {}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
 
   '@firebase/ai@2.13.0(@firebase/app-types@0.9.5)(@firebase/app@0.14.13)':
     dependencies:
@@ -8260,10 +8502,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
 
   '@zarrita/storage@0.2.0':
     dependencies:
@@ -8626,6 +8868,35 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-errors@1.3.0: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -10128,7 +10399,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -10146,6 +10417,7 @@ snapshots:
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       babel-jest: 30.4.1(@babel/core@7.29.7)
+      esbuild: 0.28.1
       jest-util: 30.4.1
 
   tslib@2.8.1: {}
@@ -10241,7 +10513,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(terser@5.46.0):
+  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10250,6 +10522,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.46.0

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {

--- a/src/components/Map/Legend.tsx
+++ b/src/components/Map/Legend.tsx
@@ -141,6 +141,7 @@ const Legend: React.FC<LegendProps> = React.memo(({
       className={`map-legend ${desktopOpen ? '' : 'map-legend--desktop-hidden'} ${mobileOpen ? 'map-legend--mobile-open' : ''}`}
       role="complementary"
       aria-label="Map Legend"
+      translate="no"
     >
       {activeOutlookType === 'categorical' ? renderCategoricalLegend() : renderProbabilisticLegend()}
     </div>

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -807,6 +807,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
       // Create popup element imperatively to prevent React/OpenLayers DOM ownership conflict.
       const popupEl = document.createElement("div");
       popupEl.className = "ol-popup";
+      popupEl.setAttribute("translate", "no");
       popupEl.style.display = "none";
       popupRef.current = popupEl;
       const overlay = new Overlay({
@@ -1459,7 +1460,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
     };
 
     return (
-      <div className="map-container">
+      <div className="map-container" translate="no">
         <div ref={mapElementRef} style={{ width: "100%", height: "100%" }} />
         <div className="map-toolbar-bottom-right">
           <div className="map-toolbar-surface">

--- a/src/components/Map/OpenLayersVerificationMap.tsx
+++ b/src/components/Map/OpenLayersVerificationMap.tsx
@@ -924,7 +924,7 @@ const OpenLayersVerificationMap = forwardRef<
   };
 
   return (
-    <div className="forecast-map-container">
+    <div className="forecast-map-container" translate="no">
       <div ref={mapElementRef} style={{ width: "100%", height: "100%" }} />
       <div className="map-toolbar-bottom-right">
         <div className="flex items-center gap-1 rounded-md bg-white dark:bg-gray-800 p-1 shadow-md border border-gray-300 dark:border-gray-600">

--- a/src/components/Monitor/MonitorAlertPopup.tsx
+++ b/src/components/Monitor/MonitorAlertPopup.tsx
@@ -26,7 +26,12 @@ const MonitorAlertPopup: React.FC<MonitorAlertPopupProps> = ({ details, onClose 
   const expires = formatNwsAlertTime(details.expires);
 
   return (
-    <div className="monitor-alert-popup" role="dialog" aria-label={`${details.event} details`}>
+    <div
+      className="monitor-alert-popup"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${details.event} details`}
+    >
       <div className="monitor-alert-popup__header">
         <h3 className="monitor-alert-popup__title">{details.event}</h3>
         <button

--- a/src/components/Monitor/MonitorMap.tsx
+++ b/src/components/Monitor/MonitorMap.tsx
@@ -1,9 +1,7 @@
 import React, { useMemo, useRef } from 'react';
-import { createPortal } from 'react-dom';
 import 'ol/ol.css';
 import type { StormReport } from '../../types/stormReports';
 import type { NwsAlertFeatureCollection } from '../../monitor/nwsAlerts';
-import MonitorAlertPopup from './MonitorAlertPopup';
 import type { OutlookData } from '../../types/outlooks';
 import type { MonitorMapView, MonitorOutlookLayerType } from '../../monitor/types';
 import { flattenMonitorOutlookFeatures } from '../../monitor/outlookLayers';
@@ -41,7 +39,7 @@ const MonitorMap: React.FC<MonitorMapProps> = ({
     [outlookData, outlookType],
   );
 
-  const { selectedAlert, handleCloseAlertPopup, popupElement } = useMonitorOlMap({
+  useMonitorOlMap({
     mapView,
     radarLayer,
     radarOpacity,
@@ -55,15 +53,8 @@ const MonitorMap: React.FC<MonitorMapProps> = ({
   });
 
   return (
-    <div className="monitor-map" aria-label="Monitor map">
+    <div className="monitor-map" aria-label="Monitor map" translate="no">
       <div ref={mapElementRef} className="monitor-map__viewport" />
-      {popupElement &&
-        createPortal(
-          selectedAlert && (
-            <MonitorAlertPopup details={selectedAlert} onClose={handleCloseAlertPopup} />
-          ),
-          popupElement,
-        )}
       <div className="monitor-map__badge">Read-only monitor</div>
     </div>
   );

--- a/src/components/Monitor/renderMonitorAlertPopup.test.ts
+++ b/src/components/Monitor/renderMonitorAlertPopup.test.ts
@@ -1,0 +1,43 @@
+import { renderMonitorAlertPopup, clearMonitorAlertPopup } from './renderMonitorAlertPopup';
+import type { NwsAlertDetails } from '../../monitor/nwsAlertDetails';
+
+const sampleDetails: NwsAlertDetails = {
+  event: 'Tornado Warning',
+  headline: null,
+  areaDesc: 'Oklahoma County',
+  severity: 'Extreme',
+  certainty: 'Observed',
+  urgency: 'Immediate',
+  effective: '2026-04-20T18:00:00-05:00',
+  expires: '2026-04-20T19:00:00-05:00',
+  description: 'Take shelter now.',
+  instruction: 'Move to basement.',
+  senderName: 'NWS Norman OK',
+  detailUrl: 'https://api.weather.gov/alerts/1',
+};
+
+describe('renderMonitorAlertPopup', () => {
+  test('renders alert fields and invokes onClose from the close button', () => {
+    const container = document.createElement('div');
+    const onClose = jest.fn();
+
+    const cleanup = renderMonitorAlertPopup(container, sampleDetails, onClose);
+
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).toHaveAttribute('aria-label', 'Tornado Warning details');
+    expect(container.textContent).toContain('Oklahoma County');
+    expect(container.textContent).toContain('Take shelter now.');
+
+    const link = container.querySelector('a.monitor-alert-popup__link');
+    expect(link).toHaveAttribute('href', 'https://api.weather.gov/alerts/1');
+
+    const closeButton = container.querySelector('button[aria-label="Close alert details"]');
+    expect(closeButton).not.toBeNull();
+    closeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    clearMonitorAlertPopup(container);
+    expect(container.childElementCount).toBe(0);
+  });
+});

--- a/src/components/Monitor/renderMonitorAlertPopup.ts
+++ b/src/components/Monitor/renderMonitorAlertPopup.ts
@@ -6,6 +6,7 @@ export const clearMonitorAlertPopup = (container: HTMLElement): void => {
   container.replaceChildren();
 };
 
+/** Appends a labeled metadata row when `value` is present. */
 const appendMetaRow = (
   parent: HTMLElement,
   label: string,
@@ -31,6 +32,7 @@ const appendMetaRow = (
   parent.appendChild(row);
 };
 
+/** Appends a titled description or instruction block to the popup. */
 const appendSection = (
   parent: HTMLElement,
   title: string,
@@ -81,10 +83,7 @@ export const renderMonitorAlertPopup = (
   closeButton.setAttribute('aria-label', 'Close alert details');
   closeButton.textContent = '×';
 
-  const handleClose = () => {
-    onClose();
-  };
-  closeButton.addEventListener('click', handleClose);
+  closeButton.addEventListener('click', onClose);
 
   header.appendChild(title);
   header.appendChild(closeButton);
@@ -129,6 +128,6 @@ export const renderMonitorAlertPopup = (
   container.appendChild(dialog);
 
   return () => {
-    closeButton.removeEventListener('click', handleClose);
+    closeButton.removeEventListener('click', onClose);
   };
 };

--- a/src/components/Monitor/renderMonitorAlertPopup.ts
+++ b/src/components/Monitor/renderMonitorAlertPopup.ts
@@ -68,6 +68,7 @@ export const renderMonitorAlertPopup = (
   const dialog = document.createElement('div');
   dialog.className = 'monitor-alert-popup';
   dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
   dialog.setAttribute('aria-label', `${details.event} details`);
 
   const header = document.createElement('div');

--- a/src/components/Monitor/renderMonitorAlertPopup.ts
+++ b/src/components/Monitor/renderMonitorAlertPopup.ts
@@ -1,0 +1,134 @@
+import type { NwsAlertDetails } from '../../monitor/nwsAlertDetails';
+import { formatNwsAlertTime } from '../../monitor/nwsAlertDetails';
+
+/** Clears imperative alert popup content from an OpenLayers overlay container. */
+export const clearMonitorAlertPopup = (container: HTMLElement): void => {
+  container.replaceChildren();
+};
+
+const appendMetaRow = (
+  parent: HTMLElement,
+  label: string,
+  value: string | null,
+): void => {
+  if (!value) {
+    return;
+  }
+
+  const row = document.createElement('div');
+  row.className = 'monitor-alert-popup__metaRow';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'monitor-alert-popup__metaLabel';
+  labelEl.textContent = label;
+
+  const valueEl = document.createElement('span');
+  valueEl.className = 'monitor-alert-popup__metaValue';
+  valueEl.textContent = value;
+
+  row.appendChild(labelEl);
+  row.appendChild(valueEl);
+  parent.appendChild(row);
+};
+
+const appendSection = (
+  parent: HTMLElement,
+  title: string,
+  body: string,
+): void => {
+  const section = document.createElement('section');
+  section.className = 'monitor-alert-popup__section';
+
+  const heading = document.createElement('h4');
+  heading.className = 'monitor-alert-popup__sectionTitle';
+  heading.textContent = title;
+
+  const paragraph = document.createElement('p');
+  paragraph.className = 'monitor-alert-popup__body';
+  paragraph.textContent = body;
+
+  section.appendChild(heading);
+  section.appendChild(paragraph);
+  parent.appendChild(section);
+};
+
+/**
+ * Renders NWS alert details into an OpenLayers overlay element without React.
+ * Returns a cleanup function that removes the close-button listener.
+ */
+export const renderMonitorAlertPopup = (
+  container: HTMLElement,
+  details: NwsAlertDetails,
+  onClose: () => void,
+): (() => void) => {
+  clearMonitorAlertPopup(container);
+
+  const dialog = document.createElement('div');
+  dialog.className = 'monitor-alert-popup';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-label', `${details.event} details`);
+
+  const header = document.createElement('div');
+  header.className = 'monitor-alert-popup__header';
+
+  const title = document.createElement('h3');
+  title.className = 'monitor-alert-popup__title';
+  title.textContent = details.event;
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'monitor-alert-popup__close';
+  closeButton.setAttribute('aria-label', 'Close alert details');
+  closeButton.textContent = '×';
+
+  const handleClose = () => {
+    onClose();
+  };
+  closeButton.addEventListener('click', handleClose);
+
+  header.appendChild(title);
+  header.appendChild(closeButton);
+  dialog.appendChild(header);
+
+  if (details.headline) {
+    const headline = document.createElement('p');
+    headline.className = 'monitor-alert-popup__headline';
+    headline.textContent = details.headline;
+    dialog.appendChild(headline);
+  }
+
+  const meta = document.createElement('div');
+  meta.className = 'monitor-alert-popup__meta';
+  appendMetaRow(meta, 'Area', details.areaDesc);
+  appendMetaRow(meta, 'Severity', details.severity);
+  appendMetaRow(meta, 'Certainty', details.certainty);
+  appendMetaRow(meta, 'Urgency', details.urgency);
+  appendMetaRow(meta, 'Effective', formatNwsAlertTime(details.effective));
+  appendMetaRow(meta, 'Expires', formatNwsAlertTime(details.expires));
+  appendMetaRow(meta, 'Issued by', details.senderName);
+  dialog.appendChild(meta);
+
+  if (details.description) {
+    appendSection(dialog, 'Description', details.description);
+  }
+
+  if (details.instruction) {
+    appendSection(dialog, 'Instructions', details.instruction);
+  }
+
+  if (details.detailUrl) {
+    const link = document.createElement('a');
+    link.className = 'monitor-alert-popup__link';
+    link.href = details.detailUrl;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = 'View full alert on weather.gov';
+    dialog.appendChild(link);
+  }
+
+  container.appendChild(dialog);
+
+  return () => {
+    closeButton.removeEventListener('click', handleClose);
+  };
+};

--- a/src/components/Monitor/useMonitorMapBootstrap.ts
+++ b/src/components/Monitor/useMonitorMapBootstrap.ts
@@ -12,6 +12,7 @@ import { buildNwsAlertStyle } from '../../monitor/nwsAlerts';
 import { parseNwsAlertFromOlProperties } from '../../monitor/nwsAlertDetails';
 import type { NwsAlertDetails } from '../../monitor/nwsAlertDetails';
 import { hideOverlay } from '../Map/OpenLayersForecastMap';
+import { clearMonitorAlertPopup } from './renderMonitorAlertPopup';
 import { useDispatch } from 'react-redux';
 import type { AppDispatch } from '../../store';
 import { setMonitorMapView } from '../../store/monitorSlice';
@@ -43,7 +44,6 @@ interface UseMonitorMapBootstrapArgs {
   mapElementRef: RefObject<HTMLDivElement | null>;
   refs: MonitorMapRefs;
   onSelectAlert: (details: NwsAlertDetails | null) => void;
-  onCreatePopupElement: (el: HTMLDivElement | null) => void;
 }
 
 export const useMonitorMapBootstrap = ({
@@ -55,7 +55,6 @@ export const useMonitorMapBootstrap = ({
   mapElementRef,
   refs,
   onSelectAlert,
-  onCreatePopupElement,
 }: UseMonitorMapBootstrapArgs) => {
   const dispatch = useDispatch<AppDispatch>();
 
@@ -168,8 +167,8 @@ export const useMonitorMapBootstrap = ({
 
     const popupEl = document.createElement("div");
     popupEl.className = "monitor-map__alertOverlay";
+    popupEl.setAttribute("translate", "no");
     refs.popupElRef.current = popupEl;
-    onCreatePopupElement(popupEl);
     const overlay = new Overlay({ element: popupEl, autoPan: false });
     map.addOverlay(overlay);
     refs.overlayRef.current = overlay;
@@ -210,6 +209,10 @@ export const useMonitorMapBootstrap = ({
       if (target instanceof HTMLElement) {
         target.style.cursor = '';
       }
+      onSelectAlert(null);
+      if (refs.popupElRef.current) {
+        clearMonitorAlertPopup(refs.popupElRef.current);
+      }
       if (refs.overlayRef.current) {
         map.removeOverlay(refs.overlayRef.current);
         refs.overlayRef.current = null;
@@ -218,7 +221,6 @@ export const useMonitorMapBootstrap = ({
         refs.popupElRef.current.remove();
         refs.popupElRef.current = null;
       }
-      onCreatePopupElement(null);
       map.setTarget();
       refs.mapRef.current = null;
       refs.baseLayerRef.current = null;

--- a/src/components/Monitor/useMonitorOlMap.ts
+++ b/src/components/Monitor/useMonitorOlMap.ts
@@ -39,7 +39,9 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
       hideOverlay(refs.overlayRef.current);
     }
     setSelectedAlert(null);
-  }, [refs]);
+    // refs omitted: wrapper object from useMonitorMapRefs() is new each render,
+    // but all inner refs are stable across renders.
+  }, []);
 
   useMonitorMapBootstrap({
     mapView: args.mapView,
@@ -82,8 +84,4 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
     onClearSelectedAlert: clearSelectedAlert,
   });
 
-  return {
-    selectedAlert,
-    handleCloseAlertPopup: clearSelectedAlert,
-  };
 };

--- a/src/components/Monitor/useMonitorOlMap.ts
+++ b/src/components/Monitor/useMonitorOlMap.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useState, type RefObject } from 'react';
 import { useSelector } from 'react-redux';
 import type { StormReport } from '../../types/stormReports';
 import type { NwsAlertFeatureCollection } from '../../monitor/nwsAlerts';
@@ -11,6 +11,10 @@ import type { SerializedMonitorOutlookFeature } from './monitorMapFeatureSync';
 import { useMonitorMapBootstrap } from './useMonitorMapBootstrap';
 import { useMonitorMapLayerSync } from './useMonitorMapLayerSync';
 import { useMonitorMapRefs } from './monitorMapRefs';
+import {
+  clearMonitorAlertPopup,
+  renderMonitorAlertPopup,
+} from './renderMonitorAlertPopup';
 
 interface UseMonitorOlMapArgs {
   mapView: MonitorMapView;
@@ -28,7 +32,6 @@ interface UseMonitorOlMapArgs {
 export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
   const [selectedAlert, setSelectedAlert] = useState<NwsAlertDetails | null>(null);
-  const [popupElement, setPopupElement] = useState<HTMLDivElement | null>(null);
   const refs = useMonitorMapRefs();
 
   const clearSelectedAlert = useCallback(() => {
@@ -47,8 +50,22 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
     mapElementRef: args.mapElementRef,
     refs,
     onSelectAlert: setSelectedAlert,
-    onCreatePopupElement: setPopupElement,
   });
+
+  useEffect(() => {
+    const container = refs.popupElRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    if (!selectedAlert) {
+      clearMonitorAlertPopup(container);
+      return undefined;
+    }
+
+    return renderMonitorAlertPopup(container, selectedAlert, clearSelectedAlert);
+    // refs omitted: wrapper object from useMonitorMapRefs() is new each render.
+  }, [clearSelectedAlert, selectedAlert]);
 
   useMonitorMapLayerSync({
     mapView: args.mapView,
@@ -68,6 +85,5 @@ export const useMonitorOlMap = (args: UseMonitorOlMapArgs) => {
   return {
     selectedAlert,
     handleCloseAlertPopup: clearSelectedAlert,
-    popupElement,
   };
 };

--- a/src/content/updates/v1.6.ts
+++ b/src/content/updates/v1.6.ts
@@ -15,6 +15,12 @@ export interface ReleaseImprovement {
   text: string;
 }
 
+export interface ReleaseHotfixes {
+  title: string;
+  body: string;
+  items: ReleaseImprovement[];
+}
+
 export interface ReleaseUpdate {
   version: string;
   title: string;
@@ -22,6 +28,7 @@ export interface ReleaseUpdate {
   /** Optional hero graphics under `public/updates/v{version}/`. */
   promoImages?: UpdateScreenshot[];
   sections: UpdateSection[];
+  hotfixes?: ReleaseHotfixes;
   improvements: ReleaseImprovement[];
 }
 
@@ -79,6 +86,21 @@ export const v16Update: ReleaseUpdate = {
       ],
     },
   ],
+  hotfixes: {
+    title: 'v1.6 Hotfixes',
+    body:
+      'Stability fixes shipped after the v1.6 release for map-heavy workflows on forecast, verification, and monitor.',
+    items: [
+      {
+        id: 'openlayers-removechild',
+        text: 'Fixed a map error that could surface as a blank or unstable editor when OpenLayers and React disagreed about popup DOM ownership — especially on Monitor alert popups and when switching outlook types or routes.',
+      },
+      {
+        id: 'map-translation-guard',
+        text: 'Map shells and legends are now marked notranslate so Chrome auto-translate is less likely to rewrite map UI text and trigger React DOM errors on mobile browsers.',
+      },
+    ],
+  },
   improvements: [
     {
       id: 'safari-hosted-sleep',

--- a/src/pages/UpdatesPage.css
+++ b/src/pages/UpdatesPage.css
@@ -185,6 +185,7 @@
   font-size: 0.875rem;
 }
 
+.updates-page__hotfixes,
 .updates-page__improvements {
   margin: 2.5rem 0 0;
   padding: 1.25rem 1.35rem;
@@ -193,11 +194,19 @@
   background: var(--bg-secondary);
 }
 
+.updates-page__hotfixes p {
+  margin: 0 0 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.updates-page__hotfixes h2,
 .updates-page__improvements h2 {
   margin: 0 0 0.75rem;
   font-size: 1.2rem;
 }
 
+.updates-page__hotfixes ul,
 .updates-page__improvements ul {
   margin: 0;
   padding-left: 1.2rem;
@@ -205,6 +214,7 @@
   line-height: 1.65;
 }
 
+.updates-page__hotfixes li + li,
 .updates-page__improvements li + li {
   margin-top: 0.45rem;
 }

--- a/src/pages/UpdatesPage.test.tsx
+++ b/src/pages/UpdatesPage.test.tsx
@@ -27,6 +27,8 @@ describe('UpdatesPage', () => {
     expect(document.querySelector('img[src="/updates/v1.6/v1.6-promo-image-light-mrms-visible.png"]')).toBeTruthy();
     expect(document.querySelector('img[src="/updates/v1.6/v1.6-promo-image-dark-single-site-shortwave-ir.png"]')).toBeTruthy();
     expect(screen.getByRole('heading', { name: /Monitor workspace/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /v1\.6 Hotfixes/i })).toBeInTheDocument();
+    expect(screen.getByText(/OpenLayers and React disagreed about popup DOM ownership/i)).toBeInTheDocument();
     expect(screen.getByText(/Signed-in home page primary buttons are easier to read/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Back to home/i })).toHaveAttribute('href', '/');
   });

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -142,6 +142,18 @@ export const UpdatesPage: React.FC = () => {
           </section>
         ))}
 
+        {v16Update.hotfixes ? (
+          <section className="updates-page__hotfixes" aria-labelledby="updates-hotfixes-heading">
+            <h2 id="updates-hotfixes-heading">{v16Update.hotfixes.title}</h2>
+            <p>{v16Update.hotfixes.body}</p>
+            <ul>
+              {v16Update.hotfixes.items.map((item) => (
+                <li key={item.id}>{item.text}</li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
         <section className="updates-page__improvements" aria-labelledby="updates-improvements-heading">
           <h2 id="updates-improvements-heading">Also improved</h2>
           <ul>


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/auto-generate-tstm-lines`.

| | |
| --- | --- |
| Original PR | #507 — [Security Hotfix] Install patched esbuild 0.28.1 |
| Source branch | `hotfix/esbuild-0.28.1` (merged into `main`) |
| Port method attempted | merge (PR head) |

### Conflicted files


- `CHANGELOG.md`
- `package.json`
- `pnpm-lock.yaml`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/507-to-feature-auto-generate-tstm-lines`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #507, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/auto-generate-tstm-lines` drifting behind `main`.