### PR TITLE
[Port] [Governance] Add dedicated beta per-PR changelog to feature/beta-changelog-governance-main

### DIFF
--- a/scripts/consolidate-beta-changelog.mjs
+++ b/scripts/consolidate-beta-changelog.mjs
@@ -28,7 +28,7 @@ const sectionBody = production.slice(sectionStart, sectionEnd);
 const changedHeadingIndex = sectionBody.indexOf(heading);
 const nextSectionBody = changedHeadingIndex === -1
   ? `${activeSection[0]}\n\n${heading}\n${bullets}\n${sectionBody.slice(activeSection[0].length).trimStart()}`
-  : sectionBody.replace(heading, `${heading}\n${bullets}`);
+  : sectionBody.replace(heading, () => `${heading}\n${bullets}`);
 const nextProduction = production.slice(0, sectionStart) + nextSectionBody + production.slice(sectionEnd);
 
 writeFileSync(betaPath, result.changelog);

--- a/scripts/lib/beta-changelog.mjs
+++ b/scripts/lib/beta-changelog.mjs
@@ -1,6 +1,28 @@
 export const BETA_CHANGELOG_PATH = 'CHANGELOG.beta.md';
 
+/** Builds the canonical heading for one beta changelog PR entry. */
 const entryHeading = (prNumber) => `### PR #${prNumber}`;
+
+/** Rejects incomplete data before an entry is formatted. */
+const validateEntryInput = (prNumber, bullets) => {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error('A positive PR number is required.');
+  }
+  if (!Array.isArray(bullets) || bullets.length === 0) {
+    throw new Error('At least one beta changelog bullet is required.');
+  }
+  if (bullets.some((bullet) => !bullet.trim())) {
+    throw new Error('Beta changelog bullets cannot be empty.');
+  }
+};
+
+/** Formats normalized input as one machine-parseable PR section. */
+const formatEntry = (prNumber, bullets) => {
+  const body = bullets
+    .map((bullet) => `- ${bullet.replace(/^[-*]\s*/, '')}`)
+    .join('\n');
+  return `${entryHeading(prNumber)}\n\n${body}`;
+};
 
 /** Returns one PR entry body, or null when it is missing. */
 export const extractBetaChangelogEntry = (changelog, prNumber) => {
@@ -37,14 +59,8 @@ export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
 
 /** Inserts or replaces one PR entry under Unreleased. */
 export const upsertBetaChangelogEntry = (changelog, prNumber, bullets) => {
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
-    throw new Error('A positive PR number is required.');
-  }
-  if (!Array.isArray(bullets) || bullets.length === 0 || bullets.some((bullet) => !bullet.trim())) {
-    throw new Error('At least one non-empty beta changelog bullet is required.');
-  }
-  const heading = entryHeading(prNumber);
-  const entry = `${heading}\n\n${bullets.map((bullet) => `- ${bullet.replace(/^[-*]\s*/, '')}`).join('\n')}`;
+  validateEntryInput(prNumber, bullets);
+  const entry = formatEntry(prNumber, bullets);
   const existing = extractBetaChangelogEntry(changelog, prNumber);
   if (existing) return changelog.replace(existing, entry);
   const unreleased = '## Unreleased';
@@ -64,5 +80,5 @@ export const takeBetaChangelogEntries = (changelog, prNumbers) => {
     entries.push(...entry.split('\n').filter((line) => /^[-*]\s+/.test(line)).map((line) => line.replace(/^[-*]\s+/, '')));
     next = next.replace(entry, '').replace(/\n{3,}/g, '\n\n');
   }
-  return { changelog: next.trimEnd() + '\n', entries };
+  return { changelog: `${next.trimEnd()}\n`, entries };
 };

--- a/scripts/lib/beta-changelog.mjs
+++ b/scripts/lib/beta-changelog.mjs
@@ -3,6 +3,11 @@ export const BETA_CHANGELOG_PATH = 'CHANGELOG.beta.md';
 /** Builds the canonical heading for one beta changelog PR entry. */
 const entryHeading = (prNumber) => `### PR #${prNumber}`;
 
