### PR TITLE
[TSTM-01] Preserve hidden Auto-TSTM client boundary

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,6 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #TBD
+### PR #526
 
 - Preserve the hidden Auto-TSTM client API boundary, response validation, and stale-request identity without mounting unfinished controls.

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,3 +4,6 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #TBD
+
+- Preserve the hidden Auto-TSTM client API boundary, response validation, and stale-request identity without mounting unfinished controls.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ importers:
         version: 11.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.5.0(postcss@8.5.15)
@@ -222,10 +222,10 @@ importers:
         version: 4.3.0
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
 
 packages:
 
@@ -1897,42 +1897,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1994,79 +1988,66 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -2254,28 +2235,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2814,49 +2791,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3833,28 +3802,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -8485,10 +8450,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
 
   '@zarrita/storage@0.2.0':
     dependencies:
@@ -10382,7 +10347,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -10496,7 +10461,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0):
+  vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10504,7 +10469,7 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0

--- a/src/types/tstmGeneration.ts
+++ b/src/types/tstmGeneration.ts
@@ -4,21 +4,34 @@ import type { DayType } from './outlooks';
 export interface TstmGenerationRequest {
   day: DayType;
   cycleDate: string;
+  issueDate?: string;
+  validDate?: string;
+  issuanceTime?: string;
 }
 
 export interface TstmGenerationThresholds {
-  calibratedThunderProbability: number;
-  minAreaSqKm: number;
+  calibratedThunderCoreProbability: number;
+  calibratedThunderSupportProbability: number;
+}
+
+export interface TstmGenerationSource {
+  product: string;
+  search?: string;
+  run?: string;
+  period?: string;
+  forecastHours?: string;
+  url?: string;
 }
 
 export interface TstmGenerationResponse {
   features: Feature[];
   run: string;
-  source: 'spc-href-calibrated-thunder';
-  threshold: number;
+  domain: string;
+  forecastHours: number[];
   effectiveStart: string;
   effectiveEnd: string;
   thresholds: TstmGenerationThresholds;
   warnings: string[];
+  sources: Record<string, TstmGenerationSource | null>;
   generatedAt: string;
 }

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -77,11 +77,17 @@ describe('tstmGeneration utilities', () => {
   });
 
   test('distinguishes stale results when cycle, day, or validity changes', () => {
-    const request = { day: 1 as const, cycleDate: '2026-06-13', validDate: '2026-06-13T12:00:00Z' };
+    const request = {
+      day: 1 as const,
+      cycleDate: '2026-06-13',
+      issueDate: '2026-06-13T06:00:00Z',
+      validDate: '2026-06-13T12:00:00Z',
+    };
     expect(getTstmRequestIdentity(request)).toContain('day-1');
     expect(isCurrentTstmRequest(request, { ...request })).toBe(true);
     expect(isCurrentTstmRequest(request, { ...request, day: 2 })).toBe(false);
     expect(isCurrentTstmRequest(request, { ...request, cycleDate: '2026-06-14' })).toBe(false);
+    expect(isCurrentTstmRequest(request, { ...request, issueDate: '2026-06-13T09:00:00Z' })).toBe(false);
   });
 
   test('normalizes a valid server response and rejects malformed payloads', () => {
@@ -99,6 +105,14 @@ describe('tstmGeneration utilities', () => {
     });
     expect(response.features[0].properties).toMatchObject({ probability: 'TSTM' });
     expect(response.domain).toBe('conus');
+    const malformedThresholds = parseTstmGenerationResponse({
+      ...response,
+      thresholds: {} as never,
+    });
+    expect(malformedThresholds.thresholds).toEqual({
+      calibratedThunderCoreProbability: 0.3,
+      calibratedThunderSupportProbability: 0.1,
+    });
     expect(() => parseTstmGenerationResponse({ features: [] })).toThrow(/invalid response/);
   });
 

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -1,7 +1,11 @@
 import {
   areTstmFeaturesEqual,
   canGenerateTstmForDay,
+  getTstmRequestIdentity,
+  isCurrentTstmRequest,
   normalizeGeneratedTstmFeatures,
+  parseTstmGenerationResponse,
+  requestTstmGeneration,
 } from './tstmGeneration';
 
 describe('tstmGeneration utilities', () => {
@@ -70,5 +74,59 @@ describe('tstmGeneration utilities', () => {
     const right = [{ type: 'Feature' as const, geometry, properties: { probability: 'TSTM', source: 'spc' } }];
 
     expect(areTstmFeaturesEqual(left, right)).toBe(true);
+  });
+
+  test('distinguishes stale results when cycle, day, or validity changes', () => {
+    const request = { day: 1 as const, cycleDate: '2026-06-13', validDate: '2026-06-13T12:00:00Z' };
+    expect(getTstmRequestIdentity(request)).toContain('day-1');
+    expect(isCurrentTstmRequest(request, { ...request })).toBe(true);
+    expect(isCurrentTstmRequest(request, { ...request, day: 2 })).toBe(false);
+    expect(isCurrentTstmRequest(request, { ...request, cycleDate: '2026-06-14' })).toBe(false);
+  });
+
+  test('normalizes a valid server response and rejects malformed payloads', () => {
+    const response = parseTstmGenerationResponse({
+      features: [{
+        type: 'Feature',
+        geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+        properties: {},
+      }],
+      run: '2026-06-13T12:00:00Z',
+      forecastHours: [24],
+      effectiveStart: '2026-06-13T12:00:00Z',
+      effectiveEnd: '2026-06-14T12:00:00Z',
+      warnings: [],
+    });
+    expect(response.features[0].properties).toMatchObject({ probability: 'TSTM' });
+    expect(response.domain).toBe('conus');
+    expect(() => parseTstmGenerationResponse({ features: [] })).toThrow(/invalid response/);
+  });
+
+  test('requests guidance and surfaces structured server errors', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          features: [],
+          run: '2026-06-13T12:00:00Z',
+          forecastHours: [24],
+          effectiveStart: '2026-06-13T12:00:00Z',
+          effectiveEnd: '2026-06-14T12:00:00Z',
+          warnings: [],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Auto-TSTM is not enabled on this deployment.' }),
+      }) as jest.Mock;
+    try {
+      await expect(requestTstmGeneration({ day: 1, cycleDate: '2026-06-13' }))
+        .resolves.toMatchObject({ features: [] });
+      await expect(requestTstmGeneration({ day: 1, cycleDate: '2026-06-13' }))
+        .rejects.toThrow(/not enabled/);
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 });

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -1,5 +1,11 @@
 import type { Feature } from 'geojson';
 import type { DayType } from '../types/outlooks';
