### PR TITLE
[Port] feat: add feature exposure labels to PR governance to feature/feature-exposure-ci-policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+- 
+
+## Feature exposure
+
+<!-- Does this PR change feature exposure? If so, describe the target state change. -->
+
+- [ ] This PR does not change feature exposure
+- [ ] This PR changes feature exposure (describe below)
+
+<!-- If exposure changes, list affected features and their new target states -->
+
+## Temporary feature removal
+
+<!-- Does this PR remove or plan to remove a temporary feature? If so, confirm removal metadata is updated. -->
+
+- [ ] N/A — no temporary features affected
+- [ ] Temporary feature removal included (confirm `removalCondition` metadata is present in `src/config/featureExposure.ts`)
+
+## Review requests
+
+- [ ] Server-backed feature changes reviewed by server owner
+- [ ] Security-sensitive feature changes flagged for security review
+
+## Testing
+
+- [ ] Tests added/updated (if applicable)
+- [ ] Build passes (`pnpm run build`)

--- a/.github/PULL_REQUEST_TEMPLATE/beta_to_main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/beta_to_main.md
@@ -16,6 +16,25 @@ This PR promotes **beta** to **production** (`main`).
 - [ ] Beta deployment smoke-tested
 - [ ] Plan to verify **staging-gfc.weatherboysuper.com** after merge (beta-gated build)
 
+### Feature exposure
+
+- [ ] Exposure report generated and reviewed (see `pnpm run exposure:report`)
+- [ ] All newly production-visible features are listed below
+- [ ] No beta-only or experimental features leak into production exposure
+- [ ] Server-backed features have matching server capability configuration
+- [ ] Temporary features approaching removal have removal condition metadata confirmed
+
+#### Newly production-visible features in this release
+
+| Feature | Target state | Server-backed | Removal condition |
+|---|---|---|---|
+| (list features promoted to production here, or write "None") | | | |
+
+### Review requests
+
+- [ ] Server-backed feature changes reviewed by server owner
+- [ ] Security-sensitive feature changes flagged for security review
+
 ### After merge (automatic)
 
 - Stable version committed on `main`

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -85,7 +85,6 @@ jobs:
               ['Component: UI', 'd4c5f9'],
               ['Component: Storage', 'fef2c0'],
               ['exposure:production', '0e8a16'],
-              ['exposure:beta-only', 'fbca04'],
               ['exposure:server-backed', 'd73a4a'],
               ['exposure:registry-change', '1f6feb'],
             ];

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -84,6 +84,10 @@ jobs:
               ['Component: Export', '5319e7'],
               ['Component: UI', 'd4c5f9'],
               ['Component: Storage', 'fef2c0'],
