### PR TITLE
Fix GFC-WEB-D draw teardown race

### DIFF
--- a/src/components/Map/OpenLayersForecastMap.test.ts
+++ b/src/components/Map/OpenLayersForecastMap.test.ts
@@ -34,6 +34,7 @@ import {
   isDrawableOutlookType,
   toOlStyle,
   toGhostOlStyle,
+  removeDrawInteraction,
 } from './OpenLayersForecastMap';
 
 type FeatureStub = {
@@ -151,6 +152,22 @@ describe('OpenLayersForecastMap helpers', () => {
   test('isDrawableOutlookType recognizes drawable types', () => {
     expect(isDrawableOutlookType({ outlookType: 'categorical' })).toBe(true);
     expect(isDrawableOutlookType({ outlookType: 'nonexistent' })).toBe(false);
+  });
+
+  test('GFC-WEB-D: clears the delayed pointer callback before map teardown', () => {
+    jest.useFakeTimers();
+    const pendingCallback = jest.fn();
+    const timeout = setTimeout(pendingCallback, 250);
+    const draw = { downTimeout_: timeout };
+    const map = { removeInteraction: jest.fn() };
+
+    removeDrawInteraction(map as never, draw as never);
+    jest.advanceTimersByTime(250);
+
+    expect(pendingCallback).not.toHaveBeenCalled();
+    expect(draw.downTimeout_).toBeUndefined();
+    expect(map.removeInteraction).toHaveBeenCalledWith(draw);
+    jest.useRealTimers();
   });
 
   test('toOlStyle and toGhostOlStyle return style objects', () => {

--- a/src/components/Map/OpenLayersForecastMap.test.ts
+++ b/src/components/Map/OpenLayersForecastMap.test.ts
@@ -156,18 +156,21 @@ describe('OpenLayersForecastMap helpers', () => {
 
   test('GFC-WEB-D: clears the delayed pointer callback before map teardown', () => {
     jest.useFakeTimers();
-    const pendingCallback = jest.fn();
-    const timeout = setTimeout(pendingCallback, 250);
-    const draw = { downTimeout_: timeout };
-    const map = { removeInteraction: jest.fn() };
+    try {
+      const pendingCallback = jest.fn();
+      const timeout = setTimeout(pendingCallback, 250);
+      const draw = { downTimeout_: timeout };
+      const map = { removeInteraction: jest.fn() };
 
-    removeDrawInteraction(map as never, draw as never);
-    jest.advanceTimersByTime(250);
+      removeDrawInteraction(map as never, draw as never);
+      jest.advanceTimersByTime(250);
 
-    expect(pendingCallback).not.toHaveBeenCalled();
-    expect(draw.downTimeout_).toBeUndefined();
-    expect(map.removeInteraction).toHaveBeenCalledWith(draw);
-    jest.useRealTimers();
+      expect(pendingCallback).not.toHaveBeenCalled();
+      expect(draw.downTimeout_).toBeUndefined();
+      expect(map.removeInteraction).toHaveBeenCalledWith(draw);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('toOlStyle and toGhostOlStyle return style objects', () => {

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -131,6 +131,24 @@ const DRAWABLE_OUTLOOK_TYPES = new Set<EditableOutlookType>([
   "day4-8",
 ]);
 
+type DrawWithPendingPointerMove = Draw & {
+  downTimeout_?: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * OpenLayers Draw keeps a delayed pointer-move callback after removal.
+ * Cancel it before detaching so it cannot read map pixels after map teardown.
+ */
+export const removeDrawInteraction = (map: OLMap, interaction: Draw): void => {
+  const draw = interaction as DrawWithPendingPointerMove;
+  if (draw.downTimeout_ !== undefined) {
+    clearTimeout(draw.downTimeout_);
+    draw.downTimeout_ = undefined;
+  }
+
+  map.removeInteraction(interaction);
+};
+
 // Helper to convert hex/rgb/hsl color strings to rgba with specified alpha
 export const toRgbaColor = ({ color, alpha }: RgbaInput): string => {
   if (!color) {
@@ -949,7 +967,8 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
           resizeObserver.disconnect();
         }
         if (drawRef.current) {
-          map.removeInteraction(drawRef.current);
+          removeDrawInteraction(map, drawRef.current);
+          drawRef.current = null;
         }
         if (modifyRef.current) {
           map.removeInteraction(modifyRef.current);
@@ -1267,7 +1286,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null>(
       if (!map) return;
 
       if (drawRef.current) {
-        map.removeInteraction(drawRef.current);
+        removeDrawInteraction(map, drawRef.current);
         drawRef.current = null;
       }
 

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -131,6 +131,10 @@ const DRAWABLE_OUTLOOK_TYPES = new Set<EditableOutlookType>([
   "day4-8",
 ]);
 
+// OpenLayers 10.9.0 stores the delayed pointer callback in this private field:
+// https://github.com/openlayers/openlayers/blob/v10.9.0/src/ol/interaction/Draw.js#L740-L751
+// Recheck this workaround whenever `ol` is upgraded; remove it once upstream
+// guarantees that detaching Draw cancels the pending callback.
 type DrawWithPendingPointerMove = Draw & {
   downTimeout_?: ReturnType<typeof setTimeout>;
 };


### PR DESCRIPTION
## What changed
- cancel OpenLayers Draw's pending pointer-move timeout before removing the interaction
- use the guarded cleanup both when replacing the active draw interaction and when tearing down the forecast map
- add a focused GFC-WEB-D regression test proving the delayed callback cannot fire after teardown

## Root cause
OpenLayers 10.9.0 leaves `Draw.downTimeout_` queued when `removeInteraction()` detaches the interaction. If the map target has already been cleared when that callback runs, `Map.getEventPixel()` reads an undefined map size and crashes.

## Changelog
- Fixed a forecast editor crash when a drawing interaction was interrupted by map teardown or replacement.

## Verification
- `pnpm test -- --runTestsByPath src/components/Map/OpenLayersForecastMap.test.ts --runInBand`
- `pnpm run build`

Closes #549