### PR TITLE
[FND-03] Gate routes, navigation, and modules without mounting side effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ greptile-comment.txt
 .vscode
 
 .playwright-mcp
+.playwright-cli/
 
 # Playwright
 /playwright-report/

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #TBD
+
+- Gate client routes, navigation, lazy modules, and mount boundaries through the feature exposure registry so disabled v1.7 work never registers paths, shows nav links, or initializes effects.
+
 ### PR #571
 
 - Add the typed feature exposure registry with per-target matrices, lifecycle metadata, and `isFeatureExposed` helpers for v1.7 workstreams.

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,7 +4,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #TBD
+### PR #572
 
 - Gate client routes, navigation, lazy modules, and mount boundaries through the feature exposure registry so disabled v1.7 work never registers paths, shows nav links, or initializes effects.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,16 @@ Every frontend build resolves one deployment target through `VITE_BUILD_TARGET`:
 
 v1.7 feature rollout is declared in `src/config/featureExposure.ts`. That registry is the single source of truth for which unfinished features may appear on each build target. Every key records an owner, added date, per-target exposure matrix, whether server capability is required, and removal metadata for temporary flags.
 
-Use `isFeatureExposed('featureKey')` for typed enablement checks. Unknown keys fail at compile time. Route, navigation, Redux, and server gates will adopt this registry in follow-up foundation work; this issue only establishes the contract and helpers.
+Use `isFeatureExposed('featureKey')` for typed enablement checks. Unknown keys fail at compile time.
+
+Client gates live in:
+
+- `src/config/featureSurfaces.ts` — declares gated lazy routes and side-effect module ownership
+- `src/config/featureNavigation.ts` — filters navbar items and keyboard shortcuts
+- `src/routing/buildFeatureGatedRoutes.tsx` — registers routes only for exposed features
+- `src/features/FeatureBoundary.tsx` — mounts children and effects only inside enabled boundaries
+
+Gated routes use `React.lazy` so disabled modules never load. Server capability gates adopt the same registry keys in follow-up foundation work.
 
 ### Local Beta Mode (developer)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import BetaAccessGuard from './components/Beta/BetaAccessGuard';
 import { GoogleAnalyticsRouteTracker } from './components/GoogleAnalyticsRouteTracker';
 import ToSModal, { hasAcceptedToS } from './components/ToS/ToSModal';
 import PrivacyPolicyModal, { hasAcceptedPrivacyPolicy } from './components/PrivacyPolicy/PrivacyPolicyModal';
+import { buildFeatureGatedRoutes } from './routing/buildFeatureGatedRoutes';
 
 // Launch gate: set VITE_COMING_SOON=true in the public build to enable pre-launch mode.
 // The app auto-unlocks at the launch date/time regardless of the env var.
