### PR TITLE
[Security Hotfix] Dependabot changelog workflow can execute non-Dependabot code with GH_PAT

### DIFF
--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -16,18 +16,22 @@ jobs:
   update-changelog:
     if: >-
       github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout head branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.GH_PAT || github.token }}
 
       - name: Fetch base branch
-        run: git fetch origin "${{ github.base_ref }}"
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$GITHUB_BASE_REF"
 
       - name: Update CHANGELOG dependencies
         env:
@@ -37,9 +41,11 @@ jobs:
         run: node scripts/update-dependabot-changelog.mjs
 
       - name: Commit and push
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
         run: |
           CHANGELOG_FILE="CHANGELOG.md"
-          if [ "${{ github.base_ref }}" = "beta" ]; then CHANGELOG_FILE="CHANGELOG.beta.md"; fi
+          if [ "$GITHUB_BASE_REF" = "beta" ]; then CHANGELOG_FILE="CHANGELOG.beta.md"; fi
           if git diff --quiet "$CHANGELOG_FILE"; then
             echo "No changelog changes to commit."
             exit 0

--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -30,22 +30,20 @@ jobs:
 
       - name: Fetch base branch
         env:
-          GITHUB_BASE_REF: ${{ github.base_ref }}
-        run: git fetch origin "$GITHUB_BASE_REF"
+          PR_BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$PR_BASE_REF"
 
       - name: Update CHANGELOG dependencies
         env:
-          GITHUB_BASE_REF: ${{ github.base_ref }}
-          GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: node scripts/update-dependabot-changelog.mjs
 
       - name: Commit and push
         env:
-          GITHUB_BASE_REF: ${{ github.base_ref }}
+          PR_BASE_REF: ${{ github.base_ref }}
         run: |
           CHANGELOG_FILE="CHANGELOG.md"
-          if [ "$GITHUB_BASE_REF" = "beta" ]; then CHANGELOG_FILE="CHANGELOG.beta.md"; fi
+          if [ "$PR_BASE_REF" = "beta" ]; then CHANGELOG_FILE="CHANGELOG.beta.md"; fi
           if git diff --quiet "$CHANGELOG_FILE"; then
             echo "No changelog changes to commit."
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 - **CI shell injection:** Pass PR branch refs through `env` in `ci.yml` and `pr-governance.yml` `git fetch` steps so branch names cannot break out of the shell command.
+- **Dependabot changelog workflow:** Require Dependabot PR provenance before checking out PR head code with `GH_PAT`; pass base ref through env in shell steps; pin `actions/checkout` to an immutable SHA.
 
 ### Changed
 - **Deploy env:** Add explicit `SERVER_TARGET` values to beta, staging, and production analytics server deploy env files.


### PR DESCRIPTION
## Summary

- Require Dependabot PR provenance (`dependabot[bot]` author, same-repo head) before the changelog workflow checks out PR head code with `GH_PAT`
- Pass `github.base_ref` through `env` in shell steps instead of direct interpolation
- Pin `actions/checkout` to immutable SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.0)

Closes #602

## Test plan

- [ ] CI required checks pass on this PR
- [ ] Confirm `dependabot-changelog.yml` job `if` blocks non-Dependabot PRs with `dependabot/*` branch names
- [ ] After merge to `main`, review automated `[Port] … to beta` PR from `pr-porting.yml`
- [ ] Monitor next real Dependabot PR to `beta` for successful changelog auto-commit
