### PR TITLE
[FND-02] Create typed feature exposure registry and lifecycle metadata

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,7 +4,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### FND-02
+### PR #571
 
 - Add the typed feature exposure registry with per-target matrices, lifecycle metadata, and `isFeatureExposed` helpers for v1.7 workstreams.
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### FND-02
+
+- Add the typed feature exposure registry with per-target matrices, lifecycle metadata, and `isFeatureExposed` helpers for v1.7 workstreams.
+
 ### PR #568
 
 - Add explicit, validated local, beta, staging, and production frontend build targets while preserving the existing beta access gate.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Use `pnpm` consistently for this repo so the checked-in `pnpm-lock.yaml` remains
 
 Every frontend build resolves one deployment target through `VITE_BUILD_TARGET`: `local`, `beta`, `staging`, or `production`. Local development and builds default to `local`; hosted deployment workflows set their target explicitly and invalid values stop the build. This target identifies the deployment surface and is separate from Vite's bundling mode and the existing beta access gate.
 
+### Feature exposure registry
+
+v1.7 feature rollout is declared in `src/config/featureExposure.ts`. That registry is the single source of truth for which unfinished features may appear on each build target. Every key records an owner, added date, per-target exposure matrix, whether server capability is required, and removal metadata for temporary flags.
+
+Use `isFeatureExposed('featureKey')` for typed enablement checks. Unknown keys fail at compile time. Route, navigation, Redux, and server gates will adopt this registry in follow-up foundation work; this issue only establishes the contract and helpers.
+
 ### Local Beta Mode (developer)
 
 Run the app with beta-only features locally (useful for testing forecast redesigns, verification flows, and discussion changes).

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -7,9 +7,10 @@ import {
   validateFeatureExposureRegistry,
   type FeatureExposureDefinition,
   type FeatureKey,
+  type TemporaryFeatureExposureDefinition,
 } from './featureExposure';
 
