### PR TITLE
[Port][Conflicts] feat: add feature exposure labels to PR governance → feature/feature-exposure-ci-policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+- 
+
+## Feature exposure
+
+<!-- Does this PR change feature exposure? If so, describe the target state change. -->
+
+- [ ] This PR does not change feature exposure
+- [ ] This PR changes feature exposure (describe below)
+
+<!-- If exposure changes, list affected features and their new target states -->
+
+## Temporary feature removal
+
+<!-- Does this PR remove or plan to remove a temporary feature? If so, confirm removal metadata is updated. -->
+
+- [ ] N/A — no temporary features affected
+- [ ] Temporary feature removal included (confirm `removalCondition` metadata is present in `src/config/featureExposure.ts`)
+
+## Review requests
+
+- [ ] Server-backed feature changes reviewed by server owner
+- [ ] Security-sensitive feature changes flagged for security review
+
+## Testing
+
+- [ ] Tests added/updated (if applicable)
+- [ ] Build passes (`pnpm run build`)

--- a/.github/PULL_REQUEST_TEMPLATE/beta_to_main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/beta_to_main.md
@@ -16,6 +16,25 @@ This PR promotes **beta** to **production** (`main`).
 - [ ] Beta deployment smoke-tested
 - [ ] Plan to verify **staging-gfc.weatherboysuper.com** after merge (beta-gated build)
 
+### Feature exposure
+
+- [ ] Exposure report generated and reviewed (see `pnpm run exposure:report`)
+- [ ] All newly production-visible features are listed below
+- [ ] No beta-only or experimental features leak into production exposure
+- [ ] Server-backed features have matching server capability configuration
+- [ ] Temporary features approaching removal have removal condition metadata confirmed
+
+#### Newly production-visible features in this release
+
+| Feature | Target state | Server-backed | Removal condition |
+|---|---|---|---|
+| (list features promoted to production here, or write "None") | | | |
+
+### Review requests
+
+- [ ] Server-backed feature changes reviewed by server owner
+- [ ] Security-sensitive feature changes flagged for security review
+
 ### After merge (automatic)
 
 - Stable version committed on `main`

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -85,7 +85,6 @@ jobs:
               ['Component: UI', 'd4c5f9'],
               ['Component: Storage', 'fef2c0'],
               ['exposure:production', '0e8a16'],
-              ['exposure:beta-only', 'fbca04'],
               ['exposure:server-backed', 'd73a4a'],
               ['exposure:registry-change', '1f6feb'],
             ];

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -84,6 +84,10 @@ jobs:
               ['Component: Export', '5319e7'],
               ['Component: UI', 'd4c5f9'],
               ['Component: Storage', 'fef2c0'],