+import type {
+  TstmGenerationRequest,
+  TstmGenerationResponse,
+} from '../types/tstmGeneration';
+
+const TSTM_GENERATION_ENDPOINT = '/api/tstm/generate';
 
 /** Returns true when SPC calibrated thunder can cover the given outlook day. */
 export const canGenerateTstmForDay = (day: DayType): boolean => day === 1 || day === 2;
@@ -43,3 +49,66 @@ export const normalizeGeneratedTstmFeatures = (features: Feature[]): Feature[] =
         originalProbability: 'TSTM',
       },
     }));
+
+/** Identifies the forecast context that owns an asynchronous guidance result. */
+export const getTstmRequestIdentity = (request: TstmGenerationRequest): string =>
+  `${request.cycleDate}:day-${request.day}:${request.validDate ?? ''}:${request.issuanceTime ?? ''}`;
+
+/** Returns true only when a response still belongs to the active forecast context. */
+export const isCurrentTstmRequest = (
+  request: TstmGenerationRequest,
+  activeRequest: TstmGenerationRequest
+): boolean => getTstmRequestIdentity(request) === getTstmRequestIdentity(activeRequest);
+
+/** Validates and normalizes a cached Auto-TSTM API response. */
+export const parseTstmGenerationResponse = (payload: unknown): TstmGenerationResponse => {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Auto-TSTM returned an invalid response.');
+  }
+  const response = payload as Partial<TstmGenerationResponse>;
+  if (
+    typeof response.run !== 'string' ||
+    typeof response.effectiveStart !== 'string' ||
+    typeof response.effectiveEnd !== 'string' ||
+    !Array.isArray(response.features) ||
+    !Array.isArray(response.forecastHours) ||
+    !Array.isArray(response.warnings)
+  ) {
+    throw new Error('Auto-TSTM returned an invalid response.');
+  }
+  return {
+    ...response,
+    domain: typeof response.domain === 'string' ? response.domain : 'conus',
+    thresholds: response.thresholds ?? {
+      calibratedThunderCoreProbability: 0.3,
+      calibratedThunderSupportProbability: 0.1,
+    },
+    sources: response.sources ?? {},
+    generatedAt: typeof response.generatedAt === 'string' ? response.generatedAt : '',
+    features: normalizeGeneratedTstmFeatures(response.features),
+  } as TstmGenerationResponse;
+};
+
+/** Requests cached guidance. No UI calls this function while the capability remains disabled. */
+export const requestTstmGeneration = async (
+  request: TstmGenerationRequest,
+  signal?: AbortSignal
+): Promise<TstmGenerationResponse> => {
+  if (!canGenerateTstmForDay(request.day)) {
+    throw new Error('SPC calibrated thunder generation is only available for Day 1 and Day 2.');
+  }
+  const response = await fetch(TSTM_GENERATION_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+    signal,
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = payload && typeof payload.error === 'string'
+      ? payload.error
+      : 'Auto-TSTM guidance is temporarily unavailable.';
+    throw new Error(error);
+  }
+  return parseTstmGenerationResponse(payload);
+};

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -52,7 +52,13 @@ export const normalizeGeneratedTstmFeatures = (features: Feature[]): Feature[] =
 
 /** Identifies the forecast context that owns an asynchronous guidance result. */
 export const getTstmRequestIdentity = (request: TstmGenerationRequest): string =>
