### PR TITLE
fix(ci): trigger VPS deploys on GitHub Release publish

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -3,17 +3,20 @@ name: Deploy Beta
 permissions:
   contents: read
 
-# Cancel stale beta deploys when merge + version-bump pushes arrive back-to-back.
-# Tradeoff: a push during active rsync can leave mixed assets until the next run
-# finishes; avoid pushing to beta while a deploy is mid-transfer.
+# One deploy per beta prerelease. post-merge-automation publishes vX.Y.Z-beta.N after
+# the version-bump push, so merge pushes no longer trigger duplicate deploys.
 concurrency:
   group: deploy-beta
-  cancel-in-progress: true
 
 on:
-  push:
-    branches: [beta]
-  workflow_dispatch:   # lets you trigger manually from the GitHub Actions tab
+  release:
+    types: [prereleased]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag or branch to deploy (default: beta HEAD)'
+        required: false
+        type: string
 
 jobs:
   deploy:
@@ -22,8 +25,21 @@ jobs:
       RSYNC_RSH: ssh -o StrictHostKeyChecking=yes
 
     steps:
+      - name: Resolve checkout ref
+        id: checkout_ref
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ inputs.ref }}" ]; then
+            echo "ref=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=beta" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout_ref.outputs.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -3,16 +3,20 @@ name: Deploy Production to VPS
 permissions:
   contents: read
 
-# Queue overlapping main deploys; release dirs are versioned but symlink swap and
+# Queue overlapping production deploys; release dirs are versioned but symlink swap and
 # pm2 restart are not safe to run concurrently across SSH sessions.
 concurrency:
   group: deploy-production
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [released]
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Git tag or branch to deploy (default: main HEAD)'
+        required: false
+        type: string
       deploy_action:
         description: 'Override manifest action (auto = use deploy/production-release.json)'
         required: false
@@ -36,8 +40,21 @@ jobs:
       RSYNC_RSH: ssh -o StrictHostKeyChecking=yes
 
     steps:
+      - name: Resolve checkout ref
+        id: checkout_ref
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ inputs.ref }}" ]; then
+            echo "ref=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout_ref.outputs.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -3,6 +3,7 @@ name: Post-merge automation
 # Runs after a PR merges. No manual workflow dispatch needed for normal releases.
 #
 # Every package.json version bump creates a GitHub Release (stable or --prerelease for -beta.N).
+# Deploy Beta / Deploy Production run on those releases (prereleased / released), not on branch pushes.
 # beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
 # release/* → main: merge main into beta, stable release + next beta line + prerelease.
 # feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Deploy env:** Add explicit `SERVER_TARGET` values to beta, staging, and production analytics server deploy env files.
+- **Deploy triggers:** Run **Deploy Beta** on beta prerelease publish and **Deploy Production** on stable release publish (one deploy per version bump; merge pushes no longer trigger VPS deploys).
 
 ### Fixed
-- **Deploy reliability:** Harden beta and production VPS deploy workflows against flaky `ssh-keyscan` host-key discovery with pinned known-host secrets, retries, deploy concurrency (cancel stale beta runs; queue production), and explicit `StrictHostKeyChecking` on SSH/rsync.
+- **Deploy reliability:** Harden beta and production VPS deploy workflows against flaky `ssh-keyscan` host-key discovery with pinned known-host secrets, retries, deploy concurrency, and explicit `StrictHostKeyChecking` on SSH/rsync.
 
 ### Added
 - **Explicit build targets:** Define and validate local, beta, staging, and production frontend build targets while preserving the existing beta access gate.

--- a/docs/hosted-rollout.md
+++ b/docs/hosted-rollout.md
@@ -56,7 +56,7 @@ bash /opt/gfc-analytics/current/release/promote-release.sh
    - `rolloutAt`: ISO UTC instant
    - `releaseId`: unique per attempt
    - `banner.phases`: pre-rollout + post-rollout
