### PR TITLE
[FND-11] Add emergency feature shutdown and fail-closed override behavior

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #632
+
+- Add server-authoritative emergency capability disable via `EMERGENCY_DISABLED_CAPABILITIES`, including fail-closed parsing, `/api/capabilities/status`, and client runtime fallback for already-mounted server-backed features (FND-11, #527).
+
 ### PR #631
 
 - Add weekly/manual stale branch reporting for `feature/*`, `fix/*`, and `research/*` branches with a 14-day grace period, orphaned vs open-PR grouping, and commits-behind-`beta` metadata (#494).

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ Server capability gates live in:
 
 Experimental APIs register `createServerCapabilityGate(serverCapabilityKey)` before auth and handlers. A capability is enabled only when the registry exposes it for the server target and the deployment env key is `true`. Disabled routes return `404` with `{ error: "<label> is not enabled on this deployment." }`.
 
+Emergency incident disable is server-authoritative via `EMERGENCY_DISABLED_CAPABILITIES` on the analytics server. That override is disable-only, overrides registry and deployment env for server-backed capabilities, and does not require a frontend rebuild. See [docs/emergency-feature-disable.md](docs/emergency-feature-disable.md) for activation, verification, rollback, and a local drill.
+
+Client runtime fallback for server-backed features lives in:
+
+- `src/config/serverCapabilityStatus.ts` — fetches `/api/capabilities/status` and tracks locally unavailable capabilities
+- `src/features/ServerBackedFeatureBoundary.tsx` — hides already-mounted server-backed UI when the server disables a capability after page load
+
 ### Local Beta Mode (developer)
 
 Run the app with beta-only features locally (useful for testing forecast redesigns, verification flows, and discussion changes).

--- a/docs/emergency-feature-disable.md
+++ b/docs/emergency-feature-disable.md
@@ -31,6 +31,8 @@ No frontend rebuild or redeploy is required.
 
 ## Verification
 
+Prerequisite: the capability must be registry-exposed on the deployment target you are testing. Today that means `autoTstm.exposure.beta` is `true` in both `src/config/featureExposure.ts` and `server/lib/serverFeatureExposure.js`. Emergency disable only appears in `/api/capabilities/status` for capabilities the registry already exposes on that target.
+
 From a shell with access to the beta site:
 
 ```bash
@@ -64,7 +66,18 @@ Already-open beta sessions should stop showing server-backed controls after the 
 
 ## Local incident drill
 
-1. Start the analytics server locally with emergency disable enabled:
+The manual curl drill below mirrors production only after the registry exposes Auto-TSTM on the target under test. Until that beta enablement lands, use the automated gate test instead.
+
+Automated gate verification (works with the current all-off registry via test overrides):
+
+```powershell
+node --test server/tstm.test.js
+```
+
+Manual server drill (requires registry exposure on the target):
+
+1. Confirm `autoTstm.exposure.beta` is `true` in `server/lib/serverFeatureExposure.js`, or run this drill against a deployment where Auto-TSTM is already live on beta.
+2. Start the analytics server locally with emergency disable enabled:
 
 ```powershell
 $env:SERVER_TARGET='beta'
@@ -73,7 +86,7 @@ $env:EMERGENCY_DISABLED_CAPABILITIES='TSTM_GENERATION_ENABLED'
 node server/analytics.js
 ```
 
-2. In another shell:
+3. In another shell:
 
 ```powershell
 curl http://127.0.0.1:3006/api/capabilities/status
@@ -82,11 +95,15 @@ curl -X POST http://127.0.0.1:3006/api/tstm/generate `
   -d '{"day":1,"cycleDate":"2026-06-13"}'
 ```
 
-3. Confirm the status reason is `emergency_disabled`, the generate route returns `404`, and no Python worker starts.
-4. Remove the env var, restart the server, and confirm normal disabled/enabled behavior resumes according to the registry matrix.
+4. Confirm the status payload includes `TSTM_GENERATION_ENABLED` with reason `emergency_disabled`, the generate route returns `404`, and no Python worker starts.
+5. Remove the env var, restart the server, and confirm normal disabled/enabled behavior resumes according to the registry matrix.
+
+## Public status endpoint security
+
+`GET /api/capabilities/status` is intentionally unauthenticated and rate-limited. It returns only non-sensitive availability booleans and reason codes for registry-exposed server-backed capabilities. The `emergency_disabled` reason can signal incident response state, so treat the endpoint as operational metadata rather than a secret control plane.
 
 ## Malformed override behavior
 
 If `EMERGENCY_DISABLED_CAPABILITIES` is malformed (for example `true`, `false`, or control characters), the server logs an error and applies **zero** emergency disables. Malformed input must never enable a capability.
 
-Unknown keys in the list are ignored with a warning.
+Unknown keys in the list are ignored with a startup warning logged once when the analytics server boots.

--- a/docs/emergency-feature-disable.md
+++ b/docs/emergency-feature-disable.md
@@ -1,0 +1,92 @@
+# Emergency feature disable runbook
+
+Use this when a server-backed beta capability must be turned off immediately without rebuilding the frontend.
+
+## Scope
+
+- **Disable-only:** `EMERGENCY_DISABLED_CAPABILITIES` can never enable a feature.
+- **Server-backed only:** only keys declared in `server/lib/serverFeatureExposure.js` are accepted.
+- **Current capability keys:** `TSTM_GENERATION_ENABLED` (Auto-TSTM).
+
+Normal rollout still comes from the checked-in registry in `src/config/featureExposure.ts` plus deployment env switches such as `TSTM_GENERATION_ENABLED=true`.
+
+## Activation (beta)
+
+1. SSH to the beta analytics host.
+2. Edit `/opt/gfc-beta-analytics/.env`.
+3. Add or update:
+
+```bash
+EMERGENCY_DISABLED_CAPABILITIES=TSTM_GENERATION_ENABLED
+```
+
+4. Restart the analytics process:
+
+```bash
+cd /opt/gfc-beta-analytics
+pm2 restart gfc-beta-analytics
+```
+
+No frontend rebuild or redeploy is required.
+
+## Verification
+
+From a shell with access to the beta site:
+
+```bash
+curl -s https://beta-gfc.weatherboysuper.com/api/capabilities/status
+curl -s -X POST https://beta-gfc.weatherboysuper.com/api/tstm/generate \
+  -H 'content-type: application/json' \
+  -d '{"day":1,"cycleDate":"2026-06-13"}'
+```
+
+Expected results:
+
+- Status endpoint reports `"available": false` with `"reason": "emergency_disabled"`.
+- Generate endpoint returns `404` with `{ "error": "Auto-TSTM is not enabled on this deployment." }`.
+- Server logs include lines like:
+  - `[capabilities] emergency_disabled=["TSTM_GENERATION_ENABLED"] target=beta`
+  - `[capabilities] rejected capability=TSTM_GENERATION_ENABLED reason=emergency_disabled`
+
+Already-open beta sessions should stop showing server-backed controls after the status endpoint refresh or the next disabled API response.
+
+## Rollback
+
+1. Remove `EMERGENCY_DISABLED_CAPABILITIES` from `/opt/gfc-beta-analytics/.env`, or set it to an empty value.
+2. Restart `gfc-beta-analytics` with pm2.
+3. Re-run the verification commands and confirm `"available": true` when registry exposure and `TSTM_GENERATION_ENABLED=true` are both in effect.
+
+## Ownership and audit
+
+- **Registry owner:** see the feature entry in `src/config/featureExposure.ts` (`owner` field).
+- **On-call maintainer:** repository maintainer with VPS access.
+- **Audit trail:** pm2/server logs record startup disable state and per-request emergency rejections. No secrets are logged.
+
+## Local incident drill
+
+1. Start the analytics server locally with emergency disable enabled:
+
+```powershell
+$env:SERVER_TARGET='beta'
+$env:TSTM_GENERATION_ENABLED='true'
+$env:EMERGENCY_DISABLED_CAPABILITIES='TSTM_GENERATION_ENABLED'
+node server/analytics.js
+```
+
+2. In another shell:
+
+```powershell
+curl http://127.0.0.1:3006/api/capabilities/status
+curl -X POST http://127.0.0.1:3006/api/tstm/generate `
+  -H 'content-type: application/json' `
+  -d '{"day":1,"cycleDate":"2026-06-13"}'
+```
+
+3. Confirm the status reason is `emergency_disabled`, the generate route returns `404`, and no Python worker starts.
+4. Remove the env var, restart the server, and confirm normal disabled/enabled behavior resumes according to the registry matrix.
+
+## Malformed override behavior
+
+If `EMERGENCY_DISABLED_CAPABILITIES` is malformed (for example `true`, `false`, or control characters), the server logs an error and applies **zero** emergency disables. Malformed input must never enable a capability.
+
+Unknown keys in the list are ignored with a warning.

--- a/server/analytics-app.js
+++ b/server/analytics-app.js
@@ -31,6 +31,7 @@ function configureApp(app, express, fs, LOG_FILE) {
   const rateLimit = require('express-rate-limit');
   const { registerBetaRoutes } = require('./beta');
   const { registerBillingRoutes } = require('./billing');
+  const { registerCapabilityRoutes } = require('./capabilities');
   const { registerMetricsRoutes } = require('./metrics');
   const { registerSentryTunnelRoutes } = require('./sentry-tunnel');
   const { registerTstmRoutes } = require('./tstm');
@@ -48,6 +49,7 @@ function configureApp(app, express, fs, LOG_FILE) {
   registerBillingRoutes(app, express);
   registerMetricsRoutes(app, express);
   registerBetaRoutes(app, express);
+  registerCapabilityRoutes(app);
   registerTstmRoutes(app, express);
 
   app.post('/collect', express.json({ limit: '1kb' }), collectRateLimit, createCollectHandler(fs, LOG_FILE));

--- a/server/analytics.js
+++ b/server/analytics.js
@@ -24,6 +24,8 @@ async function start() {
 
   const app = express();
   configureApp(app, express, fs, LOG_FILE);
+  const { logCapabilityStartupState } = require('./capabilities');
+  logCapabilityStartupState(process.env);
 
   // Bind to loopback only — never exposed to the internet directly (nginx proxies in)
   app.listen(PORT, '127.0.0.1', () => {

--- a/server/capabilities.js
+++ b/server/capabilities.js
@@ -1,14 +1,22 @@
 'use strict';
 
+const rateLimit = require('express-rate-limit');
 const { getPublicCapabilityStatus } = require('./lib/capabilityStatus');
 const { logEmergencyCapabilityOverrides } = require('./lib/emergencyCapabilityOverrides');
 const { getServerTarget } = require('./lib/serverTarget');
+
+const CAPABILITY_STATUS_RATE_LIMIT = rateLimit({
+  windowMs: 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 /** Registers the public capability status endpoint for server-backed features. */
 const registerCapabilityRoutes = (app, options = {}) => {
   const env = options.env || process.env;
 
-  app.get('/api/capabilities/status', (_req, res) => {
+  app.get('/api/capabilities/status', CAPABILITY_STATUS_RATE_LIMIT, (_req, res) => {
     res.status(200).json(getPublicCapabilityStatus({
       env,
       target: options.target,
@@ -22,6 +30,7 @@ const logCapabilityStartupState = (env = process.env) => {
 };
 
 module.exports = {
+  CAPABILITY_STATUS_RATE_LIMIT,
   logCapabilityStartupState,
   registerCapabilityRoutes,
 };

--- a/server/capabilities.js
+++ b/server/capabilities.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { getPublicCapabilityStatus } = require('./lib/capabilityStatus');
+const { logEmergencyCapabilityOverrides } = require('./lib/emergencyCapabilityOverrides');
+const { getServerTarget } = require('./lib/serverTarget');
+
+/** Registers the public capability status endpoint for server-backed features. */
+const registerCapabilityRoutes = (app, options = {}) => {
+  const env = options.env || process.env;
+
+  app.get('/api/capabilities/status', (_req, res) => {
+    res.status(200).json(getPublicCapabilityStatus({
+      env,
+      target: options.target,
+    }));
+  });
+};
+
+/** Logs active emergency disable overrides once during server startup. */
+const logCapabilityStartupState = (env = process.env) => {
+  logEmergencyCapabilityOverrides(env, { target: getServerTarget(env) });
+};
+
+module.exports = {
+  logCapabilityStartupState,
+  registerCapabilityRoutes,
+};

--- a/server/lib/capabilityStatus.js
+++ b/server/lib/capabilityStatus.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const { isEmergencyDisabledCapability } = require('./emergencyCapabilityOverrides');
+const { SERVER_FEATURE_EXPOSURE_REGISTRY } = require('./serverFeatureExposure');
+const { getServerTarget } = require('./serverTarget');
+
+const CAPABILITY_REASON = {
+  AVAILABLE: 'available',
+  REGISTRY_DISABLED: 'registry_disabled',
+  DEPLOYMENT_DISABLED: 'deployment_disabled',
+  EMERGENCY_DISABLED: 'emergency_disabled',
+  UNKNOWN: 'unknown',
+};
+
+/** Returns the server-backed feature entry for a capability key, if declared. */
+const findFeatureByCapabilityKey = (capabilityKey) => {
+  for (const [featureKey, definition] of Object.entries(SERVER_FEATURE_EXPOSURE_REGISTRY)) {
+    if (definition.serverCapabilityKey === capabilityKey) {
+      return { featureKey, definition };
+    }
+  }
+
+  return null;
+};
+
+/** Returns true when ops explicitly enabled the deployment capability env switch. */
+const isDeploymentCapabilityEnabled = (capabilityKey, env = process.env) =>
+  env[capabilityKey] === 'true';
+
+/** Resolves why a capability is unavailable on the current deployment target. */
+const resolveCapabilityAvailability = (capabilityKey, options = {}) => {
+  const env = options.env || process.env;
+  const target = options.target ?? getServerTarget(env);
+  const feature = findFeatureByCapabilityKey(capabilityKey);
+
+  if (!feature) {
+    return {
+      available: false,
+      reason: CAPABILITY_REASON.UNKNOWN,
+    };
+  }
+
+  const exposureOverride = options.exposureOverride?.[target];
+  const exposedOnTarget =
+    typeof exposureOverride === 'boolean'
+      ? exposureOverride
+      : feature.definition.exposure[target] === true;
+
+  if (!exposedOnTarget) {
+    return {
+      available: false,
+      reason: CAPABILITY_REASON.REGISTRY_DISABLED,
+    };
+  }
+
+  if (isEmergencyDisabledCapability(capabilityKey, env, options)) {
+    return {
+      available: false,
+      reason: CAPABILITY_REASON.EMERGENCY_DISABLED,
+    };
+  }
+
+  if (!isDeploymentCapabilityEnabled(capabilityKey, env)) {
+    return {
+      available: false,
+      reason: CAPABILITY_REASON.DEPLOYMENT_DISABLED,
+    };
+  }
+
+  return {
+    available: true,
+    reason: CAPABILITY_REASON.AVAILABLE,
+  };
+};
+
+/** Returns public capability status for registry-exposed server-backed features. */
+const getPublicCapabilityStatus = (options = {}) => {
+  const env = options.env || process.env;
+  const target = options.target ?? getServerTarget(env);
+  const capabilities = {};
+
+  for (const definition of Object.values(SERVER_FEATURE_EXPOSURE_REGISTRY)) {
+    const exposureOverride = options.exposureOverride?.[target];
+    const exposedOnTarget =
+      typeof exposureOverride === 'boolean'
+        ? exposureOverride
+        : definition.exposure[target] === true;
+
+    if (!exposedOnTarget) {
+      continue;
+    }
+
+    const capabilityKey = definition.serverCapabilityKey;
+    const status = resolveCapabilityAvailability(capabilityKey, options);
+    capabilities[capabilityKey] = {
+      available: status.available,
+      reason: status.reason,
+    };
+  }
+
+  return { capabilities };
+};
+
+module.exports = {
+  CAPABILITY_REASON,
+  findFeatureByCapabilityKey,
+  getPublicCapabilityStatus,
+  isDeploymentCapabilityEnabled,
+  resolveCapabilityAvailability,
+};

--- a/server/lib/capabilityStatus.test.js
+++ b/server/lib/capabilityStatus.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  CAPABILITY_REASON,
+  getPublicCapabilityStatus,
+  resolveCapabilityAvailability,
+} = require('./capabilityStatus');
+
+describe('capability status', () => {
+  it('returns unknown for undeclared capability keys', () => {
+    const status = resolveCapabilityAvailability('UNKNOWN_CAPABILITY');
+    assert.equal(status.available, false);
+    assert.equal(status.reason, CAPABILITY_REASON.UNKNOWN);
+  });
+
+  it('returns registry_disabled when the target matrix keeps the feature off', () => {
+    const status = resolveCapabilityAvailability('TSTM_GENERATION_ENABLED', {
+      env: { SERVER_TARGET: 'beta' },
+    });
+    assert.equal(status.available, false);
+    assert.equal(status.reason, CAPABILITY_REASON.REGISTRY_DISABLED);
+  });
+
+  it('returns emergency_disabled when the override env is set', () => {
+    const status = resolveCapabilityAvailability('TSTM_GENERATION_ENABLED', {
+      env: {
+        SERVER_TARGET: 'beta',
+        TSTM_GENERATION_ENABLED: 'true',
+        EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
+      },
+      exposureOverride: { beta: true },
+    });
+    assert.equal(status.available, false);
+    assert.equal(status.reason, CAPABILITY_REASON.EMERGENCY_DISABLED);
+  });
+
+  it('returns deployment_disabled when the deployment env switch is off', () => {
+    const status = resolveCapabilityAvailability('TSTM_GENERATION_ENABLED', {
+      env: { SERVER_TARGET: 'beta' },
+      exposureOverride: { beta: true },
+    });
+    assert.equal(status.available, false);
+    assert.equal(status.reason, CAPABILITY_REASON.DEPLOYMENT_DISABLED);
+  });
+
+  it('returns available when registry exposure and deployment env are both enabled', () => {
+    const status = resolveCapabilityAvailability('TSTM_GENERATION_ENABLED', {
+      env: {
+        SERVER_TARGET: 'beta',
+        TSTM_GENERATION_ENABLED: 'true',
+      },
+      exposureOverride: { beta: true },
+    });
+    assert.equal(status.available, true);
+    assert.equal(status.reason, CAPABILITY_REASON.AVAILABLE);
+  });
+
+  it('returns public status only for registry-exposed server-backed capabilities', () => {
+    const status = getPublicCapabilityStatus({
+      env: {
+        SERVER_TARGET: 'beta',
+        TSTM_GENERATION_ENABLED: 'true',
+        EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
+      },
+      exposureOverride: { beta: true },
+    });
+
+    assert.deepEqual(status, {
+      capabilities: {
+        TSTM_GENERATION_ENABLED: {
+          available: false,
+          reason: CAPABILITY_REASON.EMERGENCY_DISABLED,
+        },
+      },
+    });
+  });
+});

--- a/server/lib/emergencyCapabilityOverrides.js
+++ b/server/lib/emergencyCapabilityOverrides.js
@@ -6,6 +6,19 @@ const EMERGENCY_DISABLED_ENV_KEY = 'EMERGENCY_DISABLED_CAPABILITIES';
 const KNOWN_CAPABILITY_KEY_SET = new Set(KNOWN_SERVER_CAPABILITY_KEYS);
 const MALFORMED_SENTINEL_VALUES = new Set(['true', 'false']);
 
+/** Returns true when the value contains ASCII control characters. */
+const hasControlCharacters = (value) => {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/** Returns the default emergency override parse result. */
 const emptyParseResult = (malformed = false) => ({
   disabledKeys: new Set(),
   malformed,
@@ -27,7 +40,7 @@ const isValidEmergencyDisableValue = (value) => {
     return false;
   }
 
-  return !/[\x00-\x1F\x7F]/.test(trimmed);
+  return !hasControlCharacters(trimmed);
 };
 
 /** Collects validated disable keys from a comma-separated env value. */

--- a/server/lib/emergencyCapabilityOverrides.js
+++ b/server/lib/emergencyCapabilityOverrides.js
@@ -78,7 +78,7 @@ const logUnknownEmergencyDisableKeys = (ignoredUnknownKeys, log) => {
  * Parses EMERGENCY_DISABLED_CAPABILITIES into a validated disable set.
  * Malformed values fail closed by applying zero emergency disables.
  */
-const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => {
+const parseEmergencyDisabledCapabilities = (env = process.env) => {
   const rawValue = env[EMERGENCY_DISABLED_ENV_KEY];
 
   if (rawValue === undefined || rawValue === '') {
@@ -104,8 +104,8 @@ const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => 
 };
 
 /** Returns true when a capability key is emergency-disabled for this deployment. */
-const isEmergencyDisabledCapability = (capabilityKey, env = process.env, options = {}) => {
-  const { disabledKeys } = parseEmergencyDisabledCapabilities(env, options);
+const isEmergencyDisabledCapability = (capabilityKey, env = process.env) => {
+  const { disabledKeys } = parseEmergencyDisabledCapabilities(env);
   return disabledKeys.has(capabilityKey);
 };
 
@@ -113,7 +113,7 @@ const isEmergencyDisabledCapability = (capabilityKey, env = process.env, options
 const logEmergencyCapabilityOverrides = (env = process.env, options = {}) => {
   const log = options.log || console;
   const target = options.target || env.SERVER_TARGET || 'local';
-  const { disabledKeys, malformed, ignoredUnknownKeys } = parseEmergencyDisabledCapabilities(env, options);
+  const { disabledKeys, malformed, ignoredUnknownKeys } = parseEmergencyDisabledCapabilities(env);
 
   if (malformed) {
     log.error?.(

--- a/server/lib/emergencyCapabilityOverrides.js
+++ b/server/lib/emergencyCapabilityOverrides.js
@@ -6,6 +6,12 @@ const EMERGENCY_DISABLED_ENV_KEY = 'EMERGENCY_DISABLED_CAPABILITIES';
 const KNOWN_CAPABILITY_KEY_SET = new Set(KNOWN_SERVER_CAPABILITY_KEYS);
 const MALFORMED_SENTINEL_VALUES = new Set(['true', 'false']);
 
+const emptyParseResult = (malformed = false) => ({
+  disabledKeys: new Set(),
+  malformed,
+  ignoredUnknownKeys: [],
+});
+
 /** Returns true when the raw env value is safe to parse as a disable list. */
 const isValidEmergencyDisableValue = (value) => {
   if (typeof value !== 'string') {
@@ -21,53 +27,15 @@ const isValidEmergencyDisableValue = (value) => {
     return false;
   }
 
-  if (/[\x00-\x1F\x7F]/.test(trimmed)) {
-    return false;
-  }
-
-  return true;
+  return !/[\x00-\x1F\x7F]/.test(trimmed);
 };
 
-/**
- * Parses EMERGENCY_DISABLED_CAPABILITIES into a validated disable set.
- * Malformed values fail closed by applying zero emergency disables.
- */
-const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => {
-  const log = options.log || console;
-  const rawValue = env[EMERGENCY_DISABLED_ENV_KEY];
-
-  if (rawValue === undefined || rawValue === '') {
-    return {
-      disabledKeys: new Set(),
-      malformed: false,
-      ignoredUnknownKeys: [],
-    };
-  }
-
-  if (!isValidEmergencyDisableValue(rawValue)) {
-    log.error?.(
-      `[capabilities] malformed ${EMERGENCY_DISABLED_ENV_KEY}; applying zero emergency disables`
-    );
-    return {
-      disabledKeys: new Set(),
-      malformed: true,
-      ignoredUnknownKeys: [],
-    };
-  }
-
-  const trimmed = rawValue.trim();
-  if (!trimmed) {
-    return {
-      disabledKeys: new Set(),
-      malformed: false,
-      ignoredUnknownKeys: [],
-    };
-  }
-
+/** Collects validated disable keys from a comma-separated env value. */
+const collectEmergencyDisabledKeys = (rawValue) => {
   const disabledKeys = new Set();
   const ignoredUnknownKeys = [];
 
-  for (const entry of trimmed.split(',')) {
+  for (const entry of rawValue.split(',')) {
     const capabilityKey = entry.trim();
     if (!capabilityKey) {
       continue;
@@ -81,11 +49,44 @@ const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => 
     disabledKeys.add(capabilityKey);
   }
 
+  return { disabledKeys, ignoredUnknownKeys };
+};
+
+/** Logs ignored unknown keys from the emergency disable env var. */
+const logUnknownEmergencyDisableKeys = (ignoredUnknownKeys, log) => {
   for (const capabilityKey of ignoredUnknownKeys) {
     log.warn?.(
       `[capabilities] ignoring unknown emergency disable key ${JSON.stringify(capabilityKey)}`
     );
   }
+};
+
+/**
+ * Parses EMERGENCY_DISABLED_CAPABILITIES into a validated disable set.
+ * Malformed values fail closed by applying zero emergency disables.
+ */
+const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => {
+  const log = options.log || console;
+  const rawValue = env[EMERGENCY_DISABLED_ENV_KEY];
+
+  if (rawValue === undefined || rawValue === '') {
+    return emptyParseResult();
+  }
+
+  if (!isValidEmergencyDisableValue(rawValue)) {
+    log.error?.(
+      `[capabilities] malformed ${EMERGENCY_DISABLED_ENV_KEY}; applying zero emergency disables`
+    );
+    return emptyParseResult(true);
+  }
+
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return emptyParseResult();
+  }
+
+  const { disabledKeys, ignoredUnknownKeys } = collectEmergencyDisabledKeys(trimmed);
+  logUnknownEmergencyDisableKeys(ignoredUnknownKeys, log);
 
   return {
     disabledKeys,

--- a/server/lib/emergencyCapabilityOverrides.js
+++ b/server/lib/emergencyCapabilityOverrides.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { KNOWN_SERVER_CAPABILITY_KEYS } = require('./serverFeatureExposure');
+
+const EMERGENCY_DISABLED_ENV_KEY = 'EMERGENCY_DISABLED_CAPABILITIES';
+const KNOWN_CAPABILITY_KEY_SET = new Set(KNOWN_SERVER_CAPABILITY_KEYS);
+const MALFORMED_SENTINEL_VALUES = new Set(['true', 'false']);
+
+/** Returns true when the raw env value is safe to parse as a disable list. */
+const isValidEmergencyDisableValue = (value) => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return true;
+  }
+
+  if (MALFORMED_SENTINEL_VALUES.has(trimmed.toLowerCase())) {
+    return false;
+  }
+
+  if (/[\x00-\x1F\x7F]/.test(trimmed)) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Parses EMERGENCY_DISABLED_CAPABILITIES into a validated disable set.
+ * Malformed values fail closed by applying zero emergency disables.
+ */
+const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => {
+  const log = options.log || console;
+  const rawValue = env[EMERGENCY_DISABLED_ENV_KEY];
+
+  if (rawValue === undefined || rawValue === '') {
+    return {
+      disabledKeys: new Set(),
+      malformed: false,
+      ignoredUnknownKeys: [],
+    };
+  }
+
+  if (!isValidEmergencyDisableValue(rawValue)) {
+    log.error?.(
+      `[capabilities] malformed ${EMERGENCY_DISABLED_ENV_KEY}; applying zero emergency disables`
+    );
+    return {
+      disabledKeys: new Set(),
+      malformed: true,
+      ignoredUnknownKeys: [],
+    };
+  }
+
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return {
+      disabledKeys: new Set(),
+      malformed: false,
+      ignoredUnknownKeys: [],
+    };
+  }
+
+  const disabledKeys = new Set();
+  const ignoredUnknownKeys = [];
+
+  for (const entry of trimmed.split(',')) {
+    const capabilityKey = entry.trim();
+    if (!capabilityKey) {
+      continue;
+    }
+
+    if (!KNOWN_CAPABILITY_KEY_SET.has(capabilityKey)) {
+      ignoredUnknownKeys.push(capabilityKey);
+      continue;
+    }
+
+    disabledKeys.add(capabilityKey);
+  }
+
+  for (const capabilityKey of ignoredUnknownKeys) {
+    log.warn?.(
+      `[capabilities] ignoring unknown emergency disable key ${JSON.stringify(capabilityKey)}`
+    );
+  }
+
+  return {
+    disabledKeys,
+    malformed: false,
+    ignoredUnknownKeys,
+  };
+};
+
+/** Returns true when a capability key is emergency-disabled for this deployment. */
+const isEmergencyDisabledCapability = (capabilityKey, env = process.env, options = {}) => {
+  const { disabledKeys } = parseEmergencyDisabledCapabilities(env, options);
+  return disabledKeys.has(capabilityKey);
+};
+
+/** Logs the active emergency disable set once at startup. */
+const logEmergencyCapabilityOverrides = (env = process.env, options = {}) => {
+  const log = options.log || console;
+  const target = options.target || env.SERVER_TARGET || 'local';
+  const { disabledKeys, malformed } = parseEmergencyDisabledCapabilities(env, options);
+
+  if (malformed) {
+    return;
+  }
+
+  const disabledList = [...disabledKeys].sort();
+  if (disabledList.length === 0) {
+    return;
+  }
+
+  log.info?.(
+    `[capabilities] emergency_disabled=${JSON.stringify(disabledList)} target=${target}`
+  );
+};
+
+module.exports = {
+  EMERGENCY_DISABLED_ENV_KEY,
+  isEmergencyDisabledCapability,
+  isValidEmergencyDisableValue,
+  logEmergencyCapabilityOverrides,
+  parseEmergencyDisabledCapabilities,
+};

--- a/server/lib/emergencyCapabilityOverrides.js
+++ b/server/lib/emergencyCapabilityOverrides.js
@@ -79,7 +79,6 @@ const logUnknownEmergencyDisableKeys = (ignoredUnknownKeys, log) => {
  * Malformed values fail closed by applying zero emergency disables.
  */
 const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => {
-  const log = options.log || console;
   const rawValue = env[EMERGENCY_DISABLED_ENV_KEY];
 
   if (rawValue === undefined || rawValue === '') {
@@ -87,9 +86,6 @@ const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => 
   }
 
   if (!isValidEmergencyDisableValue(rawValue)) {
-    log.error?.(
-      `[capabilities] malformed ${EMERGENCY_DISABLED_ENV_KEY}; applying zero emergency disables`
-    );
     return emptyParseResult(true);
   }
 
@@ -99,7 +95,6 @@ const parseEmergencyDisabledCapabilities = (env = process.env, options = {}) => 
   }
 
   const { disabledKeys, ignoredUnknownKeys } = collectEmergencyDisabledKeys(trimmed);
-  logUnknownEmergencyDisableKeys(ignoredUnknownKeys, log);
 
   return {
     disabledKeys,
@@ -114,15 +109,20 @@ const isEmergencyDisabledCapability = (capabilityKey, env = process.env, options
   return disabledKeys.has(capabilityKey);
 };
 
-/** Logs the active emergency disable set once at startup. */
+/** Logs active emergency disable overrides once at startup. */
 const logEmergencyCapabilityOverrides = (env = process.env, options = {}) => {
   const log = options.log || console;
   const target = options.target || env.SERVER_TARGET || 'local';
-  const { disabledKeys, malformed } = parseEmergencyDisabledCapabilities(env, options);
+  const { disabledKeys, malformed, ignoredUnknownKeys } = parseEmergencyDisabledCapabilities(env, options);
 
   if (malformed) {
+    log.error?.(
+      `[capabilities] malformed ${EMERGENCY_DISABLED_ENV_KEY}; applying zero emergency disables`
+    );
     return;
   }
+
+  logUnknownEmergencyDisableKeys(ignoredUnknownKeys, log);
 
   const disabledList = [...disabledKeys].sort();
   if (disabledList.length === 0) {

--- a/server/lib/emergencyCapabilityOverrides.test.js
+++ b/server/lib/emergencyCapabilityOverrides.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  isEmergencyDisabledCapability,
+  isValidEmergencyDisableValue,
+  parseEmergencyDisabledCapabilities,
+} = require('./emergencyCapabilityOverrides');
+
+const createLogSpy = () => {
+  const entries = [];
+  return {
+    entries,
+    log: {
+      error(message) {
+        entries.push({ level: 'error', message });
+      },
+      warn(message) {
+        entries.push({ level: 'warn', message });
+      },
+      info(message) {
+        entries.push({ level: 'info', message });
+      },
+    },
+  };
+};
+
+describe('emergency capability overrides', () => {
+  it('returns an empty disable set when the env var is unset', () => {
+    const result = parseEmergencyDisabledCapabilities({});
+    assert.deepEqual([...result.disabledKeys], []);
+    assert.equal(result.malformed, false);
+  });
+
+  it('parses comma-separated known capability keys', () => {
+    const result = parseEmergencyDisabledCapabilities({
+      EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
+    });
+    assert.deepEqual([...result.disabledKeys], ['TSTM_GENERATION_ENABLED']);
+  });
+
+  it('ignores unknown keys and logs a warning', () => {
+    const { log, entries } = createLogSpy();
+    const result = parseEmergencyDisabledCapabilities(
+      { EMERGENCY_DISABLED_CAPABILITIES: 'UNKNOWN,TSTM_GENERATION_ENABLED' },
+      { log }
+    );
+
+    assert.deepEqual([...result.disabledKeys], ['TSTM_GENERATION_ENABLED']);
+    assert.deepEqual(result.ignoredUnknownKeys, ['UNKNOWN']);
+    assert.match(entries[0].message, /UNKNOWN/);
+  });
+
+  it('treats malformed sentinel values as zero emergency disables', () => {
+    const { log, entries } = createLogSpy();
+    const result = parseEmergencyDisabledCapabilities(
+      { EMERGENCY_DISABLED_CAPABILITIES: 'true' },
+      { log }
+    );
+
+    assert.deepEqual([...result.disabledKeys], []);
+    assert.equal(result.malformed, true);
+    assert.equal(entries[0].level, 'error');
+  });
+
+  it('treats control characters as malformed', () => {
+    assert.equal(isValidEmergencyDisableValue('TSTM\nGENERATION_ENABLED'), false);
+  });
+
+  it('reports emergency disable membership for known keys only', () => {
+    assert.equal(
+      isEmergencyDisabledCapability('TSTM_GENERATION_ENABLED', {
+        EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
+      }),
+      true
+    );
+    assert.equal(
+      isEmergencyDisabledCapability('TSTM_GENERATION_ENABLED', {}),
+      false
+    );
+  });
+});

--- a/server/lib/emergencyCapabilityOverrides.test.js
+++ b/server/lib/emergencyCapabilityOverrides.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const {
   isEmergencyDisabledCapability,
   isValidEmergencyDisableValue,
+  logEmergencyCapabilityOverrides,
   parseEmergencyDisabledCapabilities,
 } = require('./emergencyCapabilityOverrides');
 
@@ -40,7 +41,7 @@ describe('emergency capability overrides', () => {
     assert.deepEqual([...result.disabledKeys], ['TSTM_GENERATION_ENABLED']);
   });
 
-  it('ignores unknown keys and logs a warning', () => {
+  it('ignores unknown keys without logging during per-request parsing', () => {
     const { log, entries } = createLogSpy();
     const result = parseEmergencyDisabledCapabilities(
       { EMERGENCY_DISABLED_CAPABILITIES: 'UNKNOWN,TSTM_GENERATION_ENABLED' },
@@ -49,7 +50,19 @@ describe('emergency capability overrides', () => {
 
     assert.deepEqual([...result.disabledKeys], ['TSTM_GENERATION_ENABLED']);
     assert.deepEqual(result.ignoredUnknownKeys, ['UNKNOWN']);
+    assert.equal(entries.length, 0);
+  });
+
+  it('logs unknown keys only during startup logging', () => {
+    const { log, entries } = createLogSpy();
+    logEmergencyCapabilityOverrides(
+      { EMERGENCY_DISABLED_CAPABILITIES: 'UNKNOWN,TSTM_GENERATION_ENABLED', SERVER_TARGET: 'beta' },
+      { log }
+    );
+
     assert.match(entries[0].message, /UNKNOWN/);
+    assert.equal(entries[0].level, 'warn');
+    assert.match(entries[1].message, /emergency_disabled=\["TSTM_GENERATION_ENABLED"\]/);
   });
 
   it('treats malformed sentinel values as zero emergency disables', () => {
@@ -61,7 +74,19 @@ describe('emergency capability overrides', () => {
 
     assert.deepEqual([...result.disabledKeys], []);
     assert.equal(result.malformed, true);
+    assert.equal(entries.length, 0);
+  });
+
+  it('logs malformed override values only during startup logging', () => {
+    const { log, entries } = createLogSpy();
+    logEmergencyCapabilityOverrides(
+      { EMERGENCY_DISABLED_CAPABILITIES: 'true', SERVER_TARGET: 'beta' },
+      { log }
+    );
+
+    assert.equal(entries.length, 1);
     assert.equal(entries[0].level, 'error');
+    assert.match(entries[0].message, /malformed EMERGENCY_DISABLED_CAPABILITIES/);
   });
 
   it('treats control characters as malformed', () => {

--- a/server/lib/emergencyCapabilityOverrides.test.js
+++ b/server/lib/emergencyCapabilityOverrides.test.js
@@ -42,15 +42,12 @@ describe('emergency capability overrides', () => {
   });
 
   it('ignores unknown keys without logging during per-request parsing', () => {
-    const { log, entries } = createLogSpy();
-    const result = parseEmergencyDisabledCapabilities(
-      { EMERGENCY_DISABLED_CAPABILITIES: 'UNKNOWN,TSTM_GENERATION_ENABLED' },
-      { log }
-    );
+    const result = parseEmergencyDisabledCapabilities({
+      EMERGENCY_DISABLED_CAPABILITIES: 'UNKNOWN,TSTM_GENERATION_ENABLED',
+    });
 
     assert.deepEqual([...result.disabledKeys], ['TSTM_GENERATION_ENABLED']);
     assert.deepEqual(result.ignoredUnknownKeys, ['UNKNOWN']);
-    assert.equal(entries.length, 0);
   });
 
   it('logs unknown keys only during startup logging', () => {
@@ -66,15 +63,12 @@ describe('emergency capability overrides', () => {
   });
 
   it('treats malformed sentinel values as zero emergency disables', () => {
-    const { log, entries } = createLogSpy();
     const result = parseEmergencyDisabledCapabilities(
-      { EMERGENCY_DISABLED_CAPABILITIES: 'true' },
-      { log }
+      { EMERGENCY_DISABLED_CAPABILITIES: 'true' }
     );
 
     assert.deepEqual([...result.disabledKeys], []);
     assert.equal(result.malformed, true);
-    assert.equal(entries.length, 0);
   });
 
   it('logs malformed override values only during startup logging', () => {

--- a/server/lib/featureCapabilities.js
+++ b/server/lib/featureCapabilities.js
@@ -31,6 +31,17 @@ const sendDisabledCapabilityResponse = (res, { label }) => {
   });
 };
 
+/** Logs emergency rejections for audit without exposing secrets. */
+const logEmergencyGateRejection = (capabilityKey, reason, log) => {
+  if (reason !== CAPABILITY_REASON.EMERGENCY_DISABLED) {
+    return;
+  }
+
+  log.info?.(
+    `[capabilities] rejected capability=${capabilityKey} reason=${reason}`
+  );
+};
+
 /** Rejects disabled capabilities before route handlers, auth, or expensive work run. */
 const createServerCapabilityGate = (capabilityKey, options = {}) => {
   const env = options.env || process.env;
@@ -53,12 +64,7 @@ const createServerCapabilityGate = (capabilityKey, options = {}) => {
     }
 
     const reason = getServerCapabilityDisableReason(capabilityKey, gateOptions);
-    if (reason === CAPABILITY_REASON.EMERGENCY_DISABLED) {
-      log.info?.(
-        `[capabilities] rejected capability=${capabilityKey} reason=${reason}`
-      );
-    }
-
+    logEmergencyGateRejection(capabilityKey, reason, log);
     sendDisabledCapabilityResponse(res, { label });
   };
 };

--- a/server/lib/featureCapabilities.js
+++ b/server/lib/featureCapabilities.js
@@ -1,50 +1,28 @@
 'use strict';
 
 const { getServerTarget } = require('./serverTarget');
-const { SERVER_FEATURE_EXPOSURE_REGISTRY } = require('./serverFeatureExposure');
+const {
+  CAPABILITY_REASON,
+  findFeatureByCapabilityKey,
+  isDeploymentCapabilityEnabled,
+  resolveCapabilityAvailability,
+} = require('./capabilityStatus');
+const { isEmergencyDisabledCapability } = require('./emergencyCapabilityOverrides');
 
 const DISABLED_CAPABILITY_STATUS = 404;
 
-/** Returns the server-backed feature entry for a capability key, if declared. */
-const findFeatureByCapabilityKey = (capabilityKey) => {
-  for (const [featureKey, definition] of Object.entries(SERVER_FEATURE_EXPOSURE_REGISTRY)) {
-    if (definition.serverCapabilityKey === capabilityKey) {
-      return { featureKey, definition };
-    }
-  }
-
-  return null;
-};
-
-/** Returns true when ops explicitly enabled the deployment capability env switch. */
-const isDeploymentCapabilityEnabled = (capabilityKey, env = process.env) =>
-  env[capabilityKey] === 'true';
-
 /**
- * Returns true when registry exposure and the deployment capability env are both enabled.
+ * Returns true when registry exposure, deployment env, and emergency overrides all allow use.
  * Authorization is intentionally separate and must run after this gate.
  */
 const isServerCapabilityEnabled = (capabilityKey, options = {}) => {
-  const env = options.env || process.env;
-  const feature = findFeatureByCapabilityKey(capabilityKey);
-
-  if (!feature) {
-    return false;
-  }
-
-  const target = options.target ?? getServerTarget(env);
-  const exposureOverride = options.exposureOverride?.[target];
-  const exposedOnTarget =
-    typeof exposureOverride === 'boolean'
-      ? exposureOverride
-      : feature.definition.exposure[target] === true;
-
-  if (!exposedOnTarget) {
-    return false;
-  }
-
-  return isDeploymentCapabilityEnabled(capabilityKey, env);
+  const status = resolveCapabilityAvailability(capabilityKey, options);
+  return status.available;
 };
+
+/** Returns the disable reason for a capability on the current deployment target. */
+const getServerCapabilityDisableReason = (capabilityKey, options = {}) =>
+  resolveCapabilityAvailability(capabilityKey, options).reason;
 
 /** Sends the standard fail-closed response for disabled experimental APIs. */
 const sendDisabledCapabilityResponse = (res, { label }) => {
@@ -59,26 +37,40 @@ const createServerCapabilityGate = (capabilityKey, options = {}) => {
   const feature = findFeatureByCapabilityKey(capabilityKey);
   const label = options.label || feature?.definition?.label || 'This capability';
   const target = options.target ?? getServerTarget(env);
+  const log = options.log || console;
 
   return (_req, res, next) => {
-    if (!isServerCapabilityEnabled(capabilityKey, {
+    const gateOptions = {
       env,
       target,
       exposureOverride: options.exposureOverride,
-    })) {
-      sendDisabledCapabilityResponse(res, { label });
+      log,
+    };
+
+    if (isServerCapabilityEnabled(capabilityKey, gateOptions)) {
+      next();
       return;
     }
 
-    next();
+    const reason = getServerCapabilityDisableReason(capabilityKey, gateOptions);
+    if (reason === CAPABILITY_REASON.EMERGENCY_DISABLED) {
+      log.info?.(
+        `[capabilities] rejected capability=${capabilityKey} reason=${reason}`
+      );
+    }
+
+    sendDisabledCapabilityResponse(res, { label });
   };
 };
 
 module.exports = {
+  CAPABILITY_REASON,
   DISABLED_CAPABILITY_STATUS,
   createServerCapabilityGate,
   findFeatureByCapabilityKey,
+  getServerCapabilityDisableReason,
   isDeploymentCapabilityEnabled,
+  isEmergencyDisabledCapability,
   isServerCapabilityEnabled,
   sendDisabledCapabilityResponse,
 };

--- a/server/lib/featureCapabilities.test.js
+++ b/server/lib/featureCapabilities.test.js
@@ -4,8 +4,10 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const express = require('express');
 const {
+  CAPABILITY_REASON,
   DISABLED_CAPABILITY_STATUS,
   createServerCapabilityGate,
+  getServerCapabilityDisableReason,
   isServerCapabilityEnabled,
   sendDisabledCapabilityResponse,
 } = require('./featureCapabilities');
@@ -34,6 +36,65 @@ describe('server capability gates', () => {
       }),
       true
     );
+  });
+
+  it('emergency disable overrides registry exposure and deployment env', () => {
+    const env = {
+      TSTM_GENERATION_ENABLED: 'true',
+      SERVER_TARGET: 'beta',
+      EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
+    };
+
+    assert.equal(
+      isServerCapabilityEnabled('TSTM_GENERATION_ENABLED', {
+        env,
+        exposureOverride: { beta: true },
+      }),
+      false
+    );
+    assert.equal(
+      getServerCapabilityDisableReason('TSTM_GENERATION_ENABLED', {
+        env,
+        exposureOverride: { beta: true },
+      }),
+      CAPABILITY_REASON.EMERGENCY_DISABLED
+    );
+  });
+
+  it('logs emergency rejections without invoking handlers', async () => {
+    let calls = 0;
+    const logEntries = [];
+    const gate = createServerCapabilityGate('TSTM_GENERATION_ENABLED', {
+      env: {
+        TSTM_GENERATION_ENABLED: 'true',
+        SERVER_TARGET: 'beta',
+        EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
+      },
+      exposureOverride: { beta: true },
+      log: {
+        info(message) {
+          logEntries.push(message);
+        },
+      },
+    });
+    const app = express();
+    app.post('/api/test', gate, (_req, res) => {
+      calls += 1;
+      res.status(200).json({ ok: true });
+    });
+    const server = await new Promise((resolve, reject) => {
+      const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+      instance.on('error', reject);
+    });
+
+    try {
+      const response = await fetch(getUrl(server), { method: 'POST' });
+      assert.equal(response.status, DISABLED_CAPABILITY_STATUS);
+      assert.equal(calls, 0);
+      assert.match(logEntries[0], /reason=emergency_disabled/);
+    } finally {
+      server.close();
+    }
   });
 
   it('rejects disabled capabilities before handlers run', async () => {

--- a/server/server-stack.test.js
+++ b/server/server-stack.test.js
@@ -48,6 +48,15 @@ describe('analytics server stack (express 5)', () => {
     assert.equal(typeof body.billingEnabled, 'boolean');
   });
 
+  it('serves capability status on GET /api/capabilities/status', async () => {
+    const server = await serverReady;
+    const port = getServerPort(server);
+    const response = await fetch(`http://127.0.0.1:${port}/api/capabilities/status`);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(typeof body.capabilities, 'object');
+  });
+
   it('accepts POST /collect with express.json middleware', async () => {
     const server = await serverReady;
     const port = getServerPort(server);

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -106,6 +106,35 @@ describe('Auto-TSTM server foundation', () => {
     }
   });
 
+  it('does not invoke the generator when emergency disable is active', async () => {
+    let calls = 0;
+    const server = await startServer(
+      {
+        TSTM_GENERATION_ENABLED: 'true',
+        EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
+      },
+      async () => {
+        calls += 1;
+        return {};
+      },
+      ENABLED_CAPABILITY_OPTIONS,
+    );
+    try {
+      const response = await fetch(getUrl(server), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
+      });
+      assert.equal(response.status, 404);
+      assert.deepEqual(await response.json(), {
+        error: 'Auto-TSTM is not enabled on this deployment.',
+      });
+      assert.equal(calls, 0);
+    } finally {
+      server.close();
+    }
+  });
+
   it('returns sanitized errors when enabled work fails', async () => {
     const server = await startServer(
       { TSTM_GENERATION_ENABLED: 'true' },

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -40,6 +40,36 @@ const createFakeChild = () => {
   return child;
 };
 
+const postGenerateRequest = (server) => fetch(getUrl(server), {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
+});
+
+/** Asserts a disabled generate route returns 404 without invoking the generator. */
+const assertGenerateRouteRejectsWithoutWork = async ({
+  env,
+  routeOptions = {},
+  expectedBody,
+}) => {
+  let calls = 0;
+  const server = await startServer(env, async () => {
+    calls += 1;
+    return {};
+  }, routeOptions);
+
+  try {
+    const response = await postGenerateRequest(server);
+    assert.equal(response.status, 404);
+    if (expectedBody) {
+      assert.deepEqual(await response.json(), expectedBody);
+    }
+    assert.equal(calls, 0);
+  } finally {
+    server.close();
+  }
+};
+
 describe('Auto-TSTM server foundation', () => {
   it('stays disabled unless registry exposure and deployment env are both enabled', () => {
     assert.equal(isTstmGenerationEnabled({}), false);
@@ -66,73 +96,31 @@ describe('Auto-TSTM server foundation', () => {
   });
 
   it('does not invoke the generator while disabled', async () => {
-    let calls = 0;
-    const server = await startServer({}, async () => {
-      calls += 1;
-      return {};
-    });
-    try {
-      const response = await fetch(getUrl(server), {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
-      });
-      assert.equal(response.status, 404);
-      assert.deepEqual(await response.json(), {
+    await assertGenerateRouteRejectsWithoutWork({
+      env: {},
+      expectedBody: {
         error: 'Auto-TSTM is not enabled on this deployment.',
-      });
-      assert.equal(calls, 0);
-    } finally {
-      server.close();
-    }
+      },
+    });
   });
 
   it('does not invoke the generator when only the deployment env is enabled', async () => {
-    let calls = 0;
-    const server = await startServer({ TSTM_GENERATION_ENABLED: 'true' }, async () => {
-      calls += 1;
-      return {};
+    await assertGenerateRouteRejectsWithoutWork({
+      env: { TSTM_GENERATION_ENABLED: 'true' },
     });
-    try {
-      const response = await fetch(getUrl(server), {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
-      });
-      assert.equal(response.status, 404);
-      assert.equal(calls, 0);
-    } finally {
-      server.close();
-    }
   });
 
   it('does not invoke the generator when emergency disable is active', async () => {
-    let calls = 0;
-    const server = await startServer(
-      {
+    await assertGenerateRouteRejectsWithoutWork({
+      env: {
         TSTM_GENERATION_ENABLED: 'true',
         EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
       },
-      async () => {
-        calls += 1;
-        return {};
-      },
-      ENABLED_CAPABILITY_OPTIONS,
-    );
-    try {
-      const response = await fetch(getUrl(server), {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
-      });
-      assert.equal(response.status, 404);
-      assert.deepEqual(await response.json(), {
+      routeOptions: ENABLED_CAPABILITY_OPTIONS,
+      expectedBody: {
         error: 'Auto-TSTM is not enabled on this deployment.',
-      });
-      assert.equal(calls, 0);
-    } finally {
-      server.close();
-    }
+      },
+    });
   });
 
   it('returns sanitized errors when enabled work fails', async () => {

--- a/src/config/serverCapabilityStatus.test.tsx
+++ b/src/config/serverCapabilityStatus.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  fetchServerCapabilityStatus,
+  isServerCapabilityAvailable,
+  markServerCapabilityUnavailable,
+  resetServerCapabilityStatusState,
+  useServerCapabilityAvailable,
+} from './serverCapabilityStatus';
+
+const CapabilityProbe = () => {
+  const available = useServerCapabilityAvailable('autoTstm');
+  return <div>{available ? 'available' : 'unavailable'}</div>;
+};
+
+describe('serverCapabilityStatus', () => {
+  afterEach(() => {
+    resetServerCapabilityStatusState();
+    jest.restoreAllMocks();
+  });
+
+  test('fails closed before status is loaded', () => {
+    expect(isServerCapabilityAvailable('TSTM_GENERATION_ENABLED')).toBe(false);
+  });
+
+  test('treats unavailable server status as disabled', () => {
+    expect(
+      isServerCapabilityAvailable('TSTM_GENERATION_ENABLED', {
+        loaded: true,
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: false,
+            reason: 'emergency_disabled',
+          },
+        },
+      })
+    ).toBe(false);
+  });
+
+  test('marks a capability unavailable after a disabled API response', () => {
+    markServerCapabilityUnavailable('TSTM_GENERATION_ENABLED');
+    expect(
+      isServerCapabilityAvailable('TSTM_GENERATION_ENABLED', {
+        loaded: true,
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: true,
+            reason: 'available',
+          },
+        },
+      })
+    ).toBe(false);
+  });
+
+  test('fetchServerCapabilityStatus validates the response shape', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: false,
+            reason: 'emergency_disabled',
+          },
+        },
+      }),
+    }) as jest.Mock;
+
+    try {
+      await expect(fetchServerCapabilityStatus()).resolves.toMatchObject({
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: false,
+            reason: 'emergency_disabled',
+          },
+        },
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('useServerCapabilityAvailable fails closed when status fetch fails', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockRejectedValue(new Error('network')) as jest.Mock;
+
+    try {
+      render(<CapabilityProbe />);
+      await waitFor(() => {
+        expect(screen.getByText('unavailable')).toBeInTheDocument();
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('useServerCapabilityAvailable reflects emergency-disabled server status', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: false,
+            reason: 'emergency_disabled',
+          },
+        },
+      }),
+    }) as jest.Mock;
+
+    try {
+      render(<CapabilityProbe />);
+      await waitFor(() => {
+        expect(screen.getByText('unavailable')).toBeInTheDocument();
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});

--- a/src/config/serverCapabilityStatus.test.tsx
+++ b/src/config/serverCapabilityStatus.test.tsx
@@ -5,6 +5,7 @@ import {
   loadSharedServerCapabilityStatus,
   markServerCapabilityUnavailable,
   resetServerCapabilityStatusState,
+  resolveServerBackedFeatureRuntimeState,
   useServerCapabilityAvailable,
 } from './serverCapabilityStatus';
 import { ServerBackedFeatureBoundary } from '../features/ServerBackedFeatureBoundary';
@@ -22,6 +23,7 @@ describe('serverCapabilityStatus', () => {
 
   test('fails closed before status is loaded', () => {
     expect(isServerCapabilityAvailable('TSTM_GENERATION_ENABLED')).toBe(false);
+    expect(resolveServerBackedFeatureRuntimeState('autoTstm')).toBe('loading');
   });
 
   test('treats unavailable server status as disabled', () => {

--- a/src/config/serverCapabilityStatus.test.tsx
+++ b/src/config/serverCapabilityStatus.test.tsx
@@ -2,10 +2,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 import {
   fetchServerCapabilityStatus,
   isServerCapabilityAvailable,
+  loadSharedServerCapabilityStatus,
   markServerCapabilityUnavailable,
   resetServerCapabilityStatusState,
   useServerCapabilityAvailable,
 } from './serverCapabilityStatus';
+import { ServerBackedFeatureBoundary } from '../features/ServerBackedFeatureBoundary';
 
 const CapabilityProbe = () => {
   const available = useServerCapabilityAvailable('autoTstm');
@@ -112,6 +114,69 @@ describe('serverCapabilityStatus', () => {
       await waitFor(() => {
         expect(screen.getByText('unavailable')).toBeInTheDocument();
       });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('loadSharedServerCapabilityStatus fetches once for concurrent consumers', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: true,
+            reason: 'available',
+          },
+        },
+      }),
+    }) as jest.Mock;
+
+    try {
+      await Promise.all([
+        loadSharedServerCapabilityStatus(),
+        loadSharedServerCapabilityStatus(),
+      ]);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('multiple mounted server-backed boundaries share one status fetch', async () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: true,
+            reason: 'available',
+          },
+        },
+      }),
+    }) as jest.Mock;
+
+    try {
+      render(
+        <>
+          <ServerBackedFeatureBoundary feature="autoTstm">
+            <div>First boundary</div>
+          </ServerBackedFeatureBoundary>
+          <ServerBackedFeatureBoundary feature="autoTstm">
+            <div>Second boundary</div>
+          </ServerBackedFeatureBoundary>
+        </>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('First boundary')).toBeInTheDocument();
+        expect(screen.getByText('Second boundary')).toBeInTheDocument();
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     } finally {
       global.fetch = originalFetch;
     }

--- a/src/config/serverCapabilityStatus.ts
+++ b/src/config/serverCapabilityStatus.ts
@@ -149,9 +149,16 @@ export const useServerCapabilityStatus = (): CapabilityStatusSnapshot => {
 
   useEffect(() => {
     statusListeners.add(reload);
-    void loadSharedServerCapabilityStatus().then(reload);
+    let active = true;
+
+    loadSharedServerCapabilityStatus().then(() => {
+      if (active) {
+        reload();
+      }
+    });
 
     return () => {
+      active = false;
       statusListeners.delete(reload);
     };
   }, [reload]);

--- a/src/config/serverCapabilityStatus.ts
+++ b/src/config/serverCapabilityStatus.ts
@@ -24,6 +24,8 @@ type CapabilityStatusSnapshot = {
   capabilities: Record<string, CapabilityStatusEntry>;
 };
 
+export type ServerBackedFeatureRuntimeState = 'loading' | 'available' | 'unavailable';
+
 const EMPTY_STATUS: CapabilityStatusSnapshot = {
   loaded: false,
   capabilities: {},
@@ -139,6 +141,28 @@ export const isServerCapabilityAvailable = (
   return entry?.available === true;
 };
 
+/** Resolves runtime UI state for a server-backed registry feature. */
+export const resolveServerBackedFeatureRuntimeState = (
+  feature: FeatureKey,
+  status: CapabilityStatusSnapshot = EMPTY_STATUS
+): ServerBackedFeatureRuntimeState => {
+  const definition = getFeatureExposure(feature);
+  if (!definition.serverBacked) {
+    return 'available';
+  }
+
+  const capabilityKey = definition.serverCapabilityKey;
+  if (unavailableCapabilityKeys.has(capabilityKey)) {
+    return 'unavailable';
+  }
+
+  if (!status.loaded) {
+    return 'loading';
+  }
+
+  return isServerCapabilityAvailable(capabilityKey, status) ? 'available' : 'unavailable';
+};
+
 /** Loads server capability status once and keeps local unavailable markers in sync. */
 export const useServerCapabilityStatus = (): CapabilityStatusSnapshot => {
   const [status, setStatus] = useState<CapabilityStatusSnapshot>(cachedStatusSnapshot);
@@ -181,3 +205,11 @@ export const useServerCapabilityAvailable = (feature: FeatureKey): boolean => {
 /** Returns whether a server-backed feature should allow server API calls. */
 export const useServerCapabilityApiEnabled = (feature: FeatureKey): boolean =>
   useServerCapabilityAvailable(feature);
+
+/** Returns runtime UI state for a server-backed registry feature. */
+export const useServerBackedFeatureRuntimeState = (
+  feature: FeatureKey
+): ServerBackedFeatureRuntimeState => {
+  const status = useServerCapabilityStatus();
+  return resolveServerBackedFeatureRuntimeState(feature, status);
+};

--- a/src/config/serverCapabilityStatus.ts
+++ b/src/config/serverCapabilityStatus.ts
@@ -63,6 +63,17 @@ export const getServerCapabilityKeyForFeature = (feature: FeatureKey): string | 
   return definition.serverCapabilityKey;
 };
 
+/** Returns true when the payload matches the public capability status shape. */
+export const isServerCapabilityStatusResponse = (
+  payload: unknown
+): payload is ServerCapabilityStatusResponse => {
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+
+  return typeof (payload as ServerCapabilityStatusResponse).capabilities === 'object';
+};
+
 /** Reads the public server capability status document. */
 export const fetchServerCapabilityStatus = async (): Promise<ServerCapabilityStatusResponse> => {
   const response = await fetch(CAPABILITY_STATUS_ENDPOINT);
@@ -71,11 +82,11 @@ export const fetchServerCapabilityStatus = async (): Promise<ServerCapabilitySta
   }
 
   const payload = await response.json();
-  if (!payload || typeof payload !== 'object' || typeof payload.capabilities !== 'object') {
+  if (!isServerCapabilityStatusResponse(payload)) {
     throw new Error('Server capability status response was malformed.');
   }
 
-  return payload as ServerCapabilityStatusResponse;
+  return payload;
 };
 
 /** Returns whether a capability is currently treated as unavailable on the client. */

--- a/src/config/serverCapabilityStatus.ts
+++ b/src/config/serverCapabilityStatus.ts
@@ -31,6 +31,8 @@ const EMPTY_STATUS: CapabilityStatusSnapshot = {
 
 const unavailableCapabilityKeys = new Set<string>();
 const statusListeners = new Set<() => void>();
+let cachedStatusSnapshot: CapabilityStatusSnapshot = EMPTY_STATUS;
+let cachedStatusRequest: Promise<CapabilityStatusSnapshot> | null = null;
 
 /** Notifies runtime hooks when a capability becomes unavailable after page load. */
 const notifyCapabilityStatusListeners = (): void => {
@@ -47,9 +49,11 @@ export const markServerCapabilityUnavailable = (capabilityKey: string): void => 
   notifyCapabilityStatusListeners();
 };
 
-/** Resets local unavailable markers. Intended for tests. */
+/** Resets local unavailable markers and the shared status cache. Intended for tests. */
 export const resetServerCapabilityStatusState = (): void => {
   unavailableCapabilityKeys.clear();
+  cachedStatusSnapshot = EMPTY_STATUS;
+  cachedStatusRequest = null;
   notifyCapabilityStatusListeners();
 };
 
@@ -89,6 +93,35 @@ export const fetchServerCapabilityStatus = async (): Promise<ServerCapabilitySta
   return payload;
 };
 
+/** Loads capability status once per page and reuses the settled result. */
+export const loadSharedServerCapabilityStatus = (): Promise<CapabilityStatusSnapshot> => {
+  if (cachedStatusSnapshot.loaded) {
+    return Promise.resolve(cachedStatusSnapshot);
+  }
+
+  if (!cachedStatusRequest) {
+    cachedStatusRequest = fetchServerCapabilityStatus()
+      .then((response) => {
+        cachedStatusSnapshot = {
+          loaded: true,
+          capabilities: response.capabilities,
+        };
+        notifyCapabilityStatusListeners();
+        return cachedStatusSnapshot;
+      })
+      .catch(() => {
+        cachedStatusSnapshot = {
+          loaded: true,
+          capabilities: {},
+        };
+        notifyCapabilityStatusListeners();
+        return cachedStatusSnapshot;
+      });
+  }
+
+  return cachedStatusRequest;
+};
+
 /** Returns whether a capability is currently treated as unavailable on the client. */
 export const isServerCapabilityAvailable = (
   capabilityKey: string,
@@ -108,48 +141,20 @@ export const isServerCapabilityAvailable = (
 
 /** Loads server capability status once and keeps local unavailable markers in sync. */
 export const useServerCapabilityStatus = (): CapabilityStatusSnapshot => {
-  const [status, setStatus] = useState<CapabilityStatusSnapshot>(EMPTY_STATUS);
+  const [status, setStatus] = useState<CapabilityStatusSnapshot>(cachedStatusSnapshot);
 
   const reload = useCallback(() => {
-    setStatus((current) => ({ ...current }));
+    setStatus({ ...cachedStatusSnapshot });
   }, []);
 
   useEffect(() => {
     statusListeners.add(reload);
+    void loadSharedServerCapabilityStatus().then(reload);
+
     return () => {
       statusListeners.delete(reload);
     };
   }, [reload]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    fetchServerCapabilityStatus()
-      .then((response) => {
-        if (cancelled) {
-          return;
-        }
-
-        setStatus({
-          loaded: true,
-          capabilities: response.capabilities,
-        });
-      })
-      .catch(() => {
-        if (cancelled) {
-          return;
-        }
-
-        setStatus({
-          loaded: true,
-          capabilities: {},
-        });
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   return status;
 };

--- a/src/config/serverCapabilityStatus.ts
+++ b/src/config/serverCapabilityStatus.ts
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getFeatureExposure, type FeatureKey } from './featureExposure';
+
+export const CAPABILITY_STATUS_ENDPOINT = '/api/capabilities/status';
+
+export type CapabilityAvailabilityReason =
+  | 'available'
+  | 'registry_disabled'
+  | 'deployment_disabled'
+  | 'emergency_disabled'
+  | 'unknown';
+
+export type CapabilityStatusEntry = {
+  available: boolean;
+  reason: CapabilityAvailabilityReason;
+};
+
+export type ServerCapabilityStatusResponse = {
+  capabilities: Record<string, CapabilityStatusEntry>;
+};
+
+type CapabilityStatusSnapshot = {
+  loaded: boolean;
+  capabilities: Record<string, CapabilityStatusEntry>;
+};
+
+const EMPTY_STATUS: CapabilityStatusSnapshot = {
+  loaded: false,
+  capabilities: {},
+};
+
+const unavailableCapabilityKeys = new Set<string>();
+const statusListeners = new Set<() => void>();
+
+/** Notifies runtime hooks when a capability becomes unavailable after page load. */
+const notifyCapabilityStatusListeners = (): void => {
+  statusListeners.forEach((listener) => listener());
+};
+
+/** Marks a server capability unavailable after a disabled API response. */
+export const markServerCapabilityUnavailable = (capabilityKey: string): void => {
+  if (unavailableCapabilityKeys.has(capabilityKey)) {
+    return;
+  }
+
+  unavailableCapabilityKeys.add(capabilityKey);
+  notifyCapabilityStatusListeners();
+};
+
+/** Resets local unavailable markers. Intended for tests. */
+export const resetServerCapabilityStatusState = (): void => {
+  unavailableCapabilityKeys.clear();
+  notifyCapabilityStatusListeners();
+};
+
+/** Returns the server capability key for a registry feature when server-backed. */
+export const getServerCapabilityKeyForFeature = (feature: FeatureKey): string | null => {
+  const definition = getFeatureExposure(feature);
+  if (!definition.serverBacked) {
+    return null;
+  }
+
+  return definition.serverCapabilityKey;
+};
+
+/** Reads the public server capability status document. */
+export const fetchServerCapabilityStatus = async (): Promise<ServerCapabilityStatusResponse> => {
+  const response = await fetch(CAPABILITY_STATUS_ENDPOINT);
+  if (!response.ok) {
+    throw new Error('Unable to fetch server capability status.');
+  }
+
+  const payload = await response.json();
+  if (!payload || typeof payload !== 'object' || typeof payload.capabilities !== 'object') {
+    throw new Error('Server capability status response was malformed.');
+  }
+
+  return payload as ServerCapabilityStatusResponse;
+};
+
+/** Returns whether a capability is currently treated as unavailable on the client. */
+export const isServerCapabilityAvailable = (
+  capabilityKey: string,
+  status: CapabilityStatusSnapshot = EMPTY_STATUS
+): boolean => {
+  if (unavailableCapabilityKeys.has(capabilityKey)) {
+    return false;
+  }
+
+  if (!status.loaded) {
+    return false;
+  }
+
+  const entry = status.capabilities[capabilityKey];
+  return entry?.available === true;
+};
+
+/** Loads server capability status once and keeps local unavailable markers in sync. */
+export const useServerCapabilityStatus = (): CapabilityStatusSnapshot => {
+  const [status, setStatus] = useState<CapabilityStatusSnapshot>(EMPTY_STATUS);
+
+  const reload = useCallback(() => {
+    setStatus((current) => ({ ...current }));
+  }, []);
+
+  useEffect(() => {
+    statusListeners.add(reload);
+    return () => {
+      statusListeners.delete(reload);
+    };
+  }, [reload]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchServerCapabilityStatus()
+      .then((response) => {
+        if (cancelled) {
+          return;
+        }
+
+        setStatus({
+          loaded: true,
+          capabilities: response.capabilities,
+        });
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+
+        setStatus({
+          loaded: true,
+          capabilities: {},
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return status;
+};
+
+/** Returns whether a server-backed feature is available at runtime on this deployment. */
+export const useServerCapabilityAvailable = (feature: FeatureKey): boolean => {
+  const capabilityKey = getServerCapabilityKeyForFeature(feature);
+  const status = useServerCapabilityStatus();
+
+  if (!capabilityKey) {
+    return true;
+  }
+
+  return isServerCapabilityAvailable(capabilityKey, status);
+};
+
+/** Returns whether a server-backed feature should allow server API calls. */
+export const useServerCapabilityApiEnabled = (feature: FeatureKey): boolean =>
+  useServerCapabilityAvailable(feature);

--- a/src/features/ServerBackedFeatureBoundary.test.tsx
+++ b/src/features/ServerBackedFeatureBoundary.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { resetServerCapabilityStatusState } from '../config/serverCapabilityStatus';
 import { ServerBackedFeatureBoundary } from './ServerBackedFeatureBoundary';
 
 describe('ServerBackedFeatureBoundary', () => {
   afterEach(() => {
+    resetServerCapabilityStatusState();
     jest.restoreAllMocks();
   });
 

--- a/src/features/ServerBackedFeatureBoundary.test.tsx
+++ b/src/features/ServerBackedFeatureBoundary.test.tsx
@@ -81,4 +81,23 @@ describe('ServerBackedFeatureBoundary', () => {
     expect(screen.queryByText('Auto-TSTM controls')).not.toBeInTheDocument();
     expect(screen.queryByText(/temporarily unavailable/i)).not.toBeInTheDocument();
   });
+
+  test('does not render unavailable fallback while server status is loading', () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn(() => new Promise(() => {})) as jest.Mock;
+
+    try {
+      render(
+        <ServerBackedFeatureBoundary feature="autoTstm">
+          <div>Auto-TSTM controls</div>
+        </ServerBackedFeatureBoundary>
+      );
+
+      expect(screen.queryByText('Auto-TSTM controls')).not.toBeInTheDocument();
+      expect(screen.queryByText(/temporarily unavailable/i)).not.toBeInTheDocument();
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
 });

--- a/src/features/ServerBackedFeatureBoundary.test.tsx
+++ b/src/features/ServerBackedFeatureBoundary.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { ServerBackedFeatureBoundary } from './ServerBackedFeatureBoundary';
+
+describe('ServerBackedFeatureBoundary', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('renders children when compile-time exposure and server status both allow it', async () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: true,
+            reason: 'available',
+          },
+        },
+      }),
+    }) as jest.Mock;
+
+    try {
+      render(
+        <ServerBackedFeatureBoundary feature="autoTstm">
+          <div>Auto-TSTM controls</div>
+        </ServerBackedFeatureBoundary>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Auto-TSTM controls')).toBeInTheDocument();
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('renders a fallback when the server reports emergency disable', async () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        capabilities: {
+          TSTM_GENERATION_ENABLED: {
+            available: false,
+            reason: 'emergency_disabled',
+          },
+        },
+      }),
+    }) as jest.Mock;
+
+    try {
+      render(
+        <ServerBackedFeatureBoundary feature="autoTstm">
+          <div>Auto-TSTM controls</div>
+        </ServerBackedFeatureBoundary>
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText('Auto-TSTM controls')).not.toBeInTheDocument();
+        expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('does not render children while compile-time exposure is disabled', () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(false);
+
+    render(
+      <ServerBackedFeatureBoundary feature="autoTstm">
+        <div>Auto-TSTM controls</div>
+      </ServerBackedFeatureBoundary>
+    );
+
+    expect(screen.queryByText('Auto-TSTM controls')).not.toBeInTheDocument();
+    expect(screen.queryByText(/temporarily unavailable/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/ServerBackedFeatureBoundary.tsx
+++ b/src/features/ServerBackedFeatureBoundary.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from 'react';
 import { getFeatureExposure, isFeatureExposed, type FeatureKey } from '../config/featureExposure';
-import { useServerCapabilityAvailable } from '../config/serverCapabilityStatus';
+import {
+  useServerBackedFeatureRuntimeState,
+  useServerCapabilityAvailable,
+} from '../config/serverCapabilityStatus';
 import { FeatureBoundary } from './FeatureBoundary';
 
 type ServerBackedFeatureBoundaryProps = {
@@ -46,14 +49,18 @@ const ServerBackedFeatureRuntimeBoundary = ({
   children,
   unavailableMessage,
 }: ServerBackedFeatureBoundaryProps) => {
-  const available = useServerBackedFeatureAvailable(feature);
+  const runtimeState = useServerBackedFeatureRuntimeState(feature);
   const definition = getFeatureExposure(feature);
 
   if (!definition.serverBacked) {
     return children;
   }
 
-  if (!available) {
+  if (runtimeState === 'loading') {
+    return null;
+  }
+
+  if (runtimeState === 'unavailable') {
     return <ServerBackedFeatureUnavailable message={unavailableMessage} />;
   }
 

--- a/src/features/ServerBackedFeatureBoundary.tsx
+++ b/src/features/ServerBackedFeatureBoundary.tsx
@@ -40,22 +40,7 @@ export const useServerBackedFeatureAvailable = (feature: FeatureKey): boolean =>
   return serverAvailable;
 };
 
-/** Mounts children only when compile-time exposure and runtime server availability both allow it. */
-export const ServerBackedFeatureBoundary = ({
-  feature,
-  children,
-  unavailableMessage,
-}: ServerBackedFeatureBoundaryProps) => (
-  <FeatureBoundary feature={feature}>
-    <ServerBackedFeatureRuntimeBoundary
-      feature={feature}
-      unavailableMessage={unavailableMessage}
-    >
-      {children}
-    </ServerBackedFeatureRuntimeBoundary>
-  </FeatureBoundary>
-);
-
+/** Applies runtime server availability checks inside a compile-time feature boundary. */
 const ServerBackedFeatureRuntimeBoundary = ({
   feature,
   children,
@@ -74,3 +59,19 @@ const ServerBackedFeatureRuntimeBoundary = ({
 
   return children;
 };
+
+/** Mounts children only when compile-time exposure and runtime server availability both allow it. */
+export const ServerBackedFeatureBoundary = ({
+  feature,
+  children,
+  unavailableMessage,
+}: ServerBackedFeatureBoundaryProps) => (
+  <FeatureBoundary feature={feature}>
+    <ServerBackedFeatureRuntimeBoundary
+      feature={feature}
+      unavailableMessage={unavailableMessage}
+    >
+      {children}
+    </ServerBackedFeatureRuntimeBoundary>
+  </FeatureBoundary>
+);

--- a/src/features/ServerBackedFeatureBoundary.tsx
+++ b/src/features/ServerBackedFeatureBoundary.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import { getFeatureExposure, isFeatureExposed, type FeatureKey } from '../config/featureExposure';
+import { useServerCapabilityAvailable } from '../config/serverCapabilityStatus';
+import { FeatureBoundary } from './FeatureBoundary';
+
+type ServerBackedFeatureBoundaryProps = {
+  feature: FeatureKey;
+  children: ReactNode;
+  unavailableMessage?: string;
+};
+
+const DEFAULT_UNAVAILABLE_MESSAGE =
+  'This capability is temporarily unavailable on this deployment. Please check back later.';
+
+/** Renders a non-sensitive fallback when a server-backed feature is unavailable at runtime. */
+export const ServerBackedFeatureUnavailable = ({
+  message = DEFAULT_UNAVAILABLE_MESSAGE,
+}: {
+  message?: string;
+}) => (
+  <div className="rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+    {message}
+  </div>
+);
+
+/** Returns whether a server-backed feature is available at runtime on this deployment. */
+export const useServerBackedFeatureAvailable = (feature: FeatureKey): boolean => {
+  const compileTimeExposed = isFeatureExposed(feature);
+  const serverAvailable = useServerCapabilityAvailable(feature);
+
+  if (!compileTimeExposed) {
+    return false;
+  }
+
+  const definition = getFeatureExposure(feature);
+  if (!definition.serverBacked) {
+    return true;
+  }
+
+  return serverAvailable;
+};
+
+/** Mounts children only when compile-time exposure and runtime server availability both allow it. */
+export const ServerBackedFeatureBoundary = ({
+  feature,
+  children,
+  unavailableMessage,
+}: ServerBackedFeatureBoundaryProps) => (
+  <FeatureBoundary feature={feature}>
+    <ServerBackedFeatureRuntimeBoundary
+      feature={feature}
+      unavailableMessage={unavailableMessage}
+    >
+      {children}
+    </ServerBackedFeatureRuntimeBoundary>
+  </FeatureBoundary>
+);
+
+const ServerBackedFeatureRuntimeBoundary = ({
+  feature,
+  children,
+  unavailableMessage,
+}: ServerBackedFeatureBoundaryProps) => {
+  const available = useServerBackedFeatureAvailable(feature);
+  const definition = getFeatureExposure(feature);
+
+  if (!definition.serverBacked) {
+    return children;
+  }
+
+  if (!available) {
+    return <ServerBackedFeatureUnavailable message={unavailableMessage} />;
+  }
+
+  return children;
+};

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -7,8 +7,16 @@ import {
   parseTstmGenerationResponse,
   requestTstmGeneration,
 } from './tstmGeneration';
+import {
+  isServerCapabilityAvailable,
+  resetServerCapabilityStatusState,
+} from '../config/serverCapabilityStatus';
 
 describe('tstmGeneration utilities', () => {
+  afterEach(() => {
+    resetServerCapabilityStatusState();
+  });
+
   test('limits SPC calibrated thunder generation to day 1 and day 2', () => {
     expect(canGenerateTstmForDay(1)).toBe(true);
     expect(canGenerateTstmForDay(2)).toBe(true);
@@ -132,6 +140,7 @@ describe('tstmGeneration utilities', () => {
       })
       .mockResolvedValueOnce({
         ok: false,
+        status: 404,
         json: async () => ({ error: 'Auto-TSTM is not enabled on this deployment.' }),
       }) as jest.Mock;
     try {
@@ -139,6 +148,17 @@ describe('tstmGeneration utilities', () => {
         .resolves.toMatchObject({ features: [] });
       await expect(requestTstmGeneration({ day: 1, cycleDate: '2026-06-13' }))
         .rejects.toThrow(/not enabled/);
+      expect(
+        isServerCapabilityAvailable('TSTM_GENERATION_ENABLED', {
+          loaded: true,
+          capabilities: {
+            TSTM_GENERATION_ENABLED: {
+              available: true,
+              reason: 'available',
+            },
+          },
+        })
+      ).toBe(false);
     } finally {
       global.fetch = originalFetch;
     }

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -4,8 +4,11 @@ import type {
   TstmGenerationRequest,
   TstmGenerationResponse,
 } from '../types/tstmGeneration';
+import { markServerCapabilityUnavailable } from '../config/serverCapabilityStatus';
 
 const TSTM_GENERATION_ENDPOINT = '/api/tstm/generate';
+const TSTM_CAPABILITY_KEY = 'TSTM_GENERATION_ENABLED';
+const DISABLED_CAPABILITY_MESSAGE = 'Auto-TSTM is not enabled on this deployment.';
 
 /** Returns true when SPC calibrated thunder can cover the given outlook day. */
 export const canGenerateTstmForDay = (day: DayType): boolean => day === 1 || day === 2;
@@ -139,6 +142,9 @@ export const requestTstmGeneration = async (
     const error = payload && typeof payload.error === 'string'
       ? payload.error
       : 'Auto-TSTM guidance is temporarily unavailable.';
+    if (response.status === 404 && error === DISABLED_CAPABILITY_MESSAGE) {
+      markServerCapabilityUnavailable(TSTM_CAPABILITY_KEY);
+    }
     throw new Error(error);
   }
   return parseTstmGenerationResponse(payload);

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -10,6 +10,25 @@ const TSTM_GENERATION_ENDPOINT = '/api/tstm/generate';
 const TSTM_CAPABILITY_KEY = 'TSTM_GENERATION_ENABLED';
 const DISABLED_CAPABILITY_MESSAGE = 'Auto-TSTM is not enabled on this deployment.';
 
+/** Returns the error message for a failed Auto-TSTM generation request. */
+const getTstmGenerationErrorMessage = (
+  response: Response,
+  payload: unknown
+): string => {
+  if (payload && typeof payload === 'object' && typeof (payload as { error?: unknown }).error === 'string') {
+    return (payload as { error: string }).error;
+  }
+
+  return 'Auto-TSTM guidance is temporarily unavailable.';
+};
+
+/** Marks the server capability unavailable when the API returns the standard disabled response. */
+const handleDisabledTstmCapability = (response: Response, error: string): void => {
+  if (response.status === 404 && error === DISABLED_CAPABILITY_MESSAGE) {
+    markServerCapabilityUnavailable(TSTM_CAPABILITY_KEY);
+  }
+};
+
 /** Returns true when SPC calibrated thunder can cover the given outlook day. */
 export const canGenerateTstmForDay = (day: DayType): boolean => day === 1 || day === 2;
 
@@ -139,12 +158,8 @@ export const requestTstmGeneration = async (
   });
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) {
-    const error = payload && typeof payload.error === 'string'
-      ? payload.error
-      : 'Auto-TSTM guidance is temporarily unavailable.';
-    if (response.status === 404 && error === DISABLED_CAPABILITY_MESSAGE) {
-      markServerCapabilityUnavailable(TSTM_CAPABILITY_KEY);
-    }
+    const error = getTstmGenerationErrorMessage(response, payload);
+    handleDisabledTstmCapability(response, error);
     throw new Error(error);
   }
   return parseTstmGenerationResponse(payload);

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -10,17 +10,19 @@ const TSTM_GENERATION_ENDPOINT = '/api/tstm/generate';
 const TSTM_CAPABILITY_KEY = 'TSTM_GENERATION_ENABLED';
 const DISABLED_CAPABILITY_MESSAGE = 'Auto-TSTM is not enabled on this deployment.';
 
-/** Returns the error message for a failed Auto-TSTM generation request. */
-const getTstmGenerationErrorMessage = (
-  response: Response,
-  payload: unknown
-): string => {
-  if (payload && typeof payload === 'object' && typeof (payload as { error?: unknown }).error === 'string') {
-    return (payload as { error: string }).error;
+/** Returns the server error message from an Auto-TSTM API payload when present. */
+const readTstmGenerationErrorMessage = (payload: unknown): string | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
   }
 
-  return 'Auto-TSTM guidance is temporarily unavailable.';
+  const error = (payload as { error?: unknown }).error;
+  return typeof error === 'string' ? error : null;
 };
+
+/** Returns the error message for a failed Auto-TSTM generation request. */
+const getTstmGenerationErrorMessage = (payload: unknown): string =>
+  readTstmGenerationErrorMessage(payload) ?? 'Auto-TSTM guidance is temporarily unavailable.';
 
 /** Marks the server capability unavailable when the API returns the standard disabled response. */
 const handleDisabledTstmCapability = (response: Response, error: string): void => {
@@ -158,7 +160,7 @@ export const requestTstmGeneration = async (
   });
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) {
-    const error = getTstmGenerationErrorMessage(response, payload);
+    const error = getTstmGenerationErrorMessage(payload);
     handleDisabledTstmCapability(response, error);
     throw new Error(error);
   }


### PR DESCRIPTION
## Summary

- Add disable-only emergency override via `EMERGENCY_DISABLED_CAPABILITIES` on the analytics server, with fail-closed parsing against known server capability keys.
- Wire emergency disable into server capability gates with correct precedence (override beats registry exposure and deployment env), structured logging, and `GET /api/capabilities/status`.
- Add client runtime fallback (`serverCapabilityStatus`, `ServerBackedFeatureBoundary`) so already-mounted beta UI handles a capability becoming unavailable after page load.

Closes #527

## Server and security review

- [x] Server-backed exposure change reviewed: emergency disable is disable-only and cannot enable absent registry capabilities.
- [x] Public endpoint reviewed: `/api/capabilities/status` is unauthenticated, rate-limited, and returns only non-sensitive availability booleans plus reason codes for registry-exposed capabilities.
- [x] Incident-state disclosure reviewed: `emergency_disabled` is intentional operational metadata for already-exposed capabilities; documented in `docs/emergency-feature-disable.md`.

## Test plan

- [x] `node --test server/lib/emergencyCapabilityOverrides.test.js server/lib/featureCapabilities.test.js server/lib/capabilityStatus.test.js server/tstm.test.js server/server-stack.test.js`
- [x] `pnpm test -- --runTestsByPath src/config/serverCapabilityStatus.test.tsx src/features/ServerBackedFeatureBoundary.test.tsx src/utils/tstmGeneration.test.ts`
- [ ] Manual local drill per `docs/emergency-feature-disable.md` once Auto-TSTM is registry-exposed on beta
