### PR TITLE
[Port][Conflicts] [TSTM-01] Preserve disabled Python GRIB2 generator → feature/auto-generate-tstm-lines

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -1,0 +1,9 @@
+# Beta Changelog
+
+Development entries for pull requests targeting `beta`. These notes are consolidated and edited before release; they are not the production changelog.
+
+## Unreleased
+
+### PR #TBD
+
+- Preserve the Auto-TSTM Python GRIB2 generator and server adapter behind a default-off deployment capability with focused tests.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,11 @@ importers:
         version: 11.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
+<<<<<<< HEAD
         version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0))
+=======
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
       autoprefixer:
         specifier: ^10.4.27
         version: 10.5.0(postcss@8.5.15)
@@ -218,10 +222,17 @@ importers:
         version: 4.3.0
       ts-jest:
         specifier: ^29.4.11
+<<<<<<< HEAD
         version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)
+=======
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
 
 packages:
 
@@ -1893,42 +1904,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1990,79 +1995,66 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -2250,28 +2242,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2810,49 +2798,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3829,28 +3809,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -8481,10 +8457,17 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+<<<<<<< HEAD
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)
+=======
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
 
   '@zarrita/storage@0.2.0':
     dependencies:
@@ -10379,7 +10362,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
+<<<<<<< HEAD
   ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
+=======
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -10493,7 +10480,11 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+<<<<<<< HEAD
   vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0):
+=======
+  vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0):
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10502,7 +10493,11 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.2
+<<<<<<< HEAD
       esbuild: 0.27.7
+=======
+      esbuild: 0.28.1
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.46.0

