### PR TITLE
[TSTM-02] Audit and simplify Auto-TSTM to SPC HREF calibrated-thunder input

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #548
+
+- Document Auto-TSTM SPC calibrated thunder inputs, thresholds, and Day 1/2 window definitions; add fixture tests for period hours and thresholds.
+
 ### PR #526
 
 - Preserve the hidden Auto-TSTM client API boundary, response validation, and stale-request identity without mounting unfinished controls.

--- a/server/tstm.js
+++ b/server/tstm.js
@@ -12,7 +12,11 @@ const MAX_STDOUT_LENGTH = 4 * 1024 * 1024;
 /** Returns true only when the experimental generator is explicitly enabled. */
 const isTstmGenerationEnabled = (env = process.env) => env.TSTM_GENERATION_ENABLED === 'true';
 
-/** Returns true for the only outlook days covered by the preserved generator. */
+/**
+ * Returns true for the only outlook days covered by the preserved generator.
+ * Day 1: issuance time through next 12Z.  Day 2: 12Z-to-12Z one day out.
+ * SPC calibrated HREF thunder data is only available for these two windows.
+ */
 const isSupportedDay = (day) => day === 1 || day === 2;
 
 /** Normalizes the request payload passed to the Python process. */
@@ -23,6 +27,9 @@ const createGenerationPayload = (body = {}) => ({
   validDate: typeof body.validDate === 'string' ? body.validDate : undefined,
   issuanceTime: typeof body.issuanceTime === 'string' ? body.issuanceTime : undefined,
 });
