### PR TITLE
fix(security): harden cleanup-port-branches workflow guards

### DIFF
--- a/.github/workflows/cleanup-port-branches.yml
+++ b/.github/workflows/cleanup-port-branches.yml
@@ -1,23 +1,37 @@
 name: Cleanup Port Branches
 
+# SECURITY: This workflow deletes git refs with contents:write. Guards below are
+# security-critical and must not be removed or loosened:
+# - Same-repo PR only (blocks fork PRs from triggering base-repo ref deletion).
+# - port/* coarse pre-filter at job level; strict allowlist in cleanup-port-branch.mjs.
+# - Uses pull_request (not pull_request_target): port branches are same-repo only
+#   and this workflow never checks out PR code, so elevated fork context is unnecessary.
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
+
+permissions:
+  contents: write
 
 jobs:
   delete-merged-port-branch:
-    if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'port/')
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'port/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
+      - name: Checkout base branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Delete closed port branch
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           PORT_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          echo "Cleaning up remote port branch $PORT_BRANCH from PR #$PR_NUMBER"
-          gh api -X DELETE repos/${{ github.repository }}/git/refs/heads/"$PORT_BRANCH" || \
-            echo "Port branch $PORT_BRANCH was already removed or is protected."
+        run: node scripts/cleanup-port-branch.mjs

