### PR TITLE
[Port][Conflicts] [Governance] Add dedicated beta per-PR changelog → feature/beta-changelog-governance

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,9 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+<<<<<<< HEAD
 ### PR #509
 
 - Add the dedicated beta per-PR changelog, branch-aware governance checks, Dependabot routing, and release consolidation tooling.
+=======
+>>>>>>> 1459319 (feat(governance): add beta changelog workflow)

--- a/scripts/consolidate-beta-changelog.mjs
+++ b/scripts/consolidate-beta-changelog.mjs
@@ -28,7 +28,11 @@ const sectionBody = production.slice(sectionStart, sectionEnd);
 const changedHeadingIndex = sectionBody.indexOf(heading);
 const nextSectionBody = changedHeadingIndex === -1
   ? `${activeSection[0]}\n\n${heading}\n${bullets}\n${sectionBody.slice(activeSection[0].length).trimStart()}`
+<<<<<<< HEAD
   : sectionBody.replace(heading, () => `${heading}\n${bullets}`);
+=======
+  : sectionBody.replace(heading, `${heading}\n${bullets}`);
+>>>>>>> 1459319 (feat(governance): add beta changelog workflow)
 const nextProduction = production.slice(0, sectionStart) + nextSectionBody + production.slice(sectionEnd);
 
 writeFileSync(betaPath, result.changelog);

--- a/scripts/lib/beta-changelog.mjs
+++ b/scripts/lib/beta-changelog.mjs
@@ -1,5 +1,6 @@
 export const BETA_CHANGELOG_PATH = 'CHANGELOG.beta.md';
 
+<<<<<<< HEAD
 /** Builds the canonical heading for one beta changelog PR entry. */
 const entryHeading = (prNumber) => `### PR #${prNumber}`;
 
@@ -42,6 +43,14 @@ export const extractBetaChangelogEntry = (changelog, prNumber) => {
   const heading = entryHeading(prNumber);
   const match = entryHeadingPattern(prNumber).exec(changelog);
   const start = match?.index ?? -1;
+=======
+const entryHeading = (prNumber) => `### PR #${prNumber}`;
+
+/** Returns one PR entry body, or null when it is missing. */
+export const extractBetaChangelogEntry = (changelog, prNumber) => {
+  const heading = entryHeading(prNumber);
+  const start = changelog.indexOf(heading);
+>>>>>>> 1459319 (feat(governance): add beta changelog workflow)
   if (start === -1) return null;
   const rest = changelog.slice(start + heading.length);
   const next = rest.search(/\n### PR #|\n## /);
@@ -51,7 +60,11 @@ export const extractBetaChangelogEntry = (changelog, prNumber) => {
 
 /** Validates that a beta PR has exactly one non-empty bullet entry. */
 export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
+<<<<<<< HEAD
   if (!isValidPrNumber(prNumber)) {
+=======
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+>>>>>>> 1459319 (feat(governance): add beta changelog workflow)
     return { ok: false, reason: 'A valid PR_NUMBER is required for beta changelog validation.' };
   }
   if (!changedFiles.includes(BETA_CHANGELOG_PATH)) {
@@ -64,7 +77,11 @@ export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
       reason: `${BETA_CHANGELOG_PATH} must include ${entryHeading(prNumber)} with at least one bullet.`,
     };
   }
+<<<<<<< HEAD
   const occurrences = countEntryHeadings(changelog, prNumber);
+=======
+  const occurrences = changelog.split(entryHeading(prNumber)).length - 1;
+>>>>>>> 1459319 (feat(governance): add beta changelog workflow)
   if (occurrences !== 1) {
     return { ok: false, reason: `${entryHeading(prNumber)} must appear exactly once.` };
   }
@@ -73,10 +90,23 @@ export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
 
 /** Inserts or replaces one PR entry under Unreleased. */
 export const upsertBetaChangelogEntry = (changelog, prNumber, bullets) => {
+<<<<<<< HEAD
   validateEntryInput(prNumber, bullets);
   const entry = formatEntry(prNumber, bullets);
   const existing = extractBetaChangelogEntry(changelog, prNumber);
   if (existing) return changelog.replace(existing, () => entry);
+=======
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error('A positive PR number is required.');
+  }
+  if (!Array.isArray(bullets) || bullets.length === 0 || bullets.some((bullet) => !bullet.trim())) {
+    throw new Error('At least one non-empty beta changelog bullet is required.');
+  }
+  const heading = entryHeading(prNumber);
+  const entry = `${heading}\n\n${bullets.map((bullet) => `- ${bullet.replace(/^[-*]\s*/, '')}`).join('\n')}`;
+  const existing = extractBetaChangelogEntry(changelog, prNumber);
+  if (existing) return changelog.replace(existing, entry);
+>>>>>>> 1459319 (feat(governance): add beta changelog workflow)
   const unreleased = '## Unreleased';
   const index = changelog.indexOf(unreleased);
   if (index === -1) throw new Error(`${BETA_CHANGELOG_PATH} must include ${unreleased}.`);
@@ -94,5 +124,9 @@ export const takeBetaChangelogEntries = (changelog, prNumbers) => {
     entries.push(...entry.split('\n').filter((line) => /^[-*]\s+/.test(line)).map((line) => line.replace(/^[-*]\s+/, '')));
     next = next.replace(entry, '').replace(/\n{3,}/g, '\n\n');
   }
+<<<<<<< HEAD
   return { changelog: `${next.trimEnd()}\n`, entries };
+=======
+  return { changelog: next.trimEnd() + '\n', entries };
+>>>>>>> 1459319 (feat(governance): add beta changelog workflow)
 };

--- a/scripts/lib/beta-changelog.test.mjs
+++ b/scripts/lib/beta-changelog.test.mjs
@@ -53,6 +53,7 @@ test('requires valid content for generated entries and selected entries for cons
   assert.throws(() => upsertBetaChangelogEntry(sample, 503, []));
   assert.throws(() => takeBetaChangelogEntries(sample, [503]), /Missing beta changelog entry/);
 });
+<<<<<<< HEAD
 
 test('does not confuse PR numbers that share a numeric prefix', () => {
   const with500 = upsertBetaChangelogEntry(sample, 500, ['Higher-numbered PR']);
@@ -70,3 +71,5 @@ test('preserves dollar substitution tokens when replacing an entry', () => {
   const updated = upsertBetaChangelogEntry(inserted, 503, ['$& $1 $` $\' remain literal']);
   assert.match(updated, /\$& \$1 \$` \$' remain literal/);
 });
+=======
+>>>>>>> 1459319 (feat(governance): add beta changelog workflow)


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/beta-changelog-governance`.

| | |
| --- | --- |
| Original PR | #510 — [Governance] Add dedicated beta per-PR changelog |
| Source branch | `feature/release-beta-changelog-governance` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `CHANGELOG.beta.md`
- `scripts/consolidate-beta-changelog.mjs`
- `scripts/lib/beta-changelog.mjs`
- `scripts/lib/beta-changelog.test.mjs`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/510-to-feature-beta-changelog-governance`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #510, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/beta-changelog-governance` drifting behind `main`.