+/** Matches a complete PR heading without treating #50 as #500. */
+const entryHeadingPattern = (prNumber, flags = '') => (
+  new RegExp(`^${entryHeading(prNumber)}(?!\\d)`, flags.includes('m') ? flags : `${flags}m`)
+);
+
 /** Rejects incomplete data before an entry is formatted. */
 const validateEntryInput = (prNumber, bullets) => {
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
@@ -27,7 +32,8 @@ const formatEntry = (prNumber, bullets) => {
 /** Returns one PR entry body, or null when it is missing. */
 export const extractBetaChangelogEntry = (changelog, prNumber) => {
   const heading = entryHeading(prNumber);
-  const start = changelog.indexOf(heading);
+  const match = entryHeadingPattern(prNumber).exec(changelog);
+  const start = match?.index ?? -1;
   if (start === -1) return null;
   const rest = changelog.slice(start + heading.length);
   const next = rest.search(/\n### PR #|\n## /);
@@ -50,7 +56,7 @@ export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
       reason: `${BETA_CHANGELOG_PATH} must include ${entryHeading(prNumber)} with at least one bullet.`,
     };
   }
-  const occurrences = changelog.split(entryHeading(prNumber)).length - 1;
+  const occurrences = [...changelog.matchAll(entryHeadingPattern(prNumber, 'g'))].length;
   if (occurrences !== 1) {
     return { ok: false, reason: `${entryHeading(prNumber)} must appear exactly once.` };
   }
@@ -62,7 +68,7 @@ export const upsertBetaChangelogEntry = (changelog, prNumber, bullets) => {
   validateEntryInput(prNumber, bullets);
   const entry = formatEntry(prNumber, bullets);
   const existing = extractBetaChangelogEntry(changelog, prNumber);
-  if (existing) return changelog.replace(existing, entry);
+  if (existing) return changelog.replace(existing, () => entry);
   const unreleased = '## Unreleased';
   const index = changelog.indexOf(unreleased);
   if (index === -1) throw new Error(`${BETA_CHANGELOG_PATH} must include ${unreleased}.`);

--- a/scripts/lib/beta-changelog.mjs
+++ b/scripts/lib/beta-changelog.mjs
@@ -8,9 +8,17 @@ const entryHeadingPattern = (prNumber, flags = '') => (
   new RegExp(`^${entryHeading(prNumber)}(?!\\d)`, flags.includes('m') ? flags : `${flags}m`)
 );
 
+/** Reports whether a value can identify a GitHub pull request. */
+const isValidPrNumber = (prNumber) => Number.isInteger(prNumber) && prNumber > 0;
+
+/** Counts complete headings for one PR without matching numeric prefixes. */
+const countEntryHeadings = (changelog, prNumber) => (
+  [...changelog.matchAll(entryHeadingPattern(prNumber, 'g'))].length
+);
+
 /** Rejects incomplete data before an entry is formatted. */
 const validateEntryInput = (prNumber, bullets) => {
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+  if (!isValidPrNumber(prNumber)) {
     throw new Error('A positive PR number is required.');
   }
   if (!Array.isArray(bullets) || bullets.length === 0) {
@@ -43,7 +51,7 @@ export const extractBetaChangelogEntry = (changelog, prNumber) => {
 
 /** Validates that a beta PR has exactly one non-empty bullet entry. */
 export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+  if (!isValidPrNumber(prNumber)) {
     return { ok: false, reason: 'A valid PR_NUMBER is required for beta changelog validation.' };
   }
   if (!changedFiles.includes(BETA_CHANGELOG_PATH)) {
@@ -56,7 +64,7 @@ export const betaChangelogTouchesPr = (changedFiles, changelog, prNumber) => {
       reason: `${BETA_CHANGELOG_PATH} must include ${entryHeading(prNumber)} with at least one bullet.`,
     };
   }
-  const occurrences = [...changelog.matchAll(entryHeadingPattern(prNumber, 'g'))].length;
+  const occurrences = countEntryHeadings(changelog, prNumber);
   if (occurrences !== 1) {
     return { ok: false, reason: `${entryHeading(prNumber)} must appear exactly once.` };
   }

--- a/scripts/lib/beta-changelog.test.mjs
+++ b/scripts/lib/beta-changelog.test.mjs
@@ -53,3 +53,20 @@ test('requires valid content for generated entries and selected entries for cons
   assert.throws(() => upsertBetaChangelogEntry(sample, 503, []));
   assert.throws(() => takeBetaChangelogEntries(sample, [503]), /Missing beta changelog entry/);
 });
+
+test('does not confuse PR numbers that share a numeric prefix', () => {
+  const with500 = upsertBetaChangelogEntry(sample, 500, ['Higher-numbered PR']);
+  assert.equal(extractBetaChangelogEntry(with500, 50), null);
+  assert.equal(betaChangelogTouchesPr(['CHANGELOG.beta.md'], with500, 50).ok, false);
+
+  const withBoth = upsertBetaChangelogEntry(with500, 50, ['Lower-numbered PR']);
+  assert.match(extractBetaChangelogEntry(withBoth, 50) ?? '', /Lower-numbered PR/);
+  assert.match(extractBetaChangelogEntry(withBoth, 500) ?? '', /Higher-numbered PR/);
+  assert.equal(betaChangelogTouchesPr(['CHANGELOG.beta.md'], withBoth, 50).ok, true);
+});
+
+test('preserves dollar substitution tokens when replacing an entry', () => {
+  const inserted = upsertBetaChangelogEntry(sample, 503, ['Original']);
+  const updated = upsertBetaChangelogEntry(inserted, 503, ['$& $1 $` $\' remain literal']);
+  assert.match(updated, /\$& \$1 \$` \$' remain literal/);
+});

--- a/scripts/update-dependabot-changelog.mjs
+++ b/scripts/update-dependabot-changelog.mjs
@@ -36,7 +36,7 @@ const next = baseRef === 'beta'
   : applyDependencyBumpsToChangelog(changelog, bumps);
 
 if (next === changelog) {
-  console.log('CHANGELOG.md already up to date for dependency bumps.');
+  console.log(`${changelogPath} already up to date for dependency bumps.`);
   process.exit(0);
 }
 


### PR DESCRIPTION
Automated port of the original commits from PR #510 into `feature/beta-changelog-governance-main` after merge into `main`.

> Note: Changes were applied via **merge (PR head)** because cherry-pick did not apply cleanly.