@@ -149,6 +150,7 @@ const AppRoutes: React.FC<AppRoutesProps> = ({ showComingSoon }) => {
         <Route path="discussion" element={<DiscussionPage />} />
         <Route path="verification" element={<VerificationPage />} />
         <Route path="monitor" element={<MonitorPage />} />
+        {buildFeatureGatedRoutes()}
         </Route>
       </Route>
       <Route path="*" element={<Navigate to={BETA_MODE ? '/beta' : '/'} replace />} />

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { cn } from '../../lib/utils';
 import { NAVBAR_HEIGHT } from '../../lib/uiConstants';
 import { keyboardShortcutKey } from '../../utils/keyboardShortcutKey';
+import { getNavigationKeyboardShortcuts } from '../../config/featureNavigation';
 
 export interface ToastItem {
   id: string;
@@ -121,17 +122,7 @@ export const AppLayout: React.FC = () => {
         const key = keyboardShortcutKey(e);
         if (!key) return;
 
-        // Define Ctrl/Cmd+key shortcuts for navigation and actions
-        const shortcuts: Record<string, () => void> = {
-          h: () => navigate('/'),
-          '1': () => navigate('/forecast'),
-          '2': () => navigate('/discussion'),
-          '3': () => navigate('/verification'),
-          '4': () => navigate('/monitor'),
-          d: () => document.documentElement.classList.toggle('dark-mode'),
-        };
-
-        // Ctrl+H home, Ctrl+1 forecast, Ctrl+2 discussion, Ctrl+3 verification, Ctrl+4 monitor, Ctrl+D dark mode
+        const shortcuts = getNavigationKeyboardShortcuts(navigate);
         const action = shortcuts[key];
         if (action) {
           e.preventDefault();

--- a/src/components/Layout/NavbarSections.tsx
+++ b/src/components/Layout/NavbarSections.tsx
@@ -34,6 +34,7 @@ import {
 } from '../ui/dropdown-menu';
 import { cn } from '../../lib/utils';
 import { useAuth } from '../../auth/AuthProvider';
+import { getVisibleNavigationItems } from '../../config/featureNavigation';
 declare const __GFC_APP_VERSION__: string;
 
 const appVersion = typeof __GFC_APP_VERSION__ !== 'undefined' ? __GFC_APP_VERSION__ : 'dev';
@@ -53,14 +54,25 @@ interface RightActionsProps {
   onToggleDarkMode: () => void;
 }
 
-// Define the navigation items for the main tabs
-const navItems = [
-  { to: '/', label: 'Home', icon: Home, shortcut: '⌃H', end: true },
-  { to: '/forecast', label: 'Forecast', icon: Map, shortcut: '⌃1' },
-  { to: '/discussion', label: 'Discussion', icon: MessageSquare, shortcut: '⌃2' },
-  { to: '/verification', label: 'Verification', icon: CheckCircle, shortcut: '⌃3' },
-  { to: '/monitor', label: 'Monitor', icon: RadioTower, shortcut: '⌃4' },
-];
+const NAV_ITEM_ICONS = {
+  home: Home,
+  forecast: Map,
+  discussion: MessageSquare,
+  verification: CheckCircle,
+  monitor: RadioTower,
+  'tropical-workspace': Map,
+  'collaboration-room': MessageSquare,
+} as const;
+
+const NAV_ITEM_SHORTCUTS = {
+  home: '⌃H',
+  forecast: '⌃1',
+  discussion: '⌃2',
+  verification: '⌃3',
+  monitor: '⌃4',
+  'tropical-workspace': '⌃5',
+  'collaboration-room': '⌃6',
+} as const;
 
 // Define external links for the right action buttons
 const externalLinks: ExternalActionLink[] = [
@@ -117,14 +129,19 @@ export const BrandSection: FC = () => (
 // The MainTabs component keeps primary navigation next to the brand so the header reads left-to-right instead of as separate islands.
 export const MainTabs: FC = () => {
   const { pathname } = useLocation();
+  const navItems = getVisibleNavigationItems().map((item) => ({
+    ...item,
+    icon: NAV_ITEM_ICONS[item.id as keyof typeof NAV_ITEM_ICONS],
+    shortcut: NAV_ITEM_SHORTCUTS[item.id as keyof typeof NAV_ITEM_SHORTCUTS],
+  }));
 
   return (
     <div className="app-navbar__tabs">
-      {navItems.map(({ to, label, icon: Icon, shortcut, end }) => {
+      {navItems.map(({ id, to, label, icon: Icon, shortcut, end }) => {
         const isActive = end ? pathname === to : pathname === to || pathname.startsWith(`${to}/`);
 
         return (
-          <Tooltip key={to}>
+          <Tooltip key={id}>
             <TooltipTrigger asChild>
               <NavLink to={to} end={end} className={getNavLinkClassName(isActive)}>
                 <Icon className="app-navbar__tabIcon h-4 w-4" />

--- a/src/components/Layout/NavbarSections.tsx
+++ b/src/components/Layout/NavbarSections.tsx
@@ -34,7 +34,8 @@ import {
 } from '../ui/dropdown-menu';
 import { cn } from '../../lib/utils';
 import { useAuth } from '../../auth/AuthProvider';
-import { getVisibleNavigationItems } from '../../config/featureNavigation';
+import { getVisibleNavigationItems, type AppNavigationItemId } from '../../config/featureNavigation';
+import type { LucideIcon } from 'lucide-react';
 declare const __GFC_APP_VERSION__: string;
 
 const appVersion = typeof __GFC_APP_VERSION__ !== 'undefined' ? __GFC_APP_VERSION__ : 'dev';
@@ -62,17 +63,7 @@ const NAV_ITEM_ICONS = {
   monitor: RadioTower,
   'tropical-workspace': Map,
   'collaboration-room': MessageSquare,
-} as const;
-
-const NAV_ITEM_SHORTCUTS = {
-  home: '⌃H',
-  forecast: '⌃1',
-  discussion: '⌃2',
-  verification: '⌃3',
-  monitor: '⌃4',
-  'tropical-workspace': '⌃5',
-  'collaboration-room': '⌃6',
-} as const;
+} satisfies Record<AppNavigationItemId, LucideIcon>;
 
 // Define external links for the right action buttons
 const externalLinks: ExternalActionLink[] = [
@@ -131,13 +122,12 @@ export const MainTabs: FC = () => {
   const { pathname } = useLocation();
   const navItems = getVisibleNavigationItems().map((item) => ({
     ...item,
-    icon: NAV_ITEM_ICONS[item.id as keyof typeof NAV_ITEM_ICONS],
-    shortcut: NAV_ITEM_SHORTCUTS[item.id as keyof typeof NAV_ITEM_SHORTCUTS],
+    icon: NAV_ITEM_ICONS[item.id],
   }));
 
   return (
     <div className="app-navbar__tabs">
-      {navItems.map(({ id, to, label, icon: Icon, shortcut, end }) => {
+      {navItems.map(({ id, to, label, icon: Icon, shortcutLabel, end }) => {
         const isActive = end ? pathname === to : pathname === to || pathname.startsWith(`${to}/`);
 
         return (
@@ -149,7 +139,7 @@ export const MainTabs: FC = () => {
               </NavLink>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{label} <span className="text-muted-foreground ml-2">{shortcut}</span></p>
+              <p>{label} {shortcutLabel ? <span className="text-muted-foreground ml-2">{shortcutLabel}</span> : null}</p>
             </TooltipContent>
           </Tooltip>
         );

--- a/src/config/featureNavigation.test.ts
+++ b/src/config/featureNavigation.test.ts
@@ -1,0 +1,50 @@
+import * as featureExposure from './featureExposure';
+import {
+  APP_NAVIGATION_ITEMS,
+  getNavigationKeyboardShortcuts,
+  getVisibleNavigationItems,
+} from './featureNavigation';
+
+describe('featureNavigation', () => {
+  const originalTarget = globalThis.__GFC_BUILD_TARGET__;
+
+  afterEach(() => {
+    globalThis.__GFC_BUILD_TARGET__ = originalTarget;
+    jest.restoreAllMocks();
+  });
+
+  test('keeps core navigation visible when gated features are disabled', () => {
+    globalThis.__GFC_BUILD_TARGET__ = 'production';
+
+    expect(getVisibleNavigationItems('production').map((item) => item.id)).toEqual([
+      'home',
+      'forecast',
+      'discussion',
+      'verification',
+      'monitor',
+    ]);
+  });
+
+  test('includes gated navigation only when the feature is exposed on the target', () => {
+    jest.spyOn(featureExposure, 'isFeatureExposedOnTarget').mockImplementation(
+      (feature, target) => feature === 'tropicalWorkspace' && target === 'local'
+    );
+
+    expect(getVisibleNavigationItems('local').map((item) => item.id)).toContain('tropical-workspace');
+    expect(getVisibleNavigationItems('production').map((item) => item.id)).not.toContain('tropical-workspace');
+  });
+
+  test('omits keyboard shortcuts for hidden gated destinations', () => {
+    const navigate = jest.fn();
+    const shortcuts = getNavigationKeyboardShortcuts(navigate, 'production');
+
+    expect(Object.keys(shortcuts).sort()).toEqual(['1', '2', '3', '4', 'd', 'h']);
+    expect(shortcuts['5']).toBeUndefined();
+    expect(shortcuts['6']).toBeUndefined();
+  });
+
+  test('declares every navigation item with a stable id', () => {
+    const ids = APP_NAVIGATION_ITEMS.map((item) => item.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/config/featureNavigation.ts
+++ b/src/config/featureNavigation.ts
@@ -1,0 +1,61 @@
+import type { BuildTarget } from './buildTarget';
+import { getBuildTarget } from './buildTarget';
+import { isFeatureExposedOnTarget, type FeatureKey } from './featureExposure';
+
+export type AppNavigationItem = {
+  id: string;
+  to: string;
+  label: string;
+  shortcutKey?: string;
+  end?: boolean;
+  feature?: FeatureKey;
+};
+
+/** Primary navbar destinations. Items with a feature key render only when that feature is exposed. */
+export const APP_NAVIGATION_ITEMS = [
+  { id: 'home', to: '/', label: 'Home', shortcutKey: 'h', end: true },
+  { id: 'forecast', to: '/forecast', label: 'Forecast', shortcutKey: '1' },
+  { id: 'discussion', to: '/discussion', label: 'Discussion', shortcutKey: '2' },
+  { id: 'verification', to: '/verification', label: 'Verification', shortcutKey: '3' },
+  { id: 'monitor', to: '/monitor', label: 'Monitor', shortcutKey: '4' },
+  {
+    id: 'tropical-workspace',
+    to: '/tropical',
+    label: 'Tropical',
+    shortcutKey: '5',
+    feature: 'tropicalWorkspace',
+  },
+  {
+    id: 'collaboration-room',
+    to: '/collaborate',
+    label: 'Collaborate',
+    shortcutKey: '6',
+    feature: 'collaborationRoom',
+  },
+] as const satisfies readonly AppNavigationItem[];
+
+/** Returns navbar items visible for the given deployment target. */
+export const getVisibleNavigationItems = (
+  target: BuildTarget = getBuildTarget()
+): AppNavigationItem[] =>
+  APP_NAVIGATION_ITEMS.filter(
+    (item) => !item.feature || isFeatureExposedOnTarget(item.feature, target)
+  );
+
+/** Builds Ctrl/Cmd navigation shortcuts for visible navbar destinations. */
+export const getNavigationKeyboardShortcuts = (
+  navigate: (path: string) => void,
+  target: BuildTarget = getBuildTarget()
+): Record<string, () => void> => {
+  const shortcuts: Record<string, () => void> = {
+    d: () => document.documentElement.classList.toggle('dark-mode'),
+  };
+
+  for (const item of getVisibleNavigationItems(target)) {
+    if (item.shortcutKey) {
+      shortcuts[item.shortcutKey] = () => navigate(item.to);
+    }
+  }
+
+  return shortcuts;
+};

--- a/src/config/featureNavigation.ts
+++ b/src/config/featureNavigation.ts
@@ -7,22 +7,24 @@ export type AppNavigationItem = {
   to: string;
   label: string;
   shortcutKey?: string;
+  shortcutLabel?: string;
   end?: boolean;
   feature?: FeatureKey;
 };
 
 /** Primary navbar destinations. Items with a feature key render only when that feature is exposed. */
 export const APP_NAVIGATION_ITEMS = [
-  { id: 'home', to: '/', label: 'Home', shortcutKey: 'h', end: true },
-  { id: 'forecast', to: '/forecast', label: 'Forecast', shortcutKey: '1' },
-  { id: 'discussion', to: '/discussion', label: 'Discussion', shortcutKey: '2' },
-  { id: 'verification', to: '/verification', label: 'Verification', shortcutKey: '3' },
-  { id: 'monitor', to: '/monitor', label: 'Monitor', shortcutKey: '4' },
+  { id: 'home', to: '/', label: 'Home', shortcutKey: 'h', shortcutLabel: '⌃H', end: true },
+  { id: 'forecast', to: '/forecast', label: 'Forecast', shortcutKey: '1', shortcutLabel: '⌃1' },
+  { id: 'discussion', to: '/discussion', label: 'Discussion', shortcutKey: '2', shortcutLabel: '⌃2' },
+  { id: 'verification', to: '/verification', label: 'Verification', shortcutKey: '3', shortcutLabel: '⌃3' },
+  { id: 'monitor', to: '/monitor', label: 'Monitor', shortcutKey: '4', shortcutLabel: '⌃4' },
   {
     id: 'tropical-workspace',
     to: '/tropical',
     label: 'Tropical',
     shortcutKey: '5',
+    shortcutLabel: '⌃5',
     feature: 'tropicalWorkspace',
   },
   {
@@ -30,14 +32,17 @@ export const APP_NAVIGATION_ITEMS = [
     to: '/collaborate',
     label: 'Collaborate',
     shortcutKey: '6',
+    shortcutLabel: '⌃6',
     feature: 'collaborationRoom',
   },
 ] as const satisfies readonly AppNavigationItem[];
 
+export type AppNavigationItemId = (typeof APP_NAVIGATION_ITEMS)[number]['id'];
+
 /** Returns navbar items visible for the given deployment target. */
 export const getVisibleNavigationItems = (
   target: BuildTarget = getBuildTarget()
-): AppNavigationItem[] =>
+): (typeof APP_NAVIGATION_ITEMS)[number][] =>
   APP_NAVIGATION_ITEMS.filter(
     (item) => !item.feature || isFeatureExposedOnTarget(item.feature, target)
   );

--- a/src/config/featureSurfaces.test.ts
+++ b/src/config/featureSurfaces.test.ts
@@ -1,0 +1,14 @@
+import { GATED_ROUTE_DEFINITIONS, FEATURE_SIDE_EFFECT_MODULES } from './featureSurfaces';
+
+describe('featureSurfaces', () => {
+  test('declares lazy route loaders for gated workspace features', () => {
+    expect(GATED_ROUTE_DEFINITIONS.map((definition) => definition.path)).toEqual([
+      'tropical',
+      'collaborate',
+    ]);
+  });
+
+  test('documents side-effect modules that must stay behind feature boundaries', () => {
+    expect(FEATURE_SIDE_EFFECT_MODULES.autoTstm).toEqual(['../utils/tstmGeneration']);
+  });
+});

--- a/src/config/featureSurfaces.ts
+++ b/src/config/featureSurfaces.ts
@@ -1,0 +1,27 @@
+import type { ComponentType } from 'react';
+import type { FeatureKey } from './featureExposure';
+
+export type GatedRouteDefinition = {
+  feature: FeatureKey;
+  path: string;
+  loadPage: () => Promise<{ default: ComponentType }>;
+};
+
+/** Declares lazy routes owned by registry features. Core app routes stay outside this list. */
+export const GATED_ROUTE_DEFINITIONS = [
+  {
+    feature: 'tropicalWorkspace',
+    path: 'tropical',
+    loadPage: () => import('../pages/gated/TropicalWorkspacePage'),
+  },
+  {
+    feature: 'collaborationRoom',
+    path: 'collaborate',
+    loadPage: () => import('../pages/gated/CollaborationRoomPage'),
+  },
+] as const satisfies readonly GatedRouteDefinition[];
+
+/** Documents modules that must only initialize behind a feature boundary. */
+export const FEATURE_SIDE_EFFECT_MODULES = {
+  autoTstm: ['../utils/tstmGeneration'],
+} as const satisfies Partial<Record<FeatureKey, readonly string[]>>;

--- a/src/features/FeatureBoundary.test.tsx
+++ b/src/features/FeatureBoundary.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { FEATURE_EXPOSURE_REGISTRY } from '../config/featureExposure';
+import { FeatureBoundary, useFeatureEffect } from './FeatureBoundary';
+
+const effectSpy = jest.fn();
+
+const EffectProbe = () => {
+  useFeatureEffect('autoTstm', () => {
+    effectSpy();
+    return undefined;
+  }, []);
+
+  return <div>Effect probe</div>;
+};
+
+describe('FeatureBoundary', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    effectSpy.mockReset();
+  });
+
+  test('renders children only when the feature is exposed', () => {
+    jest.spyOn(
+      require('../config/featureExposure'),
+      'isFeatureExposed'
+    ).mockReturnValue(false);
+
+    const { rerender } = render(
+      <FeatureBoundary feature="autoTstm">
+        <div>Auto-TSTM controls</div>
+      </FeatureBoundary>
+    );
+
+    expect(screen.queryByText('Auto-TSTM controls')).not.toBeInTheDocument();
+
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
+    rerender(
+      <FeatureBoundary feature="autoTstm">
+        <div>Auto-TSTM controls</div>
+      </FeatureBoundary>
+    );
+
+    expect(screen.getByText('Auto-TSTM controls')).toBeInTheDocument();
+  });
+
+  test('does not run gated effects while the feature remains disabled', () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(false);
+
+    render(
+      <FeatureBoundary feature="autoTstm">
+        <EffectProbe />
+      </FeatureBoundary>
+    );
+
+    expect(effectSpy).not.toHaveBeenCalled();
+  });
+
+  test('runs gated effects when the feature is exposed', () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
+
+    render(<EffectProbe />);
+
+    expect(effectSpy).toHaveBeenCalledTimes(1);
+    expect(FEATURE_EXPOSURE_REGISTRY.autoTstm.serverCapabilityKey).toBe('TSTM_GENERATION_ENABLED');
+  });
+});

--- a/src/features/FeatureBoundary.tsx
+++ b/src/features/FeatureBoundary.tsx
@@ -1,0 +1,38 @@
+import { useEffect, type DependencyList, type EffectCallback, type ReactNode } from 'react';
+import { isFeatureExposed, type FeatureKey } from '../config/featureExposure';
+
+type FeatureBoundaryProps = {
+  feature: FeatureKey;
+  children: ReactNode;
+};
+
+/** Renders children only when the feature is exposed on the current build target. */
+export const FeatureBoundary = ({ feature, children }: FeatureBoundaryProps) => {
+  if (!isFeatureExposed(feature)) {
+    return null;
+  }
+
+  return children;
+};
+
+/** Returns whether a registry feature is exposed on the current build target. */
+export const useFeatureExposed = (feature: FeatureKey): boolean => isFeatureExposed(feature);
+
+/** Runs an effect only while the feature is exposed on the current build target. */
+export const useFeatureEffect = (
+  feature: FeatureKey,
+  effect: EffectCallback,
+  deps: DependencyList
+): void => {
+  const exposed = isFeatureExposed(feature);
+
+  useEffect(() => {
+    if (!exposed) {
+      return undefined;
+    }
+
+    return effect();
+    // Feature exposure is compile-time stable per build; deps carry caller state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [exposed, feature, ...deps]);
+};

--- a/src/pages/gated/CollaborationRoomPage.tsx
+++ b/src/pages/gated/CollaborationRoomPage.tsx
@@ -2,7 +2,7 @@
 const CollaborationRoomPage = () => (
   <main className="p-6">
     <h1 className="text-2xl font-semibold">Collaboration Room</h1>
-    <p className="mt-2 text-muted-foreground">Collaboration room foundations are not enabled on this build.</p>
+    <p className="mt-2 text-muted-foreground">Collaboration room foundations are under construction.</p>
   </main>
 );
 

--- a/src/pages/gated/CollaborationRoomPage.tsx
+++ b/src/pages/gated/CollaborationRoomPage.tsx
@@ -1,0 +1,9 @@
+/** Placeholder page for the gated collaboration room route. */
+const CollaborationRoomPage = () => (
+  <main className="p-6">
+    <h1 className="text-2xl font-semibold">Collaboration Room</h1>
+    <p className="mt-2 text-muted-foreground">Collaboration room foundations are not enabled on this build.</p>
+  </main>
+);
+
+export default CollaborationRoomPage;

--- a/src/pages/gated/TropicalWorkspacePage.tsx
+++ b/src/pages/gated/TropicalWorkspacePage.tsx
@@ -2,7 +2,7 @@
 const TropicalWorkspacePage = () => (
   <main className="p-6">
     <h1 className="text-2xl font-semibold">Tropical Workspace</h1>
-    <p className="mt-2 text-muted-foreground">Tropical workspace foundations are not enabled on this build.</p>
+    <p className="mt-2 text-muted-foreground">Tropical workspace foundations are under construction.</p>
   </main>
 );
 

--- a/src/pages/gated/TropicalWorkspacePage.tsx
+++ b/src/pages/gated/TropicalWorkspacePage.tsx
@@ -1,0 +1,9 @@
+/** Placeholder page for the gated tropical workspace route. */
+const TropicalWorkspacePage = () => (
+  <main className="p-6">
+    <h1 className="text-2xl font-semibold">Tropical Workspace</h1>
+    <p className="mt-2 text-muted-foreground">Tropical workspace foundations are not enabled on this build.</p>
+  </main>
+);
+
+export default TropicalWorkspacePage;

--- a/src/routing/buildFeatureGatedRoutes.test.tsx
+++ b/src/routing/buildFeatureGatedRoutes.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes } from 'react-router-dom';
+import * as featureExposure from '../config/featureExposure';
+import { buildFeatureGatedRoutes, getExposedGatedRoutePaths } from './buildFeatureGatedRoutes';
+
+jest.mock('../pages/gated/TropicalWorkspacePage', () => ({
+  __esModule: true,
+  default: () => <div>Tropical workspace page</div>,
+}));
+
+jest.mock('../pages/gated/CollaborationRoomPage', () => ({
+  __esModule: true,
+  default: () => <div>Collaboration room page</div>,
+}));
+
+describe('buildFeatureGatedRoutes', () => {
+  const originalTarget = globalThis.__GFC_BUILD_TARGET__;
+
+  afterEach(() => {
+    globalThis.__GFC_BUILD_TARGET__ = originalTarget;
+    jest.restoreAllMocks();
+  });
+
+  test('does not register gated routes while every feature remains disabled', () => {
+    globalThis.__GFC_BUILD_TARGET__ = 'beta';
+
+    expect(getExposedGatedRoutePaths('beta')).toEqual([]);
+    expect(buildFeatureGatedRoutes('beta')).toEqual([]);
+  });
+
+  test('registers exposed gated routes and lazy-loads their modules', async () => {
+    jest.spyOn(featureExposure, 'isFeatureExposedOnTarget').mockImplementation(
+      (feature, target) => feature === 'tropicalWorkspace' && target === 'local'
+    );
+
+    expect(getExposedGatedRoutePaths('local')).toEqual(['/tropical']);
+
+    render(
+      <MemoryRouter initialEntries={['/tropical']}>
+        <Routes>{buildFeatureGatedRoutes('local')}</Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Tropical workspace page')).toBeInTheDocument();
+  });
+});

--- a/src/routing/buildFeatureGatedRoutes.tsx
+++ b/src/routing/buildFeatureGatedRoutes.tsx
@@ -25,6 +25,10 @@ export const getExposedGatedRoutePaths = (target: BuildTarget = getBuildTarget()
     (definition) => `/${definition.path}`
   );
 
+const GatedRouteFallback = () => (
+  <div className="flex h-full items-center justify-center p-6" aria-busy="true" aria-label="Loading page" />
+);
+
 /** Registers lazy routes only for features exposed on the current build target. */
 export const buildFeatureGatedRoutes = (target: BuildTarget = getBuildTarget()): ReactElement[] =>
   GATED_ROUTE_DEFINITIONS.filter((definition) => isFeatureExposedOnTarget(definition.feature, target)).map(
@@ -36,7 +40,7 @@ export const buildFeatureGatedRoutes = (target: BuildTarget = getBuildTarget()):
           key={definition.path}
           path={definition.path}
           element={
-            <Suspense fallback={null}>
+            <Suspense fallback={<GatedRouteFallback />}>
               <Page />
             </Suspense>
           }

--- a/src/routing/buildFeatureGatedRoutes.tsx
+++ b/src/routing/buildFeatureGatedRoutes.tsx
@@ -25,6 +25,7 @@ export const getExposedGatedRoutePaths = (target: BuildTarget = getBuildTarget()
     (definition) => `/${definition.path}`
   );
 
+/** Minimal loading placeholder shown while a gated lazy route chunk downloads. */
 const GatedRouteFallback = () => (
   <div className="flex h-full items-center justify-center p-6" aria-busy="true" aria-label="Loading page" />
 );

--- a/src/routing/buildFeatureGatedRoutes.tsx
+++ b/src/routing/buildFeatureGatedRoutes.tsx
@@ -1,0 +1,46 @@
+import { lazy, Suspense, type ComponentType, type LazyExoticComponent, type ReactElement } from 'react';
+import { Route } from 'react-router-dom';
+import type { BuildTarget } from '../config/buildTarget';
+import { getBuildTarget } from '../config/buildTarget';
+import { isFeatureExposedOnTarget } from '../config/featureExposure';
+import { GATED_ROUTE_DEFINITIONS, type GatedRouteDefinition } from '../config/featureSurfaces';
+
+const lazyPageCache = new Map<string, LazyExoticComponent<ComponentType>>();
+
+/** Returns a cached lazy component for one gated route definition. */
+const getLazyPage = (definition: GatedRouteDefinition): LazyExoticComponent<ComponentType> => {
+  const cached = lazyPageCache.get(definition.path);
+  if (cached) {
+    return cached;
+  }
+
+  const lazyPage = lazy(definition.loadPage);
+  lazyPageCache.set(definition.path, lazyPage);
+  return lazyPage;
+};
+
+/** Returns gated route pathnames that would register for the given deployment target. */
+export const getExposedGatedRoutePaths = (target: BuildTarget = getBuildTarget()): string[] =>
+  GATED_ROUTE_DEFINITIONS.filter((definition) => isFeatureExposedOnTarget(definition.feature, target)).map(
+    (definition) => `/${definition.path}`
+  );
+
+/** Registers lazy routes only for features exposed on the current build target. */
+export const buildFeatureGatedRoutes = (target: BuildTarget = getBuildTarget()): ReactElement[] =>
+  GATED_ROUTE_DEFINITIONS.filter((definition) => isFeatureExposedOnTarget(definition.feature, target)).map(
+    (definition) => {
+      const Page = getLazyPage(definition);
+
+      return (
+        <Route
+          key={definition.path}
+          path={definition.path}
+          element={
+            <Suspense fallback={null}>
+              <Page />
+            </Suspense>
+          }
+        />
+      );
+    }
+  );


### PR DESCRIPTION
## Summary
- Add client-side route, navigation, and mount gates wired to the typed feature exposure registry (FND-03 / #438).
- Register gated routes only when `isFeatureExposed` is true, using `React.lazy` so disabled modules never load.
- Filter navbar tabs and keyboard shortcuts through the same registry, and add `FeatureBoundary` / `useFeatureEffect` for gated side effects.
- Add stub lazy pages for tropical workspace and collaboration room as representative gated routes (all registry flags remain off).

## Test plan
- [x] `pnpm test -- --runTestsByPath src/config/featureNavigation.test.ts src/config/featureSurfaces.test.ts src/routing/buildFeatureGatedRoutes.test.tsx src/features/FeatureBoundary.test.tsx src/components/Layout/NavbarSections.test.tsx src/App.updates-route.test.tsx`
- [x] `pnpm run build`
- [ ] Confirm core nav and routes unchanged on production/beta builds (gated tabs hidden)
- [ ] Verify `/tropical` and `/collaborate` redirect to home when features remain disabled

Closes #438