+              ['exposure:production', '0e8a16'],
+              ['exposure:beta-only', 'fbca04'],
+              ['exposure:server-backed', 'd73a4a'],
+              ['exposure:registry-change', '1f6feb'],
             ];
             for (const [name, color] of labelDefs) {
               try {

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,36 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+<<<<<<< HEAD
+=======
+- **PR governance:** Add feature exposure labels (`exposure:production`, `exposure:server-backed`, `exposure:registry-change`) to automatically tag PRs that change feature exposure configuration.
+
+### PR #582
+
+- Dependency: @radix-ui/react-dialog ^1.1.16 → ^1.1.17
+- Dependency: @radix-ui/react-dropdown-menu ^2.1.17 → ^2.1.18
+- Dependency: @radix-ui/react-popover ^1.1.16 → ^1.1.17
+- Dependency: @radix-ui/react-slot ^1.2.5 → ^1.3.0
+- Dependency: @radix-ui/react-tabs ^1.1.14 → ^1.1.15
+- Dependency: @radix-ui/react-tooltip ^1.2.9 → ^1.2.10
+- Dependency: @sentry/react ^10.58.0 → ^10.59.0
+- Dependency: @types/node ^25.9.3 → ^26.0.0
+- Dependency: firebase ^12.14.0 → ^12.15.0
+- Dependency: lucide-react ^1.18.0 → ^1.21.0
+- Dependency: react-router-dom ^7.17.0 → ^7.18.0
+- Dependency: rollup >=4.62.0 → >=4.62.2
+- Dependency: uuid ^14.0.0 → ^14.0.1
+- Dependency: @babel/core ^7.29.7 → ^8.0.1
+- Dependency: @babel/preset-env ^7.29.7 → ^8.0.2
+- Dependency: @babel/preset-react ^7.29.7 → ^8.0.1
+- Dependency: @babel/preset-typescript ^7.29.7 → ^8.0.1
+- Dependency: @sentry/node ^10.58.0 → ^10.59.0 (`server`)
+- Dependency: stripe ^22.2.1 → ^22.2.2 (`server`)
+### PR #579
+
+- Add CI policy validation for feature exposure metadata, gated routes, navigation, and matching server capabilities.
+
+>>>>>>> a26c228 (docs: add beta changelog entry for exposure labels)
 ### PR #577
 
 - Replace mutable Redux product flags with typed build-target exposure selectors so core forecast capabilities read from the feature registry instead of browser state.

--- a/scripts/lib/pr-label-exposure.mjs
+++ b/scripts/lib/pr-label-exposure.mjs
@@ -2,16 +2,19 @@ import { anyFileMatches } from './glob-match.mjs';
 
 /** @typedef {{ changedFiles: string[] }} ExposureContext */
 
+// Exact file paths (no glob) — these are the canonical exposure registry files.
 const REGISTRY_FILE_PATTERNS = [
   'src/config/featureExposure.ts',
   'src/config/featureExposure.test.ts',
 ];
 
+// Glob patterns for server-side exposure and capability files.
 const SERVER_EXPOSURE_FILE_PATTERNS = [
   'server/lib/serverFeatureExposure.*',
   'server/lib/featureCapabilities.*',
 ];
 
+// Glob patterns for client-side feature gating and surface configuration.
 const FEATURE_GATING_FILE_PATTERNS = [
   'src/components/FeatureBoundary.*',
   'src/config/featureSurfaces.*',

--- a/scripts/lib/pr-label-exposure.mjs
+++ b/scripts/lib/pr-label-exposure.mjs
@@ -1,0 +1,55 @@
+import { anyFileMatches } from './glob-match.mjs';
+
+/** @typedef {{ changedFiles: string[] }} ExposureContext */
+
+const REGISTRY_FILE_PATTERNS = [
+  'src/config/featureExposure.ts',
+  'src/config/featureExposure.test.ts',
+];
+
+const SERVER_EXPOSURE_FILE_PATTERNS = [
+  'server/lib/serverFeatureExposure.*',
+  'server/lib/featureCapabilities.*',
+];
+
+const FEATURE_GATING_FILE_PATTERNS = [
+  'src/components/FeatureBoundary.*',
+  'src/config/featureSurfaces.*',
+  'src/config/featureNavigation.*',
+];
+
+/**
+ * Compute exposure-related labels for a PR based on changed files.
+ *
+ * @param {ExposureContext} context
+ * @returns {Set<string>}
+ */
+export const exposureLabels = ({ changedFiles }) => {
+  const labels = new Set();
+
+  const hasRegistryChange = REGISTRY_FILE_PATTERNS.some((pattern) =>
+    anyFileMatches(changedFiles, pattern),
+  );
+
+  const hasServerExposureChange = SERVER_EXPOSURE_FILE_PATTERNS.some((pattern) =>
+    anyFileMatches(changedFiles, pattern),
+  );
+
+  const hasGatingChange = FEATURE_GATING_FILE_PATTERNS.some((pattern) =>
+    anyFileMatches(changedFiles, pattern),
+  );
+
+  if (hasRegistryChange) {
+    labels.add('exposure:registry-change');
+  }
+
+  if (hasServerExposureChange) {
+    labels.add('exposure:server-backed');
+  }
+
+  if (hasRegistryChange || hasGatingChange) {
+    labels.add('exposure:production');
+  }
+
+  return labels;
+};

--- a/scripts/lib/pr-label-exposure.test.mjs
+++ b/scripts/lib/pr-label-exposure.test.mjs
@@ -62,4 +62,18 @@ describe('exposureLabels', () => {
     const labels = exposureLabels({ changedFiles: [] });
     assert.equal(labels.size, 0);
   });
+
+  it('never applies exposure:beta-only for any file pattern', () => {
+    const testCases = [
+      ['src/config/featureExposure.ts'],
+      ['server/lib/featureCapabilities.js'],
+      ['src/components/FeatureBoundary.tsx'],
+      ['src/config/featureSurfaces.ts'],
+      ['src/config/featureNavigation.ts'],
+    ];
+    for (const changedFiles of testCases) {
+      const labels = exposureLabels({ changedFiles });
+      assert.ok(!labels.has('exposure:beta-only'), `exposure:beta-only should not be produced for ${changedFiles.join(', ')}`);
+    }
+  });
 });

--- a/scripts/lib/pr-label-exposure.test.mjs
+++ b/scripts/lib/pr-label-exposure.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { exposureLabels } from './pr-label-exposure.mjs';
+
+describe('exposureLabels', () => {
+  it('applies exposure:registry-change when featureExposure.ts is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureExposure.ts'] });
+    assert.ok(labels.has('exposure:registry-change'));
+  });
+
+  it('applies exposure:registry-change when featureExposure.test.ts is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureExposure.test.ts'] });
+    assert.ok(labels.has('exposure:registry-change'));
+  });
+
+  it('applies exposure:server-backed when serverFeatureExposure.js is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['server/lib/serverFeatureExposure.js'] });
+    assert.ok(labels.has('exposure:server-backed'));
+  });
+
+  it('applies exposure:server-backed when featureCapabilities.js is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.js'] });
+    assert.ok(labels.has('exposure:server-backed'));
+  });
+
+  it('applies exposure:server-backed when featureCapabilities.test.js is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.test.js'] });
+    assert.ok(labels.has('exposure:server-backed'));
+  });
+
+  it('applies exposure:production when feature surfaces are changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureSurfaces.ts'] });
+    assert.ok(labels.has('exposure:production'));
+    assert.ok(!labels.has('exposure:server-backed'));
+  });
+
+  it('applies exposure:production when feature navigation is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureNavigation.ts'] });
+    assert.ok(labels.has('exposure:production'));
+  });
+
+  it('applies exposure:production when FeatureBoundary is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/components/FeatureBoundary.tsx'] });
+    assert.ok(labels.has('exposure:production'));
+  });
+
+  it('applies both exposure:registry-change and exposure:server-backed for combined changes', () => {
+    const labels = exposureLabels({
+      changedFiles: ['src/config/featureExposure.ts', 'server/lib/featureCapabilities.js'],
+    });
+    assert.ok(labels.has('exposure:registry-change'));
+    assert.ok(labels.has('exposure:server-backed'));
+    assert.ok(labels.has('exposure:production'));
+  });
+
+  it('applies no exposure labels for unrelated files', () => {
+    const labels = exposureLabels({ changedFiles: ['src/App.tsx', 'docs/readme.md'] });
+    assert.equal(labels.size, 0);
+  });
+
+  it('applies no exposure labels for empty changed files', () => {
+    const labels = exposureLabels({ changedFiles: [] });
+    assert.equal(labels.size, 0);
+  });
+});

