### PR TITLE
feat(foundation): add server capability gates for experimental APIs (FND-04)

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -78,6 +78,7 @@ jobs:
           PORT=3007
           LOG_DIR=/opt/gfc-beta-analytics/logs
           APP_BASE_URL=https://beta-gfc.weatherboysuper.com
+          SERVER_TARGET=beta
           BETA_MODE=true
           BETA_INVITE_TOKEN=${{ secrets.BETA_INVITE_TOKEN }}
           BETA_INVITE_PATH=${{ secrets.BETA_INVITE_PATH }}

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -156,6 +156,7 @@ jobs:
           PORT=3006
           LOG_DIR=/opt/gfc-analytics/logs
           APP_BASE_URL=https://gfc.weatherboysuper.com
+          SERVER_TARGET=production
           BETA_MODE=false
           BETA_INVITE_TOKEN=
           BETA_INVITE_PATH=
@@ -180,6 +181,7 @@ jobs:
           PORT=3008
           LOG_DIR=/opt/gfc-staging-analytics/logs
           APP_BASE_URL=https://staging-gfc.weatherboysuper.com
+          SERVER_TARGET=staging
           BETA_MODE=true
           BETA_INVITE_TOKEN=${{ secrets.BETA_INVITE_TOKEN }}
           BETA_INVITE_PATH=${{ secrets.BETA_INVITE_PATH }}

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,7 +4,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### FND-04
+### PR #573
 
 - Add centralized server capability lookup, route gates, and `SERVER_TARGET` deploy env wiring so experimental APIs reject before expensive work and stay aligned with the client feature exposure registry.
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### FND-04
+
+- Add centralized server capability lookup, route gates, and `SERVER_TARGET` deploy env wiring so experimental APIs reject before expensive work and stay aligned with the client feature exposure registry.
+
 ### PR #572
 
 - Gate client routes, navigation, lazy modules, and mount boundaries through the feature exposure registry so disabled v1.7 work never registers paths, shows nav links, or initializes effects.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,15 @@ Client gates live in:
 - `src/routing/buildFeatureGatedRoutes.tsx` — registers routes only for exposed features
 - `src/features/FeatureBoundary.tsx` — mounts children and effects only inside enabled boundaries
 
-Gated routes use `React.lazy` so disabled modules never load. Server capability gates adopt the same registry keys in follow-up foundation work.
+Gated routes use `React.lazy` so disabled modules never load.
+
+Server capability gates live in:
+
+- `server/lib/serverFeatureExposure.js` — server-backed slice of the registry
+- `server/lib/featureCapabilities.js` — deployment env + target exposure lookup and route middleware
+- `server/lib/serverTarget.js` — resolves `SERVER_TARGET` (with `SENTRY_ENVIRONMENT` fallback)
+
+Experimental APIs register `createServerCapabilityGate(serverCapabilityKey)` before auth and handlers. A capability is enabled only when the registry exposes it for the server target and the deployment env key is `true`. Disabled routes return `404` with `{ error: "<label> is not enabled on this deployment." }`.
 
 ### Local Beta Mode (developer)
 