-const BASE_DEFINITION: FeatureExposureDefinition = {
+const BASE_DEFINITION: TemporaryFeatureExposureDefinition = {
   exposure: { local: false, beta: false, staging: false, production: false },
   owner: 'WxboySuper',
   addedDate: '2026-06-20',
@@ -19,12 +20,12 @@ const BASE_DEFINITION: FeatureExposureDefinition = {
 };
 
 const expectRegistryValidationError = (
-  definition: Partial<FeatureExposureDefinition>,
+  overrides: Partial<TemporaryFeatureExposureDefinition> & Record<string, unknown>,
   pattern: RegExp
 ): void => {
   expect(() =>
     validateFeatureExposureRegistry({
-      sample: { ...BASE_DEFINITION, ...definition },
+      sample: { ...BASE_DEFINITION, ...overrides } as FeatureExposureDefinition,
     })
   ).toThrow(pattern);
 };
@@ -43,6 +44,12 @@ describe('featureExposure registry', () => {
   test.each([
     ['temporary features without removal metadata', { removalCondition: '   ' }, /removalCondition/],
     ['server-backed features without capability keys', { serverBacked: true }, /serverCapabilityKey/],
+    [
+      'non-server-backed features with capability keys',
+      { serverBacked: false, serverCapabilityKey: 'TSTM_GENERATION_ENABLED' },
+      /serverCapabilityKey/,
+    ],
+    ['added dates with impossible calendar values', { addedDate: '2026-13-40' }, /addedDate/],
   ] as const)('rejects %s', (_label, overrides, pattern) => {
     expectRegistryValidationError(overrides, pattern);
   });

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -5,8 +5,29 @@ import {
   isFeatureExposed,
   isFeatureExposedOnTarget,
   validateFeatureExposureRegistry,
+  type FeatureExposureDefinition,
   type FeatureKey,
 } from './featureExposure';
+
+const BASE_DEFINITION: FeatureExposureDefinition = {
+  exposure: { local: false, beta: false, staging: false, production: false },
+  owner: 'WxboySuper',
+  addedDate: '2026-06-20',
+  temporary: true,
+  removalCondition: 'Remove after launch.',
+  serverBacked: false,
+};
+
+const expectRegistryValidationError = (
+  definition: Partial<FeatureExposureDefinition>,
+  pattern: RegExp
+): void => {
+  expect(() =>
+    validateFeatureExposureRegistry({
+      sample: { ...BASE_DEFINITION, ...definition },
+    })
+  ).toThrow(pattern);
+};
 
 describe('featureExposure registry', () => {
   const originalTarget = globalThis.__GFC_BUILD_TARGET__;
@@ -19,34 +40,11 @@ describe('featureExposure registry', () => {
     expect(() => validateFeatureExposureRegistry()).not.toThrow();
   });
 
-  test('rejects temporary features without removal metadata', () => {
-    expect(() =>
-      validateFeatureExposureRegistry({
-        sample: {
-          exposure: { local: false, beta: false, staging: false, production: false },
-          owner: 'WxboySuper',
-          addedDate: '2026-06-20',
-          temporary: true,
-          removalCondition: '   ',
-          serverBacked: false,
-        },
-      })
-    ).toThrow(/removalCondition/);
-  });
-
-  test('rejects server-backed features without capability keys', () => {
-    expect(() =>
-      validateFeatureExposureRegistry({
-        sample: {
-          exposure: { local: false, beta: false, staging: false, production: false },
-          owner: 'WxboySuper',
-          addedDate: '2026-06-20',
-          temporary: true,
-          removalCondition: 'Remove after launch.',
-          serverBacked: true,
-        },
-      })
-    ).toThrow(/serverCapabilityKey/);
+  test.each([
+    ['temporary features without removal metadata', { removalCondition: '   ' }, /removalCondition/],
+    ['server-backed features without capability keys', { serverBacked: true }, /serverCapabilityKey/],
+  ] as const)('rejects %s', (_label, overrides, pattern) => {
+    expectRegistryValidationError(overrides, pattern);
   });
 
   test('lists every registry key in typed order', () => {

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -1,0 +1,112 @@
+import {
+  FEATURE_EXPOSURE_REGISTRY,
+  getFeatureExposure,
+  getFeatureKeys,
+  isFeatureExposed,
+  isFeatureExposedOnTarget,
+  validateFeatureExposureRegistry,
+  type FeatureKey,
+} from './featureExposure';
+
+describe('featureExposure registry', () => {
+  const originalTarget = globalThis.__GFC_BUILD_TARGET__;
+
+  afterEach(() => {
+    globalThis.__GFC_BUILD_TARGET__ = originalTarget;
+  });
+
+  test('validates every declared feature and lifecycle field', () => {
+    expect(() => validateFeatureExposureRegistry()).not.toThrow();
+  });
+
+  test('rejects temporary features without removal metadata', () => {
+    expect(() =>
+      validateFeatureExposureRegistry({
+        sample: {
+          exposure: { local: false, beta: false, staging: false, production: false },
+          owner: 'WxboySuper',
+          addedDate: '2026-06-20',
+          temporary: true,
+          removalCondition: '   ',
+          serverBacked: false,
+        },
+      })
+    ).toThrow(/removalCondition/);
+  });
+
+  test('rejects server-backed features without capability keys', () => {
+    expect(() =>
+      validateFeatureExposureRegistry({
+        sample: {
+          exposure: { local: false, beta: false, staging: false, production: false },
+          owner: 'WxboySuper',
+          addedDate: '2026-06-20',
+          temporary: true,
+          removalCondition: 'Remove after launch.',
+          serverBacked: true,
+        },
+      })
+    ).toThrow(/serverCapabilityKey/);
+  });
+
+  test('lists every registry key in typed order', () => {
+    expect(getFeatureKeys()).toEqual([
+      'autoTstm',
+      'forecastWorkflowV2',
+      'verificationRelaunch',
+      'customProducts',
+      'tropicalWorkspace',
+      'collaborationRoom',
+    ]);
+  });
+
+  test('returns registry metadata for a known feature key', () => {
+    expect(getFeatureExposure('autoTstm')).toMatchObject({
+      serverBacked: true,
+      serverCapabilityKey: 'TSTM_GENERATION_ENABLED',
+      trackingIssue: 427,
+    });
+  });
+
+  test.each(['local', 'beta', 'staging', 'production'] as const)(
+    'reports exposure for autoTstm on %s from the registry matrix',
+    (target) => {
+      expect(isFeatureExposedOnTarget('autoTstm', target)).toBe(
+        FEATURE_EXPOSURE_REGISTRY.autoTstm.exposure[target]
+      );
+    }
+  );
+
+  test('defaults exposure checks to the embedded build target', () => {
+    globalThis.__GFC_BUILD_TARGET__ = 'beta';
+    expect(isFeatureExposed('collaborationRoom')).toBe(false);
+  });
+
+  test('keeps v1.7 workstream keys disabled on every target until adoption', () => {
+    for (const feature of getFeatureKeys()) {
+      for (const target of ['local', 'beta', 'staging', 'production'] as const) {
+        expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
+      }
+    }
+  });
+
+  test('only autoTstm is server-backed in the initial registry', () => {
+    for (const feature of getFeatureKeys()) {
+      const definition = getFeatureExposure(feature);
+      if (feature === 'autoTstm') {
+        expect(definition.serverBacked).toBe(true);
+        expect(definition.serverCapabilityKey).toBe('TSTM_GENERATION_ENABLED');
+      } else {
+        expect(definition.serverBacked).toBe(false);
+        expect(definition.serverCapabilityKey).toBeUndefined();
+      }
+    }
+  });
+});
+
+type ExpectFalse<T extends false> = T;
+
+type UnknownFeatureKeyRejected = 'notRegistered' extends FeatureKey ? true : false;
+
+// Compile-time guard: unknown registry keys must not type-check at call sites.
+type _unknownFeatureKeyMustFail = ExpectFalse<UnknownFeatureKeyRejected>;

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -85,35 +85,35 @@ export type FeatureKey = keyof typeof FEATURE_EXPOSURE_REGISTRY;
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
-const assertExposureMatrix = (featureKey: string, exposure: FeatureExposureMatrix): void => {
+function assertExposureMatrix(featureKey: string, exposure: FeatureExposureMatrix): void {
   for (const target of BUILD_TARGETS) {
     if (typeof exposure[target] !== 'boolean') {
       throw new Error(`Feature ${featureKey} is missing exposure for target ${target}.`);
     }
   }
-};
+}
 
-const assertAddedDate = (featureKey: string, addedDate: string): void => {
+function assertAddedDate(featureKey: string, addedDate: string): void {
   if (!ISO_DATE_PATTERN.test(addedDate)) {
     throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(addedDate)}.`);
   }
-};
+}
 
-const assertTemporaryMetadata = (
+function assertTemporaryMetadata(
   featureKey: string,
   temporary: boolean,
   removalCondition: string
-): void => {
+): void {
   if (temporary && removalCondition.trim().length === 0) {
     throw new Error(`Temporary feature ${featureKey} must declare a removalCondition.`);
   }
-};
+}
 
-const assertServerBackedMetadata = (
+function assertServerBackedMetadata(
   featureKey: string,
   serverBacked: boolean,
   serverCapabilityKey?: string
-): void => {
+): void {
   if (serverBacked && !serverCapabilityKey?.trim()) {
     throw new Error(`Server-backed feature ${featureKey} must declare serverCapabilityKey.`);
   }
@@ -121,14 +121,14 @@ const assertServerBackedMetadata = (
   if (!serverBacked && serverCapabilityKey) {
     throw new Error(`Feature ${featureKey} must not declare serverCapabilityKey when serverBacked is false.`);
   }
-};
+}
 
-const assertFeatureExposureDefinition = (featureKey: string, definition: FeatureExposureDefinition): void => {
+function assertFeatureExposureDefinition(featureKey: string, definition: FeatureExposureDefinition): void {
   assertExposureMatrix(featureKey, definition.exposure);
   assertAddedDate(featureKey, definition.addedDate);
   assertTemporaryMetadata(featureKey, definition.temporary, definition.removalCondition);
   assertServerBackedMetadata(featureKey, definition.serverBacked, definition.serverCapabilityKey);
-};
+}
 
 /** Validates registry shape and lifecycle metadata for tests and future CI policy checks. */
 export const validateFeatureExposureRegistry = (

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -85,32 +85,57 @@ export type FeatureKey = keyof typeof FEATURE_EXPOSURE_REGISTRY;
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+const assertExposureMatrix = (featureKey: string, exposure: FeatureExposureMatrix): void => {
+  for (const target of BUILD_TARGETS) {
+    if (typeof exposure[target] !== 'boolean') {
+      throw new Error(`Feature ${featureKey} is missing exposure for target ${target}.`);
+    }
+  }
+};
+
+const assertAddedDate = (featureKey: string, addedDate: string): void => {
+  if (!ISO_DATE_PATTERN.test(addedDate)) {
+    throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(addedDate)}.`);
+  }
+};
+
+const assertTemporaryMetadata = (
+  featureKey: string,
+  temporary: boolean,
+  removalCondition: string
+): void => {
+  if (temporary && removalCondition.trim().length === 0) {
+    throw new Error(`Temporary feature ${featureKey} must declare a removalCondition.`);
+  }
+};
+
+const assertServerBackedMetadata = (
+  featureKey: string,
+  serverBacked: boolean,
+  serverCapabilityKey?: string
+): void => {
+  if (serverBacked && !serverCapabilityKey?.trim()) {
+    throw new Error(`Server-backed feature ${featureKey} must declare serverCapabilityKey.`);
+  }
+
+  if (!serverBacked && serverCapabilityKey) {
+    throw new Error(`Feature ${featureKey} must not declare serverCapabilityKey when serverBacked is false.`);
+  }
+};
+
+const assertFeatureExposureDefinition = (featureKey: string, definition: FeatureExposureDefinition): void => {
+  assertExposureMatrix(featureKey, definition.exposure);
+  assertAddedDate(featureKey, definition.addedDate);
+  assertTemporaryMetadata(featureKey, definition.temporary, definition.removalCondition);
+  assertServerBackedMetadata(featureKey, definition.serverBacked, definition.serverCapabilityKey);
+};
+
 /** Validates registry shape and lifecycle metadata for tests and future CI policy checks. */
 export const validateFeatureExposureRegistry = (
   registry: Record<string, FeatureExposureDefinition> = FEATURE_EXPOSURE_REGISTRY
 ): void => {
   for (const [featureKey, definition] of Object.entries(registry)) {
-    for (const target of BUILD_TARGETS) {
-      if (typeof definition.exposure[target] !== 'boolean') {
-        throw new Error(`Feature ${featureKey} is missing exposure for target ${target}.`);
-      }
-    }
-
-    if (!ISO_DATE_PATTERN.test(definition.addedDate)) {
-      throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(definition.addedDate)}.`);
-    }
-
-    if (definition.temporary && definition.removalCondition.trim().length === 0) {
-      throw new Error(`Temporary feature ${featureKey} must declare a removalCondition.`);
-    }
-
-    if (definition.serverBacked && !definition.serverCapabilityKey?.trim()) {
-      throw new Error(`Server-backed feature ${featureKey} must declare serverCapabilityKey.`);
-    }
-
-    if (!definition.serverBacked && definition.serverCapabilityKey) {
-      throw new Error(`Feature ${featureKey} must not declare serverCapabilityKey when serverBacked is false.`);
-    }
+    assertFeatureExposureDefinition(featureKey, definition);
   }
 };
 

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -85,6 +85,7 @@ export type FeatureKey = keyof typeof FEATURE_EXPOSURE_REGISTRY;
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+/** Ensures every build target has a boolean exposure value. */
 function assertExposureMatrix(featureKey: string, exposure: FeatureExposureMatrix): void {
   for (const target of BUILD_TARGETS) {
     if (typeof exposure[target] !== 'boolean') {
@@ -93,12 +94,14 @@ function assertExposureMatrix(featureKey: string, exposure: FeatureExposureMatri
   }
 }
 
+/** Ensures addedDate uses the registry ISO date format. */
 function assertAddedDate(featureKey: string, addedDate: string): void {
   if (!ISO_DATE_PATTERN.test(addedDate)) {
     throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(addedDate)}.`);
   }
 }
 
+/** Ensures temporary features declare when they should be removed. */
 function assertTemporaryMetadata(
   featureKey: string,
   temporary: boolean,
@@ -109,6 +112,7 @@ function assertTemporaryMetadata(
   }
 }
 
+/** Ensures server-backed metadata matches the declared capability key. */
 function assertServerBackedMetadata(
   featureKey: string,
   serverBacked: boolean,
@@ -123,6 +127,7 @@ function assertServerBackedMetadata(
   }
 }
 
+/** Runs every registry lifecycle assertion for one feature entry. */
 function assertFeatureExposureDefinition(featureKey: string, definition: FeatureExposureDefinition): void {
   assertExposureMatrix(featureKey, definition.exposure);
   assertAddedDate(featureKey, definition.addedDate);

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -100,6 +100,12 @@ export type FeatureKey = keyof typeof FEATURE_EXPOSURE_REGISTRY;
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+type FeatureValidationContext = {
+  featureKey: string;
+  definition: FeatureExposureDefinition;
+};
+
+/** Returns true when addedDate is a real YYYY-MM-DD calendar value. */
 function isValidIsoCalendarDate(addedDate: string): boolean {
   if (!ISO_DATE_PATTERN.test(addedDate)) {
     return false;
@@ -116,30 +122,32 @@ function isValidIsoCalendarDate(addedDate: string): boolean {
 }
 
 /** Ensures every build target has a boolean exposure value. */
-function assertExposureMatrix(featureKey: string, exposure: FeatureExposureMatrix): void {
+function assertExposureMatrix({ featureKey, definition }: FeatureValidationContext): void {
   for (const target of BUILD_TARGETS) {
-    if (typeof exposure[target] !== 'boolean') {
+    if (typeof definition.exposure[target] !== 'boolean') {
       throw new Error(`Feature ${featureKey} is missing exposure for target ${target}.`);
     }
   }
 }
 
 /** Ensures addedDate uses a real ISO calendar date. */
-function assertAddedDate(featureKey: string, addedDate: string): void {
-  if (!isValidIsoCalendarDate(addedDate)) {
-    throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(addedDate)}.`);
+function assertAddedDate({ featureKey, definition }: FeatureValidationContext): void {
+  if (!isValidIsoCalendarDate(definition.addedDate)) {
+    throw new Error(
+      `Feature ${featureKey} has an invalid addedDate ${JSON.stringify(definition.addedDate)}.`
+    );
   }
 }
 
 /** Ensures temporary features declare when they should be removed. */
-function assertTemporaryMetadata(featureKey: string, definition: FeatureExposureDefinition): void {
+function assertTemporaryMetadata({ featureKey, definition }: FeatureValidationContext): void {
   if (definition.temporary && definition.removalCondition.trim().length === 0) {
     throw new Error(`Temporary feature ${featureKey} must declare a removalCondition.`);
   }
 }
 
 /** Ensures server-backed metadata matches the declared capability key. */
-function assertServerBackedMetadata(featureKey: string, definition: FeatureExposureDefinition): void {
+function assertServerBackedMetadata({ featureKey, definition }: FeatureValidationContext): void {
   if (definition.serverBacked && !definition.serverCapabilityKey?.trim()) {
     throw new Error(`Server-backed feature ${featureKey} must declare serverCapabilityKey.`);
   }
@@ -151,10 +159,12 @@ function assertServerBackedMetadata(featureKey: string, definition: FeatureExpos
 
 /** Runs every registry lifecycle assertion for one feature entry. */
 function assertFeatureExposureDefinition(featureKey: string, definition: FeatureExposureDefinition): void {
-  assertExposureMatrix(featureKey, definition.exposure);
-  assertAddedDate(featureKey, definition.addedDate);
-  assertTemporaryMetadata(featureKey, definition);
-  assertServerBackedMetadata(featureKey, definition);
+  const context: FeatureValidationContext = { featureKey, definition };
+
+  assertExposureMatrix(context);
+  assertAddedDate(context);
+  assertTemporaryMetadata(context);
+  assertServerBackedMetadata(context);
 }
 
 /** Validates registry shape and lifecycle metadata for tests and future CI policy checks. */

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -100,6 +100,21 @@ export type FeatureKey = keyof typeof FEATURE_EXPOSURE_REGISTRY;
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+function isValidIsoCalendarDate(addedDate: string): boolean {
+  if (!ISO_DATE_PATTERN.test(addedDate)) {
+    return false;
+  }
+
+  const [year, month, day] = addedDate.split('-').map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
+  );
+}
+
 /** Ensures every build target has a boolean exposure value. */
 function assertExposureMatrix(featureKey: string, exposure: FeatureExposureMatrix): void {
   for (const target of BUILD_TARGETS) {
@@ -111,17 +126,7 @@ function assertExposureMatrix(featureKey: string, exposure: FeatureExposureMatri
 
 /** Ensures addedDate uses a real ISO calendar date. */
 function assertAddedDate(featureKey: string, addedDate: string): void {
-  if (!ISO_DATE_PATTERN.test(addedDate)) {
-    throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(addedDate)}.`);
-  }
-
-  const [year, month, day] = addedDate.split('-').map(Number);
-  const parsed = new Date(Date.UTC(year, month - 1, day));
-  if (
-    parsed.getUTCFullYear() !== year ||
-    parsed.getUTCMonth() !== month - 1 ||
-    parsed.getUTCDate() !== day
-  ) {
+  if (!isValidIsoCalendarDate(addedDate)) {
     throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(addedDate)}.`);
   }
 }

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -2,16 +2,31 @@ import { BUILD_TARGETS, type BuildTarget, getBuildTarget } from './buildTarget';
 
 export type FeatureExposureMatrix = Record<BuildTarget, boolean>;
 
-export interface FeatureExposureDefinition {
+type FeatureExposureBase = {
   exposure: FeatureExposureMatrix;
   owner: string;
   addedDate: string;
-  temporary: boolean;
-  removalCondition: string;
-  serverBacked: boolean;
-  serverCapabilityKey?: string;
   trackingIssue?: number;
-}
+};
+
+type ServerBackedMetadata =
+  | { serverBacked: true; serverCapabilityKey: string }
+  | { serverBacked: false; serverCapabilityKey?: never };
+
+export type TemporaryFeatureExposureDefinition = FeatureExposureBase & {
+  temporary: true;
+  removalCondition: string;
+} & ServerBackedMetadata;
+
+export type PermanentFeatureExposureDefinition = FeatureExposureBase & {
+  temporary: false;
+  serverBacked: false;
+  serverCapabilityKey?: never;
+};
+
+export type FeatureExposureDefinition =
+  | TemporaryFeatureExposureDefinition
+  | PermanentFeatureExposureDefinition;
 
 const ALL_TARGETS_OFF: FeatureExposureMatrix = {
   local: false,
@@ -94,35 +109,37 @@ function assertExposureMatrix(featureKey: string, exposure: FeatureExposureMatri
   }
 }
 
-/** Ensures addedDate uses the registry ISO date format. */
+/** Ensures addedDate uses a real ISO calendar date. */
 function assertAddedDate(featureKey: string, addedDate: string): void {
   if (!ISO_DATE_PATTERN.test(addedDate)) {
+    throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(addedDate)}.`);
+  }
+
+  const [year, month, day] = addedDate.split('-').map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
     throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(addedDate)}.`);
   }
 }
 
 /** Ensures temporary features declare when they should be removed. */
-function assertTemporaryMetadata(
-  featureKey: string,
-  temporary: boolean,
-  removalCondition: string
-): void {
-  if (temporary && removalCondition.trim().length === 0) {
+function assertTemporaryMetadata(featureKey: string, definition: FeatureExposureDefinition): void {
+  if (definition.temporary && definition.removalCondition.trim().length === 0) {
     throw new Error(`Temporary feature ${featureKey} must declare a removalCondition.`);
   }
 }
 
 /** Ensures server-backed metadata matches the declared capability key. */
-function assertServerBackedMetadata(
-  featureKey: string,
-  serverBacked: boolean,
-  serverCapabilityKey?: string
-): void {
-  if (serverBacked && !serverCapabilityKey?.trim()) {
+function assertServerBackedMetadata(featureKey: string, definition: FeatureExposureDefinition): void {
+  if (definition.serverBacked && !definition.serverCapabilityKey?.trim()) {
     throw new Error(`Server-backed feature ${featureKey} must declare serverCapabilityKey.`);
   }
 
-  if (!serverBacked && serverCapabilityKey) {
+  if (!definition.serverBacked && definition.serverCapabilityKey) {
     throw new Error(`Feature ${featureKey} must not declare serverCapabilityKey when serverBacked is false.`);
   }
 }
@@ -131,8 +148,8 @@ function assertServerBackedMetadata(
 function assertFeatureExposureDefinition(featureKey: string, definition: FeatureExposureDefinition): void {
   assertExposureMatrix(featureKey, definition.exposure);
   assertAddedDate(featureKey, definition.addedDate);
-  assertTemporaryMetadata(featureKey, definition.temporary, definition.removalCondition);
-  assertServerBackedMetadata(featureKey, definition.serverBacked, definition.serverCapabilityKey);
+  assertTemporaryMetadata(featureKey, definition);
+  assertServerBackedMetadata(featureKey, definition);
 }
 
 /** Validates registry shape and lifecycle metadata for tests and future CI policy checks. */

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -1,0 +1,133 @@
+import { BUILD_TARGETS, type BuildTarget, getBuildTarget } from './buildTarget';
+
+export type FeatureExposureMatrix = Record<BuildTarget, boolean>;
+
+export interface FeatureExposureDefinition {
+  exposure: FeatureExposureMatrix;
+  owner: string;
+  addedDate: string;
+  temporary: boolean;
+  removalCondition: string;
+  serverBacked: boolean;
+  serverCapabilityKey?: string;
+  trackingIssue?: number;
+}
+
+const ALL_TARGETS_OFF: FeatureExposureMatrix = {
+  local: false,
+  beta: false,
+  staging: false,
+  production: false,
+};
+
+/** Single source of truth for v1.7 feature exposure and lifecycle metadata. */
+export const FEATURE_EXPOSURE_REGISTRY = {
+  autoTstm: {
+    exposure: { ...ALL_TARGETS_OFF },
+    owner: 'WxboySuper',
+    addedDate: '2026-06-20',
+    temporary: true,
+    removalCondition:
+      'Enable on beta when Auto-TSTM client and server gates ship (#427); remove after stable production rollout.',
+    serverBacked: true,
+    serverCapabilityKey: 'TSTM_GENERATION_ENABLED',
+    trackingIssue: 427,
+  },
+  forecastWorkflowV2: {
+    exposure: { ...ALL_TARGETS_OFF },
+    owner: 'WxboySuper',
+    addedDate: '2026-06-20',
+    temporary: true,
+    removalCondition: 'Remove after forecast workflow v2 replaces the current cycle workflow (#429).',
+    serverBacked: false,
+    trackingIssue: 429,
+  },
+  verificationRelaunch: {
+    exposure: { ...ALL_TARGETS_OFF },
+    owner: 'WxboySuper',
+    addedDate: '2026-06-20',
+    temporary: true,
+    removalCondition: 'Remove after verification analytics relaunch reaches production (#430).',
+    serverBacked: false,
+    trackingIssue: 430,
+  },
+  customProducts: {
+    exposure: { ...ALL_TARGETS_OFF },
+    owner: 'WxboySuper',
+    addedDate: '2026-06-20',
+    temporary: true,
+    removalCondition: 'Remove after custom layers and premium forecast products ship (#431).',
+    serverBacked: false,
+    trackingIssue: 431,
+  },
+  tropicalWorkspace: {
+    exposure: { ...ALL_TARGETS_OFF },
+    owner: 'WxboySuper',
+    addedDate: '2026-06-20',
+    temporary: true,
+    removalCondition:
+      'Keep disabled on production until tropical workspace foundations are complete (#432).',
+    serverBacked: false,
+    trackingIssue: 432,
+  },
+  collaborationRoom: {
+    exposure: { ...ALL_TARGETS_OFF },
+    owner: 'WxboySuper',
+    addedDate: '2026-06-20',
+    temporary: true,
+    removalCondition: 'Remove after forecast collaboration room foundations ship (#433).',
+    serverBacked: false,
+    trackingIssue: 433,
+  },
+} as const satisfies Record<string, FeatureExposureDefinition>;
+
+export type FeatureKey = keyof typeof FEATURE_EXPOSURE_REGISTRY;
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Validates registry shape and lifecycle metadata for tests and future CI policy checks. */
+export const validateFeatureExposureRegistry = (
+  registry: Record<string, FeatureExposureDefinition> = FEATURE_EXPOSURE_REGISTRY
+): void => {
+  for (const [featureKey, definition] of Object.entries(registry)) {
+    for (const target of BUILD_TARGETS) {
+      if (typeof definition.exposure[target] !== 'boolean') {
+        throw new Error(`Feature ${featureKey} is missing exposure for target ${target}.`);
+      }
+    }
+
+    if (!ISO_DATE_PATTERN.test(definition.addedDate)) {
+      throw new Error(`Feature ${featureKey} has an invalid addedDate ${JSON.stringify(definition.addedDate)}.`);
+    }
+
+    if (definition.temporary && definition.removalCondition.trim().length === 0) {
+      throw new Error(`Temporary feature ${featureKey} must declare a removalCondition.`);
+    }
+
+    if (definition.serverBacked && !definition.serverCapabilityKey?.trim()) {
+      throw new Error(`Server-backed feature ${featureKey} must declare serverCapabilityKey.`);
+    }
+
+    if (!definition.serverBacked && definition.serverCapabilityKey) {
+      throw new Error(`Feature ${featureKey} must not declare serverCapabilityKey when serverBacked is false.`);
+    }
+  }
+};
+
+validateFeatureExposureRegistry();
+
+/** Returns every typed feature key declared in the registry. */
+export const getFeatureKeys = (): FeatureKey[] =>
+  Object.keys(FEATURE_EXPOSURE_REGISTRY) as FeatureKey[];
+
+/** Returns the full registry entry for diagnostics and governance tooling. */
+export const getFeatureExposure = (feature: FeatureKey): FeatureExposureDefinition =>
+  FEATURE_EXPOSURE_REGISTRY[feature];
+
+/** Returns whether a feature is exposed for the given deployment target. */
+export const isFeatureExposedOnTarget = (feature: FeatureKey, target: BuildTarget): boolean =>
+  FEATURE_EXPOSURE_REGISTRY[feature].exposure[target];
+
+/** Returns whether a feature is exposed on the current build target. */
+export const isFeatureExposed = (feature: FeatureKey, target: BuildTarget = getBuildTarget()): boolean =>
+  isFeatureExposedOnTarget(feature, target);


### PR DESCRIPTION
## Summary
- Add `FEATURE_EXPOSURE_REGISTRY` with per-target exposure matrices for v1.7 workstreams
- Record owner, added date, temporary/removal metadata, and server-backed capability keys
- Add typed `isFeatureExposed` helpers with compile-time key safety
- Document the registry contract in README

Closes #437.

## Changelog

- Add the typed feature exposure registry with per-target matrices, lifecycle metadata, and `isFeatureExposed` helpers for v1.7 workstreams.

## Test plan

- [x] `pnpm test -- --runTestsByPath src/config/featureExposure.test.ts src/config/buildTarget.test.ts --runInBand`
- [x] `pnpm run build`
- [x] No product gate migration in this PR (foundation contract only)

Made with [Cursor](https://cursor.com)