### PR TITLE
[Port][Conflicts] [TSTM-02] Audit and simplify Auto-TSTM to SPC HREF calibrated-thunder input → feature/auto-generate-tstm-lines

### DIFF
--- a/server/tstm.js
+++ b/server/tstm.js
@@ -17,6 +17,17 @@ const TSTM_GENERATION_RATE_LIMIT = rateLimit({
 const TSTM_GENERATION_TIMEOUT_MS = Number(process.env.TSTM_GENERATION_TIMEOUT_MS || 480000);
 const MAX_STDERR_LENGTH = 2000;
 
+<<<<<<< HEAD
+=======
+/** Returns true only when the experimental generator is explicitly enabled. */
+const isTstmGenerationEnabled = (env = process.env) => env.TSTM_GENERATION_ENABLED === 'true';
+
+/**
+ * Returns true for the only outlook days covered by the preserved generator.
+ * Day 1: issuance time through next 12Z.  Day 2: 12Z-to-12Z one day out.
+ * SPC calibrated HREF thunder data is only available for these two windows.
+ */
+>>>>>>> afe549d (docs: audit and document Auto-TSTM SPC HREF calibrated-thunder input)
 const isSupportedDay = (day) => day === 1 || day === 2;
 
 const createGenerationPayload = (body = {}) => ({
@@ -26,6 +37,9 @@ const createGenerationPayload = (body = {}) => ({
   validDate: typeof body.validDate === 'string' ? body.validDate : undefined,
   issuanceTime: typeof body.issuanceTime === 'string' ? body.issuanceTime : undefined,
 });
+// Thresholds are not accepted from the client; the Python generator uses its
+// own DEFAULT_THRESHOLDS (core=0.30, support=0.10) and echoes them in the
+// response so the client can display the exact values used.
 
 const getDefaultCondaPython = () => {
   if (process.platform !== 'win32') return null;

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -4,6 +4,34 @@
 Input is a small JSON object on stdin. Output is a JSON response on stdout.
 Uses the SPC calibrated thunder endpoint; returns empty features with warnings
 when the SPC data is unavailable for the requested period.
+
+Supported outlook days
+----------------------
+Day 1 and Day 2 only. Day 1 windows are defined by the issuance time (or
+valid/issue dates when provided) through the next 12Z boundary. Day 2 windows
+span the 12Z-to-12Z period one and two days out from the cycle date.
+
+SPC thunder periods
+-------------------
+The SPC calibrated HREF thunder product is available in three accumulation
+windows: ``full`` (24-hour), ``4hr``, and ``1hr``. The ``full`` period is the
+primary source; ``4hr`` and ``1hr`` act as fallbacks when the latest ``full``
+run has not yet been posted. Each period defines a pair of candidate forecast
+hours (start and end of its window); the ``full`` period breaks after the
+first successful download while ``4hr`` and ``1hr`` combine both frames.
+This fallback chain ensures guidance is available as early as possible in
+the operational cycle.
+
+Thresholds
+----------
+Two calibrated-thunder probability thresholds control the mask:
+- ``calibratedThunderCoreProbability`` (0.30): cells above this value are
+  treated as the core thunderstorm area.
+- ``calibratedThunderSupportProbability`` (0.10): connected support regions
+  that link core cells are included to produce a coherent polygon.
+
+These values are echoed in the response ``thresholds`` field so the client
+can display the exact thresholds used.
 """
 
 from __future__ import annotations
@@ -29,7 +57,17 @@ DEFAULT_DOMAIN = "conus"
 FORECAST_HOUR_STEP = max(1, int(os.environ.get("TSTM_HREF_HOUR_STEP", "3")))
 MAX_FORECAST_HOURS = max(1, int(os.environ.get("TSTM_HREF_MAX_HOURS", "17")))
 SPC_POST_BASE_URL = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/spc_post/prod"
+# SPC calibrated thunder periods in fallback order.  "full" is the 24-hour
+# accumulation and the primary source.  "4hr" and "1hr" are shorter windows
+# that may be posted earlier in the operational cycle; they are tried only
+# when "full" is not yet available for the requested run.
 SPC_THUNDER_PERIODS = ("full", "4hr", "1hr")
+
+# Probability thresholds used to derive the thunderstorm mask.  The core
+# threshold (30 %) identifies the high-confidence thunder area; the support
+# threshold (10 %) extends connected regions so the final polygon is
+# contiguous.  Any change here must be reflected in the TypeScript client
+# fallback defaults (src/utils/tstmGeneration.ts parseThresholds).
 DEFAULT_THRESHOLDS = {
     "calibratedThunderCoreProbability": 0.30,
     "calibratedThunderSupportProbability": 0.10,
@@ -85,6 +123,11 @@ def parse_issuance_time(value: str | None) -> tuple[int, int]:
 
 
 def previous_spc_cycle(value: datetime) -> datetime:
+    """Select the SPC run cycle to use for a given valid time.
+
+    SPC posts at 0Z and 12Z.  This returns the most recent posted cycle
+    that is not after ``value`` (floor to 0Z or 12Z on the same day).
+    """
     value = value.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
     if value.hour >= 12:
         return value.replace(hour=12)
@@ -107,6 +150,18 @@ def build_forecast_hours(start: datetime, end: datetime, run: datetime) -> list[
 
 
 def build_effective_window(payload: dict[str, Any]) -> EffectiveWindow:
+    """Compute the valid-time window and HREF run for a Day 1 or Day 2 request.
+
+    Day 1 window
+        start: ``validDate`` > ``issueDate`` > cycle date at the issuance hour.
+        end:   cycle date + 1 day at 12Z.
+        run:   SPC cycle closest to (but not after) the start time.
+
+    Day 2 window
+        start: cycle date + 1 day at 12Z.
+        end:   cycle date + 2 days at 12Z.
+        run:   cycle date at 12Z.
+    """
     day = int(payload.get("day", 0))
     if day not in (1, 2):
         raise ValueError("HREF-based TSTM generation is only available for Day 1 and Day 2.")
@@ -295,6 +350,30 @@ def fetch_spc_period_for_window(window: EffectiveWindow, period: str) -> SpcThun
     return None
 
 
+<<<<<<< HEAD
+=======
+def spc_period_hours(end_hour: int, period: str) -> list[int]:
+    """Return the forecast hours to try for a given SPC period.
+
+    "full": two candidate frames spanning the 24-hour window
+            (``end_hour - 23`` and ``end_hour``).  In practice
+            ``load_spc_period_arrays`` breaks after the first match.
+    "4hr":  two frames spanning the 4-hour window (``end_hour - 3``
+            and ``end_hour``).
+    Any other period: single frame at ``end_hour``.
+    """
+    offset = {"full": 23, "4hr": 3}.get(period)
+    return [end_hour] if offset is None else sorted({max(1, end_hour - offset), end_hour})
+
+
+def combine_spc_arrays(arrays: list[np.ndarray]) -> np.ndarray:
+    stacked = np.stack(arrays)
+    if np.all(np.isnan(stacked)):
+        return np.full(stacked.shape[1:], np.nan)
+    return np.nanmax(stacked, axis=0)
+
+
+>>>>>>> afe549d (docs: audit and document Auto-TSTM SPC HREF calibrated-thunder input)
 def fetch_spc_calibrated_thunder(window: EffectiveWindow) -> tuple[SpcThunderSignal | None, list[str]]:
     warnings: list[str] = []
     candidates = spc_candidate_windows(window)
@@ -337,6 +416,13 @@ def calibrated_thunder_mask(
     lat: np.ndarray | None = None,
     lon: np.ndarray | None = None,
 ) -> np.ndarray:
+    """Derive a boolean thunder mask from calibrated probability values.
+
+    Applies Gaussian smoothing, then uses the core threshold (30 %) to
+    identify high-confidence cells and the support threshold (10 %) to
+    connect them into contiguous regions.  Morphological closing, hole
+    removal, and small-object removal clean up the result.
+    """
     from skimage import filters, measure, morphology
 
     values = np.nan_to_num(np.asarray(probability, dtype=float), nan=0.0)

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -1,0 +1,145 @@
+"""Pure tests for the preserved Auto-TSTM GRIB2 generator."""
+
+from datetime import datetime, timezone
+import unittest
+
+import numpy as np
+
+import generate_tstm
+
+
+class GenerateTstmTests(unittest.TestCase):
+    def test_day_one_window_ends_at_upcoming_12z(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13", "issuanceTime": "0600"}
+        )
+        self.assertEqual(window.start, datetime(2026, 6, 13, 6, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+        self.assertTrue(window.forecast_hours)
+
+    def test_day_one_window_uses_valid_date_when_provided(self):
+        window = generate_tstm.build_effective_window(
+            {
+                "day": 1,
+                "cycleDate": "2026-06-13",
+                "validDate": "2026-06-13T18:00:00Z",
+            }
+        )
+        self.assertEqual(window.start, datetime(2026, 6, 13, 18, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+
+    def test_day_one_window_falls_back_to_issue_date(self):
+        window = generate_tstm.build_effective_window(
+            {
+                "day": 1,
+                "cycleDate": "2026-06-13",
+                "issueDate": "2026-06-13T20:00:00Z",
+            }
+        )
+        self.assertEqual(window.start, datetime(2026, 6, 13, 20, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+
+    def test_day_one_window_falls_back_to_cycle_start_hour(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        # Default issuance time is 06Z when no dates are provided
+        self.assertEqual(window.start, datetime(2026, 6, 13, 6, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+
+    def test_day_one_window_href_run_is_previous_spc_cycle(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13", "issuanceTime": "1600"}
+        )
+        # Start is 16Z; previous SPC cycle is 12Z same day
+        self.assertEqual(window.href_run, datetime(2026, 6, 13, 12, tzinfo=timezone.utc))
+
+    def test_day_two_window_is_12z_to_12z(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 2, "cycleDate": "2026-06-13"}
+        )
+        self.assertEqual(window.start, datetime(2026, 6, 14, 12, tzinfo=timezone.utc))
+        self.assertEqual(window.end, datetime(2026, 6, 15, 12, tzinfo=timezone.utc))
+
+    def test_day_two_window_href_run_is_cycle_12z(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 2, "cycleDate": "2026-06-13"}
+        )
+        self.assertEqual(window.href_run, datetime(2026, 6, 13, 12, tzinfo=timezone.utc))
+
+    def test_spc_thunder_periods_are_full_only_in_primary_position(self):
+        """The primary period must be "full" (24-hour accumulation)."""
+        self.assertEqual(generate_tstm.SPC_THUNDER_PERIODS[0], "full")
+        self.assertIn("full", generate_tstm.SPC_THUNDER_PERIODS)
+
+    def test_spc_period_hours_full_returns_two_frames(self):
+        hours = generate_tstm.spc_period_hours(24, "full")
+        self.assertEqual(hours, [1, 24])
+
+    def test_spc_period_hours_4hr_returns_two_frames(self):
+        hours = generate_tstm.spc_period_hours(24, "4hr")
+        self.assertEqual(hours, [21, 24])
+
+    def test_spc_period_hours_unknown_returns_single_frame(self):
+        hours = generate_tstm.spc_period_hours(24, "unknown")
+        self.assertEqual(hours, [24])
+
+    def test_default_thresholds_are_explicit(self):
+        """Fixture: core=0.30, support=0.10.  Any change must be intentional."""
+        self.assertEqual(
+            generate_tstm.DEFAULT_THRESHOLDS,
+            {
+                "calibratedThunderCoreProbability": 0.30,
+                "calibratedThunderSupportProbability": 0.10,
+            },
+        )
+
+    def test_spc_url_uses_calibrated_thunder_product(self):
+        url, filename = generate_tstm.spc_thunder_url(
+            datetime(2026, 6, 13, 12, tzinfo=timezone.utc), 24, "full"
+        )
+        self.assertIn("/thunder/", url)
+        self.assertEqual(filename, "spc_post.t12z.hrefct_full.f024.grib2")
+
+    def test_probability_normalization_supports_percent_fields(self):
+        normalized = generate_tstm.as_probability(np.array([[0.0, 30.0, 100.0]]))
+        np.testing.assert_allclose(normalized, np.array([[0.0, 0.3, 1.0]]))
+
+    def test_probability_normalization_preserves_all_nan_fields(self):
+        normalized = generate_tstm.as_probability(np.array([[np.nan, np.nan]]))
+        self.assertTrue(np.isnan(normalized).all())
+
+    def test_spc_array_combination_preserves_all_nan_fields(self):
+        combined = generate_tstm.combine_spc_arrays(
+            [np.array([[np.nan, np.nan]]), np.array([[np.nan, np.nan]])]
+        )
+        self.assertEqual(combined.shape, (1, 2))
+        self.assertTrue(np.isnan(combined).all())
+
+    def test_response_shape_preserves_source_metadata(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        response = generate_tstm.response_payload(
+            window,
+            [],
+            ["not ready"],
+            {"calibratedThunder": {"product": "spc_hrefct_full"}},
+        )
+        self.assertEqual(response["features"], [])
+        self.assertEqual(response["warnings"], ["not ready"])
+        self.assertEqual(
+            response["sources"]["calibratedThunder"]["product"],
+            "spc_hrefct_full",
+        )
+
+    def test_response_thresholds_match_defaults(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        response = generate_tstm.response_payload(window, [], [], {})
+        self.assertEqual(response["thresholds"], generate_tstm.DEFAULT_THRESHOLDS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/auto-generate-tstm-lines`.

| | |
| --- | --- |
| Original PR | #548 — [TSTM-02] Audit and simplify Auto-TSTM to SPC HREF calibrated-thunder input |
| Source branch | `fix/tstm-02-audit-simplify-auto-tstm-input` (merged into `beta`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `server/tstm.js`
- `server/weather/generate_tstm.py`
- `server/weather/test_generate_tstm.py`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/548-to-feature-auto-generate-tstm-lines`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #548, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/auto-generate-tstm-lines` drifting behind `beta`.