### PR TITLE
[Port] [Backport] Add beta per-PR changelog governance to feature/auto-generate-tstm-lines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,8 +24,8 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 **Example**: `feat(map): add support for high-resolution CWA boundaries`
 
 ## 📖 Change Documentation
-### 1. CHANGELOG.md
-Every user-facing change must be recorded in [CHANGELOG.md](../CHANGELOG.md) under the `[Unreleased]` or current version section using these categories:
+### 1. Changelogs
+PRs targeting `beta` add one concise entry to [CHANGELOG.beta.md](../CHANGELOG.beta.md) under `## Unreleased` using a `### PR #123` heading. PRs targeting `main` update [CHANGELOG.md](../CHANGELOG.md) under the current production version.
 *   `Added`: For new features.
 *   `Changed`: For changes in existing functionality.
 *   `Deprecated`: For soon-to-be removed features.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: node scripts/check-changelog-pr.mjs
 
       - name: Production release manifest (beta → main)
@@ -66,7 +67,7 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
-        run: node --test scripts/lib/package-version.test.mjs scripts/lib/bump-beta-after-main-release.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/pr-ci-label-state.test.mjs scripts/lib/github-paginate.test.mjs scripts/lib/changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/bump-beta-after-main-release.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/pr-ci-label-state.test.mjs scripts/lib/github-paginate.test.mjs scripts/lib/changelog.test.mjs scripts/lib/beta-changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
 
       - name: Validate package version for target branch
         env:

--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -33,16 +33,19 @@ jobs:
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: node scripts/update-dependabot-changelog.mjs
 
       - name: Commit and push
         run: |
-          if git diff --quiet CHANGELOG.md; then
-            echo "No CHANGELOG changes to commit."
+          CHANGELOG_FILE="CHANGELOG.md"
+          if [ "${{ github.base_ref }}" = "beta" ]; then CHANGELOG_FILE="CHANGELOG.beta.md"; fi
+          if git diff --quiet "$CHANGELOG_FILE"; then
+            echo "No changelog changes to commit."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "chore: update CHANGELOG dependencies for Dependabot bump"
+          git add "$CHANGELOG_FILE"
+          git commit -m "chore: update dependency changelog for Dependabot bump"
           git push

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -40,6 +40,7 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: node scripts/compute-pr-labels.mjs > pr-labels.json
 
       - name: Apply PR labels

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,3 +4,6 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #509
+
+- Add the dedicated beta per-PR changelog, branch-aware governance checks, Dependabot routing, and release consolidation tooling.

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -1,0 +1,6 @@
+# Beta Changelog
+
+Development entries for pull requests targeting `beta`. These notes are consolidated and edited before release; they are not the production changelog.
+
+## Unreleased
+

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test": "jest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "changelog:consolidate-beta": "node scripts/consolidate-beta-changelog.mjs",
     "predeploy": "pnpm run build",
     "deploy": "gh-pages -d build"
   },

--- a/scripts/check-changelog-pr.mjs
+++ b/scripts/check-changelog-pr.mjs
@@ -6,10 +6,12 @@ import {
 } from './lib/dependabot-changelog.mjs';
 import { evaluateBranchPolicy } from './lib/branch-policy.mjs';
 import { listChangedFilesBetweenRefs } from './lib/git-changed-files.mjs';
+import { BETA_CHANGELOG_PATH, betaChangelogTouchesPr } from './lib/beta-changelog.mjs';
 
 const baseRef = process.env.GITHUB_BASE_REF ?? '';
 const headRef = process.env.GITHUB_HEAD_REF ?? '';
 const prBody = process.env.PR_BODY ?? '';
+const prNumber = Number(process.env.PR_NUMBER ?? 0);
 
 if (!baseRef || !headRef) {
   console.log('No PR base/head branch; skipping changelog check.');
@@ -40,10 +42,26 @@ const changedFiles = listChangedFilesBetweenRefs(baseRef, headRef);
 
 if (headRef.startsWith('dependabot/')) {
   const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
-  const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:CHANGELOG.md`], {
+  const changelogPath = baseRef === 'beta' ? BETA_CHANGELOG_PATH : 'CHANGELOG.md';
+  const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:${changelogPath}`], {
     encoding: 'utf8',
   });
