### PR TITLE
chore(ci): set SERVER_TARGET in beta, staging, and production deploy env

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -78,6 +78,7 @@ jobs:
           PORT=3007
           LOG_DIR=/opt/gfc-beta-analytics/logs
           APP_BASE_URL=https://beta-gfc.weatherboysuper.com
+          SERVER_TARGET=beta
           BETA_MODE=true
           BETA_INVITE_TOKEN=${{ secrets.BETA_INVITE_TOKEN }}
           BETA_INVITE_PATH=${{ secrets.BETA_INVITE_PATH }}

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -114,7 +114,6 @@ jobs:
           VITE_BETA_INVITE_PATH: ''
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: production
-          VITE_GA_MEASUREMENT_ID: G-44J5RQTQDB
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -114,6 +114,7 @@ jobs:
           VITE_BETA_INVITE_PATH: ''
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: production
+          VITE_GA_MEASUREMENT_ID: G-44J5RQTQDB
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
@@ -155,6 +156,7 @@ jobs:
           PORT=3006
           LOG_DIR=/opt/gfc-analytics/logs
           APP_BASE_URL=https://gfc.weatherboysuper.com
+          SERVER_TARGET=production
           BETA_MODE=false
           BETA_INVITE_TOKEN=
           BETA_INVITE_PATH=
@@ -179,6 +181,7 @@ jobs:
           PORT=3008
           LOG_DIR=/opt/gfc-staging-analytics/logs
           APP_BASE_URL=https://staging-gfc.weatherboysuper.com
+          SERVER_TARGET=staging
           BETA_MODE=true
           BETA_INVITE_TOKEN=${{ secrets.BETA_INVITE_TOKEN }}
           BETA_INVITE_PATH=${{ secrets.BETA_INVITE_PATH }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+- **Deploy env:** Add explicit `SERVER_TARGET` values to beta, staging, and production analytics server deploy env files.
+
 ### Added
 - **Explicit build targets:** Define and validate local, beta, staging, and production frontend build targets while preserving the existing beta access gate.
 


### PR DESCRIPTION
## Summary
- Workflow-only companion to beta PR #573 (FND-04).
- Adds explicit \SERVER_TARGET\ values to analytics server deploy env files for beta, staging, and production.
- Safe on pre-v1.7 \main\ server code (extra env vars are ignored until v1.7 lands).

## Test plan
- [x] Workflow YAML diff review only — no product code changes.
- [ ] Merge after beta PR #573 lands (beta merges first).


Made with [Cursor](https://cursor.com)