-2. Merge → **Deploy Production to VPS** stages build; **live site stays on previous `current`**.
+2. Merge → post-merge publishes a stable GitHub Release → **Deploy Production to VPS** stages the build from that release tag; **live site stays on previous `current`**.
 3. Smoke **staging-gfc** (beta access guard, same as beta-gfc).
 4. At `rolloutAt`, cron promotes; live banner switches via `write-live-alert-banner.mjs`.
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -42,7 +42,8 @@ Automation auto-resolves version-policy file conflicts on beta ports (`package.j
    - Strips `-beta` from `package.json` on `main` (e.g. `1.6.0-beta.3` → `1.6.0`) and pushes.
    - Creates a **GitHub Release** `v1.6.0` using the matching section in `CHANGELOG.md`.
    - Bumps **beta** to the next line (e.g. `1.7.0-beta.1`) and creates a **prerelease** `v1.7.0-beta.1`.
-3. **Deploy Production to VPS** runs on the push to `main` (Sentry release uses the **stable** version even if the merge commit still had `-beta` briefly).
+3. **Deploy Production to VPS** runs when the stable GitHub Release is published (checks out tag `v1.6.0`, so the build matches the released version).
+4. **Deploy Beta** runs when the new beta prerelease is published (e.g. `v1.7.0-beta.1`).
 
 ### release/* → main (optional prepare workflow)
 
@@ -59,12 +60,14 @@ Infrastructure fixes that land via `release/*` → `main` (not only `feature/rel
 - Other branch names are allowed into beta except `hotfix/*` (labeled `integration:other`).
 - Automation increments the beta prerelease on each merge: `1.6.0-beta.1` → `1.6.0-beta.2`, etc.
 - Each bump creates a **GitHub prerelease** (`v1.6.0-beta.2`) from the matching `CHANGELOG.md` line section, or from **\[Unreleased\]** when no line section exists yet.
+- **Deploy Beta** runs when that prerelease is published (not on the merge or version-bump pushes).
 - Port branches (`port/*`) skip the version bump.
 
 ### hotfix/* → main
 
 - Automation bumps the **patch** on `main` after merge (e.g. `1.6.0` → `1.6.1`).
 - Creates a **GitHub Release** for the new patch version from `CHANGELOG.md`.
+- **Deploy Production to VPS** runs when that stable release is published.
 
 ### `feature/release-*` → main (release infrastructure)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wire VPS deploy workflows to GitHub Releases instead of branch pushes. `post-merge-automation` already publishes a prerelease after every beta bump and a stable release after every main bump — deploys now listen to those events, so merge + version-bump no longer fire two deploys.

## Changes

| Workflow | Old trigger | New trigger | Checkout |
|----------|-------------|-------------|----------|
| Deploy Beta | `push` to `beta` | `release` `prereleased` | Release tag (e.g. `v1.7.0-beta.26`) |
| Deploy Production | `push` to `main` | `release` `released` | Release tag (e.g. `v1.6.13`) |

- Removed beta `cancel-in-progress` concurrency (root cause was double push deploys).
- Kept production deploy queue concurrency for overlapping stable releases.
- `workflow_dispatch` retained with optional `ref` input for manual recovery.

## Flow after merge

**Beta integration PR:**
1. Merge → no deploy
2. Post-merge bumps version, pushes, publishes prerelease → **one** Deploy Beta

**Hotfix → main:**
1. Merge → no deploy
2. Post-merge bumps patch, pushes, publishes stable release → **one** Deploy Production

**Beta → main promotion:**
1. Stable release `vX.Y.Z` → Deploy Production
2. Beta prerelease `vX.(Y+1).0-beta.1` → Deploy Beta

## Test plan

- [ ] Merge to `main` and confirm Deploy Production runs only after stable GitHub Release publish (not on merge/bump pushes)
- [ ] Merge a PR to `beta` and confirm Deploy Beta runs only after prerelease publish
- [ ] Verify checkout uses release tag (`package.json` version matches release name)
- [ ] `workflow_dispatch` with no `ref` still deploys `main` / `beta` HEAD for recovery
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1c30c14-0e01-4479-9c9a-7607397946aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1c30c14-0e01-4479-9c9a-7607397946aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