--- a/.github/workflows/cleanup-port-branches.yml
+++ b/.github/workflows/cleanup-port-branches.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: write
-
 jobs:
   delete-merged-port-branch:
     if: >-

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #630
+
+- Harden `cleanup-port-branches` workflow: replace `pull_request_target` with `pull_request`, validate port branch names against the automation allowlist before ref deletion, and document security-critical guards (#606).
+
 ### PR #629
 
 - Pin all third-party workflow actions to immutable commit SHAs; enable Dependabot `github-actions` updates (#604).

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -33,6 +33,12 @@ If both tried to port the same merge into `beta`, you would get a port PR and a 
 
 Automation auto-resolves version-policy file conflicts on beta ports (`package.json`, lockfiles, `CHANGELOG.md`, `deploy/production-release.json`). Remaining code conflicts open a **draft** `[Port][Conflicts]` PR — no tracking issue. See [`AGENTS.md`](../AGENTS.md) for manual port steps.
 
+### Port branch cleanup (security)
+
+When a port PR closes, [`cleanup-port-branches.yml`](../.github/workflows/cleanup-port-branches.yml) deletes the remote head branch. This is intentional hygiene for temporary `port/<pr>-to-<target>` branches created by [`port-changes.sh`](../.github/scripts/port-changes.sh).
+
+**Do not loosen the workflow guards.** The job only runs for same-repo PRs whose head ref starts with `port/`, and the cleanup script enforces the stricter allowlist in [`scripts/lib/port-pr-policy.mjs`](../scripts/lib/port-pr-policy.mjs) (`^port\/(\d+)-to-(.+)$`). Those checks prevent arbitrary ref deletion. Port branch naming must stay aligned across `port-changes.sh`, `port-pr-policy.mjs`, and this workflow.
+
 ## What happens when you merge
 
 ### beta → main (promotion)

--- a/scripts/cleanup-port-branch.mjs
+++ b/scripts/cleanup-port-branch.mjs
@@ -32,7 +32,14 @@ try {
   console.log(`Deleted port branch ${portBranch}.`);
 } catch (err) {
   const message = err instanceof Error ? err.message : String(err);
-  if (message.includes('404') || message.includes('Reference does not exist')) {
+  const stdout =
+    err && typeof err === 'object' && 'stdout' in err ? String(err.stdout) : '';
+  const combined = message + stdout;
+  if (
+    combined.includes('404') ||
+    combined.includes('422') ||
+    combined.includes('Reference does not exist')
+  ) {
     console.log(`Port branch ${portBranch} was already removed or is protected.`);
     process.exit(0);
   }

--- a/scripts/cleanup-port-branch.mjs
+++ b/scripts/cleanup-port-branch.mjs
@@ -1,0 +1,41 @@
+import { execFileSync } from 'node:child_process';
+import { isDeletablePortBranch } from './lib/port-pr-policy.mjs';
+
+const portBranch = process.env.PORT_BRANCH ?? '';
+const prNumber = process.env.PR_NUMBER ?? '';
+const repository = process.env.GITHUB_REPOSITORY ?? '';
+
+if (!portBranch || !repository) {
+  console.error('cleanup-port-branch: PORT_BRANCH and GITHUB_REPOSITORY are required.');
+  process.exit(1);
+}
+
+if (!isDeletablePortBranch(portBranch)) {
+  console.log(
+    `Skipping cleanup for "${portBranch}" from PR #${prNumber}: not an automation port branch.`,
+  );
+  process.exit(0);
+}
+
+console.log(`Cleaning up remote port branch ${portBranch} from PR #${prNumber}`);
+
+try {
+  execFileSync(
+    'gh',
+    ['api', '-X', 'DELETE', `repos/${repository}/git/refs/heads/${portBranch}`],
+    {
+      encoding: 'utf8',
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  console.log(`Deleted port branch ${portBranch}.`);
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  if (message.includes('404') || message.includes('Reference does not exist')) {
+    console.log(`Port branch ${portBranch} was already removed or is protected.`);
+    process.exit(0);
+  }
+  console.error(`Failed to delete port branch ${portBranch}: ${message}`);
+  process.exit(1);
+}

--- a/scripts/lib/port-pr-policy.mjs
+++ b/scripts/lib/port-pr-policy.mjs
@@ -11,6 +11,14 @@ export const parsePortBranch = (headRef) => {
 };
 
 /**
+ * Port branches eligible for automated cleanup after their PR closes.
+ * Must stay aligned with port-changes.sh naming and cleanup-port-branches.yml guards.
+ *
+ * @param {string} headRef
+ */
+export const isDeletablePortBranch = (headRef) => parsePortBranch(headRef) !== null;
+
+/**
  * Reverse port-changes.sh slugging: `feature/foo-bar` → `feature/foo/bar` only for known prefixes.
  *
  * @param {string} slug

--- a/scripts/lib/port-pr-policy.test.mjs
+++ b/scripts/lib/port-pr-policy.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
   evaluatePortPrPolicy,
+  isDeletablePortBranch,
   isRedundantBetaPortPr,
   parsePortBranch,
   postMergeOwnsMainToBetaSync,
@@ -9,6 +10,16 @@ import {
 } from './port-pr-policy.mjs';
 
 describe('port PR policy', () => {
+  it('identifies deletable automation port branches', () => {
+    assert.equal(isDeletablePortBranch('port/346-to-beta'), true);
+    assert.equal(isDeletablePortBranch('port/346-to-feature-dependabot-changelog-skip'), true);
+    assert.equal(isDeletablePortBranch('port/beta'), false);
+    assert.equal(isDeletablePortBranch('port/main'), false);
+    assert.equal(isDeletablePortBranch('feature/foo'), false);
+    assert.equal(isDeletablePortBranch('port/'), false);
+    assert.equal(isDeletablePortBranch('port/abc'), false);
+  });
+
   it('parses port branch names', () => {
     assert.deepEqual(parsePortBranch('port/346-to-beta'), {
       sourcePrNumber: 346,


### PR DESCRIPTION
## Summary

- Hardens `cleanup-port-branches.yml` against arbitrary ref deletion flagged in #606 (deepsec `pull_request_target` finding).
- Replaces `pull_request_target` with `pull_request` (`types: [closed]`) since port branches are same-repo only and the workflow never needs fork-elevated context.
- Adds `isDeletablePortBranch()` and `scripts/cleanup-port-branch.mjs` to enforce the existing `^port\/(\d+)-to-(.+)$` allowlist before calling `gh api DELETE`.
- Checks out the PR base branch (not head) so cleanup logic always runs from trusted code.
- Documents security-critical guards in the workflow and `docs/release-workflow.md`.

Fixes #606

## Test plan

- [x] `node --test scripts/lib/port-pr-policy.test.mjs`
- [ ] Confirm workflow runs on next closed port PR and deletes only `port/<n>-to-<target>` branches
- [ ] Verify fork PR with `port/*` head is skipped by job `if`
- [ ] Verify same-repo `port/beta`-style head is rejected by script before DELETE