--- a/scripts/lib/pr-label-managed.mjs
+++ b/scripts/lib/pr-label-managed.mjs
@@ -31,6 +31,10 @@ export const CONTENT_MANAGED_LABELS = [
   'Component: Export',
   'Component: UI',
   'Component: Storage',
+  'exposure:production',
+  'exposure:beta-only',
+  'exposure:server-backed',
+  'exposure:registry-change',
 ];
 
 /** @deprecated Use CONTENT_MANAGED_LABELS or CI_MANAGED_LABELS */

--- a/scripts/lib/pr-label-managed.mjs
+++ b/scripts/lib/pr-label-managed.mjs
@@ -32,7 +32,6 @@ export const CONTENT_MANAGED_LABELS = [
   'Component: UI',
   'Component: Storage',
   'exposure:production',
-  'exposure:beta-only',
   'exposure:server-backed',
   'exposure:registry-change',
 ];

--- a/scripts/lib/pr-labels.mjs
+++ b/scripts/lib/pr-labels.mjs
@@ -1,9 +1,11 @@
 import { descriptiveLabels } from './pr-label-content.mjs';
+import { exposureLabels } from './pr-label-exposure.mjs';
 import { routingLabels } from './pr-label-routing.mjs';
 
 export { CONTENT_MANAGED_LABELS, CI_MANAGED_LABELS, MANAGED_LABELS } from './pr-label-managed.mjs';
 export { routingLabels } from './pr-label-routing.mjs';
 export { descriptiveLabels } from './pr-label-content.mjs';
+export { exposureLabels } from './pr-label-exposure.mjs';
 
 /**
  * @param {{
@@ -20,6 +22,7 @@ export const computePrLabels = ({ head, base, changedFiles, mergeable, draft, ch
   const labels = new Set([
     ...routingLabels({ head, base }),
     ...descriptiveLabels({ changedFiles, head }),
+    ...exposureLabels({ changedFiles }),
   ]);
 
   if (mergeable === false) labels.add('has conflicts');

--- a/scripts/lib/pr-labels.test.mjs
+++ b/scripts/lib/pr-labels.test.mjs
@@ -83,4 +83,30 @@ describe('computePrLabels', () => {
     assert.ok(labels.includes('Component: Map'));
     assert.ok(labels.includes('changelog:ok'));
   });
+
+  it('includes exposure labels when exposure files are changed', () => {
+    const labels = computePrLabels({
+      head: 'feature/exposure',
+      base: 'beta',
+      changedFiles: ['src/config/featureExposure.ts'],
+      mergeable: null,
+      draft: false,
+      changelogOk: true,
+    });
+    assert.ok(labels.includes('exposure:registry-change'));
+    assert.ok(labels.includes('exposure:production'));
+  });
+
+  it('includes no exposure labels for unrelated changes', () => {
+    const labels = computePrLabels({
+      head: 'fix/typo',
+      base: 'beta',
+      changedFiles: ['src/components/Map/MapContainer.tsx'],
+      mergeable: null,
+      draft: false,
+      changelogOk: true,
+    });
+    assert.ok(!labels.includes('exposure:registry-change'));
+    assert.ok(!labels.includes('exposure:server-backed'));
+  });
 });


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `feature/feature-exposure-ci-policy`.

| | |
| --- | --- |
| Original PR | #590 — feat: add feature exposure labels to PR governance |
| Source branch | `feature/exposure-pr-labels` (merged into `beta`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `CHANGELOG.beta.md`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/590-to-feature-feature-exposure-ci-policy`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #590, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `feature/feature-exposure-ci-policy` drifting behind `beta`.