+              ['exposure:production', '0e8a16'],
+              ['exposure:beta-only', 'fbca04'],
+              ['exposure:server-backed', 'd73a4a'],
+              ['exposure:registry-change', '1f6feb'],
             ];
             for (const [name, color] of labelDefs) {
               try {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **Explicit build targets:** Define and validate local, beta, staging, and production frontend build targets while preserving the existing beta access gate.
+- **PR governance:** Add feature exposure labels (`exposure:production`, `exposure:server-backed`, `exposure:registry-change`) to automatically tag PRs that change feature exposure configuration.
 
 ## v1.6.6
 

--- a/scripts/lib/pr-label-exposure.mjs
+++ b/scripts/lib/pr-label-exposure.mjs
@@ -2,16 +2,19 @@ import { anyFileMatches } from './glob-match.mjs';
 
 /** @typedef {{ changedFiles: string[] }} ExposureContext */
 
+// Exact file paths (no glob) — these are the canonical exposure registry files.
 const REGISTRY_FILE_PATTERNS = [
   'src/config/featureExposure.ts',
   'src/config/featureExposure.test.ts',
 ];
 
+// Glob patterns for server-side exposure and capability files.
 const SERVER_EXPOSURE_FILE_PATTERNS = [
   'server/lib/serverFeatureExposure.*',
   'server/lib/featureCapabilities.*',
 ];
 
+// Glob patterns for client-side feature gating and surface configuration.
 const FEATURE_GATING_FILE_PATTERNS = [
   'src/components/FeatureBoundary.*',
   'src/config/featureSurfaces.*',

--- a/scripts/lib/pr-label-exposure.mjs
+++ b/scripts/lib/pr-label-exposure.mjs
@@ -7,17 +7,26 @@ const REGISTRY_FILE_PATTERNS = [
   'src/config/featureExposure.ts',
 ];
 
+// Test files for the registry — trigger registry-change but not production labels.
+const REGISTRY_TEST_PATTERNS = [
+  'src/config/featureExposure.test.ts',
+];
+
 // Exact file paths for server-side exposure and capability files.
 const SERVER_EXPOSURE_FILE_PATTERNS = [
   'server/lib/serverFeatureExposure.js',
   'server/lib/featureCapabilities.js',
 ];
 
-// Exact file paths for client-side feature gating and surface configuration.
+// Client-side feature gating and surface configuration.
+// Exact files cover flat-file layout; directory globs cover future index-based modules.
 const FEATURE_GATING_FILE_PATTERNS = [
   'src/components/FeatureBoundary.tsx',
+  'src/components/FeatureBoundary/**',
   'src/config/featureSurfaces.ts',
+  'src/config/featureSurfaces/**',
   'src/config/featureNavigation.ts',
+  'src/config/featureNavigation/**',
 ];
 
 /**
@@ -33,6 +42,10 @@ export const exposureLabels = ({ changedFiles }) => {
     anyFileMatches(changedFiles, pattern),
   );
 
+  const hasRegistryTestChange = REGISTRY_TEST_PATTERNS.some((pattern) =>
+    anyFileMatches(changedFiles, pattern),
+  );
+
   const hasServerExposureChange = SERVER_EXPOSURE_FILE_PATTERNS.some((pattern) =>
     anyFileMatches(changedFiles, pattern),
   );
@@ -41,7 +54,7 @@ export const exposureLabels = ({ changedFiles }) => {
     anyFileMatches(changedFiles, pattern),
   );
 
-  if (hasRegistryChange) {
+  if (hasRegistryChange || hasRegistryTestChange) {
     labels.add('exposure:registry-change');
   }
 

--- a/scripts/lib/pr-label-exposure.mjs
+++ b/scripts/lib/pr-label-exposure.mjs
@@ -54,6 +54,8 @@ export const exposureLabels = ({ changedFiles }) => {
     anyFileMatches(changedFiles, pattern),
   );
 
+  const affectsProduction = hasRegistryChange || hasGatingChange || hasServerExposureChange;
+
   if (hasRegistryChange || hasRegistryTestChange) {
     labels.add('exposure:registry-change');
   }
@@ -62,7 +64,7 @@ export const exposureLabels = ({ changedFiles }) => {
     labels.add('exposure:server-backed');
   }
 
-  if (hasRegistryChange || hasGatingChange || hasServerExposureChange) {
+  if (affectsProduction) {
     labels.add('exposure:production');
   }
 

--- a/scripts/lib/pr-label-exposure.mjs
+++ b/scripts/lib/pr-label-exposure.mjs
@@ -5,20 +5,19 @@ import { anyFileMatches } from './glob-match.mjs';
 // Exact file paths (no glob) — these are the canonical exposure registry files.
 const REGISTRY_FILE_PATTERNS = [
   'src/config/featureExposure.ts',
-  'src/config/featureExposure.test.ts',
 ];
 
-// Glob patterns for server-side exposure and capability files.
+// Exact file paths for server-side exposure and capability files.
 const SERVER_EXPOSURE_FILE_PATTERNS = [
-  'server/lib/serverFeatureExposure.*',
-  'server/lib/featureCapabilities.*',
+  'server/lib/serverFeatureExposure.js',
+  'server/lib/featureCapabilities.js',
 ];
 
-// Glob patterns for client-side feature gating and surface configuration.
+// Exact file paths for client-side feature gating and surface configuration.
 const FEATURE_GATING_FILE_PATTERNS = [
-  'src/components/FeatureBoundary.*',
-  'src/config/featureSurfaces.*',
-  'src/config/featureNavigation.*',
+  'src/components/FeatureBoundary.tsx',
+  'src/config/featureSurfaces.ts',
+  'src/config/featureNavigation.ts',
 ];
 
 /**
@@ -50,7 +49,7 @@ export const exposureLabels = ({ changedFiles }) => {
     labels.add('exposure:server-backed');
   }
 
-  if (hasRegistryChange || hasGatingChange) {
+  if (hasRegistryChange || hasGatingChange || hasServerExposureChange) {
     labels.add('exposure:production');
   }
 

--- a/scripts/lib/pr-label-exposure.mjs
+++ b/scripts/lib/pr-label-exposure.mjs
@@ -1,0 +1,55 @@
+import { anyFileMatches } from './glob-match.mjs';
+
+/** @typedef {{ changedFiles: string[] }} ExposureContext */
+
+const REGISTRY_FILE_PATTERNS = [
+  'src/config/featureExposure.ts',
+  'src/config/featureExposure.test.ts',
+];
+
+const SERVER_EXPOSURE_FILE_PATTERNS = [
+  'server/lib/serverFeatureExposure.*',
+  'server/lib/featureCapabilities.*',
+];
+
+const FEATURE_GATING_FILE_PATTERNS = [
+  'src/components/FeatureBoundary.*',
+  'src/config/featureSurfaces.*',
+  'src/config/featureNavigation.*',
+];
+
+/**
+ * Compute exposure-related labels for a PR based on changed files.
+ *
+ * @param {ExposureContext} context
+ * @returns {Set<string>}
+ */
+export const exposureLabels = ({ changedFiles }) => {
+  const labels = new Set();
+
+  const hasRegistryChange = REGISTRY_FILE_PATTERNS.some((pattern) =>
+    anyFileMatches(changedFiles, pattern),
+  );
+
+  const hasServerExposureChange = SERVER_EXPOSURE_FILE_PATTERNS.some((pattern) =>
+    anyFileMatches(changedFiles, pattern),
+  );
+
+  const hasGatingChange = FEATURE_GATING_FILE_PATTERNS.some((pattern) =>
+    anyFileMatches(changedFiles, pattern),
+  );
+
+  if (hasRegistryChange) {
+    labels.add('exposure:registry-change');
+  }
+
+  if (hasServerExposureChange) {
+    labels.add('exposure:server-backed');
+  }
+
+  if (hasRegistryChange || hasGatingChange) {
+    labels.add('exposure:production');
+  }
+
+  return labels;
+};

--- a/scripts/lib/pr-label-exposure.test.mjs
+++ b/scripts/lib/pr-label-exposure.test.mjs
@@ -8,9 +8,9 @@ describe('exposureLabels', () => {
     assert.ok(labels.has('exposure:registry-change'));
   });
 
-  it('does not apply exposure labels when only the registry test file is changed', () => {
+  it('applies exposure:registry-change but not exposure:production when only the registry test file is changed', () => {
     const labels = exposureLabels({ changedFiles: ['src/config/featureExposure.test.ts'] });
-    assert.ok(!labels.has('exposure:registry-change'));
+    assert.ok(labels.has('exposure:registry-change'));
     assert.ok(!labels.has('exposure:production'));
   });
 
@@ -45,6 +45,16 @@ describe('exposureLabels', () => {
 
   it('applies exposure:production when FeatureBoundary is changed', () => {
     const labels = exposureLabels({ changedFiles: ['src/components/FeatureBoundary.tsx'] });
+    assert.ok(labels.has('exposure:production'));
+  });
+
+  it('applies exposure:production when FeatureBoundary directory index is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/components/FeatureBoundary/index.tsx'] });
+    assert.ok(labels.has('exposure:production'));
+  });
+
+  it('applies exposure:production when featureSurfaces directory module is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureSurfaces/index.ts'] });
     assert.ok(labels.has('exposure:production'));
   });
 