-  const result = dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps);
+  const result = baseRef === 'beta'
+    ? betaChangelogTouchesPr(changedFiles, changelogAtHead, prNumber)
+    : dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps);
+  if (!result.ok) {
+    console.error(result.reason);
+    process.exit(1);
+  }
+  console.log(result.reason);
+  process.exit(0);
+}
+
+if (baseRef === 'beta') {
+  const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:${BETA_CHANGELOG_PATH}`], {
+    encoding: 'utf8',
+  });
+  const result = betaChangelogTouchesPr(changedFiles, changelogAtHead, prNumber);
   if (!result.ok) {
     console.error(result.reason);
     process.exit(1);

--- a/scripts/compute-pr-labels.mjs
+++ b/scripts/compute-pr-labels.mjs
@@ -7,10 +7,12 @@ import {
 } from './lib/dependabot-changelog.mjs';
 import { listChangedFilesBetweenRefs } from './lib/git-changed-files.mjs';
 import { CONTENT_MANAGED_LABELS, computePrLabels } from './lib/pr-labels.mjs';
+import { BETA_CHANGELOG_PATH, betaChangelogTouchesPr } from './lib/beta-changelog.mjs';
 
 const baseRef = process.env.GITHUB_BASE_REF ?? '';
 const headRef = process.env.GITHUB_HEAD_REF ?? '';
 const prBody = process.env.PR_BODY ?? '';
+const prNumber = Number(process.env.PR_NUMBER ?? 0);
 
 if (!baseRef || !headRef) {
   console.log('No PR base/head branch; skipping label computation.');
@@ -30,10 +32,18 @@ if (
 ) {
   if (headRef.startsWith('dependabot/')) {
     const bumps = listDependencyBumpsBetweenRefs(baseRef, headRef);
-    const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:CHANGELOG.md`], {
+    const changelogPath = baseRef === 'beta' ? BETA_CHANGELOG_PATH : 'CHANGELOG.md';
+    const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:${changelogPath}`], {
       encoding: 'utf8',
     });
-    changelogOk = dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps).ok;
+    changelogOk = baseRef === 'beta'
+      ? betaChangelogTouchesPr(changedFiles, changelogAtHead, prNumber).ok
+      : dependabotChangelogTouchesPr(changedFiles, changelogAtHead, bumps).ok;
+  } else if (baseRef === 'beta') {
+    const changelogAtHead = execFileSync('git', ['show', `origin/${headRef}:${BETA_CHANGELOG_PATH}`], {
+      encoding: 'utf8',
+    });
+    changelogOk = betaChangelogTouchesPr(changedFiles, changelogAtHead, prNumber).ok;
   } else {
     const changelogResult = changelogTouchesPr(changedFiles, prBody);
     changelogOk = changelogResult.ok;

--- a/scripts/consolidate-beta-changelog.mjs
+++ b/scripts/consolidate-beta-changelog.mjs
@@ -1,0 +1,36 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { takeBetaChangelogEntries } from './lib/beta-changelog.mjs';
+
+const prNumbers = process.argv.slice(2).map(Number);
+if (prNumbers.length === 0 || prNumbers.some((value) => !Number.isInteger(value) || value <= 0)) {
+  console.error('Usage: node scripts/consolidate-beta-changelog.mjs <pr-number> [...]');
+  process.exit(1);
+}
+
+const betaPath = 'CHANGELOG.beta.md';
+const productionPath = 'CHANGELOG.md';
+const beta = readFileSync(betaPath, 'utf8');
+const production = readFileSync(productionPath, 'utf8');
+const result = takeBetaChangelogEntries(beta, prNumbers);
+const heading = '### Changed';
+const bullets = result.entries.map((entry) => `- ${entry}`).join('\n');
+const activeSection = production.match(/^## (?:\[?Unreleased\]?|v[\d.]+).*$/m);
+if (!activeSection?.index && activeSection?.index !== 0) {
+  throw new Error('CHANGELOG.md needs an Unreleased or version section before consolidation.');
+}
+const sectionStart = activeSection.index;
+const sectionTail = production.slice(sectionStart);
+const nextSectionOffset = sectionTail.slice(activeSection[0].length).search(/\n## /);
+const sectionEnd = nextSectionOffset === -1
+  ? production.length
+  : sectionStart + activeSection[0].length + nextSectionOffset;
+const sectionBody = production.slice(sectionStart, sectionEnd);
+const changedHeadingIndex = sectionBody.indexOf(heading);
+const nextSectionBody = changedHeadingIndex === -1
+  ? `${activeSection[0]}\n\n${heading}\n${bullets}\n${sectionBody.slice(activeSection[0].length).trimStart()}`
+  : sectionBody.replace(heading, `${heading}\n${bullets}`);
+const nextProduction = production.slice(0, sectionStart) + nextSectionBody + production.slice(sectionEnd);
+
+writeFileSync(betaPath, result.changelog);
+writeFileSync(productionPath, nextProduction);
+console.log(`Consolidated beta changelog entries for PRs: ${prNumbers.join(', ')}`);

--- a/scripts/consolidate-beta-changelog.mjs
+++ b/scripts/consolidate-beta-changelog.mjs
@@ -28,7 +28,7 @@ const sectionBody = production.slice(sectionStart, sectionEnd);
 const changedHeadingIndex = sectionBody.indexOf(heading);
 const nextSectionBody = changedHeadingIndex === -1
   ? `${activeSection[0]}\n\n${heading}\n${bullets}\n${sectionBody.slice(activeSection[0].length).trimStart()}`
-  : sectionBody.replace(heading, `${heading}\n${bullets}`);
+  : sectionBody.replace(heading, () => `${heading}\n${bullets}`);
 const nextProduction = production.slice(0, sectionStart) + nextSectionBody + production.slice(sectionEnd);
 
 writeFileSync(betaPath, result.changelog);

--- a/scripts/lib/beta-changelog.mjs
+++ b/scripts/lib/beta-changelog.mjs
@@ -1,6 +1,28 @@
 export const BETA_CHANGELOG_PATH = 'CHANGELOG.beta.md';
 
+/** Builds the canonical heading for one beta changelog PR entry. */
 const entryHeading = (prNumber) => `### PR #${prNumber}`;
+
+/** Rejects incomplete data before an entry is formatted. */
+const validateEntryInput = (prNumber, bullets) => {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error('A positive PR number is required.');
+  }
+  if (!Array.isArray(bullets) || bullets.length === 0) {
+    throw new Error('At least one beta changelog bullet is required.');
+  }
+  if (bullets.some((bullet) => !bullet.trim())) {
+    throw new Error('Beta changelog bullets cannot be empty.');
+  }
+};
+
+/** Formats normalized input as one machine-parseable PR section. */
+const formatEntry = (prNumber, bullets) => {
+  const body = bullets
+    .map((bullet) => `- ${bullet.replace(/^[-*]\s*/, '')}`)
+    .join('\n');
+  return `${entryHeading(prNumber)}\n\n${body}`;
+};
 
 /** Returns one PR entry body, or null when it is missing. */
 export const extractBetaChangelogEntry = (changelog, prNumber) => {
@@ -37,14 +59,8 @@ export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
 
 /** Inserts or replaces one PR entry under Unreleased. */
 export const upsertBetaChangelogEntry = (changelog, prNumber, bullets) => {
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
-    throw new Error('A positive PR number is required.');
-  }
-  if (!Array.isArray(bullets) || bullets.length === 0 || bullets.some((bullet) => !bullet.trim())) {
-    throw new Error('At least one non-empty beta changelog bullet is required.');
-  }
-  const heading = entryHeading(prNumber);
-  const entry = `${heading}\n\n${bullets.map((bullet) => `- ${bullet.replace(/^[-*]\s*/, '')}`).join('\n')}`;
+  validateEntryInput(prNumber, bullets);
+  const entry = formatEntry(prNumber, bullets);
   const existing = extractBetaChangelogEntry(changelog, prNumber);
   if (existing) return changelog.replace(existing, entry);
   const unreleased = '## Unreleased';
@@ -64,5 +80,5 @@ export const takeBetaChangelogEntries = (changelog, prNumbers) => {
     entries.push(...entry.split('\n').filter((line) => /^[-*]\s+/.test(line)).map((line) => line.replace(/^[-*]\s+/, '')));
     next = next.replace(entry, '').replace(/\n{3,}/g, '\n\n');
   }
-  return { changelog: next.trimEnd() + '\n', entries };
+  return { changelog: `${next.trimEnd()}\n`, entries };
 };

