### PR TITLE
[Port][Conflicts] [TSTM-01] Preserve hidden Auto-TSTM client boundary → feature/auto-generate-tstm-lines

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -1,0 +1,9 @@
+# Beta Changelog
+
+Development entries for pull requests targeting `beta`. These notes are consolidated and edited before release; they are not the production changelog.
+
+## Unreleased
+
+### PR #TBD
+
+- Preserve the hidden Auto-TSTM client API boundary, response validation, and stale-request identity without mounting unfinished controls.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,11 @@ importers:
         version: 11.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
+<<<<<<< HEAD
         version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0))
+=======
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
       autoprefixer:
         specifier: ^10.4.27
         version: 10.5.0(postcss@8.5.15)
@@ -218,10 +222,17 @@ importers:
         version: 4.3.0
       ts-jest:
         specifier: ^29.4.11
+<<<<<<< HEAD
         version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)
+=======
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
 
 packages:
 
@@ -1893,42 +1904,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1990,79 +1995,66 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -2250,28 +2242,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2810,49 +2798,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3829,28 +3809,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -8481,10 +8457,17 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+<<<<<<< HEAD
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)
+=======
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
 
   '@zarrita/storage@0.2.0':
     dependencies:
@@ -10379,7 +10362,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
+<<<<<<< HEAD
   ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
+=======
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.2)(babel-plugin-macros@3.1.0))(typescript@6.0.3):
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -10493,7 +10480,11 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+<<<<<<< HEAD
   vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0):
+=======
+  vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0):
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10502,7 +10493,11 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.2
+<<<<<<< HEAD
       esbuild: 0.27.7
+=======
+      esbuild: 0.28.1
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.46.0