--- a/scripts/lib/pr-label-exposure.test.mjs
+++ b/scripts/lib/pr-label-exposure.test.mjs
@@ -8,24 +8,28 @@ describe('exposureLabels', () => {
     assert.ok(labels.has('exposure:registry-change'));
   });
 
-  it('applies exposure:registry-change when featureExposure.test.ts is changed', () => {
+  it('does not apply exposure labels when only the registry test file is changed', () => {
     const labels = exposureLabels({ changedFiles: ['src/config/featureExposure.test.ts'] });
-    assert.ok(labels.has('exposure:registry-change'));
+    assert.ok(!labels.has('exposure:registry-change'));
+    assert.ok(!labels.has('exposure:production'));
   });
 
   it('applies exposure:server-backed when serverFeatureExposure.js is changed', () => {
     const labels = exposureLabels({ changedFiles: ['server/lib/serverFeatureExposure.js'] });
     assert.ok(labels.has('exposure:server-backed'));
+    assert.ok(labels.has('exposure:production'));
   });
 
   it('applies exposure:server-backed when featureCapabilities.js is changed', () => {
     const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.js'] });
     assert.ok(labels.has('exposure:server-backed'));
+    assert.ok(labels.has('exposure:production'));
   });
 
-  it('applies exposure:server-backed when featureCapabilities.test.js is changed', () => {
+  it('does not apply exposure labels when featureCapabilities test is changed', () => {
     const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.test.js'] });
-    assert.ok(labels.has('exposure:server-backed'));
+    assert.ok(!labels.has('exposure:server-backed'));
+    assert.ok(!labels.has('exposure:production'));
   });
 
   it('applies exposure:production when feature surfaces are changed', () => {
@@ -61,6 +65,18 @@ describe('exposureLabels', () => {
   it('applies no exposure labels for empty changed files', () => {
     const labels = exposureLabels({ changedFiles: [] });
     assert.equal(labels.size, 0);
+  });
+
+  it('does not apply exposure labels for gating test files', () => {
+    const testFiles = [
+      'src/components/FeatureBoundary.test.tsx',
+      'src/config/featureSurfaces.test.ts',
+      'src/config/featureNavigation.test.ts',
+    ];
+    for (const file of testFiles) {
+      const labels = exposureLabels({ changedFiles: [file] });
+      assert.ok(!labels.has('exposure:production'), `exposure:production should not be produced for ${file}`);
+    }
   });
 
   it('never applies exposure:beta-only for any file pattern', () => {

--- a/scripts/lib/pr-label-exposure.test.mjs
+++ b/scripts/lib/pr-label-exposure.test.mjs
@@ -62,4 +62,18 @@ describe('exposureLabels', () => {
     const labels = exposureLabels({ changedFiles: [] });
     assert.equal(labels.size, 0);
   });
+
+  it('never applies exposure:beta-only for any file pattern', () => {
+    const testCases = [
+      ['src/config/featureExposure.ts'],
+      ['server/lib/featureCapabilities.js'],
+      ['src/components/FeatureBoundary.tsx'],
+      ['src/config/featureSurfaces.ts'],
+      ['src/config/featureNavigation.ts'],
+    ];
+    for (const changedFiles of testCases) {
+      const labels = exposureLabels({ changedFiles });
+      assert.ok(!labels.has('exposure:beta-only'), `exposure:beta-only should not be produced for ${changedFiles.join(', ')}`);
+    }
+  });
 });

--- a/scripts/lib/pr-label-exposure.test.mjs
+++ b/scripts/lib/pr-label-exposure.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { exposureLabels } from './pr-label-exposure.mjs';
+
+describe('exposureLabels', () => {
+  it('applies exposure:registry-change when featureExposure.ts is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureExposure.ts'] });
+    assert.ok(labels.has('exposure:registry-change'));
+  });
+
+  it('applies exposure:registry-change when featureExposure.test.ts is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureExposure.test.ts'] });
+    assert.ok(labels.has('exposure:registry-change'));
+  });
+
+  it('applies exposure:server-backed when serverFeatureExposure.js is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['server/lib/serverFeatureExposure.js'] });
+    assert.ok(labels.has('exposure:server-backed'));
+  });
+
+  it('applies exposure:server-backed when featureCapabilities.js is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.js'] });
+    assert.ok(labels.has('exposure:server-backed'));
+  });
+
+  it('applies exposure:server-backed when featureCapabilities.test.js is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['server/lib/featureCapabilities.test.js'] });
+    assert.ok(labels.has('exposure:server-backed'));
+  });
+
+  it('applies exposure:production when feature surfaces are changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureSurfaces.ts'] });
+    assert.ok(labels.has('exposure:production'));
+    assert.ok(!labels.has('exposure:server-backed'));
+  });
+
+  it('applies exposure:production when feature navigation is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/config/featureNavigation.ts'] });
+    assert.ok(labels.has('exposure:production'));
+  });
+
+  it('applies exposure:production when FeatureBoundary is changed', () => {
+    const labels = exposureLabels({ changedFiles: ['src/components/FeatureBoundary.tsx'] });
+    assert.ok(labels.has('exposure:production'));
+  });
+
+  it('applies both exposure:registry-change and exposure:server-backed for combined changes', () => {
+    const labels = exposureLabels({
+      changedFiles: ['src/config/featureExposure.ts', 'server/lib/featureCapabilities.js'],
+    });
+    assert.ok(labels.has('exposure:registry-change'));
+    assert.ok(labels.has('exposure:server-backed'));
+    assert.ok(labels.has('exposure:production'));
+  });
+
+  it('applies no exposure labels for unrelated files', () => {
+    const labels = exposureLabels({ changedFiles: ['src/App.tsx', 'docs/readme.md'] });
+    assert.equal(labels.size, 0);
+  });
+
+  it('applies no exposure labels for empty changed files', () => {
+    const labels = exposureLabels({ changedFiles: [] });
+    assert.equal(labels.size, 0);
+  });
+});

