### PR TITLE
[Port][Conflicts] fix(ci): trigger VPS deploys on GitHub Release publish → beta

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -3,18 +3,48 @@ name: Deploy Beta
 permissions:
   contents: read
 
+<<<<<<< HEAD
+=======
+# One deploy per beta prerelease. post-merge-automation publishes vX.Y.Z-beta.N after
+# the version-bump push, so merge pushes no longer trigger duplicate deploys.
+concurrency:
+  group: deploy-beta
+
+>>>>>>> 541ab3e (fix(ci): trigger VPS deploys on GitHub Release publish)
 on:
-  push:
-    branches: [beta]
-  workflow_dispatch:   # lets you trigger manually from the GitHub Actions tab
+  release:
+    types: [prereleased]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag or branch to deploy (default: beta HEAD)'
+        required: false
+        type: string
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Resolve checkout ref
+        id: checkout_ref
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ inputs.ref }}" ]; then
+            echo "ref=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=beta" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
+<<<<<<< HEAD
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+=======
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout_ref.outputs.ref }}
+>>>>>>> 541ab3e (fix(ci): trigger VPS deploys on GitHub Release publish)
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -3,11 +3,23 @@ name: Deploy Production to VPS
 permissions:
   contents: read
 
+<<<<<<< HEAD
+=======
+# Queue overlapping production deploys; release dirs are versioned but symlink swap and
+# pm2 restart are not safe to run concurrently across SSH sessions.
+concurrency:
+  group: deploy-production
+
+>>>>>>> 541ab3e (fix(ci): trigger VPS deploys on GitHub Release publish)
 on:
-  push:
-    branches: [main]
+  release:
+    types: [released]
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Git tag or branch to deploy (default: main HEAD)'
+        required: false
+        type: string
       deploy_action:
         description: 'Override manifest action (auto = use deploy/production-release.json)'
         required: false
@@ -29,8 +41,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Resolve checkout ref
+        id: checkout_ref
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ inputs.ref }}" ]; then
+            echo "ref=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
+<<<<<<< HEAD
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+=======
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout_ref.outputs.ref }}
+>>>>>>> 541ab3e (fix(ci): trigger VPS deploys on GitHub Release publish)
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -3,6 +3,7 @@ name: Post-merge automation
 # Runs after a PR merges. No manual workflow dispatch needed for normal releases.
 #
 # Every package.json version bump creates a GitHub Release (stable or --prerelease for -beta.N).
+# Deploy Beta / Deploy Production run on those releases (prereleased / released), not on branch pushes.
 # beta → main: strip stable on main, release vX.Y.Z, start next beta line + prerelease for new beta.
 # release/* → main: merge main into beta, stable release + next beta line + prerelease.
 # feature/*|fix/*|other → beta: bump -beta.N and prerelease vX.Y.Z-beta.N.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+<<<<<<< HEAD
+=======
+### Security
+- **CI shell injection:** Pass PR branch refs through `env` in `ci.yml` and `pr-governance.yml` `git fetch` steps so branch names cannot break out of the shell command.
+- **Dependabot changelog workflow:** Require Dependabot PR provenance before checking out PR head code with `GH_PAT`; pass base ref through env in shell steps; pin `actions/checkout` to an immutable SHA.
+- **Beta deploy supply chain:** Use `pnpm install --frozen-lockfile` in the beta deploy workflow so builds cannot silently resolve new dependency versions at deploy time.
+- **Production deploy supply chain:** Use `pnpm install --frozen-lockfile` in the production deploy workflow so builds cannot silently resolve new dependency versions at deploy time.
+
+### Changed
+- **Deploy env:** Add explicit `SERVER_TARGET` values to beta, staging, and production analytics server deploy env files.
+- **Deploy triggers:** Run **Deploy Beta** on beta prerelease publish and **Deploy Production** on stable release publish (one deploy per version bump; merge pushes no longer trigger VPS deploys).
+
+### Fixed
+- **Deploy reliability:** Harden beta and production VPS deploy workflows against flaky `ssh-keyscan` host-key discovery with pinned known-host secrets, retries, deploy concurrency, and explicit `StrictHostKeyChecking` on SSH/rsync.
+
+>>>>>>> 541ab3e (fix(ci): trigger VPS deploys on GitHub Release publish)
 ### Added
 - **Explicit build targets:** Define and validate local, beta, staging, and production frontend build targets while preserving the existing beta access gate.
 - **PR governance:** Add feature exposure labels (`exposure:production`, `exposure:server-backed`, `exposure:registry-change`) to automatically tag PRs that change feature exposure configuration.

