### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,3 +169,20 @@ Automation detects both and skips creating a duplicate `port/*` PR.
 
 Full release policy: [`docs/release-workflow.md`](docs/release-workflow.md). Key automation: [`.github/scripts/port-changes.sh`](.github/scripts/port-changes.sh), [`scripts/lib/port-targets.mjs`](scripts/lib/port-targets.mjs), [`scripts/lib/port-conflicts.mjs`](scripts/lib/port-conflicts.mjs).
 
+## Cursor Cloud specific instructions
+
+Dependencies are installed automatically by the startup update script (`pnpm install --frozen-lockfile` for the root frontend, `npm --prefix server install` for the backend). The two packages use **different package managers** — pnpm at the repo root, npm in `server/` — so they are installed separately and have separate lockfiles.
+
+Services (standard commands are in `README.md` / `package.json`):
+
+- **Frontend (the core product):** `pnpm run dev` → http://localhost:3000. This is sufficient on its own; forecast/verification/discussion data persists to browser `localStorage`, and no database is required.
+- **Analytics/billing backend (optional):** `cd server && npm start` → binds `127.0.0.1:3006`. Only needed for auth/billing/analytics/Sentry-tunnel flows. Vite proxies `/api` → `127.0.0.1:3006`, so start the backend if you exercise `/api`.
+
+Non-obvious notes:
+
+- **Lint:** there is no ESLint setup (no eslint dependency, no `lint` script). CI only runs build + tests. Do not expect a lint command; the closest static check is the Vite build plus `pnpm test`.
+- **`tsc --noEmit` does not work standalone** — it errors with `vite.config.ts is not under rootDir 'src'` because of the `tsconfig.json` layout. This is a config quirk, not a real type error; type safety is enforced via the build and `ts-jest` during `pnpm test`. Do not treat that `tsc` error as a regression.
+- **Checks that mirror CI:** `pnpm run build` (frontend), `pnpm test` (Jest), and `cd server && npm test` (`node --test`). Run `pnpm test` from the repo root — running it from `server/` invokes the backend's test script instead.
+- pnpm reports "Ignored build scripts" for `esbuild`/`@sentry/cli`/etc.; the dev server and build still work fine via prebuilt platform binaries, so this warning is safe to ignore.
+- Firebase, Stripe, and Sentry are all optional and degrade gracefully when their env vars are absent; the app and backend boot without any secrets.
+

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #636
+
+- Document Cursor Cloud development environment setup in `AGENTS.md` (dependency install flow, frontend/backend run commands, and non-obvious lint/typecheck/test caveats).
+
 ### PR #632
 
 - Add server-authoritative emergency capability disable via `EMERGENCY_DISABLED_CAPABILITIES`, including fail-closed parsing, `/api/capabilities/status`, and client runtime fallback for already-mounted server-backed features (FND-11, #527).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the Cursor Cloud development environment for this repo. Adds a new `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing durable, non-obvious setup/run caveats for future agents, plus the required `CHANGELOG.beta.md` entry.

Targets `beta` per the branch policy (feature/fix branches integrate into `beta`, not `main`).

## Environment

- Frontend (root): pnpm (`pnpm-lock.yaml`); backend (`server/`): npm (`server/package-lock.json`) — installed separately.
- Update script run on startup: `pnpm install --frozen-lockfile` then `npm --prefix server install`.

## What was verified

- `pnpm run build` — Vite production build succeeds.
- `pnpm test` — 479 Jest tests pass (126 suites).
- `cd server && npm test` — 8 `node --test` backend tests pass.
- `pnpm run dev` — Vite dev server on `:3000`; backend `npm start` on `127.0.0.1:3006`; `/api` proxy verified.
- Hello-world: drew a Tornado risk polygon in the forecast editor and confirmed it renders on the map.

## Notes

- No ESLint is configured; CI runs build + tests only. Standalone `tsc --noEmit` errors on a `tsconfig` rootDir quirk and is not a real type error (documented in `AGENTS.md`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcc1d95f-8b90-4475-9e17-f8a10ceab6a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcc1d95f-8b90-4475-9e17-f8a10ceab6a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