--- a/scripts/lib/pr-label-managed.mjs
+++ b/scripts/lib/pr-label-managed.mjs
@@ -31,6 +31,10 @@ export const CONTENT_MANAGED_LABELS = [
   'Component: Export',
   'Component: UI',
   'Component: Storage',
+  'exposure:production',
+  'exposure:beta-only',
+  'exposure:server-backed',
+  'exposure:registry-change',
 ];
 
 /** @deprecated Use CONTENT_MANAGED_LABELS or CI_MANAGED_LABELS */

--- a/scripts/lib/pr-label-managed.mjs
+++ b/scripts/lib/pr-label-managed.mjs
@@ -32,7 +32,6 @@ export const CONTENT_MANAGED_LABELS = [
   'Component: UI',
   'Component: Storage',
   'exposure:production',
-  'exposure:beta-only',
   'exposure:server-backed',
   'exposure:registry-change',
 ];

--- a/scripts/lib/pr-labels.mjs
+++ b/scripts/lib/pr-labels.mjs
@@ -1,9 +1,11 @@
 import { descriptiveLabels } from './pr-label-content.mjs';
+import { exposureLabels } from './pr-label-exposure.mjs';
 import { routingLabels } from './pr-label-routing.mjs';
 
 export { CONTENT_MANAGED_LABELS, CI_MANAGED_LABELS, MANAGED_LABELS } from './pr-label-managed.mjs';
 export { routingLabels } from './pr-label-routing.mjs';
 export { descriptiveLabels } from './pr-label-content.mjs';