--- a/src/types/tstmGeneration.ts
+++ b/src/types/tstmGeneration.ts
@@ -10,6 +10,7 @@ export interface TstmGenerationRequest {
 }
 
 export interface TstmGenerationThresholds {
+<<<<<<< HEAD
   calibratedThunderProbability?: number;
   calibratedThunderCoreProbability?: number;
   calibratedThunderSupportProbability?: number;
@@ -21,6 +22,19 @@ export interface TstmGenerationThresholds {
   cinJkg: number;
   reflectivityDbz: number;
   minAreaSqKm: number;
+=======
+  calibratedThunderCoreProbability: number;
+  calibratedThunderSupportProbability: number;
+}
+
+export interface TstmGenerationSource {
+  product: string;
+  search?: string;
+  run?: string;
+  period?: string;
+  forecastHours?: string;
+  url?: string;
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
 }
 
 export interface TstmGenerationResponse {
@@ -32,6 +46,10 @@ export interface TstmGenerationResponse {
   effectiveEnd: string;
   thresholds: TstmGenerationThresholds;
   warnings: string[];
+<<<<<<< HEAD
   sources?: Record<string, { product: string; search: string; run?: string; period?: string; forecastHours?: string; url?: string } | null>;
+=======
+  sources: Record<string, TstmGenerationSource | null>;
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
   generatedAt: string;
 }

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -1,4 +1,16 @@
+<<<<<<< HEAD
 import { canGenerateTstmForDay, normalizeGeneratedTstmFeatures } from './tstmGeneration';
+=======
+import {
+  areTstmFeaturesEqual,
+  canGenerateTstmForDay,
+  getTstmRequestIdentity,
+  isCurrentTstmRequest,
+  normalizeGeneratedTstmFeatures,
+  parseTstmGenerationResponse,
+  requestTstmGeneration,
+} from './tstmGeneration';
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
 
 describe('tstmGeneration utilities', () => {
   test('limits SPC calibrated thunder generation to day 1 and day 2', () => {
@@ -27,4 +39,101 @@ describe('tstmGeneration utilities', () => {
     });
     expect(feature.id).toBe('generated-tstm-0');
   });
+<<<<<<< HEAD
+=======
+
+  test('keeps existing feature ids and accepts multipolygons', () => {
+    const [feature] = normalizeGeneratedTstmFeatures([
+      {
+        type: 'Feature',
+        id: 'cached-guidance-1',
+        geometry: {
+          type: 'MultiPolygon',
+          coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
+        },
+        properties: {},
+      },
+    ]);
+
+    expect(feature.id).toBe('cached-guidance-1');
+    expect(feature.geometry.type).toBe('MultiPolygon');
+  });
+
+  test('drops non-polygon guidance instead of placing it in forecast state', () => {
+    const features = normalizeGeneratedTstmFeatures([
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      },
+    ]);
+
+    expect(features).toEqual([]);
+  });
+
+  test('compares equivalent features without depending on property key order', () => {
+    const geometry = {
+      type: 'Polygon' as const,
+      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+    };
+    const left = [{ type: 'Feature' as const, geometry, properties: { source: 'spc', probability: 'TSTM' } }];
+    const right = [{ type: 'Feature' as const, geometry, properties: { probability: 'TSTM', source: 'spc' } }];
+
+    expect(areTstmFeaturesEqual(left, right)).toBe(true);
+  });
+
+  test('distinguishes stale results when cycle, day, or validity changes', () => {
+    const request = { day: 1 as const, cycleDate: '2026-06-13', validDate: '2026-06-13T12:00:00Z' };
+    expect(getTstmRequestIdentity(request)).toContain('day-1');
+    expect(isCurrentTstmRequest(request, { ...request })).toBe(true);
+    expect(isCurrentTstmRequest(request, { ...request, day: 2 })).toBe(false);
+    expect(isCurrentTstmRequest(request, { ...request, cycleDate: '2026-06-14' })).toBe(false);
+  });
+
+  test('normalizes a valid server response and rejects malformed payloads', () => {
+    const response = parseTstmGenerationResponse({
+      features: [{
+        type: 'Feature',
+        geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+        properties: {},
+      }],
+      run: '2026-06-13T12:00:00Z',
+      forecastHours: [24],
+      effectiveStart: '2026-06-13T12:00:00Z',
+      effectiveEnd: '2026-06-14T12:00:00Z',
+      warnings: [],
+    });
+    expect(response.features[0].properties).toMatchObject({ probability: 'TSTM' });
+    expect(response.domain).toBe('conus');
+    expect(() => parseTstmGenerationResponse({ features: [] })).toThrow(/invalid response/);
+  });
+
+  test('requests guidance and surfaces structured server errors', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          features: [],
+          run: '2026-06-13T12:00:00Z',
+          forecastHours: [24],
+          effectiveStart: '2026-06-13T12:00:00Z',
+          effectiveEnd: '2026-06-14T12:00:00Z',
+          warnings: [],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Auto-TSTM is not enabled on this deployment.' }),
+      }) as jest.Mock;
+    try {
+      await expect(requestTstmGeneration({ day: 1, cycleDate: '2026-06-13' }))
+        .resolves.toMatchObject({ features: [] });
+      await expect(requestTstmGeneration({ day: 1, cycleDate: '2026-06-13' }))
+        .rejects.toThrow(/not enabled/);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
 });

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -1,5 +1,13 @@
 import type { Feature } from 'geojson';
+<<<<<<< HEAD
 import type { TstmGenerationRequest, TstmGenerationResponse } from '../types/tstmGeneration';
+=======
+import type { DayType } from '../types/outlooks';
+import type {
+  TstmGenerationRequest,
+  TstmGenerationResponse,
+} from '../types/tstmGeneration';
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
 
 const TSTM_GENERATION_ENDPOINT = '/api/tstm/generate';
 
@@ -8,6 +16,7 @@ export const canGenerateTstmForDay = (day: number): boolean => day === 1 || day 
 
 /** Normalizes generated polygons so they can enter the existing editable categorical/TSTM flow. */
 export const normalizeGeneratedTstmFeatures = (features: Feature[]): Feature[] =>
+<<<<<<< HEAD
   features.map((feature, index) => ({
     ...feature,
     id: feature.id ?? `generated-tstm-${index}`,
@@ -24,15 +33,83 @@ export const normalizeGeneratedTstmFeatures = (features: Feature[]): Feature[] =
 /** Calls the server-side SPC calibrated thunder generator and returns normalized editable TSTM features. */
 export const generateTstmLines = async (
   request: TstmGenerationRequest
+=======
+  features
+    .filter(
+      (feature) =>
+        feature.type === 'Feature' &&
+        (feature.geometry?.type === 'Polygon' || feature.geometry?.type === 'MultiPolygon')
+    )
+    .map((feature, index) => ({
+      ...feature,
+      id: feature.id ?? `generated-tstm-${index}`,
+      properties: {
+        ...feature.properties,
+        outlookType: 'categorical',
+        probability: 'TSTM',
+        isSignificant: false,
+        derivedFrom: 'spc-href-calibrated-thunder',
+        originalProbability: 'TSTM',
+      },
+    }));
+
+/** Identifies the forecast context that owns an asynchronous guidance result. */
+export const getTstmRequestIdentity = (request: TstmGenerationRequest): string =>
+  `${request.cycleDate}:day-${request.day}:${request.validDate ?? ''}:${request.issuanceTime ?? ''}`;
+
+/** Returns true only when a response still belongs to the active forecast context. */
+export const isCurrentTstmRequest = (
+  request: TstmGenerationRequest,
+  activeRequest: TstmGenerationRequest
+): boolean => getTstmRequestIdentity(request) === getTstmRequestIdentity(activeRequest);
+
+/** Validates and normalizes a cached Auto-TSTM API response. */
+export const parseTstmGenerationResponse = (payload: unknown): TstmGenerationResponse => {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Auto-TSTM returned an invalid response.');
+  }
+  const response = payload as Partial<TstmGenerationResponse>;
+  if (
+    typeof response.run !== 'string' ||
+    typeof response.effectiveStart !== 'string' ||
+    typeof response.effectiveEnd !== 'string' ||
+    !Array.isArray(response.features) ||
+    !Array.isArray(response.forecastHours) ||
+    !Array.isArray(response.warnings)
+  ) {
+    throw new Error('Auto-TSTM returned an invalid response.');
+  }
+  return {
+    ...response,
+    domain: typeof response.domain === 'string' ? response.domain : 'conus',
+    thresholds: response.thresholds ?? {
+      calibratedThunderCoreProbability: 0.3,
+      calibratedThunderSupportProbability: 0.1,
+    },
+    sources: response.sources ?? {},
+    generatedAt: typeof response.generatedAt === 'string' ? response.generatedAt : '',
+    features: normalizeGeneratedTstmFeatures(response.features),
+  } as TstmGenerationResponse;
+};
+
+/** Requests cached guidance. No UI calls this function while the capability remains disabled. */
+export const requestTstmGeneration = async (
+  request: TstmGenerationRequest,
+  signal?: AbortSignal
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
 ): Promise<TstmGenerationResponse> => {
   if (!canGenerateTstmForDay(request.day)) {
     throw new Error('SPC calibrated thunder generation is only available for Day 1 and Day 2.');
   }
+<<<<<<< HEAD
 
+=======
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
   const response = await fetch(TSTM_GENERATION_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(request),
+<<<<<<< HEAD
   });
 
   const payload = await response.json().catch(() => ({}));
@@ -44,4 +121,16 @@ export const generateTstmLines = async (
     ...payload,
     features: normalizeGeneratedTstmFeatures(Array.isArray(payload.features) ? payload.features : []),
   } as TstmGenerationResponse;
+=======
+    signal,
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = payload && typeof payload.error === 'string'
+      ? payload.error
+      : 'Auto-TSTM guidance is temporarily unavailable.';
+    throw new Error(error);
+  }
+  return parseTstmGenerationResponse(payload);
+>>>>>>> 0d5d372 (feat(auto-tstm): preserve hidden client boundary)
 };


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/auto-generate-tstm-lines`.

| | |
| --- | --- |
| Original PR | #526 — [TSTM-01] Preserve hidden Auto-TSTM client boundary |
| Source branch | `feature/auto-tstm-client-foundation` (merged into `beta`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `CHANGELOG.beta.md`
- `pnpm-lock.yaml`
- `src/types/tstmGeneration.ts`
- `src/utils/tstmGeneration.test.ts`
- `src/utils/tstmGeneration.ts`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/526-to-feature-auto-generate-tstm-lines`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #526, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/auto-generate-tstm-lines` drifting behind `beta`.