+// Thresholds are not accepted from the client; the Python generator uses its
+// own DEFAULT_THRESHOLDS (core=0.30, support=0.10) and echoes them in the
+// response so the client can display the exact values used.
 
 /** Finds a common local Conda Python on Windows. */
 const getDefaultCondaPython = () => {

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -445,7 +445,7 @@ def log_calibrated_thunder_components(fields: dict[str, np.ndarray]) -> None:
         if n < 5:
             continue
         print(
-            f"[tstm:spc] component id={label} kept={bool(np.any(mask & comp))} "
+            f"[tstm:spc] component id={label} kept={str(bool(np.any(mask & comp))).lower()} "
             f"cells={n} bounds=({float(np.nanmin(lon[comp])):.2f},"
             f"{float(np.nanmin(lat[comp])):.2f},{float(np.nanmax(lon[comp])):.2f},"
             f"{float(np.nanmax(lat[comp])):.2f}) "

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -5,33 +5,9 @@ Input is a small JSON object on stdin. Output is a JSON response on stdout.
 Uses the SPC calibrated thunder endpoint; returns empty features with warnings
 when the SPC data is unavailable for the requested period.
 
-Supported outlook days
-----------------------
-Day 1 and Day 2 only. Day 1 windows are defined by the issuance time (or
-valid/issue dates when provided) through the next 12Z boundary. Day 2 windows
-span the 12Z-to-12Z period one and two days out from the cycle date.
-
-SPC thunder periods
--------------------
-The SPC calibrated HREF thunder product is available in three accumulation
-windows: ``full`` (24-hour), ``4hr``, and ``1hr``. The ``full`` period is the
-primary source; ``4hr`` and ``1hr`` act as fallbacks when the latest ``full``
-run has not yet been posted. Each period defines a pair of candidate forecast
-hours (start and end of its window); the ``full`` period breaks after the
-first successful download while ``4hr`` and ``1hr`` combine both frames.
-This fallback chain ensures guidance is available as early as possible in
-the operational cycle.
-
-Thresholds
-----------
-Two calibrated-thunder probability thresholds control the mask:
-- ``calibratedThunderCoreProbability`` (0.30): cells above this value are
-  treated as the core thunderstorm area.
-- ``calibratedThunderSupportProbability`` (0.10): connected support regions
-  that link core cells are included to produce a coherent polygon.
-
-These values are echoed in the response ``thresholds`` field so the client
-can display the exact thresholds used.
+Supported days: Day 1 (issuance→next 12Z) and Day 2 (12Z→12Z).
+SPC periods: "full" (24h, primary), "4hr" and "1hr" (fallbacks).
+Thresholds: core=0.30, support=0.10 (mirrored in client defaults).
 """
 
 from __future__ import annotations
@@ -57,17 +33,14 @@ DEFAULT_DOMAIN = "conus"
 FORECAST_HOUR_STEP = max(1, int(os.environ.get("TSTM_HREF_HOUR_STEP", "3")))
 MAX_FORECAST_HOURS = max(1, int(os.environ.get("TSTM_HREF_MAX_HOURS", "17")))
 SPC_POST_BASE_URL = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/spc_post/prod"
-# SPC calibrated thunder periods in fallback order.  "full" is the 24-hour
-# accumulation and the primary source.  "4hr" and "1hr" are shorter windows
-# that may be posted earlier in the operational cycle; they are tried only
-# when "full" is not yet available for the requested run.
+# SPC calibrated thunder periods in fallback order.  "full" (24h) is the
+# primary source; "4hr" and "1hr" are shorter windows tried when "full"
+# is not yet posted for the requested run.
 SPC_THUNDER_PERIODS = ("full", "4hr", "1hr")
 
-# Probability thresholds used to derive the thunderstorm mask.  The core
-# threshold (30 %) identifies the high-confidence thunder area; the support
-# threshold (10 %) extends connected regions so the final polygon is
-# contiguous.  Any change here must be reflected in the TypeScript client
-# fallback defaults (src/utils/tstmGeneration.ts parseThresholds).
+# Probability thresholds for the thunder mask.  Core (30%) identifies the
+# high-confidence area; support (10%) connects core cells into contiguous
+# regions.  Must stay in sync with TypeScript client fallbacks.
 DEFAULT_THRESHOLDS = {
     "calibratedThunderCoreProbability": 0.30,
     "calibratedThunderSupportProbability": 0.10,
@@ -127,11 +100,7 @@ def parse_issuance_time(value: str | None) -> tuple[int, int]:
 
 
 def previous_spc_cycle(value: datetime) -> datetime:
-    """Select the SPC run cycle to use for a given valid time.
-
-    SPC posts at 0Z and 12Z.  This returns the most recent posted cycle
-    that is not after ``value`` (floor to 0Z or 12Z on the same day).
-    """
+    """Floor a valid time to the most recent SPC cycle (0Z or 12Z)."""
     value = value.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
     if value.hour >= 12:
         return value.replace(hour=12)
@@ -154,18 +123,7 @@ def build_forecast_hours(start: datetime, end: datetime, run: datetime) -> list[
 
 
 def build_effective_window(payload: dict[str, Any]) -> EffectiveWindow:
-    """Compute the valid-time window and HREF run for a Day 1 or Day 2 request.
-
-    Day 1 window
-        start: ``validDate`` > ``issueDate`` > cycle date at the issuance hour.
-        end:   cycle date + 1 day at 12Z.
-        run:   SPC cycle closest to (but not after) the start time.
-
-    Day 2 window
-        start: cycle date + 1 day at 12Z.
-        end:   cycle date + 2 days at 12Z.
-        run:   cycle date at 12Z.
-    """
+    """Compute valid-time window and HREF run for Day 1 (→12Z) or Day 2 (12Z→12Z)."""
     day = int(payload.get("day", 0))
     if day not in (1, 2):
         raise ValueError("HREF-based TSTM generation is only available for Day 1 and Day 2.")
@@ -362,15 +320,7 @@ def fetch_spc_period_for_window(window: EffectiveWindow, period: str) -> SpcThun
 
 
 def spc_period_hours(end_hour: int, period: str) -> list[int]:
-    """Return the forecast hours to try for a given SPC period.
-
-    "full": two candidate frames spanning the 24-hour window
-            (``end_hour - 23`` and ``end_hour``).  In practice
-            ``load_spc_period_arrays`` breaks after the first match.
-    "4hr":  two frames spanning the 4-hour window (``end_hour - 3``
-            and ``end_hour``).
-    Any other period: single frame at ``end_hour``.
-    """
+    """Candidate forecast hours: "full"=2 frames/24h, "4hr"=2 frames/4h, else=[end]."""
     offset = {"full": 23, "4hr": 3}.get(period)
     return [end_hour] if offset is None else sorted({max(1, end_hour - offset), end_hour})
 
@@ -430,13 +380,7 @@ def calibrated_thunder_mask(
     lat: np.ndarray | None = None,
     lon: np.ndarray | None = None,
 ) -> np.ndarray:
-    """Derive a boolean thunder mask from calibrated probability values.
-
-    Applies Gaussian smoothing, then uses the core threshold (30 %) to
-    identify high-confidence cells and the support threshold (10 %) to
-    connect them into contiguous regions.  Morphological closing, hole
-    removal, and small-object removal clean up the result.
-    """
+    """Boolean thunder mask from calibrated probability via smoothing + morphology."""
     from skimage import filters, measure, morphology
 
     values = np.nan_to_num(np.asarray(probability, dtype=float), nan=0.0)

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -4,6 +4,34 @@
 Input is a small JSON object on stdin. Output is a JSON response on stdout.
 Uses the SPC calibrated thunder endpoint; returns empty features with warnings
 when the SPC data is unavailable for the requested period.
+
+Supported outlook days
+----------------------
+Day 1 and Day 2 only. Day 1 windows are defined by the issuance time (or
+valid/issue dates when provided) through the next 12Z boundary. Day 2 windows
+span the 12Z-to-12Z period one and two days out from the cycle date.
+
+SPC thunder periods
+-------------------
+The SPC calibrated HREF thunder product is available in three accumulation
+windows: ``full`` (24-hour), ``4hr``, and ``1hr``. The ``full`` period is the
+primary source; ``4hr`` and ``1hr`` act as fallbacks when the latest ``full``
+run has not yet been posted. Each period defines a pair of candidate forecast
+hours (start and end of its window); the ``full`` period breaks after the
+first successful download while ``4hr`` and ``1hr`` combine both frames.
+This fallback chain ensures guidance is available as early as possible in
+the operational cycle.
+
+Thresholds
+----------
+Two calibrated-thunder probability thresholds control the mask:
+- ``calibratedThunderCoreProbability`` (0.30): cells above this value are
+  treated as the core thunderstorm area.
+- ``calibratedThunderSupportProbability`` (0.10): connected support regions
+  that link core cells are included to produce a coherent polygon.
+
+These values are echoed in the response ``thresholds`` field so the client
+can display the exact thresholds used.
 """
 
 from __future__ import annotations
@@ -29,7 +57,17 @@ DEFAULT_DOMAIN = "conus"
 FORECAST_HOUR_STEP = max(1, int(os.environ.get("TSTM_HREF_HOUR_STEP", "3")))
 MAX_FORECAST_HOURS = max(1, int(os.environ.get("TSTM_HREF_MAX_HOURS", "17")))
 SPC_POST_BASE_URL = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/spc_post/prod"
+# SPC calibrated thunder periods in fallback order.  "full" is the 24-hour
+# accumulation and the primary source.  "4hr" and "1hr" are shorter windows
+# that may be posted earlier in the operational cycle; they are tried only
+# when "full" is not yet available for the requested run.
 SPC_THUNDER_PERIODS = ("full", "4hr", "1hr")
+
+# Probability thresholds used to derive the thunderstorm mask.  The core
+# threshold (30 %) identifies the high-confidence thunder area; the support
+# threshold (10 %) extends connected regions so the final polygon is
+# contiguous.  Any change here must be reflected in the TypeScript client
+# fallback defaults (src/utils/tstmGeneration.ts parseThresholds).
 DEFAULT_THRESHOLDS = {
     "calibratedThunderCoreProbability": 0.30,
     "calibratedThunderSupportProbability": 0.10,
@@ -89,6 +127,11 @@ def parse_issuance_time(value: str | None) -> tuple[int, int]:
 
 
 def previous_spc_cycle(value: datetime) -> datetime:
+    """Select the SPC run cycle to use for a given valid time.
+
+    SPC posts at 0Z and 12Z.  This returns the most recent posted cycle
+    that is not after ``value`` (floor to 0Z or 12Z on the same day).
+    """
     value = value.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
     if value.hour >= 12:
         return value.replace(hour=12)
@@ -111,6 +154,18 @@ def build_forecast_hours(start: datetime, end: datetime, run: datetime) -> list[
 
 
 def build_effective_window(payload: dict[str, Any]) -> EffectiveWindow:
+    """Compute the valid-time window and HREF run for a Day 1 or Day 2 request.
+
+    Day 1 window
+        start: ``validDate`` > ``issueDate`` > cycle date at the issuance hour.
+        end:   cycle date + 1 day at 12Z.
+        run:   SPC cycle closest to (but not after) the start time.
+
+    Day 2 window
+        start: cycle date + 1 day at 12Z.
+        end:   cycle date + 2 days at 12Z.
+        run:   cycle date at 12Z.
+    """
     day = int(payload.get("day", 0))
     if day not in (1, 2):
         raise ValueError("HREF-based TSTM generation is only available for Day 1 and Day 2.")
@@ -307,6 +362,15 @@ def fetch_spc_period_for_window(window: EffectiveWindow, period: str) -> SpcThun
 
 
 def spc_period_hours(end_hour: int, period: str) -> list[int]:
+    """Return the forecast hours to try for a given SPC period.
+
+    "full": two candidate frames spanning the 24-hour window
+            (``end_hour - 23`` and ``end_hour``).  In practice
+            ``load_spc_period_arrays`` breaks after the first match.
+    "4hr":  two frames spanning the 4-hour window (``end_hour - 3``
+            and ``end_hour``).
+    Any other period: single frame at ``end_hour``.
+    """
     offset = {"full": 23, "4hr": 3}.get(period)
     return [end_hour] if offset is None else sorted({max(1, end_hour - offset), end_hour})
 
@@ -366,6 +430,13 @@ def calibrated_thunder_mask(
     lat: np.ndarray | None = None,
     lon: np.ndarray | None = None,
 ) -> np.ndarray:
+    """Derive a boolean thunder mask from calibrated probability values.
+
+    Applies Gaussian smoothing, then uses the core threshold (30 %) to
+    identify high-confidence cells and the support threshold (10 %) to
+    connect them into contiguous regions.  Morphological closing, hole
+    removal, and small-object removal clean up the result.
+    """
     from skimage import filters, measure, morphology
 
     values = np.nan_to_num(np.asarray(probability, dtype=float), nan=0.0)

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -405,77 +405,53 @@ def calibrated_thunder_mask(
         mask = morphology.remove_small_holes(mask, 64)
         mask = morphology.remove_small_objects(mask, 12)
     if lat is not None and lon is not None:
-        log_calibrated_thunder_components(
-            {
-                "raw_probability": values,
-                "smoothed_probability": smoothed,
-                "support": support,
-                "core": core,
-                "mask": mask,
-                "lat": lat,
-                "lon": lon,
-            }
-        )
+        log_calibrated_thunder_components({
+            "raw_probability": values, "smoothed_probability": smoothed,
+            "support": support, "core": core, "mask": mask, "lat": lat, "lon": lon,
+        })
     return mask
 
 
-def log_calibrated_thunder_components(
-    fields: dict[str, np.ndarray],
-) -> None:
+def log_calibrated_thunder_components(fields: dict[str, np.ndarray]) -> None:
     from skimage import measure
 
-    raw_probability = fields["raw_probability"]
-    smoothed_probability = fields["smoothed_probability"]
-    support = fields["support"]
-    core = fields["core"]
-    mask = fields["mask"]
-    lat = fields["lat"]
-    lon = fields["lon"]
-    finite = raw_probability[np.isfinite(raw_probability)]
+    raw = fields["raw_probability"]
+    smoothed = fields["smoothed_probability"]
+    support, core, mask = fields["support"], fields["core"], fields["mask"]
+    lat, lon = fields["lat"], fields["lon"]
+    finite = raw[np.isfinite(raw)]
     if finite.size:
-        percentiles = np.nanpercentile(finite, [50, 75, 90, 95, 99])
+        pcts = np.nanpercentile(finite, [50, 75, 90, 95, 99])
         print(
-            "[tstm:spc] calibrated thunder stats "
-            f"shape={raw_probability.shape} "
-            f"lat={float(np.nanmin(lat)):.2f}..{float(np.nanmax(lat)):.2f} "
+            f"[tstm:spc] calibrated thunder stats "
+            f"shape={raw.shape} lat={float(np.nanmin(lat)):.2f}..{float(np.nanmax(lat)):.2f} "
             f"lon={float(np.nanmin(lon)):.2f}..{float(np.nanmax(lon)):.2f} "
             f"min={float(np.nanmin(finite)):.3f} max={float(np.nanmax(finite)):.3f} "
-            f"p50/p75/p90/p95/p99={','.join(f'{value:.3f}' for value in percentiles)}",
-            file=sys.stderr,
-            flush=True,
+            f"p50/p75/p90/p95/p99={','.join(f'{v:.3f}' for v in pcts)}",
+            file=sys.stderr, flush=True,
         )
-
     labels = measure.label(support, connectivity=2)
     print(
-        "[tstm:spc] calibrated thunder mask "
+        f"[tstm:spc] calibrated thunder mask "
         f"support_cells={int(np.count_nonzero(support))} "
         f"core_cells={int(np.count_nonzero(core))} "
         f"kept_cells={int(np.count_nonzero(mask))} "
         f"support_components={int(labels.max())}",
-        file=sys.stderr,
-        flush=True,
+        file=sys.stderr, flush=True,
     )
     for label in range(1, labels.max() + 1):
-        component = labels == label
-        cell_count = int(np.count_nonzero(component))
-        if cell_count < 5:
+        comp = labels == label
+        n = int(np.count_nonzero(comp))
+        if n < 5:
             continue
-        component_lat = lat[component]
-        component_lon = lon[component]
-        component_raw = raw_probability[component]
-        component_smooth = smoothed_probability[component]
-        is_kept = bool(np.any(mask & component))
         print(
-            "[tstm:spc] component "
-            f"id={label} kept={str(is_kept).lower()} cells={cell_count} "
-            f"bounds=({float(np.nanmin(component_lon)):.2f},"
-            f"{float(np.nanmin(component_lat)):.2f},"
-            f"{float(np.nanmax(component_lon)):.2f},"
-            f"{float(np.nanmax(component_lat)):.2f}) "
-            f"raw_max={float(np.nanmax(component_raw)):.3f} "
-            f"smooth_max={float(np.nanmax(component_smooth)):.3f}",
-            file=sys.stderr,
-            flush=True,
+            f"[tstm:spc] component id={label} kept={bool(np.any(mask & comp))} "
+            f"cells={n} bounds=({float(np.nanmin(lon[comp])):.2f},"
+            f"{float(np.nanmin(lat[comp])):.2f},{float(np.nanmax(lon[comp])):.2f},"
+            f"{float(np.nanmax(lat[comp])):.2f}) "
+            f"raw_max={float(np.nanmax(raw[comp])):.3f} "
+            f"smooth_max={float(np.nanmax(smoothed[comp])):.3f}",
+            file=sys.stderr, flush=True,
         )
 
 
@@ -519,72 +495,30 @@ def clean_mask(mask: np.ndarray) -> np.ndarray:
         cleaned = morphology.opening(cleaned, morphology.disk(1))
         cleaned = morphology.remove_small_holes(cleaned, 36)
         cleaned = morphology.remove_small_objects(cleaned, 12)
-    cleaned[0, :] = False
-    cleaned[-1, :] = False
-    cleaned[:, 0] = False
-    cleaned[:, -1] = False
+    cleaned[0, :] = cleaned[-1, :] = cleaned[:, 0] = cleaned[:, -1] = False
     return cleaned
 
 
 def conus_land_clip_geometry() -> Any:
     from shapely.geometry import Polygon
-
-    return Polygon(
-        [
-            (-124.8, 48.9),
-            (-122.8, 49.0),
-            (-117.0, 49.1),
-            (-111.0, 49.1),
-            (-104.0, 49.0),
-            (-96.0, 49.0),
-            (-89.0, 48.8),
-            (-82.5, 46.4),
-            (-75.0, 44.9),
-            (-67.0, 47.3),
-            (-66.8, 45.0),
-            (-69.0, 43.5),
-            (-70.5, 42.5),
-            (-72.8, 41.1),
-            (-74.8, 40.3),
-            (-75.5, 38.8),
-            (-76.2, 36.6),
-            (-77.6, 34.6),
-            (-79.0, 33.1),
-            (-80.4, 31.0),
-            (-81.0, 29.6),
-            (-80.4, 27.6),
-            (-80.0, 25.2),
-            (-81.1, 24.5),
-            (-82.8, 24.7),
-            (-83.2, 25.8),
-            (-83.2, 27.0),
-            (-82.8, 28.1),
-            (-83.3, 29.2),
-            (-84.7, 29.8),
-            (-86.0, 30.2),
-            (-87.6, 30.3),
-            (-89.2, 30.1),
-            (-91.4, 29.2),
-            (-93.7, 29.7),
-            (-95.7, 29.2),
-            (-97.2, 25.8),
-            (-99.2, 26.4),
-            (-100.4, 28.4),
-            (-101.8, 29.0),
-            (-103.2, 29.0),
-            (-104.9, 30.2),
-            (-106.5, 31.8),
-            (-111.1, 31.3),
-            (-114.8, 32.7),
-            (-117.2, 32.5),
-            (-119.8, 34.1),
-            (-121.2, 36.4),
-            (-122.6, 38.1),
-            (-124.0, 41.6),
-            (-124.6, 45.6),
-            (-124.8, 48.9),
-        ]
-    ).buffer(0)
+    # fmt: off
+    coords = [
+        (-124.8, 48.9), (-122.8, 49.0), (-117.0, 49.1), (-111.0, 49.1),
+        (-104.0, 49.0), (-96.0, 49.0), (-89.0, 48.8), (-82.5, 46.4),
+        (-75.0, 44.9), (-67.0, 47.3), (-66.8, 45.0), (-69.0, 43.5),
+        (-70.5, 42.5), (-72.8, 41.1), (-74.8, 40.3), (-75.5, 38.8),
+        (-76.2, 36.6), (-77.6, 34.6), (-79.0, 33.1), (-80.4, 31.0),
+        (-81.0, 29.6), (-80.4, 27.6), (-80.0, 25.2), (-81.1, 24.5),
+        (-82.8, 24.7), (-83.2, 25.8), (-83.2, 27.0), (-82.8, 28.1),
+        (-83.3, 29.2), (-84.7, 29.8), (-86.0, 30.2), (-87.6, 30.3),
+        (-89.2, 30.1), (-91.4, 29.2), (-93.7, 29.7), (-95.7, 29.2),
+        (-97.2, 25.8), (-99.2, 26.4), (-100.4, 28.4), (-101.8, 29.0),
+        (-103.2, 29.0), (-104.9, 30.2), (-106.5, 31.8), (-111.1, 31.3),
+        (-114.8, 32.7), (-117.2, 32.5), (-119.8, 34.1), (-121.2, 36.4),
+        (-122.6, 38.1), (-124.0, 41.6), (-124.6, 45.6), (-124.8, 48.9),
+    ]
+    # fmt: on
+    return Polygon(coords).buffer(0)
 
 
 def smooth_and_clip_geometry(geometry: Any) -> Any:
@@ -622,12 +556,6 @@ def smooth_geometry(geometry: Any) -> Any:
     if geometry.geom_type == "MultiPolygon":
         return MultiPolygon([smooth_geometry(part) for part in geometry.geoms if not part.is_empty]).buffer(0)
     return geometry
-
-
-def grid_land_mask(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
-    from shapely import contains_xy
-
-    return contains_xy(conus_land_clip_geometry(), lon, lat)
 
 
 def grid_near_land_mask(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -17,12 +17,82 @@ class GenerateTstmTests(unittest.TestCase):
         self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
         self.assertTrue(window.forecast_hours)
 
+    def test_day_one_window_uses_valid_date_when_provided(self):
+        window = generate_tstm.build_effective_window(
+            {
+                "day": 1,
+                "cycleDate": "2026-06-13",
+                "validDate": "2026-06-13T18:00:00Z",
+            }
+        )
+        self.assertEqual(window.start, datetime(2026, 6, 13, 18, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+
+    def test_day_one_window_falls_back_to_issue_date(self):
+        window = generate_tstm.build_effective_window(
+            {
+                "day": 1,
+                "cycleDate": "2026-06-13",
+                "issueDate": "2026-06-13T20:00:00Z",
+            }
+        )
+        self.assertEqual(window.start, datetime(2026, 6, 13, 20, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+
+    def test_day_one_window_falls_back_to_cycle_start_hour(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        # Default issuance time is 06Z when no dates are provided
+        self.assertEqual(window.start, datetime(2026, 6, 13, 6, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+
+    def test_day_one_window_href_run_is_previous_spc_cycle(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13", "issuanceTime": "1600"}
+        )
+        # Start is 16Z; previous SPC cycle is 12Z same day
+        self.assertEqual(window.href_run, datetime(2026, 6, 13, 12, tzinfo=timezone.utc))
+
     def test_day_two_window_is_12z_to_12z(self):
         window = generate_tstm.build_effective_window(
             {"day": 2, "cycleDate": "2026-06-13"}
         )
         self.assertEqual(window.start, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
         self.assertEqual(window.end, datetime(2026, 6, 15, 12, tzinfo=timezone.utc))
+
+    def test_day_two_window_href_run_is_cycle_12z(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 2, "cycleDate": "2026-06-13"}
+        )
+        self.assertEqual(window.href_run, datetime(2026, 6, 13, 12, tzinfo=timezone.utc))
+
+    def test_spc_thunder_periods_are_full_only_in_primary_position(self):
+        """The primary period must be "full" (24-hour accumulation)."""
+        self.assertEqual(generate_tstm.SPC_THUNDER_PERIODS[0], "full")
+        self.assertIn("full", generate_tstm.SPC_THUNDER_PERIODS)
+
+    def test_spc_period_hours_full_returns_two_frames(self):
+        hours = generate_tstm.spc_period_hours(24, "full")
+        self.assertEqual(hours, [1, 24])
+
+    def test_spc_period_hours_4hr_returns_two_frames(self):
+        hours = generate_tstm.spc_period_hours(24, "4hr")
+        self.assertEqual(hours, [21, 24])
+
+    def test_spc_period_hours_unknown_returns_single_frame(self):
+        hours = generate_tstm.spc_period_hours(24, "unknown")
+        self.assertEqual(hours, [24])
+
+    def test_default_thresholds_are_explicit(self):
+        """Fixture: core=0.30, support=0.10.  Any change must be intentional."""
+        self.assertEqual(
+            generate_tstm.DEFAULT_THRESHOLDS,
+            {
+                "calibratedThunderCoreProbability": 0.30,
+                "calibratedThunderSupportProbability": 0.10,
+            },
+        )
 
     def test_spc_url_uses_calibrated_thunder_product(self):
         url, filename = generate_tstm.spc_thunder_url(
@@ -62,6 +132,13 @@ class GenerateTstmTests(unittest.TestCase):
             response["sources"]["calibratedThunder"]["product"],
             "spc_hrefct_full",
         )
+
+    def test_response_thresholds_match_defaults(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        response = generate_tstm.response_payload(window, [], [], {})
+        self.assertEqual(response["thresholds"], generate_tstm.DEFAULT_THRESHOLDS)
 
 
 if __name__ == "__main__":

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -29,7 +29,7 @@ class GenerateTstmTests(unittest.TestCase):
         self.assertEqual(window.start, datetime(2026, 6, 13, 20, tzinfo=timezone.utc))
         self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
 
-    def test_day_one_window_falls_back_to_cycle_start_hour(self):
+    def test_day_one_window_falls_back_to_default_issuance_hour(self):
         window = self._build_day1_window()
         self.assertEqual(window.start, datetime(2026, 6, 13, 6, tzinfo=timezone.utc))
         self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
@@ -57,7 +57,6 @@ class GenerateTstmTests(unittest.TestCase):
     def test_spc_thunder_periods_are_full_only_in_primary_position(self):
         """The primary period must be "full" (24-hour accumulation)."""
         self.assertEqual(generate_tstm.SPC_THUNDER_PERIODS[0], "full")
-        self.assertIn("full", generate_tstm.SPC_THUNDER_PERIODS)
 
     def test_spc_period_hours_full_returns_two_frames(self):
         hours = generate_tstm.spc_period_hours(24, "full")

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -9,41 +9,28 @@ import generate_tstm
 
 
 class GenerateTstmTests(unittest.TestCase):
+    def _build_day1_window(self, **overrides):
+        payload = {"day": 1, "cycleDate": "2026-06-13", **overrides}
+        return generate_tstm.build_effective_window(payload)
+
     def test_day_one_window_ends_at_upcoming_12z(self):
-        window = generate_tstm.build_effective_window(
-            {"day": 1, "cycleDate": "2026-06-13", "issuanceTime": "0600"}
-        )
+        window = self._build_day1_window(issuanceTime="0600")
         self.assertEqual(window.start, datetime(2026, 6, 13, 6, tzinfo=timezone.utc))
         self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
         self.assertTrue(window.forecast_hours)
 
     def test_day_one_window_uses_valid_date_when_provided(self):
-        window = generate_tstm.build_effective_window(
-            {
-                "day": 1,
-                "cycleDate": "2026-06-13",
-                "validDate": "2026-06-13T18:00:00Z",
-            }
-        )
+        window = self._build_day1_window(validDate="2026-06-13T18:00:00Z")
         self.assertEqual(window.start, datetime(2026, 6, 13, 18, tzinfo=timezone.utc))
         self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
 
     def test_day_one_window_falls_back_to_issue_date(self):
-        window = generate_tstm.build_effective_window(
-            {
-                "day": 1,
-                "cycleDate": "2026-06-13",
-                "issueDate": "2026-06-13T20:00:00Z",
-            }
-        )
+        window = self._build_day1_window(issueDate="2026-06-13T20:00:00Z")
         self.assertEqual(window.start, datetime(2026, 6, 13, 20, tzinfo=timezone.utc))
         self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
 
     def test_day_one_window_falls_back_to_cycle_start_hour(self):
-        window = generate_tstm.build_effective_window(
-            {"day": 1, "cycleDate": "2026-06-13"}
-        )
-        # Default issuance time is 06Z when no dates are provided
+        window = self._build_day1_window()
         self.assertEqual(window.start, datetime(2026, 6, 13, 6, tzinfo=timezone.utc))
         self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
 


### PR DESCRIPTION
Documents branch inputs, SPC thunder period fallback chain, calibrated thresholds (30%/10%), and Day 1/2 12Z-valid window definitions in the Python generator and Node adapter. Adds fixture tests (6→18 Python tests) for thresholds, period hours, and window boundaries.

Deferred: removal of `4hr`/`1hr` periods — keeping until backend changes.

All tests pass. Builds clean.

Closes #473