### PR TITLE
[Port] [Security Hotfix] CI shell injection via github.head_ref in git fetch to beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
           token: ${{ secrets.GH_PAT || github.token }}
 
       - name: Fetch PR branches
-        run: git fetch origin "${{ github.base_ref }}" "${{ github.head_ref }}"
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: git fetch origin "$GITHUB_BASE_REF" "$GITHUB_HEAD_REF"
 
       - name: Branch policy
         env:

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -28,7 +28,10 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR branches
-        run: git fetch origin "${{ github.base_ref }}" "${{ github.head_ref }}"
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: git fetch origin "$GITHUB_BASE_REF" "$GITHUB_HEAD_REF"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,16 @@ pnpm exec playwright test e2e/smoke.spec.ts
 - Mention unrelated dirty files only when they matter.
 - Do not bury the result under process narration.
 
+## GitHub PR and issue bodies
+
+When writing or updating PR descriptions, issue comments, or `gh pr create` / `gh pr edit` bodies:
+
+- Use real Markdown backticks for inline code: `` `ci.yml` ``, `` `$GITHUB_HEAD_REF` ``, `` `main` ``.
+- Never escape backticks for the shell (`\``) inside PR/issue bodies — that renders as garbage on GitHub.
+- On Windows/PowerShell, prefer `gh pr edit <n> --body-file path/to/body.md` (or a here-string written to a temp file) instead of passing `--body` with nested quotes and backticks on the command line.
+- Use normal Markdown structure: `##` headings, `- [ ]` checklists, and fenced code blocks only for multi-line snippets.
+- File paths and branch names belong in backticks; issue/PR references use `#123` without backticks.
+
 ## Porting main → beta
 
 Use this when you need to land a **main** change on **beta** yourself, or when automated porting opened a draft conflict PR.


### PR DESCRIPTION
Automated port of the original commits from PR #614 into `beta` after merge into `main`.

> Note: Changes were applied via **cherry-pick (conflicts) (auto-resolved policy files)**.