### PR TITLE
fix(ci): harden VPS deploy host key trust and beta concurrency

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -3,6 +3,10 @@ name: Deploy Beta
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-beta
+  cancel-in-progress: true
+
 on:
   push:
     branches: [beta]
@@ -11,6 +15,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      RSYNC_RSH: ssh -o StrictHostKeyChecking=yes
 
     steps:
       - name: Checkout
@@ -60,7 +66,27 @@ jobs:
           ssh-private-key: ${{ secrets.BETA_SSH_KEY }}
 
       - name: Trust VPS host key
-        run: ssh-keyscan -H ${{ secrets.BETA_SSH_HOST }} >> ~/.ssh/known_hosts
+        env:
+          SSH_HOST: ${{ secrets.BETA_SSH_HOST }}
+          SSH_KNOWN_HOSTS: ${{ secrets.BETA_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          if [ -n "$SSH_KNOWN_HOSTS" ]; then
+            printf '%s\n' "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          else
+            for attempt in 1 2 3 4 5; do
+              if scan_output=$(ssh-keyscan -T 15 -p 22 -H "$SSH_HOST" 2>/tmp/ssh-keyscan.err) && [ -n "$scan_output" ]; then
+                printf '%s\n' "$scan_output" >> ~/.ssh/known_hosts
+                exit 0
+              fi
+              cat /tmp/ssh-keyscan.err >&2 || true
+              echo "ssh-keyscan attempt $attempt failed; retrying..." >&2
+              sleep $((attempt * 5))
+            done
+            exit 1
+          fi
 
       - name: Deploy via rsync
         run: |
@@ -103,7 +129,7 @@ jobs:
 
       - name: Install analytics dependencies and restart
         run: |
-          ssh root@${{ secrets.BETA_SSH_HOST }} '
+          ssh -o StrictHostKeyChecking=yes root@${{ secrets.BETA_SSH_HOST }} '
             cd /opt/gfc-beta-analytics
             npm install --omit=dev --quiet
             mkdir -p /opt/gfc-beta-analytics/logs

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -27,6 +27,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      RSYNC_RSH: ssh -o StrictHostKeyChecking=yes
 
     steps:
       - name: Checkout
@@ -67,7 +69,27 @@ jobs:
           ssh-private-key: ${{ secrets.PROD_SSH_KEY }}
 
       - name: Trust VPS host key
-        run: ssh-keyscan -H ${{ secrets.PROD_SSH_HOST }} >> ~/.ssh/known_hosts
+        env:
+          SSH_HOST: ${{ secrets.PROD_SSH_HOST }}
+          SSH_KNOWN_HOSTS: ${{ secrets.PROD_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          if [ -n "$SSH_KNOWN_HOSTS" ]; then
+            printf '%s\n' "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          else
+            for attempt in 1 2 3 4 5; do
+              if scan_output=$(ssh-keyscan -T 15 -p 22 -H "$SSH_HOST" 2>/tmp/ssh-keyscan.err) && [ -n "$scan_output" ]; then
+                printf '%s\n' "$scan_output" >> ~/.ssh/known_hosts
+                exit 0
+              fi
+              cat /tmp/ssh-keyscan.err >&2 || true
+              echo "ssh-keyscan attempt $attempt failed; retrying..." >&2
+              sleep $((attempt * 5))
+            done
+            exit 1
+          fi
 
       - name: Validate production release manifest
         id: manifest
@@ -210,14 +232,14 @@ jobs:
           set -euo pipefail
           HOST="root@${{ secrets.PROD_SSH_HOST }}"
 
-          ssh "$HOST" "mkdir -p /var/www/gfc/releases /opt/gfc-analytics/releases /opt/gfc-analytics/config /opt/gfc-analytics/logs"
+          ssh -o StrictHostKeyChecking=yes "$HOST" "mkdir -p /var/www/gfc/releases /opt/gfc-analytics/releases /opt/gfc-analytics/config /opt/gfc-analytics/logs"
 
           rsync -avz --delete build/ "$HOST:/var/www/gfc/releases/$RELEASE_DIR/"
           rsync -avz --exclude='node_modules' --exclude='logs' server/ "$HOST:/opt/gfc-analytics/releases/$RELEASE_DIR/"
           rsync -avz deploy/production-release.json "$HOST:/opt/gfc-analytics/config/production-release.json"
           rsync -avz prod-server.env "$HOST:/opt/gfc-analytics/config/.env"
 
-          ssh "$HOST" "RELEASE_DIR='$RELEASE_DIR' bash -s" <<'REMOTE'
+          ssh -o StrictHostKeyChecking=yes "$HOST" "RELEASE_DIR='$RELEASE_DIR' bash -s" <<'REMOTE'
           set -euo pipefail
           WEB_ROOT=/var/www/gfc
           ANALYTICS_ROOT=/opt/gfc-analytics
@@ -256,7 +278,7 @@ jobs:
           set -euo pipefail
           HOST="root@${{ secrets.PROD_SSH_HOST }}"
 
-          ssh "$HOST" "mkdir -p \
+          ssh -o StrictHostKeyChecking=yes "$HOST" "mkdir -p \
             /var/www/gfc/releases \
             /var/www/gfc-staging/releases \
             /opt/gfc-analytics/releases \
@@ -272,7 +294,7 @@ jobs:
           rsync -avz build/alert-banner-live-pre.json "$HOST:/tmp/alert-banner-live-pre.json"
           rsync -avz staging-server.env "$HOST:/opt/gfc-staging-analytics/config/.env"
 
-          ssh "$HOST" "RELEASE_DIR='$RELEASE_DIR' bash -s" <<'REMOTE'
+          ssh -o StrictHostKeyChecking=yes "$HOST" "RELEASE_DIR='$RELEASE_DIR' bash -s" <<'REMOTE'
           set -euo pipefail
           WEB_ROOT=/var/www/gfc
           STAGING_WEB_ROOT=/var/www/gfc-staging


### PR DESCRIPTION
## Summary

- Harden beta and production VPS deploy workflows against flaky `ssh-keyscan` host-key discovery (the actual failure mode in recent Deploy Beta runs — not SSH private-key auth).
- Serialize beta deploys with `concurrency` so merge + post-merge version-bump pushes do not race on the same host.
- Support pinned host keys via `BETA_SSH_KNOWN_HOSTS` / `PROD_SSH_KNOWN_HOSTS` secrets, with a 5-attempt `ssh-keyscan` retry fallback.
- Use `StrictHostKeyChecking=yes` for rsync/ssh deploy commands.

## Manual setup (before merge)

Add GitHub Actions secrets (one-time):

```bash
ssh-keyscan -H -p 22 YOUR_BETA_HOST
# → BETA_SSH_KNOWN_HOSTS

ssh-keyscan -H -p 22 YOUR_PROD_HOST
# → PROD_SSH_KNOWN_HOSTS
```

Paste the full output line(s) for each secret. Update if the VPS host key rotates.

## Test plan

- [ ] Add `BETA_SSH_KNOWN_HOSTS` and `PROD_SSH_KNOWN_HOSTS` secrets
- [ ] Merge to `main` and confirm Deploy Beta / Deploy Production trust steps pass
- [ ] Merge a PR to `beta` and confirm only one Deploy Beta run completes (earlier run cancelled when bump follows)
- [ ] Re-run a previously failed Deploy Beta workflow via `workflow_dispatch`