-  `${request.cycleDate}:day-${request.day}:${request.validDate ?? ''}:${request.issuanceTime ?? ''}`;
+  [
+    request.cycleDate,
+    `day-${request.day}`,
+    request.issueDate ?? '',
+    request.validDate ?? '',
+    request.issuanceTime ?? '',
+  ].join(':');
 
 /** Returns true only when a response still belongs to the active forecast context. */
 export const isCurrentTstmRequest = (
@@ -60,29 +66,50 @@ export const isCurrentTstmRequest = (
   activeRequest: TstmGenerationRequest
 ): boolean => getTstmRequestIdentity(request) === getTstmRequestIdentity(activeRequest);
 
+const isString = (value: unknown): value is string => typeof value === 'string';
+const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
+
+const hasResponseShape = (
+  response: Partial<TstmGenerationResponse>
+): response is Partial<TstmGenerationResponse> & Pick<
+  TstmGenerationResponse,
+  'features' | 'run' | 'forecastHours' | 'effectiveStart' | 'effectiveEnd' | 'warnings'
+> => [
+  isArray(response.features),
+  isString(response.run),
+  isArray(response.forecastHours),
+  isString(response.effectiveStart),
+  isString(response.effectiveEnd),
+  isArray(response.warnings),
+].every(Boolean);
+
+const parseThresholds = (
+  thresholds: Partial<TstmGenerationResponse['thresholds']> | undefined
+): TstmGenerationResponse['thresholds'] => {
+  const core = thresholds?.calibratedThunderCoreProbability;
+  const support = thresholds?.calibratedThunderSupportProbability;
+  if (typeof core === 'number' && typeof support === 'number') {
+    return { calibratedThunderCoreProbability: core, calibratedThunderSupportProbability: support };
+  }
+  return {
+    calibratedThunderCoreProbability: 0.3,
+    calibratedThunderSupportProbability: 0.1,
+  };
+};
+
 /** Validates and normalizes a cached Auto-TSTM API response. */
 export const parseTstmGenerationResponse = (payload: unknown): TstmGenerationResponse => {
   if (!payload || typeof payload !== 'object') {
     throw new Error('Auto-TSTM returned an invalid response.');
   }
   const response = payload as Partial<TstmGenerationResponse>;
-  if (
-    typeof response.run !== 'string' ||
-    typeof response.effectiveStart !== 'string' ||
-    typeof response.effectiveEnd !== 'string' ||
-    !Array.isArray(response.features) ||
-    !Array.isArray(response.forecastHours) ||
-    !Array.isArray(response.warnings)
-  ) {
+  if (!hasResponseShape(response)) {
     throw new Error('Auto-TSTM returned an invalid response.');
   }
   return {
     ...response,
     domain: typeof response.domain === 'string' ? response.domain : 'conus',
-    thresholds: response.thresholds ?? {
-      calibratedThunderCoreProbability: 0.3,
-      calibratedThunderSupportProbability: 0.1,
-    },
+    thresholds: parseThresholds(response.thresholds),
     sources: response.sources ?? {},
     generatedAt: typeof response.generatedAt === 'string' ? response.generatedAt : '',
     features: normalizeGeneratedTstmFeatures(response.features),

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -66,9 +66,12 @@ export const isCurrentTstmRequest = (
   activeRequest: TstmGenerationRequest
 ): boolean => getTstmRequestIdentity(request) === getTstmRequestIdentity(activeRequest);
 
+/** Narrows unknown API fields to strings. */
 const isString = (value: unknown): value is string => typeof value === 'string';
+/** Narrows unknown API fields to arrays. */
 const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
 
+/** Checks the required top-level response fields before normalization. */
 const hasResponseShape = (
   response: Partial<TstmGenerationResponse>
 ): response is Partial<TstmGenerationResponse> & Pick<
@@ -83,6 +86,7 @@ const hasResponseShape = (
   isArray(response.warnings),
 ].every(Boolean);
 
+/** Returns validated probability thresholds or the documented defaults. */
 const parseThresholds = (
   thresholds: Partial<TstmGenerationResponse['thresholds']> | undefined
 ): TstmGenerationResponse['thresholds'] => {


### PR DESCRIPTION
## Summary

Preserves the useful client-side boundary from the legacy Auto-TSTM branch without mounting its unfinished toolbar or modal controls.

## Changes

- expand the request and response contracts to match the preserved calibrated-thunder generator
- add a hidden API request helper with structured error handling and abort-signal support
- validate and normalize server responses before generated polygons can enter forecast state
- add stable request identity helpers so later UI work can reject stale cycle/day responses
- add focused tests for response validation, server errors, stale identities, and geometry normalization
- carry the minimal beta lockfile repair required for frozen CI installs

## Exposure

No component imports or calls the request helper. No toolbar action, modal, route, or navigation entry is added. Visible preview/apply integration remains tracked by #476.

## Verification

- focused Jest suites: 2 suites, 24 tests passed
- pnpm 9 frozen install
- `pnpm run build`
- `git diff --check`

Partial completion of #472. Companion server/Python preservation: #525.