### PR TITLE
fix(security): use frozen lockfile in deploy workflows

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Read app version
         id: app_version

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -44,7 +44,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Read app version
         id: app_version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 ### Security
 - **CI shell injection:** Pass PR branch refs through `env` in `ci.yml` and `pr-governance.yml` `git fetch` steps so branch names cannot break out of the shell command.
 - **Dependabot changelog workflow:** Require Dependabot PR provenance before checking out PR head code with `GH_PAT`; pass base ref through env in shell steps; pin `actions/checkout` to an immutable SHA.
+- **Beta deploy supply chain:** Use `pnpm install --frozen-lockfile` in the beta deploy workflow so builds cannot silently resolve new dependency versions at deploy time.
+- **Production deploy supply chain:** Use `pnpm install --frozen-lockfile` in the production deploy workflow so builds cannot silently resolve new dependency versions at deploy time.
 
 ### Changed
 - **Deploy env:** Add explicit `SERVER_TARGET` values to beta, staging, and production analytics server deploy env files.


### PR DESCRIPTION
## Summary

- Use `pnpm install --frozen-lockfile` in the beta deploy workflow so builds cannot silently resolve new dependency versions at deploy time.
- Apply the same hardening to the production deploy workflow (same root cause, not separately tracked).
- Align deploy install behavior with CI, which already enforces a frozen lockfile.

Fixes #603

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds locally
- [x] `pnpm run build` succeeds locally
- [ ] CI `build-and-test` passes
- [ ] Changelog policy passes for `hotfix/*` → `main`
- [ ] After merge and port to `beta`, confirm Deploy Beta workflow succeeds