+export { exposureLabels } from './pr-label-exposure.mjs';
 
 /**
  * @param {{
@@ -20,6 +22,7 @@ export const computePrLabels = ({ head, base, changedFiles, mergeable, draft, ch
   const labels = new Set([
     ...routingLabels({ head, base }),
     ...descriptiveLabels({ changedFiles, head }),
+    ...exposureLabels({ changedFiles }),
   ]);
 
   if (mergeable === false) labels.add('has conflicts');

--- a/scripts/lib/pr-labels.test.mjs
+++ b/scripts/lib/pr-labels.test.mjs
@@ -83,4 +83,30 @@ describe('computePrLabels', () => {
     assert.ok(labels.includes('Component: Map'));
     assert.ok(labels.includes('changelog:ok'));
   });
+
+  it('includes exposure labels when exposure files are changed', () => {
+    const labels = computePrLabels({
+      head: 'feature/exposure',
+      base: 'beta',
+      changedFiles: ['src/config/featureExposure.ts'],
+      mergeable: null,
+      draft: false,
+      changelogOk: true,
+    });
+    assert.ok(labels.includes('exposure:registry-change'));
+    assert.ok(labels.includes('exposure:production'));
+  });
+
+  it('includes no exposure labels for unrelated changes', () => {
+    const labels = computePrLabels({
+      head: 'fix/typo',
+      base: 'beta',
+      changedFiles: ['src/components/Map/MapContainer.tsx'],
+      mergeable: null,
+      draft: false,
+      changelogOk: true,
+    });
+    assert.ok(!labels.includes('exposure:registry-change'));
+    assert.ok(!labels.includes('exposure:server-backed'));
+  });
 });

--- a/scripts/lib/pr-labels.test.mjs
+++ b/scripts/lib/pr-labels.test.mjs
@@ -2,6 +2,16 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { computePrLabels, descriptiveLabels, routingLabels } from './pr-labels.mjs';
 
+const makeComputeArgs = (overrides) => ({
+  head: 'feature/test',
+  base: 'beta',
+  changedFiles: ['src/App.tsx'],
+  mergeable: null,
+  draft: false,
+  changelogOk: true,
+  ...overrides,
+});
+
 describe('pr routing labels', () => {
   it('tags beta promotion', () => {
     const labels = routingLabels({ head: 'beta', base: 'main' });
@@ -70,14 +80,11 @@ describe('pr descriptive labels', () => {
 
 describe('computePrLabels', () => {
   it('merges routing, descriptive, and changelog status', () => {
-    const labels = computePrLabels({
+    const labels = computePrLabels(makeComputeArgs({
       head: 'fix/keyboard',
-      base: 'beta',
       changedFiles: ['src/components/Map/x.ts', 'CHANGELOG.md'],
       mergeable: true,
-      draft: false,
-      changelogOk: true,
-    });
+    }));
     assert.ok(labels.includes('fix'));
     assert.ok(labels.includes('Bug'));
     assert.ok(labels.includes('Component: Map'));
@@ -85,27 +92,19 @@ describe('computePrLabels', () => {
   });
 
   it('includes exposure labels when exposure files are changed', () => {
-    const labels = computePrLabels({
+    const labels = computePrLabels(makeComputeArgs({
       head: 'feature/exposure',
-      base: 'beta',
       changedFiles: ['src/config/featureExposure.ts'],
-      mergeable: null,
-      draft: false,
-      changelogOk: true,
-    });
+    }));
     assert.ok(labels.includes('exposure:registry-change'));
     assert.ok(labels.includes('exposure:production'));
   });
 
   it('includes no exposure labels for unrelated changes', () => {
-    const labels = computePrLabels({
+    const labels = computePrLabels(makeComputeArgs({
       head: 'fix/typo',
-      base: 'beta',
       changedFiles: ['src/components/Map/MapContainer.tsx'],
-      mergeable: null,
-      draft: false,
-      changelogOk: true,
-    });
+    }));
     assert.ok(!labels.includes('exposure:registry-change'));
     assert.ok(!labels.includes('exposure:server-backed'));
   });

--- a/scripts/lib/pr-labels.test.mjs
+++ b/scripts/lib/pr-labels.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { computePrLabels, descriptiveLabels, routingLabels } from './pr-labels.mjs';
 
+/** Helper to build default computePrLabels arguments with optional overrides. */
 const makeComputeArgs = (overrides) => ({
   head: 'feature/test',
   base: 'beta',


### PR DESCRIPTION
Automated port of the original commits from PR #591 into `feature/feature-exposure-ci-policy` after merge into `main`.

> Note: Changes were applied via **merge (PR head)** because cherry-pick did not apply cleanly.