--- a/docs/hosted-rollout.md
+++ b/docs/hosted-rollout.md
@@ -56,7 +56,7 @@ bash /opt/gfc-analytics/current/release/promote-release.sh
    - `rolloutAt`: ISO UTC instant
    - `releaseId`: unique per attempt
    - `banner.phases`: pre-rollout + post-rollout
-2. Merge → **Deploy Production to VPS** stages build; **live site stays on previous `current`**.
+2. Merge → post-merge publishes a stable GitHub Release → **Deploy Production to VPS** stages the build from that release tag; **live site stays on previous `current`**.
 3. Smoke **staging-gfc** (beta access guard, same as beta-gfc).
 4. At `rolloutAt`, cron promotes; live banner switches via `write-live-alert-banner.mjs`.
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -50,7 +50,8 @@ Before opening the promotion PR, run `pnpm exposure:report` locally to review pr
    - Strips `-beta` from `package.json` on `main` (e.g. `1.6.0-beta.3` → `1.6.0`) and pushes.
    - Creates a **GitHub Release** `v1.6.0` using the matching section in `CHANGELOG.md`.
    - Bumps **beta** to the next line (e.g. `1.7.0-beta.1`) and creates a **prerelease** `v1.7.0-beta.1`.
-3. **Deploy Production to VPS** runs on the push to `main` (Sentry release uses the **stable** version even if the merge commit still had `-beta` briefly).
+3. **Deploy Production to VPS** runs when the stable GitHub Release is published (checks out tag `v1.6.0`, so the build matches the released version).
+4. **Deploy Beta** runs when the new beta prerelease is published (e.g. `v1.7.0-beta.1`).
 
 ### release/* → main (optional prepare workflow)
 
@@ -67,13 +68,18 @@ Infrastructure fixes that land via `release/*` → `main` (not only `feature/rel
 - Other branch names are allowed into beta except `hotfix/*` (labeled `integration:other`).
 - Automation increments the beta prerelease on each merge: `1.6.0-beta.1` → `1.6.0-beta.2`, etc.
 - Each bump creates a **GitHub prerelease** (`v1.6.0-beta.2`) from the matching `CHANGELOG.md` line section, or from **\[Unreleased\]** when no line section exists yet.
+- **Deploy Beta** runs when that prerelease is published (not on the merge or version-bump pushes).
 - Port branches (`port/*`) skip the version bump.
 
 ### hotfix/* → main
 
 - Automation bumps the **patch** on `main` after merge (e.g. `1.6.0` → `1.6.1`).
 - Creates a **GitHub Release** for the new patch version from `CHANGELOG.md`.
+<<<<<<< HEAD
 - **PR porting** opens a reviewable port PR into `beta` (or skips when `porting/manual` is set or a manual beta PR already exists).
+=======
+- **Deploy Production to VPS** runs when that stable release is published.
+>>>>>>> 541ab3e (fix(ci): trigger VPS deploys on GitHub Release publish)
 
 ### `feature/release-*` → main (release infrastructure)
 


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #639 — fix(ci): trigger VPS deploys on GitHub Release publish |
| Source branch | `cursor/release-triggered-deploys-46aa` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `.github/workflows/deploy-beta.yml`
- `.github/workflows/deploy-main-to-vps.yml`
- `CHANGELOG.md`
- `docs/release-workflow.md`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/639-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #639, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.