--- a/scripts/lib/beta-changelog.mjs
+++ b/scripts/lib/beta-changelog.mjs
@@ -3,6 +3,11 @@ export const BETA_CHANGELOG_PATH = 'CHANGELOG.beta.md';
 /** Builds the canonical heading for one beta changelog PR entry. */
 const entryHeading = (prNumber) => `### PR #${prNumber}`;
 
+/** Matches a complete PR heading without treating #50 as #500. */
+const entryHeadingPattern = (prNumber, flags = '') => (
+  new RegExp(`^${entryHeading(prNumber)}(?!\\d)`, flags.includes('m') ? flags : `${flags}m`)
+);
+
 /** Rejects incomplete data before an entry is formatted. */
 const validateEntryInput = (prNumber, bullets) => {
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
@@ -27,7 +32,8 @@ const formatEntry = (prNumber, bullets) => {
 /** Returns one PR entry body, or null when it is missing. */
 export const extractBetaChangelogEntry = (changelog, prNumber) => {
   const heading = entryHeading(prNumber);
-  const start = changelog.indexOf(heading);
+  const match = entryHeadingPattern(prNumber).exec(changelog);
+  const start = match?.index ?? -1;
   if (start === -1) return null;
   const rest = changelog.slice(start + heading.length);
   const next = rest.search(/\n### PR #|\n## /);
@@ -50,7 +56,7 @@ export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
       reason: `${BETA_CHANGELOG_PATH} must include ${entryHeading(prNumber)} with at least one bullet.`,
     };
   }
-  const occurrences = changelog.split(entryHeading(prNumber)).length - 1;
+  const occurrences = [...changelog.matchAll(entryHeadingPattern(prNumber, 'g'))].length;
   if (occurrences !== 1) {
     return { ok: false, reason: `${entryHeading(prNumber)} must appear exactly once.` };
   }
@@ -62,7 +68,7 @@ export const upsertBetaChangelogEntry = (changelog, prNumber, bullets) => {
   validateEntryInput(prNumber, bullets);
   const entry = formatEntry(prNumber, bullets);
   const existing = extractBetaChangelogEntry(changelog, prNumber);
-  if (existing) return changelog.replace(existing, entry);
+  if (existing) return changelog.replace(existing, () => entry);
   const unreleased = '## Unreleased';
   const index = changelog.indexOf(unreleased);
   if (index === -1) throw new Error(`${BETA_CHANGELOG_PATH} must include ${unreleased}.`);

--- a/scripts/lib/beta-changelog.mjs
+++ b/scripts/lib/beta-changelog.mjs
@@ -8,9 +8,17 @@ const entryHeadingPattern = (prNumber, flags = '') => (
   new RegExp(`^${entryHeading(prNumber)}(?!\\d)`, flags.includes('m') ? flags : `${flags}m`)
 );
 
+/** Reports whether a value can identify a GitHub pull request. */
+const isValidPrNumber = (prNumber) => Number.isInteger(prNumber) && prNumber > 0;
+
+/** Counts complete headings for one PR without matching numeric prefixes. */
+const countEntryHeadings = (changelog, prNumber) => (
+  [...changelog.matchAll(entryHeadingPattern(prNumber, 'g'))].length
+);
+
 /** Rejects incomplete data before an entry is formatted. */
 const validateEntryInput = (prNumber, bullets) => {
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+  if (!isValidPrNumber(prNumber)) {
     throw new Error('A positive PR number is required.');
   }
   if (!Array.isArray(bullets) || bullets.length === 0) {
@@ -43,7 +51,7 @@ export const extractBetaChangelogEntry = (changelog, prNumber) => {
 
 /** Validates that a beta PR has exactly one non-empty bullet entry. */
 export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+  if (!isValidPrNumber(prNumber)) {
     return { ok: false, reason: 'A valid PR_NUMBER is required for beta changelog validation.' };
   }
   if (!changedFiles.includes(BETA_CHANGELOG_PATH)) {
@@ -56,7 +64,7 @@ export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
       reason: `${BETA_CHANGELOG_PATH} must include ${entryHeading(prNumber)} with at least one bullet.`,
     };
   }
-  const occurrences = [...changelog.matchAll(entryHeadingPattern(prNumber, 'g'))].length;
+  const occurrences = countEntryHeadings(changelog, prNumber);
   if (occurrences !== 1) {
     return { ok: false, reason: `${entryHeading(prNumber)} must appear exactly once.` };
   }

--- a/scripts/lib/beta-changelog.mjs
+++ b/scripts/lib/beta-changelog.mjs
@@ -1,0 +1,68 @@
+export const BETA_CHANGELOG_PATH = 'CHANGELOG.beta.md';
+
+const entryHeading = (prNumber) => `### PR #${prNumber}`;
+
+/** Returns one PR entry body, or null when it is missing. */
+export const extractBetaChangelogEntry = (changelog, prNumber) => {
+  const heading = entryHeading(prNumber);
+  const start = changelog.indexOf(heading);
+  if (start === -1) return null;
+  const rest = changelog.slice(start + heading.length);
+  const next = rest.search(/\n### PR #|\n## /);
+  const body = (next === -1 ? rest : rest.slice(0, next)).trim();
+  return body ? `${heading}\n\n${body}` : null;
+};
+
+/** Validates that a beta PR has exactly one non-empty bullet entry. */
+export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    return { ok: false, reason: 'A valid PR_NUMBER is required for beta changelog validation.' };
+  }
+  if (!changedFiles.includes(BETA_CHANGELOG_PATH)) {
+    return { ok: false, reason: `PRs targeting beta must update ${BETA_CHANGELOG_PATH}.` };
+  }
+  const entry = extractBetaChangelogEntry(changelog, prNumber);
+  if (!entry || !/^\s*[-*]\s+\S/m.test(entry)) {
+    return {
+      ok: false,
+      reason: `${BETA_CHANGELOG_PATH} must include ${entryHeading(prNumber)} with at least one bullet.`,
+    };
+  }
+  const occurrences = changelog.split(entryHeading(prNumber)).length - 1;
+  if (occurrences !== 1) {
+    return { ok: false, reason: `${entryHeading(prNumber)} must appear exactly once.` };
+  }
+  return { ok: true, reason: `${BETA_CHANGELOG_PATH} documents PR #${prNumber}.` };
+};
+
+/** Inserts or replaces one PR entry under Unreleased. */
+export const upsertBetaChangelogEntry = (changelog, prNumber, bullets) => {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error('A positive PR number is required.');
+  }
+  if (!Array.isArray(bullets) || bullets.length === 0 || bullets.some((bullet) => !bullet.trim())) {
+    throw new Error('At least one non-empty beta changelog bullet is required.');
+  }
+  const heading = entryHeading(prNumber);
+  const entry = `${heading}\n\n${bullets.map((bullet) => `- ${bullet.replace(/^[-*]\s*/, '')}`).join('\n')}`;
+  const existing = extractBetaChangelogEntry(changelog, prNumber);
+  if (existing) return changelog.replace(existing, entry);
+  const unreleased = '## Unreleased';
+  const index = changelog.indexOf(unreleased);
+  if (index === -1) throw new Error(`${BETA_CHANGELOG_PATH} must include ${unreleased}.`);
+  const insertAt = index + unreleased.length;
+  return `${changelog.slice(0, insertAt)}\n\n${entry}\n${changelog.slice(insertAt).replace(/^\s*/, '')}`;
+};
+
+/** Removes selected entries and returns their bullet text for release editing. */
+export const takeBetaChangelogEntries = (changelog, prNumbers) => {
+  const entries = [];
+  let next = changelog;
+  for (const prNumber of prNumbers) {
+    const entry = extractBetaChangelogEntry(next, prNumber);
+    if (!entry) throw new Error(`Missing beta changelog entry for PR #${prNumber}.`);
+    entries.push(...entry.split('\n').filter((line) => /^[-*]\s+/.test(line)).map((line) => line.replace(/^[-*]\s+/, '')));
+    next = next.replace(entry, '').replace(/\n{3,}/g, '\n\n');
+  }
+  return { changelog: next.trimEnd() + '\n', entries };
+};

--- a/scripts/lib/beta-changelog.test.mjs
+++ b/scripts/lib/beta-changelog.test.mjs
@@ -53,3 +53,20 @@ test('requires valid content for generated entries and selected entries for cons
   assert.throws(() => upsertBetaChangelogEntry(sample, 503, []));
   assert.throws(() => takeBetaChangelogEntries(sample, [503]), /Missing beta changelog entry/);
 });
+
+test('does not confuse PR numbers that share a numeric prefix', () => {
+  const with500 = upsertBetaChangelogEntry(sample, 500, ['Higher-numbered PR']);
+  assert.equal(extractBetaChangelogEntry(with500, 50), null);
+  assert.equal(betaChangelogTouchesPr(['CHANGELOG.beta.md'], with500, 50).ok, false);
+
+  const withBoth = upsertBetaChangelogEntry(with500, 50, ['Lower-numbered PR']);
+  assert.match(extractBetaChangelogEntry(withBoth, 50) ?? '', /Lower-numbered PR/);
+  assert.match(extractBetaChangelogEntry(withBoth, 500) ?? '', /Higher-numbered PR/);
+  assert.equal(betaChangelogTouchesPr(['CHANGELOG.beta.md'], withBoth, 50).ok, true);
+});
+
+test('preserves dollar substitution tokens when replacing an entry', () => {
+  const inserted = upsertBetaChangelogEntry(sample, 503, ['Original']);
+  const updated = upsertBetaChangelogEntry(inserted, 503, ['$& $1 $` $\' remain literal']);
+  assert.match(updated, /\$& \$1 \$` \$' remain literal/);
+});

--- a/scripts/lib/beta-changelog.test.mjs
+++ b/scripts/lib/beta-changelog.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  betaChangelogTouchesPr,
+  extractBetaChangelogEntry,
+  takeBetaChangelogEntries,
+  upsertBetaChangelogEntry,
+} from './beta-changelog.mjs';
+
+const sample = '# Beta Changelog\n\n## Unreleased\n';
+
+test('upserts and replaces one PR entry without duplicates', () => {
+  const inserted = upsertBetaChangelogEntry(sample, 503, ['First note']);
+  const updated = upsertBetaChangelogEntry(inserted, 503, ['Updated note']);
+  assert.match(updated, /### PR #503[\s\S]*Updated note/);
+  assert.doesNotMatch(updated, /First note/);
+  assert.equal(updated.split('### PR #503').length - 1, 1);
+});
+
+test('validates the current PR entry and rejects another PR entry', () => {
+  const changelog = upsertBetaChangelogEntry(sample, 503, ['Feature foundation']);
+  assert.equal(betaChangelogTouchesPr(['CHANGELOG.beta.md'], changelog, 503).ok, true);
+  assert.equal(betaChangelogTouchesPr(['CHANGELOG.beta.md'], changelog, 504).ok, false);
+  assert.equal(betaChangelogTouchesPr(['CHANGELOG.beta.md'], changelog, 0).ok, false);
+});
+
+test('rejects missing, malformed, and duplicate entries', () => {
+  assert.equal(betaChangelogTouchesPr([], sample, 503).ok, false);
+  assert.equal(
+    betaChangelogTouchesPr(
+      ['CHANGELOG.beta.md'],
+      `${sample}\n### PR #503\n\nNo bullet\n`,
+      503,
+    ).ok,
+    false,
+  );
+  const duplicate = `${upsertBetaChangelogEntry(sample, 503, ['First'])}\n### PR #503\n\n- Second\n`;
+  assert.equal(betaChangelogTouchesPr(['CHANGELOG.beta.md'], duplicate, 503).ok, false);
+});
+
+test('extracts and consolidates selected entries without discarding others', () => {
+  const first = upsertBetaChangelogEntry(sample, 503, ['Foundation']);
+  const changelog = upsertBetaChangelogEntry(first, 504, ['Governance']);
+  assert.match(extractBetaChangelogEntry(changelog, 503) ?? '', /Foundation/);
+  const result = takeBetaChangelogEntries(changelog, [503]);
+  assert.deepEqual(result.entries, ['Foundation']);
+  assert.doesNotMatch(result.changelog, /PR #503/);
+  assert.match(result.changelog, /PR #504/);
+});
+
+test('requires valid content for generated entries and selected entries for consolidation', () => {
+  assert.throws(() => upsertBetaChangelogEntry(sample, 0, ['Invalid PR']));
+  assert.throws(() => upsertBetaChangelogEntry(sample, 503, []));
+  assert.throws(() => takeBetaChangelogEntries(sample, [503]), /Missing beta changelog entry/);
+});

--- a/scripts/lib/pr-label-content.mjs
+++ b/scripts/lib/pr-label-content.mjs
@@ -54,7 +54,7 @@ const CONTENT_LABEL_RULES = [
   { label: 'javascript', patterns: ['src/**', 'server/**', 'vite.config.*', 'tsconfig*.json', 'playwright.config.*'] },
 ];
 
-const DOC_ONLY_PATTERNS = ['docs/**', '**/*.md', '.github/**/*.md', 'CHANGELOG.md'];
+const DOC_ONLY_PATTERNS = ['docs/**', '**/*.md', '.github/**/*.md', 'CHANGELOG.md', 'CHANGELOG.beta.md'];
 
 /**
  * @param {string} head

--- a/scripts/update-dependabot-changelog.mjs
+++ b/scripts/update-dependabot-changelog.mjs
@@ -3,10 +3,12 @@ import {
   applyDependencyBumpsToChangelog,
   listDependencyBumpsBetweenRefs,
 } from './lib/dependabot-changelog.mjs';
+import { upsertBetaChangelogEntry } from './lib/beta-changelog.mjs';
 
 const baseRef = process.env.GITHUB_BASE_REF ?? '';
 const headRef = process.env.GITHUB_HEAD_REF ?? '';
-const changelogPath = process.env.CHANGELOG_FILE ?? 'CHANGELOG.md';
+const prNumber = Number(process.env.PR_NUMBER ?? 0);
+const changelogPath = process.env.CHANGELOG_FILE ?? (baseRef === 'beta' ? 'CHANGELOG.beta.md' : 'CHANGELOG.md');
 
 if (!baseRef || !headRef) {
   console.error('Set GITHUB_BASE_REF and GITHUB_HEAD_REF.');
@@ -25,7 +27,13 @@ if (bumps.length === 0) {
 }
 
 const changelog = readFileSync(changelogPath, 'utf8');
-const next = applyDependencyBumpsToChangelog(changelog, bumps);
+const next = baseRef === 'beta'
+  ? upsertBetaChangelogEntry(
+      changelog,
+      prNumber,
+      bumps.map((bump) => `Dependency: ${bump.name} ${bump.from} → ${bump.to}${bump.directory === 'root' ? '' : ` (\`${bump.directory}\`)`}`),
+    )
+  : applyDependencyBumpsToChangelog(changelog, bumps);
 
 if (next === changelog) {
   console.log('CHANGELOG.md already up to date for dependency bumps.');
@@ -33,6 +41,4 @@ if (next === changelog) {
 }
 
 writeFileSync(changelogPath, next);
-console.log(
-  `Updated CHANGELOG.md ### Dependencies for: ${bumps.map((b) => b.name).join(', ')}`,
-);
+console.log(`Updated ${changelogPath} for: ${bumps.map((b) => b.name).join(', ')}`);

--- a/scripts/update-dependabot-changelog.mjs
+++ b/scripts/update-dependabot-changelog.mjs
@@ -36,7 +36,7 @@ const next = baseRef === 'beta'
   : applyDependencyBumpsToChangelog(changelog, bumps);
 
 if (next === changelog) {
-  console.log('CHANGELOG.md already up to date for dependency bumps.');
+  console.log(`${changelogPath} already up to date for dependency bumps.`);
   process.exit(0);
 }
 


### PR DESCRIPTION
Automated port of the original commits from PR #509 into `feature/auto-generate-tstm-lines` after merge into `beta`.