### PR TITLE
Align beta porting infrastructure with main baseline

### DIFF
--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -6,7 +6,7 @@ name: Post-merge automation
 # beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
 # release/* → main: merge main into beta, stable release + next beta line + prerelease.
 # feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.
-# hotfix/* → main: patch bump on main + stable release + merge main into beta.
+# hotfix/* → main: patch bump on main + stable release.
 # feature/release-*|workflow_dispatch: sync main→beta, stable release for main, prerelease for new beta.
 #
 # Required secret: GH_PAT (repo scope)
@@ -213,35 +213,6 @@ jobs:
 
           export NOTES_FILE=$(mktemp)
           node scripts/create-github-release.mjs "$STABLE" main
-
-      - name: Sync beta after hotfix merge
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.base.ref == 'main' &&
-          startsWith(github.event.pull_request.head.ref, 'hotfix/')
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          set -euo pipefail
-          git fetch origin main beta
-          git show origin/main:package.json > /tmp/main-package.json
-          STABLE=$(node scripts/read-package-version.mjs /tmp/main-package.json)
-          git checkout beta
-          git pull --ff-only origin beta
-          BETA_VERSION=$(node scripts/read-package-version.mjs)
-          git merge origin/main -X theirs -m "chore: sync hotfix merge from main into beta"
-          node scripts/bump-beta-after-main-release.mjs "$STABLE" "$BETA_VERSION"
-          if ! git diff --quiet package.json; then
-            git add package.json
-            git commit -m "chore: start next beta cycle after hotfix merge (was $BETA_VERSION)"
-          fi
-          git push origin beta
-
-          NEXT=$(node scripts/read-package-version.mjs)
-          export NOTES_FILE=$(mktemp)
-          if [ "$NEXT" != "$BETA_VERSION" ]; then
-            node scripts/create-github-release.mjs "$NEXT" beta
-          fi
 
       - name: Integration merge into beta
         if: >-

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,7 +4,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #TBD
+### PR #613
 
 - Align beta porting and post-merge automation with `main` (PR #612 baseline): hotfix merges use reviewable port PRs instead of direct beta sync, and restore main's port PR policy checks.
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #TBD
+
+- Align beta porting and post-merge automation with `main` (PR #612 baseline): hotfix merges use reviewable port PRs instead of direct beta sync, and restore main's port PR policy checks.
+
 ### PR #610
 
 - Add beta-to-main production exposure report (\`pnpm exposure:report\`), promotion CI gate, and single upserted PR comment with pass/fail status tables for promotion PRs (FND-07).

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -67,7 +67,7 @@ Infrastructure fixes that land via `release/*` → `main` (not only `feature/rel
 
 - Automation bumps the **patch** on `main` after merge (e.g. `1.6.0` → `1.6.1`).
 - Creates a **GitHub Release** for the new patch version from `CHANGELOG.md`.
-- Post-merge automation then merges **main** into **beta** so beta picks up the hotfix code without a redundant port PR.
+- **PR porting** opens a reviewable port PR into `beta` (or skips when `porting/manual` is set or a manual beta PR already exists).
 
 ### `feature/release-*` → main (release infrastructure)
 
@@ -90,7 +90,7 @@ If you merged release automation before this step existed, run **Post-merge auto
 | `beta` | `main` | Yes (promotion) |
 | `feature/release-*` | `main` | Yes (release infrastructure) |
 | `feature/*`, `fix/*`, other | `main` | **Blocked** |
-| `hotfix/*` | `beta` | **Blocked** (beta sync is handled after the `main` merge) |
+| `hotfix/*` | `beta` | **Blocked** |
 
 `main` and `beta` are protected; direct pushes are already restricted.
 

--- a/scripts/lib/port-pr-policy.mjs
+++ b/scripts/lib/port-pr-policy.mjs
@@ -34,8 +34,7 @@ export const targetBranchFromSlug = (slug) => {
 export const postMergeOwnsMainToBetaSync = (sourceHeadRef) =>
   sourceHeadRef === 'beta' ||
   sourceHeadRef.startsWith('release/') ||
-  sourceHeadRef.startsWith('feature/release-') ||
-  sourceHeadRef.startsWith('hotfix/');
+  sourceHeadRef.startsWith('feature/release-');
 
 /**
  * @param {{
@@ -43,7 +42,6 @@ export const postMergeOwnsMainToBetaSync = (sourceHeadRef) =>
  *   baseRef: string;
  *   sourcePrBaseRef: string;
  *   sourcePrHeadRef: string;
- *   betaContainsMain?: boolean;
  * }} context
  */
 export const isRedundantBetaPortPr = ({
@@ -51,13 +49,11 @@ export const isRedundantBetaPortPr = ({
   baseRef,
   sourcePrBaseRef,
   sourcePrHeadRef,
-  betaContainsMain = true,
 }) =>
   targetBranch === 'beta' &&
   baseRef === 'beta' &&
   sourcePrBaseRef === 'main' &&
-  postMergeOwnsMainToBetaSync(sourcePrHeadRef) &&
-  betaContainsMain;
+  postMergeOwnsMainToBetaSync(sourcePrHeadRef);
 
 /**
  * @param {{
@@ -67,7 +63,6 @@ export const isRedundantBetaPortPr = ({
  *   sourcePrHeadRef: string;
  *   sourcePrBaseRef: string;
  *   sourcePrNumber: number;
- *   betaContainsMain?: boolean;
  * }} context
  */
 export const evaluatePortPrPolicy = ({
@@ -77,7 +72,6 @@ export const evaluatePortPrPolicy = ({
   sourcePrHeadRef,
   sourcePrBaseRef,
   sourcePrNumber,
-  betaContainsMain = true,
 }) => {
   if (!parsePortBranch(headRef)) {
     return { ok: true };
@@ -89,7 +83,6 @@ export const evaluatePortPrPolicy = ({
       baseRef,
       sourcePrBaseRef,
       sourcePrHeadRef,
-      betaContainsMain,
     })
   ) {
     return {

--- a/scripts/lib/port-pr-policy.test.mjs
+++ b/scripts/lib/port-pr-policy.test.mjs
@@ -32,7 +32,7 @@ describe('port PR policy', () => {
     assert.equal(postMergeOwnsMainToBetaSync('beta'), true);
     assert.equal(postMergeOwnsMainToBetaSync('release/v1.0.0'), true);
     assert.equal(postMergeOwnsMainToBetaSync('feature/release-post-merge-github-release'), true);
-    assert.equal(postMergeOwnsMainToBetaSync('hotfix/urgent'), true);
+    assert.equal(postMergeOwnsMainToBetaSync('hotfix/urgent'), false);
   });
 
   it('detects redundant beta port PRs', () => {
@@ -52,7 +52,7 @@ describe('port PR policy', () => {
         sourcePrBaseRef: 'main',
         sourcePrHeadRef: 'hotfix/patch',
       }),
-      true,
+      false,
     );
   });
 
@@ -68,23 +68,15 @@ describe('port PR policy', () => {
     assert.equal(result.ok, false);
   });
 
-  it('evaluates hotfix ports into beta based on whether main is on beta', () => {
-    const hotfixPort = {
+  it('allows hotfix ports into beta', () => {
+    const result = evaluatePortPrPolicy({
       headRef: 'port/99-to-beta',
       baseRef: 'beta',
       targetBranch: 'beta',
       sourcePrHeadRef: 'hotfix/patch',
       sourcePrBaseRef: 'main',
       sourcePrNumber: 99,
-    };
-
-    assert.equal(
-      evaluatePortPrPolicy({ ...hotfixPort, betaContainsMain: true }).ok,
-      false,
-    );
-    assert.equal(
-      evaluatePortPrPolicy({ ...hotfixPort, betaContainsMain: false }).ok,
-      true,
-    );
+    });
+    assert.equal(result.ok, true);
   });
 });

--- a/scripts/validate-port-pr-policy.mjs
+++ b/scripts/validate-port-pr-policy.mjs
@@ -38,22 +38,6 @@ try {
 }
 
 const sourcePr = JSON.parse(sourcePrJson);
-
-try {
-  execFileSync('git', ['fetch', 'origin', 'beta', 'main'], { stdio: 'ignore' });
-} catch (err) {
-  const message = err instanceof Error ? err.message : String(err);
-  console.error(`Port PR policy: could not fetch origin/beta and origin/main — ${message}`);
-  process.exit(1);
-}
-
-let betaContainsMain = true;
-try {
-  execFileSync('git', ['merge-base', '--is-ancestor', 'origin/main', 'origin/beta']);
-} catch {
-  betaContainsMain = false;
-}
-
 const result = evaluatePortPrPolicy({
   headRef,
   baseRef,
@@ -61,7 +45,6 @@ const result = evaluatePortPrPolicy({
   sourcePrHeadRef: sourcePr.headRefName,
   sourcePrBaseRef: sourcePr.baseRefName,
   sourcePrNumber: parsed.sourcePrNumber,
-  betaContainsMain,
 });
 
 if (!result.ok) {


### PR DESCRIPTION
## Summary

Ports the remaining **main** infrastructure deltas into **beta** so both branches share the PR #612 porting model.

PR #612 files were already on beta via post-merge sync (946faa4), but beta had diverged on:

- \post-merge-automation.yml\ — removed superseded **hotfix → beta direct sync** (now handled by reviewable port PRs)
- \port-pr-policy.mjs\ / \alidate-port-pr-policy.mjs\ — restored **main** policy (hotfix ports allowed; no \etaContainsMain\ guard tied to direct sync)
- \docs/release-workflow.md\ — updated hotfix docs to match port-PR flow; kept beta exposure promotion docs

Beta-only CI (feature exposure, promotion exposure report) is unchanged.

## Test plan

- [x] \
ode --test scripts/lib/port-pr-policy.test.mjs scripts/lib/port-targets.test.mjs scripts/lib/port-conflicts.test.mjs\ (20 passing)
- [ ] CI on this PR

Made with [Cursor](https://cursor.com)