--- a/server/analytics-app.js
+++ b/server/analytics-app.js
@@ -33,6 +33,7 @@ function configureApp(app, express, fs, LOG_FILE) {
   const { registerBillingRoutes } = require('./billing');
   const { registerMetricsRoutes } = require('./metrics');
   const { registerSentryTunnelRoutes } = require('./sentry-tunnel');
+  const { registerTstmRoutes } = require('./tstm');
 
   app.set('trust proxy', 'loopback');
 
@@ -47,6 +48,7 @@ function configureApp(app, express, fs, LOG_FILE) {
   registerBillingRoutes(app, express);
   registerMetricsRoutes(app, express);
   registerBetaRoutes(app, express);
+  registerTstmRoutes(app, express);
 
   app.post('/collect', express.json({ limit: '1kb' }), collectRateLimit, createCollectHandler(fs, LOG_FILE));
 

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "main": "analytics.js",
   "scripts": {
     "start": "node analytics.js",
-    "test": "node --test billing-stripe-period.test.js qs-dos.test.js server-stack.test.js"
+    "test": "node --test billing-stripe-period.test.js qs-dos.test.js server-stack.test.js tstm.test.js"
   },
   "dependencies": {
     "@sentry/node": "^10.56.0",

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 herbie-data
 cfgrib
 xarray
@@ -5,3 +6,10 @@ numpy
 scikit-image
 shapely
 geojson
+=======
+cfgrib==0.9.15.1
+numpy==2.4.1
+scikit-image==0.26.0
+shapely==2.1.2
+xarray==2026.2.0
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)

--- a/server/tstm.js
+++ b/server/tstm.js
@@ -4,6 +4,7 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+<<<<<<< HEAD
 const rateLimit = require('express-rate-limit');
 
 const TSTM_GENERATION_RATE_LIMIT = rateLimit({
@@ -19,6 +20,19 @@ const MAX_STDERR_LENGTH = 2000;
 
 const isSupportedDay = (day) => day === 1 || day === 2;
 
+=======
+
+const DEFAULT_TIMEOUT_MS = 480000;
+const MAX_STDERR_LENGTH = 2000;
+
+/** Returns true only when the experimental generator is explicitly enabled. */
+const isTstmGenerationEnabled = (env = process.env) => env.TSTM_GENERATION_ENABLED === 'true';
+
+/** Returns true for the only outlook days covered by the preserved generator. */
+const isSupportedDay = (day) => day === 1 || day === 2;
+
+/** Normalizes the request payload passed to the Python process. */
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
 const createGenerationPayload = (body = {}) => ({
   day: Number(body.day),
   cycleDate: typeof body.cycleDate === 'string' ? body.cycleDate : '',
@@ -27,6 +41,7 @@ const createGenerationPayload = (body = {}) => ({
   issuanceTime: typeof body.issuanceTime === 'string' ? body.issuanceTime : undefined,
 });
 
+<<<<<<< HEAD
 const getDefaultCondaPython = () => {
   if (process.platform !== 'win32') return null;
   const candidates = [
@@ -127,6 +142,102 @@ const registerTstmRoutes = (app, express) => {
       res.status(500).json({
         error: error instanceof Error ? error.message : 'Unable to generate TSTM lines right now.',
       });
+=======
+/** Finds a common local Conda Python on Windows. */
+const getDefaultCondaPython = () => {
+  if (process.platform !== 'win32') return null;
+  const candidates = ['miniforge3', 'miniconda3', 'anaconda3']
+    .map((folder) => path.join(os.homedir(), folder, 'python.exe'));
+  return candidates.find((candidate) => fs.existsSync(candidate)) || null;
+};
+
+/** Resolves the Python executable used by the experimental worker. */
+const getPythonCommand = (env = process.env) => (
+  env.PYTHON_BIN || env.PYTHON || getDefaultCondaPython() || 'python'
+);
+
+/** Executes the preserved GRIB2 generator while the capability is enabled. */
+const runTstmGenerator = (payload, options = {}) => new Promise((resolve, reject) => {
+  const env = options.env || process.env;
+  const spawnProcess = options.spawnProcess || spawn;
+  const timeoutMs = Number(env.TSTM_GENERATION_TIMEOUT_MS || DEFAULT_TIMEOUT_MS);
+  const script = path.join(__dirname, 'weather', 'generate_tstm.py');
+  const child = spawnProcess(getPythonCommand(env), [script], {
+    cwd: __dirname,
+    env: {
+      ...env,
+      HERBIE_DIR: env.HERBIE_DIR || path.join(__dirname, 'cache', 'herbie'),
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let stdout = '';
+  let stderr = '';
+  let finished = false;
+  let timer;
+  const finish = (callback) => {
+    if (finished) return;
+    finished = true;
+    clearTimeout(timer);
+    callback();
+  };
+  timer = setTimeout(() => {
+    child.kill('SIGTERM');
+    finish(() => reject(new Error('TSTM_GENERATION_TIMEOUT')));
+  }, timeoutMs);
+
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on('data', (chunk) => {
+    stderr = `${stderr}${chunk.toString()}`.slice(-MAX_STDERR_LENGTH);
+  });
+  child.on('error', (error) => finish(() => reject(error)));
+  child.on('close', (code) => finish(() => {
+    if (code !== 0) {
+      reject(new Error(stderr || `TSTM_GENERATOR_EXIT_${code}`));
+      return;
+    }
+    try {
+      resolve(JSON.parse(stdout));
+    } catch {
+      reject(new Error('TSTM_GENERATOR_INVALID_JSON'));
+    }
+  }));
+  child.stdin.end(JSON.stringify(payload));
+});
+
+/** Validates a request before any process can be started. */
+const validatePayload = (payload) => {
+  if (!isSupportedDay(payload.day)) {
+    return 'SPC calibrated thunder generation is only available for Day 1 and Day 2.';
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(payload.cycleDate)) {
+    return 'A valid cycleDate in YYYY-MM-DD format is required.';
+  }
+  return null;
+};
+
+/** Registers the preserved endpoint in a fail-closed, default-off state. */
+const registerTstmRoutes = (app, express, options = {}) => {
+  const env = options.env || process.env;
+  const runGenerator = options.runGenerator || runTstmGenerator;
+  app.post('/api/tstm/generate', express.json({ limit: '4kb' }), async (req, res) => {
+    if (!isTstmGenerationEnabled(env)) {
+      res.status(404).json({ error: 'Auto-TSTM is not enabled on this deployment.' });
+      return;
+    }
+    const payload = createGenerationPayload(req.body);
+    const validationError = validatePayload(payload);
+    if (validationError) {
+      res.status(400).json({ error: validationError });
+      return;
+    }
+    try {
+      res.json(await runGenerator(payload));
+    } catch {
+      res.status(503).json({ error: 'Auto-TSTM guidance is temporarily unavailable.' });
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
     }
   });
 };
@@ -134,5 +245,12 @@ const registerTstmRoutes = (app, express) => {
 module.exports = {
   createGenerationPayload,
   isSupportedDay,
+<<<<<<< HEAD
   registerTstmRoutes,
+=======
+  isTstmGenerationEnabled,
+  registerTstmRoutes,
+  runTstmGenerator,
+  validatePayload,
+>>>>>>> 945cd5c (feat(auto-tstm): preserve disabled Python generator)
 };

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const {
+  createGenerationPayload,
+  isTstmGenerationEnabled,
+  registerTstmRoutes,
+  validatePayload,
+} = require('./tstm');
+
+const startServer = (env, runGenerator) => {
+  const app = express();
+  registerTstmRoutes(app, express, { env, runGenerator });
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+    server.on('error', reject);
+  });
+};
+
+const getUrl = (server) => {
+  const address = server.address();
+  return `http://127.0.0.1:${address.port}/api/tstm/generate`;
+};
+
+describe('Auto-TSTM server foundation', () => {
+  it('stays disabled unless explicitly enabled', () => {
+    assert.equal(isTstmGenerationEnabled({}), false);
+    assert.equal(isTstmGenerationEnabled({ TSTM_GENERATION_ENABLED: 'false' }), false);
+    assert.equal(isTstmGenerationEnabled({ TSTM_GENERATION_ENABLED: 'true' }), true);
+  });
+
+  it('normalizes and validates request payloads', () => {
+    const payload = createGenerationPayload({ day: '2', cycleDate: '2026-06-13', ignored: true });
+    assert.deepEqual(payload, {
+      day: 2,
+      cycleDate: '2026-06-13',
+      issueDate: undefined,
+      validDate: undefined,
+      issuanceTime: undefined,
+    });
+    assert.equal(validatePayload(payload), null);
+    assert.match(validatePayload({ ...payload, day: 3 }), /Day 1 and Day 2/);
+    assert.match(validatePayload({ ...payload, cycleDate: 'bad' }), /cycleDate/);
+  });
+
+  it('does not invoke the generator while disabled', async () => {
+    let calls = 0;
+    const server = await startServer({}, async () => {
+      calls += 1;
+      return {};
+    });
+    try {
+      const response = await fetch(getUrl(server), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
+      });
+      assert.equal(response.status, 404);
+      assert.equal(calls, 0);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns sanitized errors when enabled work fails', async () => {
+    const server = await startServer(
+      { TSTM_GENERATION_ENABLED: 'true' },
+      async () => { throw new Error('internal path and stderr'); },
+    );
+    try {
+      const response = await fetch(getUrl(server), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
+      });
+      assert.equal(response.status, 503);
+      assert.deepEqual(await response.json(), {
+        error: 'Auto-TSTM guidance is temporarily unavailable.',
+      });
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -1,0 +1,57 @@
+"""Pure tests for the preserved Auto-TSTM GRIB2 generator."""
+
+from datetime import datetime, timezone
+import unittest
+
+import numpy as np
+
+import generate_tstm
+
+
+class GenerateTstmTests(unittest.TestCase):
+    def test_day_one_window_ends_at_upcoming_12z(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13", "issuanceTime": "0600"}
+        )
+        self.assertEqual(window.start, datetime(2026, 6, 13, 6, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+        self.assertTrue(window.forecast_hours)
+
+    def test_day_two_window_is_12z_to_12z(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 2, "cycleDate": "2026-06-13"}
+        )
+        self.assertEqual(window.start, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 15, 12, tzinfo=timezone.utc))
+
+    def test_spc_url_uses_calibrated_thunder_product(self):
+        url, filename = generate_tstm.spc_thunder_url(
+            datetime(2026, 6, 13, 12, tzinfo=timezone.utc), 24, "full"
+        )
+        self.assertIn("/thunder/", url)
+        self.assertEqual(filename, "spc_post.t12z.hrefct_full.f024.grib2")
+
+    def test_probability_normalization_supports_percent_fields(self):
+        normalized = generate_tstm.as_probability(np.array([[0.0, 30.0, 100.0]]))
+        np.testing.assert_allclose(normalized, np.array([[0.0, 0.3, 1.0]]))
+
+    def test_response_shape_preserves_source_metadata(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        response = generate_tstm.response_payload(
+            window,
+            [],
+            ["not ready"],
+            {"calibratedThunder": {"product": "spc_hrefct_full"}},
+        )
+        self.assertEqual(response["features"], [])
+        self.assertEqual(response["warnings"], ["not ready"])
+        self.assertEqual(
+            response["sources"]["calibratedThunder"]["product"],
+            "spc_hrefct_full",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/auto-generate-tstm-lines`.

| | |
| --- | --- |
| Original PR | #525 — [TSTM-01] Preserve disabled Python GRIB2 generator |
| Source branch | `feature/auto-tstm-python-foundation` (merged into `beta`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `CHANGELOG.beta.md`
- `pnpm-lock.yaml`
- `server/requirements.txt`
- `server/tstm.js`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/525-to-feature-auto-generate-tstm-lines`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #525, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/auto-generate-tstm-lines` drifting behind `beta`.