--- a/server/lib/featureCapabilities.js
+++ b/server/lib/featureCapabilities.js
@@ -58,11 +58,12 @@ const createServerCapabilityGate = (capabilityKey, options = {}) => {
   const env = options.env || process.env;
   const feature = findFeatureByCapabilityKey(capabilityKey);
   const label = options.label || feature?.definition?.label || 'This capability';
+  const target = options.target ?? getServerTarget(env);
 
   return (_req, res, next) => {
     if (!isServerCapabilityEnabled(capabilityKey, {
       env,
-      target: options.target,
+      target,
       exposureOverride: options.exposureOverride,
     })) {
       sendDisabledCapabilityResponse(res, { label });

--- a/server/lib/featureCapabilities.js
+++ b/server/lib/featureCapabilities.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { getServerTarget } = require('./serverTarget');
+const { SERVER_FEATURE_EXPOSURE_REGISTRY } = require('./serverFeatureExposure');
+
+const DISABLED_CAPABILITY_STATUS = 404;
+
+/** Returns the server-backed feature entry for a capability key, if declared. */
+const findFeatureByCapabilityKey = (capabilityKey) => {
+  for (const [featureKey, definition] of Object.entries(SERVER_FEATURE_EXPOSURE_REGISTRY)) {
+    if (definition.serverCapabilityKey === capabilityKey) {
+      return { featureKey, definition };
+    }
+  }
+
+  return null;
+};
+
+/** Returns true when ops explicitly enabled the deployment capability env switch. */
+const isDeploymentCapabilityEnabled = (capabilityKey, env = process.env) =>
+  env[capabilityKey] === 'true';
+
+/**
+ * Returns true when registry exposure and the deployment capability env are both enabled.
+ * Authorization is intentionally separate and must run after this gate.
+ */
+const isServerCapabilityEnabled = (capabilityKey, options = {}) => {
+  const env = options.env || process.env;
+  const feature = findFeatureByCapabilityKey(capabilityKey);
+
+  if (!feature) {
+    return false;
+  }
+
+  const target = options.target ?? getServerTarget(env);
+  const exposureOverride = options.exposureOverride?.[target];
+  const exposedOnTarget =
+    typeof exposureOverride === 'boolean'
+      ? exposureOverride
+      : feature.definition.exposure[target] === true;
+
+  if (!exposedOnTarget) {
+    return false;
+  }
+
+  return isDeploymentCapabilityEnabled(capabilityKey, env);
+};
+
+/** Sends the standard fail-closed response for disabled experimental APIs. */
+const sendDisabledCapabilityResponse = (res, { label }) => {
+  res.status(DISABLED_CAPABILITY_STATUS).json({
+    error: `${label} is not enabled on this deployment.`,
+  });
+};
+
+/** Rejects disabled capabilities before route handlers, auth, or expensive work run. */
+const createServerCapabilityGate = (capabilityKey, options = {}) => {
+  const env = options.env || process.env;
+  const feature = findFeatureByCapabilityKey(capabilityKey);
+  const label = options.label || feature?.definition?.label || 'This capability';
+
+  return (_req, res, next) => {
+    if (!isServerCapabilityEnabled(capabilityKey, {
+      env,
+      target: options.target,
+      exposureOverride: options.exposureOverride,
+    })) {
+      sendDisabledCapabilityResponse(res, { label });
+      return;
+    }
+
+    next();
+  };
+};
+
+module.exports = {
+  DISABLED_CAPABILITY_STATUS,
+  createServerCapabilityGate,
+  findFeatureByCapabilityKey,
+  isDeploymentCapabilityEnabled,
+  isServerCapabilityEnabled,
+  sendDisabledCapabilityResponse,
+};

--- a/server/lib/featureCapabilities.test.js
+++ b/server/lib/featureCapabilities.test.js
@@ -64,6 +64,15 @@ describe('server capability gates', () => {
     }
   });
 
+  it('fails route registration when SERVER_TARGET is invalid', () => {
+    assert.throws(
+      () => createServerCapabilityGate('TSTM_GENERATION_ENABLED', {
+        env: { SERVER_TARGET: 'preview' },
+      }),
+      /Invalid SERVER_TARGET/
+    );
+  });
+
   it('uses a consistent disabled response helper', () => {
     const response = {
       statusCode: null,

--- a/server/lib/featureCapabilities.test.js
+++ b/server/lib/featureCapabilities.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const {
+  DISABLED_CAPABILITY_STATUS,
+  createServerCapabilityGate,
+  isServerCapabilityEnabled,
+  sendDisabledCapabilityResponse,
+} = require('./featureCapabilities');
+
+const getUrl = (server) => {
+  const address = server.address();
+  return `http://127.0.0.1:${address.port}/api/test`;
+};
+
+describe('server capability gates', () => {
+  it('stays disabled for unknown capability keys', () => {
+    assert.equal(
+      isServerCapabilityEnabled('UNKNOWN_CAPABILITY', { env: { UNKNOWN_CAPABILITY: 'true' } }),
+      false
+    );
+  });
+
+  it('requires registry exposure and deployment env to both be enabled', () => {
+    const env = { TSTM_GENERATION_ENABLED: 'true', SERVER_TARGET: 'beta' };
+    assert.equal(isServerCapabilityEnabled('TSTM_GENERATION_ENABLED', { env }), false);
+
+    assert.equal(
+      isServerCapabilityEnabled('TSTM_GENERATION_ENABLED', {
+        env,
+        exposureOverride: { beta: true },
+      }),
+      true
+    );
+  });
+
+  it('rejects disabled capabilities before handlers run', async () => {
+    let calls = 0;
+    const gate = createServerCapabilityGate('TSTM_GENERATION_ENABLED', {
+      env: { TSTM_GENERATION_ENABLED: 'true', SERVER_TARGET: 'beta' },
+      exposureOverride: { beta: false },
+    });
+    const app = express();
+    app.post('/api/test', gate, (_req, res) => {
+      calls += 1;
+      res.status(200).json({ ok: true });
+    });
+    const server = await new Promise((resolve, reject) => {
+      const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+      instance.on('error', reject);
+    });
+
+    try {
+      const response = await fetch(getUrl(server), { method: 'POST' });
+      assert.equal(response.status, DISABLED_CAPABILITY_STATUS);
+      assert.deepEqual(await response.json(), {
+        error: 'Auto-TSTM is not enabled on this deployment.',
+      });
+      assert.equal(calls, 0);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('uses a consistent disabled response helper', () => {
+    const response = {
+      statusCode: null,
+      body: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.body = payload;
+      },
+    };
+
+    sendDisabledCapabilityResponse(response, { label: 'Auto-TSTM' });
+    assert.equal(response.statusCode, DISABLED_CAPABILITY_STATUS);
+    assert.deepEqual(response.body, {
+      error: 'Auto-TSTM is not enabled on this deployment.',
+    });
+  });
+});

--- a/server/lib/serverFeatureExposure.js
+++ b/server/lib/serverFeatureExposure.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const ALL_TARGETS_OFF = {
+  local: false,
+  beta: false,
+  staging: false,
+  production: false,
+};
+
+/**
+ * Server-backed slice of the client feature exposure registry.
+ * Keep aligned with src/config/featureExposure.ts; FND-06 adds CI drift checks.
+ */
+const SERVER_FEATURE_EXPOSURE_REGISTRY = {
+  autoTstm: {
+    serverCapabilityKey: 'TSTM_GENERATION_ENABLED',
+    exposure: { ...ALL_TARGETS_OFF },
+    label: 'Auto-TSTM',
+  },
+};
+
+const KNOWN_SERVER_CAPABILITY_KEYS = Object.values(SERVER_FEATURE_EXPOSURE_REGISTRY).map(
+  (definition) => definition.serverCapabilityKey
+);
+
+module.exports = {
+  KNOWN_SERVER_CAPABILITY_KEYS,
+  SERVER_FEATURE_EXPOSURE_REGISTRY,
+};

--- a/server/lib/serverTarget.js
+++ b/server/lib/serverTarget.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const SERVER_TARGETS = ['local', 'beta', 'staging', 'production'];
+
+/** Returns true when the value is a known deployment target. */
+const isServerTarget = (value) => SERVER_TARGETS.includes(value);
+
+/**
+ * Resolves a deployment target from an explicit env value.
+ * Omitted values default to local development.
+ */
+const resolveServerTarget = (value) => {
+  if (value === undefined || value === '') {
+    return 'local';
+  }
+
+  if (isServerTarget(value)) {
+    return value;
+  }
+
+  throw new Error(
+    `Invalid SERVER_TARGET ${JSON.stringify(value)}. Expected one of: ${SERVER_TARGETS.join(', ')}.`
+  );
+};
+
+/**
+ * Resolves the analytics server deployment target.
+ * SERVER_TARGET wins; SENTRY_ENVIRONMENT is a transitional fallback for hosted env files.
+ */
+const getServerTarget = (env = process.env) => {
+  if (env.SERVER_TARGET !== undefined && env.SERVER_TARGET !== '') {
+    return resolveServerTarget(env.SERVER_TARGET);
+  }
+
+  if (env.SENTRY_ENVIRONMENT !== undefined && env.SENTRY_ENVIRONMENT !== '') {
+    if (isServerTarget(env.SENTRY_ENVIRONMENT)) {
+      return env.SENTRY_ENVIRONMENT;
+    }
+  }
+
+  return 'local';
+};
+
+module.exports = {
+  SERVER_TARGETS,
+  getServerTarget,
+  isServerTarget,
+  resolveServerTarget,
+};

--- a/server/lib/serverTarget.test.js
+++ b/server/lib/serverTarget.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { getServerTarget, resolveServerTarget } = require('./serverTarget');
+
+describe('server deployment target', () => {
+  it('defaults omitted values to local', () => {
+    assert.equal(resolveServerTarget(undefined), 'local');
+    assert.equal(getServerTarget({}), 'local');
+  });
+
+  it('prefers SERVER_TARGET over SENTRY_ENVIRONMENT', () => {
+    assert.equal(
+      getServerTarget({ SERVER_TARGET: 'staging', SENTRY_ENVIRONMENT: 'production' }),
+      'staging'
+    );
+  });
+
+  it('falls back to SENTRY_ENVIRONMENT when SERVER_TARGET is unset', () => {
+    assert.equal(getServerTarget({ SENTRY_ENVIRONMENT: 'beta' }), 'beta');
+    assert.equal(getServerTarget({ SENTRY_ENVIRONMENT: 'production' }), 'production');
+  });
+
+  it('rejects invalid explicit SERVER_TARGET values', () => {
+    assert.throws(() => resolveServerTarget('invalid'), /Invalid SERVER_TARGET/);
+  });
+
+  it('ignores invalid SENTRY_ENVIRONMENT values and defaults to local', () => {
+    assert.equal(getServerTarget({ SENTRY_ENVIRONMENT: 'preview' }), 'local');
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "main": "analytics.js",
   "scripts": {
     "start": "node analytics.js",
-    "test": "node --test billing-stripe-period.test.js qs-dos.test.js server-stack.test.js tstm.test.js"
+    "test": "node --test billing-stripe-period.test.js qs-dos.test.js lib/serverTarget.test.js lib/featureCapabilities.test.js server-stack.test.js tstm.test.js"
   },
   "dependencies": {
     "@sentry/node": "^10.58.0",

--- a/server/tstm.js
+++ b/server/tstm.js
@@ -5,12 +5,16 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const { createServerCapabilityGate, isServerCapabilityEnabled } = require('./lib/featureCapabilities');
+
 const DEFAULT_TIMEOUT_MS = 480000;
 const MAX_STDERR_LENGTH = 2000;
 const MAX_STDOUT_LENGTH = 4 * 1024 * 1024;
+const TSTM_CAPABILITY_KEY = 'TSTM_GENERATION_ENABLED';
 
-/** Returns true only when the experimental generator is explicitly enabled. */
-const isTstmGenerationEnabled = (env = process.env) => env.TSTM_GENERATION_ENABLED === 'true';
+/** Returns true when Auto-TSTM is exposed on this deployment target and capability env. */
+const isTstmGenerationEnabled = (env = process.env, options = {}) =>
+  isServerCapabilityEnabled(TSTM_CAPABILITY_KEY, { env, ...options });
 
 /**
  * Returns true for the only outlook days covered by the preserved generator.
@@ -124,23 +128,30 @@ const registerTstmRoutes = (app, express, options = {}) => {
     standardHeaders: true,
     legacyHeaders: false,
   });
-  app.post('/api/tstm/generate', generationLimiter, express.json({ limit: '4kb' }), async (req, res) => {
-    if (!isTstmGenerationEnabled(env)) {
-      res.status(404).json({ error: 'Auto-TSTM is not enabled on this deployment.' });
-      return;
-    }
-    const payload = createGenerationPayload(req.body);
-    const validationError = validatePayload(payload);
-    if (validationError) {
-      res.status(400).json({ error: validationError });
-      return;
-    }
-    try {
-      res.json(await runGenerator(payload));
-    } catch {
-      res.status(503).json({ error: 'Auto-TSTM guidance is temporarily unavailable.' });
-    }
-  });
+  const capabilityOptions = {
+    env,
+    exposureOverride: options.exposureOverride,
+    target: options.target,
+  };
+  app.post(
+    '/api/tstm/generate',
+    createServerCapabilityGate(TSTM_CAPABILITY_KEY, capabilityOptions),
+    generationLimiter,
+    express.json({ limit: '4kb' }),
+    async (req, res) => {
+      const payload = createGenerationPayload(req.body);
+      const validationError = validatePayload(payload);
+      if (validationError) {
+        res.status(400).json({ error: validationError });
+        return;
+      }
+      try {
+        res.json(await runGenerator(payload));
+      } catch {
+        res.status(503).json({ error: 'Auto-TSTM guidance is temporarily unavailable.' });
+      }
+    },
+  );
 };
 
 module.exports = {

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -13,9 +13,13 @@ const {
   validatePayload,
 } = require('./tstm');
 
-const startServer = (env, runGenerator) => {
+const ENABLED_CAPABILITY_OPTIONS = {
+  exposureOverride: { local: true, beta: true, staging: true, production: true },
+};
+
+const startServer = (env, runGenerator, routeOptions = {}) => {
   const app = express();
-  registerTstmRoutes(app, express, { env, runGenerator });
+  registerTstmRoutes(app, express, { env, runGenerator, ...routeOptions });
   return new Promise((resolve, reject) => {
     const server = app.listen(0, '127.0.0.1', () => resolve(server));
     server.on('error', reject);
@@ -37,10 +41,14 @@ const createFakeChild = () => {
 };
 
 describe('Auto-TSTM server foundation', () => {
-  it('stays disabled unless explicitly enabled', () => {
+  it('stays disabled unless registry exposure and deployment env are both enabled', () => {
     assert.equal(isTstmGenerationEnabled({}), false);
     assert.equal(isTstmGenerationEnabled({ TSTM_GENERATION_ENABLED: 'false' }), false);
-    assert.equal(isTstmGenerationEnabled({ TSTM_GENERATION_ENABLED: 'true' }), true);
+    assert.equal(isTstmGenerationEnabled({ TSTM_GENERATION_ENABLED: 'true' }), false);
+    assert.equal(
+      isTstmGenerationEnabled({ TSTM_GENERATION_ENABLED: 'true' }, ENABLED_CAPABILITY_OPTIONS),
+      true
+    );
   });
 
   it('normalizes and validates request payloads', () => {
@@ -70,6 +78,28 @@ describe('Auto-TSTM server foundation', () => {
         body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
       });
       assert.equal(response.status, 404);
+      assert.deepEqual(await response.json(), {
+        error: 'Auto-TSTM is not enabled on this deployment.',
+      });
+      assert.equal(calls, 0);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('does not invoke the generator when only the deployment env is enabled', async () => {
+    let calls = 0;
+    const server = await startServer({ TSTM_GENERATION_ENABLED: 'true' }, async () => {
+      calls += 1;
+      return {};
+    });
+    try {
+      const response = await fetch(getUrl(server), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
+      });
+      assert.equal(response.status, 404);
       assert.equal(calls, 0);
     } finally {
       server.close();
@@ -80,6 +110,7 @@ describe('Auto-TSTM server foundation', () => {
     const server = await startServer(
       { TSTM_GENERATION_ENABLED: 'true' },
       async () => { throw new Error('internal path and stderr'); },
+      ENABLED_CAPABILITY_OPTIONS,
     );
     try {
       const response = await fetch(getUrl(server), {

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -107,6 +107,31 @@ describe('featureExposure registry', () => {
       }
     }
   });
+
+  test('keeps server capability metadata aligned with the analytics registry', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const {
+      KNOWN_SERVER_CAPABILITY_KEYS,
+      SERVER_FEATURE_EXPOSURE_REGISTRY,
+    } = require('../../server/lib/serverFeatureExposure');
+
+    const clientBackedKeys = getFeatureKeys()
+      .filter((feature) => getFeatureExposure(feature).serverBacked)
+      .map((feature) => ({
+        feature,
+        definition: getFeatureExposure(feature),
+      }));
+
+    expect(clientBackedKeys).toHaveLength(1);
+    expect(KNOWN_SERVER_CAPABILITY_KEYS).toEqual(['TSTM_GENERATION_ENABLED']);
+
+    for (const { feature, definition } of clientBackedKeys) {
+      const serverDefinition = SERVER_FEATURE_EXPOSURE_REGISTRY[feature];
+      expect(serverDefinition).toBeDefined();
+      expect(serverDefinition.serverCapabilityKey).toBe(definition.serverCapabilityKey);
+      expect(serverDefinition.exposure).toEqual(definition.exposure);
+    }
+  });
 });
 
 type ExpectFalse<T extends false> = T;


### PR DESCRIPTION
## Summary
- Add centralized server capability lookup, route gates, and deployment target resolution aligned with the client feature exposure registry.
- Refactor Auto-TSTM to use shared fail-closed middleware before expensive work.
- Include matching \SERVER_TARGET\ workflow env wiring for v1.7 mergability (companion main PR follows).

Closes #439

## Test plan
- [x] \cd server && npm test\
- [x] \pnpm test -- --runTestsByPath src/config/featureExposure.test.ts\
- [x] \pnpm run build\


Made with [Cursor](https://cursor.com)