### PR TITLE
[Port][Conflicts] feat: add feature exposure labels to PR governance → beta

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -85,6 +85,10 @@ jobs:
               ['Component: UI', 'd4c5f9'],
               ['Component: Storage', 'fef2c0'],
               ['exposure:production', '0e8a16'],
+<<<<<<< HEAD
+=======
+              ['exposure:beta-only', 'fbca04'],
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
               ['exposure:server-backed', 'd73a4a'],
               ['exposure:registry-change', '1f6feb'],
             ];

--- a/scripts/lib/pr-label-exposure.mjs
+++ b/scripts/lib/pr-label-exposure.mjs
@@ -2,6 +2,7 @@ import { anyFileMatches } from './glob-match.mjs';
 
 /** @typedef {{ changedFiles: string[] }} ExposureContext */
 
+<<<<<<< HEAD
 // Exact file paths (no glob) — these are the canonical exposure registry files.
 const REGISTRY_FILE_PATTERNS = [
   'src/config/featureExposure.ts',
@@ -18,6 +19,22 @@ const FEATURE_GATING_FILE_PATTERNS = [
   'src/components/FeatureBoundary.tsx',
   'src/config/featureSurfaces.ts',
   'src/config/featureNavigation.ts',
+=======
+const REGISTRY_FILE_PATTERNS = [
+  'src/config/featureExposure.ts',
+  'src/config/featureExposure.test.ts',
+];
+
+const SERVER_EXPOSURE_FILE_PATTERNS = [
+  'server/lib/serverFeatureExposure.*',
+  'server/lib/featureCapabilities.*',
+];
+
+const FEATURE_GATING_FILE_PATTERNS = [
+  'src/components/FeatureBoundary.*',
+  'src/config/featureSurfaces.*',
+  'src/config/featureNavigation.*',
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
 ];
 
 /**
@@ -49,8 +66,12 @@ export const exposureLabels = ({ changedFiles }) => {
     labels.add('exposure:server-backed');
   }
 
+<<<<<<< HEAD
   const affectsProduction = hasRegistryChange || hasGatingChange || hasServerExposureChange;
   if (affectsProduction) {
+=======
+  if (hasRegistryChange || hasGatingChange) {
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
     labels.add('exposure:production');
   }
 

--- a/scripts/lib/pr-label-exposure.test.mjs
+++ b/scripts/lib/pr-label-exposure.test.mjs
@@ -8,6 +8,7 @@ describe('exposureLabels', () => {
     assert.ok(labels.has('exposure:registry-change'));
   });
 
+<<<<<<< HEAD
   it('does not apply exposure:registry-change when only the test file is changed', () => {
     const labels = exposureLabels({ changedFiles: ['src/config/featureExposure.test.ts'] });
     assert.ok(!labels.has('exposure:registry-change'));
@@ -24,6 +25,16 @@ describe('exposureLabels', () => {
     const labels = exposureLabels({ changedFiles: ['server/lib/serverFeatureExposure.test.js'] });
     assert.ok(!labels.has('exposure:server-backed'));
     assert.ok(!labels.has('exposure:production'));
+=======
+  it('applies exposure:registry-change when featureExposure.test.ts is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureExposure.test.ts'] });
+    assert.ok(labels.has('exposure:registry-change'));
+  });
+
+  it('applies exposure:server-backed when serverFeatureExposure.js is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['server/lib/serverFeatureExposure.js'] });
+    assert.ok(labels.has('exposure:server-backed'));
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
   });
 
   it('applies exposure:server-backed when featureCapabilities.js is changed', () => {
@@ -31,6 +42,7 @@ describe('exposureLabels', () => {
     assert.ok(labels.has('exposure:server-backed'));
   });
 
+<<<<<<< HEAD
   it('applies both exposure:server-backed and exposure:production when server feature exposure is changed', () => {
     const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.js'] });
     assert.ok(labels.has('exposure:server-backed'));
@@ -41,6 +53,11 @@ describe('exposureLabels', () => {
     const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.test.js'] });
     assert.ok(!labels.has('exposure:server-backed'));
     assert.ok(!labels.has('exposure:production'));
+=======
+  it('applies exposure:server-backed when featureCapabilities.test.js is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.test.js'] });
+    assert.ok(labels.has('exposure:server-backed'));
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
   });
 
   it('applies exposure:production when feature surfaces are changed', () => {
@@ -77,6 +94,7 @@ describe('exposureLabels', () => {
     const labels = exposureLabels({ changedFiles: [] });
     assert.equal(labels.size, 0);
   });
+<<<<<<< HEAD
 
   it('does not apply exposure labels for gating test files', () => {
     const testFiles = [
@@ -103,4 +121,6 @@ describe('exposureLabels', () => {
       assert.ok(!labels.has('exposure:beta-only'), `exposure:beta-only should not be produced for ${changedFiles.join(', ')}`);
     }
   });
+=======
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
 });

--- a/scripts/lib/pr-label-managed.mjs
+++ b/scripts/lib/pr-label-managed.mjs
@@ -32,6 +32,10 @@ export const CONTENT_MANAGED_LABELS = [
   'Component: UI',
   'Component: Storage',
   'exposure:production',
+<<<<<<< HEAD
+=======
+  'exposure:beta-only',
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
   'exposure:server-backed',
   'exposure:registry-change',
 ];

--- a/scripts/lib/pr-labels.test.mjs
+++ b/scripts/lib/pr-labels.test.mjs
@@ -93,19 +93,41 @@ describe('computePrLabels', () => {
   });
 
   it('includes exposure labels when exposure files are changed', () => {
+<<<<<<< HEAD
     const labels = computePrLabels(makeComputeArgs({
       head: 'feature/exposure',
       changedFiles: ['src/config/featureExposure.ts'],
     }));
+=======
+    const labels = computePrLabels({
+      head: 'feature/exposure',
+      base: 'beta',
+      changedFiles: ['src/config/featureExposure.ts'],
+      mergeable: null,
+      draft: false,
+      changelogOk: true,
+    });
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
     assert.ok(labels.includes('exposure:registry-change'));
     assert.ok(labels.includes('exposure:production'));
   });
 
   it('includes no exposure labels for unrelated changes', () => {
+<<<<<<< HEAD
     const labels = computePrLabels(makeComputeArgs({
       head: 'fix/typo',
       changedFiles: ['src/components/Map/MapContainer.tsx'],
     }));
+=======
+    const labels = computePrLabels({
+      head: 'fix/typo',
+      base: 'beta',
+      changedFiles: ['src/components/Map/MapContainer.tsx'],
+      mergeable: null,
+      draft: false,
+      changelogOk: true,
+    });
+>>>>>>> fc1e174 (feat: add feature exposure labels to PR governance)
     assert.ok(!labels.includes('exposure:registry-change'));
     assert.ok(!labels.includes('exposure:server-backed'));
   });


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #591 — feat: add feature exposure labels to PR governance |
| Source branch | `hotfix/exposure-pr-labels-main` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `.github/workflows/pr-governance.yml`
- `scripts/lib/pr-label-exposure.mjs`
- `scripts/lib/pr-label-exposure.test.mjs`
- `scripts/lib/pr-label-managed.mjs`
- `scripts/lib/pr-labels.test.mjs`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/591-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #591, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.