### PR TITLE
[FND-14] Adopt feature exposure registry across v1.7 workstreams

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #TBD
+
+- Adopt the feature exposure registry across all six v1.7 workstreams: adoption manifest, registry-only acknowledgements, v1.7 adoption policy rule, adoption exposure tests, gated-route smoke checks, and tracker cross-links (FND-14, #530).
+
 ### PR #643
 
 - Add reusable feature exposure test fixtures and harness for client/server disabled-side-effect contracts, exemplar coverage for `tropicalWorkspace` and `autoTstm`, `pnpm test:exposure`, and documentation (FND-13, #529).

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,7 +4,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #TBD
+### PR #644
 
 - Adopt the feature exposure registry across all six v1.7 workstreams: adoption manifest, registry-only acknowledgements, v1.7 adoption policy rule, adoption exposure tests, gated-route smoke checks, and tracker cross-links (FND-14, #530).
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Client runtime fallback for server-backed features lives in:
 
 Disabled-side-effect test fixtures and the minimum per-feature contract are documented in [docs/feature-exposure-testing.md](docs/feature-exposure-testing.md). Run `pnpm test:exposure` locally or adopt `src/testing/featureExposure/harness.tsx` in a new `*.exposure.test.ts` file.
 
+v1.7 workstream adoption (registry keys, gates, beta-enablement records) is documented in [docs/feature-exposure-workstreams.md](docs/feature-exposure-workstreams.md).
+
 ### Local Beta Mode (developer)
 
 Run the app with beta-only features locally (useful for testing forecast redesigns, verification flows, and discussion changes).

--- a/docs/feature-exposure-testing.md
+++ b/docs/feature-exposure-testing.md
@@ -2,6 +2,8 @@
 
 Reusable fixtures and assertions for proving gated features stay inert while disabled. This is the minimum contract expected by FND-13 (#529) before a v1.7 workstream enables beta exposure in FND-14 (#530).
 
+Workstream registry keys, surfaces, and beta-enablement records: [feature-exposure-workstreams.md](./feature-exposure-workstreams.md).
+
 ## Minimum test contract
 
 Every gated feature must either:

--- a/docs/feature-exposure-workstreams.md
+++ b/docs/feature-exposure-workstreams.md
@@ -1,0 +1,77 @@
+# v1.7 feature exposure workstreams
+
+Single adoption manifest for every unfinished v1.7 workstream registered in `src/config/featureExposure.ts`. Completing this adoption is tracked in FND-14 (#530).
+
+## Adoption rule
+
+Every workstream must:
+
+1. Declare a registry key with an initial exposure matrix (all targets off until enablement criteria pass).
+2. Gate routes, navigation, boundaries, side-effect modules, and server capabilities **before** the first exposed slice merges.
+3. Ship disabled-side-effect tests or a documented acknowledgement (see [feature-exposure-testing.md](./feature-exposure-testing.md)).
+4. Record the tracker issue and the PR that may first flip `exposure.beta` (TBD until an implementation slice is ready).
+
+## Summary
+
+| Workstream | Registry key | Tracker | Surfaces today | Coverage |
+| --- | --- | --- | --- | --- |
+| Auto-TSTM | `autoTstm` | #427 | Side-effect module + server capability gate | Exemplar + server exposure tests |
+| Forecast workflow v2 | `forecastWorkflowV2` | #429 | Registry only (no product slice yet) | Acknowledgement + adoption test |
+| Verification relaunch | `verificationRelaunch` | #430 | Registry only; core `/verification` is separate | Acknowledgement + adoption test |
+| Custom products | `customProducts` | #431 | Registry only (no product slice yet) | Acknowledgement + adoption test |
+| Tropical workspace | `tropicalWorkspace` | #432 | Gated route `/tropical` + navbar | Exemplar + route/nav tests |
+| Collaboration room | `collaborationRoom` | #433 | Gated route `/collaborate` + navbar | Exemplar + route/nav tests |
+
+Initial exposure matrix for every row above: `local`, `beta`, `staging`, and `production` are all `false`.
+
+## Per-workstream detail
+
+### Auto-TSTM (`autoTstm`, #427)
+
+- **Registry:** `temporary: true`, `serverBacked: true`, `serverCapabilityKey: TSTM_GENERATION_ENABLED`
+- **Gates:** `FEATURE_SIDE_EFFECT_MODULES.autoTstm`, `ServerBackedFeatureBoundary`, `server/tstm.js` capability gate
+- **Tests:** `src/testing/featureExposure/exemplar.exposure.test.tsx`, `server/testing/autoTstm.exposure.test.js`
+- **Beta enablement:** tracker #427; first enable PR: TBD (flip `exposure.beta` after TSTM-03+ surfaces ship and disabled-side-effect tests pass)
+
+### Forecast workflow v2 (`forecastWorkflowV2`, #429)
+
+- **Registry:** `temporary: true`, client-only
+- **Gates:** none yet — add route/boundary gates when WF-01+ implementation merges
+- **Tests:** acknowledgement in `featureExposure.acknowledgements.json`, `src/config/v17WorkstreamAdoption.exposure.test.ts`
+- **Beta enablement:** tracker #429; first enable PR: TBD
+
+### Verification relaunch (`verificationRelaunch`, #430)
+
+- **Registry:** `temporary: true`, client-only
+- **Gates:** none yet — the existing `/verification` route is core product, not this relaunch key
+- **Tests:** acknowledgement in `featureExposure.acknowledgements.json`, `src/config/v17WorkstreamAdoption.exposure.test.ts`
+- **Beta enablement:** tracker #430; first enable PR: TBD
+
+### Custom products (`customProducts`, #431)
+
+- **Registry:** `temporary: true`, client-only
+- **Gates:** none yet — add when CUS-01+ implementation merges
+- **Tests:** acknowledgement in `featureExposure.acknowledgements.json`, `src/config/v17WorkstreamAdoption.exposure.test.ts`
+- **Beta enablement:** tracker #431; first enable PR: TBD
+
+### Tropical workspace (`tropicalWorkspace`, #432)
+
+- **Registry:** `temporary: true`, client-only
+- **Gates:** gated lazy route `/tropical`, navbar item `tropical-workspace`
+- **Tests:** exemplar + `buildFeatureGatedRoutes.test.tsx` + `featureNavigation.test.ts`
+- **Beta enablement:** tracker #432; first enable PR: TBD
+
+### Collaboration room (`collaborationRoom`, #433)
+
+- **Registry:** `temporary: true`, client-only
+- **Gates:** gated lazy route `/collaborate`, navbar item `collaboration-room`
+- **Tests:** exemplar contract runner + route/nav tests
+- **Beta enablement:** tracker #433; first enable PR: TBD
+
+## Commands
+
+```powershell
+pnpm test:exposure
+pnpm validate:feature-exposure
+pnpm exposure:report
+```

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -145,4 +145,15 @@ test.describe('App smoke tests', () => {
     // App shell (navbar) should still render — not a blank page
     await expect(page.locator('body')).not.toBeEmpty();
   });
+
+  test('gated workstream routes stay unreachable while disabled', async ({ page }) => {
+    await bypassLocalBeta(page);
+    await page.goto('/tropical?localBetaBypass=true');
+    await acceptAgreementsIfPresent(page);
+    await expect(page.getByRole('heading', { name: /Tropical Workspace/i })).not.toBeVisible();
+
+    await page.goto('/collaborate?localBetaBypass=true');
+    await acceptAgreementsIfPresent(page);
+    await expect(page.getByRole('heading', { name: /Collaboration Room/i })).not.toBeVisible();
+  });
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -148,12 +148,15 @@ test.describe('App smoke tests', () => {
 
   test('gated workstream routes stay unreachable while disabled', async ({ page }) => {
     await bypassLocalBeta(page);
+
     await page.goto('/tropical?localBetaBypass=true');
     await acceptAgreementsIfPresent(page);
-    await expect(page.getByRole('heading', { name: /Tropical Workspace/i })).not.toBeVisible();
+    await expect(page).not.toHaveURL(/\/tropical(?:\?|$)/);
+    await expect(page.getByRole('heading', { name: /Tropical Workspace/i })).not.toBeVisible({ timeout: 5000 });
 
     await page.goto('/collaborate?localBetaBypass=true');
     await acceptAgreementsIfPresent(page);
-    await expect(page.getByRole('heading', { name: /Collaboration Room/i })).not.toBeVisible();
+    await expect(page).not.toHaveURL(/\/collaborate(?:\?|$)/);
+    await expect(page.getByRole('heading', { name: /Collaboration Room/i })).not.toBeVisible({ timeout: 5000 });
   });
 });

--- a/scripts/generate-exposure-report.mjs
+++ b/scripts/generate-exposure-report.mjs
@@ -30,6 +30,7 @@ function runPolicy(inputs) {
       sideEffectModules,
       acknowledgements,
       existingTestFiles,
+      requireV17WorkstreamRegistry: true,
     }
   );
 }

--- a/scripts/lib/feature-exposure-policy-contract.mjs
+++ b/scripts/lib/feature-exposure-policy-contract.mjs
@@ -44,45 +44,44 @@ export const V17_WORKSTREAM_KEYS = [
   'collaborationRoom',
 ];
 
-const V17_BUILD_TARGETS = ['local', 'beta', 'staging', 'production'];
-
-/** Returns true when the registry includes the full v1.7 workstream key set. */
-function hasCompleteV17WorkstreamRegistry(registry) {
-  const presentKeys = V17_WORKSTREAM_KEYS.filter((featureKey) => featureKey in registry);
-  if (presentKeys.length === 0) {
-    return false;
-  }
-
-  return presentKeys.length === V17_WORKSTREAM_KEYS.length;
-}
-
 /** Adds an error when the registry declares only part of the v1.7 workstream key set. */
 function validateV17RegistryCompleteness(registry, errors) {
-  if (!hasCompleteV17WorkstreamRegistry(registry)) {
-    const presentCount = V17_WORKSTREAM_KEYS.filter((featureKey) => featureKey in registry).length;
-    if (presentCount > 0) {
-      errors.push(
-        `Registry declares ${presentCount} of ${V17_WORKSTREAM_KEYS.length} v1.7 workstream keys; partial adoption is not allowed.`
-      );
-    }
-    return false;
+  const presentKeys = V17_WORKSTREAM_KEYS.filter((featureKey) => featureKey in registry);
+  if (presentKeys.length === V17_WORKSTREAM_KEYS.length) {
+    return true;
   }
 
-  return true;
+  errors.push(
+    `Registry declares ${presentKeys.length} of ${V17_WORKSTREAM_KEYS.length} v1.7 workstream keys; partial adoption is not allowed.`
+  );
+  return false;
+}
+
+/** Returns true when a workstream acknowledgement explicitly approves beta enablement. */
+function isV17BetaEnablementApproved(featureKey, acknowledgements) {
+  return acknowledgements[featureKey]?.betaEnablementApproved === true;
 }
 
 /** Adds lifecycle violations for one v1.7 workstream registry entry. */
-function validateV17WorkstreamLifecycle(featureKey, definition, errors) {
+function validateV17WorkstreamLifecycle(featureKey, definition, contract, errors) {
+  const { acknowledgements } = contract;
+
   if (definition.temporary !== true) {
     errors.push(`v1.7 workstream "${featureKey}" must remain temporary until production promotion.`);
   }
 
-  for (const target of V17_BUILD_TARGETS) {
+  for (const target of ['local', 'staging', 'production']) {
     if (definition.exposure?.[target] !== false) {
       errors.push(
         `v1.7 workstream "${featureKey}" must stay disabled on target "${target}" until adoption enables it.`
       );
     }
+  }
+
+  if (definition.exposure?.beta === true && !isV17BetaEnablementApproved(featureKey, acknowledgements)) {
+    errors.push(
+      `v1.7 workstream "${featureKey}" cannot enable beta without betaEnablementApproved in src/config/featureExposure.acknowledgements.json.`
+    );
   }
 }
 
@@ -133,7 +132,19 @@ export function validateExposureTestContract(contract, errors) {
 }
 
 /** Requires every v1.7 workstream key to stay fully disabled with documented adoption coverage. */
-export function validateV17WorkstreamAdoption(registry, contract, errors) {
+export function validateV17WorkstreamAdoption(registry, contract, errors, options = {}) {
+  const { requireV17WorkstreamRegistry = false } = options;
+  const presentCount = V17_WORKSTREAM_KEYS.filter((featureKey) => featureKey in registry).length;
+
+  if (presentCount === 0) {
+    if (requireV17WorkstreamRegistry) {
+      errors.push(
+        `Registry is missing all ${V17_WORKSTREAM_KEYS.length} required v1.7 workstream keys.`
+      );
+    }
+    return;
+  }
+
   if (!validateV17RegistryCompleteness(registry, errors)) {
     return;
   }
@@ -142,7 +153,7 @@ export function validateV17WorkstreamAdoption(registry, contract, errors) {
 
   for (const featureKey of V17_WORKSTREAM_KEYS) {
     const definition = registry[featureKey];
-    validateV17WorkstreamLifecycle(featureKey, definition, errors);
+    validateV17WorkstreamLifecycle(featureKey, definition, contract, errors);
     validateV17WorkstreamCoverage(featureKey, gatedFeatures, contract, errors);
   }
 }

--- a/scripts/lib/feature-exposure-policy-contract.mjs
+++ b/scripts/lib/feature-exposure-policy-contract.mjs
@@ -34,8 +34,18 @@ function hasValidAcknowledgementTrackingIssue(acknowledgement) {
   return typeof acknowledgement?.trackingIssue === 'number' && acknowledgement.trackingIssue > 0;
 }
 
+/** Canonical v1.7 workstream keys — keep aligned with featureExposure.test.ts and v17WorkstreamAdoption.exposure.test.ts */
+export const V17_WORKSTREAM_KEYS = [
+  'autoTstm',
+  'forecastWorkflowV2',
+  'verificationRelaunch',
+  'customProducts',
+  'tropicalWorkspace',
+  'collaborationRoom',
+];
+
 /** Returns true when a gated feature has a valid acknowledgement entry. */
-function hasValidAcknowledgement(featureKey, acknowledgements) {
+export function hasValidAcknowledgement(featureKey, acknowledgements) {
   const acknowledgement = acknowledgements[featureKey];
   return hasValidAcknowledgementReason(acknowledgement) && hasValidAcknowledgementTrackingIssue(acknowledgement);
 }
@@ -49,5 +59,52 @@ export function validateExposureTestContract(contract, errors) {
     errors.push(
       `Gated feature "${featureKey}" has no exposure test coverage or acknowledgement. Add a per-feature test or an entry to src/config/featureExposure.acknowledgements.json.`
     );
+  }
+}
+
+/** Requires every v1.7 workstream key to stay fully disabled with documented adoption coverage. */
+export function validateV17WorkstreamAdoption(registry, contract, errors) {
+  const presentKeys = V17_WORKSTREAM_KEYS.filter((featureKey) => featureKey in registry);
+  if (presentKeys.length === 0) {
+    return;
+  }
+
+  if (presentKeys.length !== V17_WORKSTREAM_KEYS.length) {
+    errors.push(
+      `Registry declares ${presentKeys.length} of ${V17_WORKSTREAM_KEYS.length} v1.7 workstream keys; partial adoption is not allowed.`
+    );
+    return;
+  }
+
+  const { surfaces, sideEffectModules, acknowledgements, existingTestFiles } = contract;
+  const gatedFeatures = collectGatedFeatures(surfaces, sideEffectModules);
+
+  for (const featureKey of V17_WORKSTREAM_KEYS) {
+    const definition = registry[featureKey];
+
+    if (definition.temporary !== true) {
+      errors.push(`v1.7 workstream "${featureKey}" must remain temporary until production promotion.`);
+    }
+
+    for (const target of ['local', 'beta', 'staging', 'production']) {
+      if (definition.exposure?.[target] !== false) {
+        errors.push(`v1.7 workstream "${featureKey}" must stay disabled on target "${target}" until adoption enables it.`);
+      }
+    }
+
+    if (gatedFeatures.has(featureKey)) {
+      if (hasPerFeatureTestFile(featureKey, existingTestFiles)) continue;
+      if (hasValidAcknowledgement(featureKey, acknowledgements)) continue;
+      errors.push(
+        `v1.7 workstream "${featureKey}" is gated but has no exposure test coverage or acknowledgement.`
+      );
+      continue;
+    }
+
+    if (!hasValidAcknowledgement(featureKey, acknowledgements)) {
+      errors.push(
+        `v1.7 workstream "${featureKey}" has no gated surfaces yet and requires a valid acknowledgement in src/config/featureExposure.acknowledgements.json.`
+      );
+    }
   }
 }

--- a/scripts/lib/feature-exposure-policy-contract.mjs
+++ b/scripts/lib/feature-exposure-policy-contract.mjs
@@ -44,6 +44,76 @@ export const V17_WORKSTREAM_KEYS = [
   'collaborationRoom',
 ];
 
+const V17_BUILD_TARGETS = ['local', 'beta', 'staging', 'production'];
+
+/** Returns true when the registry includes the full v1.7 workstream key set. */
+function hasCompleteV17WorkstreamRegistry(registry) {
+  const presentKeys = V17_WORKSTREAM_KEYS.filter((featureKey) => featureKey in registry);
+  if (presentKeys.length === 0) {
+    return false;
+  }
+
+  return presentKeys.length === V17_WORKSTREAM_KEYS.length;
+}
+
+/** Adds an error when the registry declares only part of the v1.7 workstream key set. */
+function validateV17RegistryCompleteness(registry, errors) {
+  if (!hasCompleteV17WorkstreamRegistry(registry)) {
+    const presentCount = V17_WORKSTREAM_KEYS.filter((featureKey) => featureKey in registry).length;
+    if (presentCount > 0) {
+      errors.push(
+        `Registry declares ${presentCount} of ${V17_WORKSTREAM_KEYS.length} v1.7 workstream keys; partial adoption is not allowed.`
+      );
+    }
+    return false;
+  }
+
+  return true;
+}
+
+/** Adds lifecycle violations for one v1.7 workstream registry entry. */
+function validateV17WorkstreamLifecycle(featureKey, definition, errors) {
+  if (definition.temporary !== true) {
+    errors.push(`v1.7 workstream "${featureKey}" must remain temporary until production promotion.`);
+  }
+
+  for (const target of V17_BUILD_TARGETS) {
+    if (definition.exposure?.[target] !== false) {
+      errors.push(
+        `v1.7 workstream "${featureKey}" must stay disabled on target "${target}" until adoption enables it.`
+      );
+    }
+  }
+}
+
+/** Returns true when a v1.7 workstream has per-feature tests or a valid acknowledgement. */
+function hasV17WorkstreamCoverage(featureKey, contract) {
+  const { acknowledgements, existingTestFiles } = contract;
+  if (hasPerFeatureTestFile(featureKey, existingTestFiles)) {
+    return true;
+  }
+
+  return hasValidAcknowledgement(featureKey, acknowledgements);
+}
+
+/** Adds coverage violations for one v1.7 workstream registry entry. */
+function validateV17WorkstreamCoverage(featureKey, gatedFeatures, contract, errors) {
+  if (hasV17WorkstreamCoverage(featureKey, contract)) {
+    return;
+  }
+
+  if (gatedFeatures.has(featureKey)) {
+    errors.push(
+      `v1.7 workstream "${featureKey}" is gated but has no exposure test coverage or acknowledgement.`
+    );
+    return;
+  }
+
+  errors.push(
+    `v1.7 workstream "${featureKey}" has no gated surfaces yet and requires a valid acknowledgement in src/config/featureExposure.acknowledgements.json.`
+  );
+}
+
 /** Returns true when a gated feature has a valid acknowledgement entry. */
 export function hasValidAcknowledgement(featureKey, acknowledgements) {
   const acknowledgement = acknowledgements[featureKey];
@@ -64,47 +134,15 @@ export function validateExposureTestContract(contract, errors) {
 
 /** Requires every v1.7 workstream key to stay fully disabled with documented adoption coverage. */
 export function validateV17WorkstreamAdoption(registry, contract, errors) {
-  const presentKeys = V17_WORKSTREAM_KEYS.filter((featureKey) => featureKey in registry);
-  if (presentKeys.length === 0) {
+  if (!validateV17RegistryCompleteness(registry, errors)) {
     return;
   }
 
-  if (presentKeys.length !== V17_WORKSTREAM_KEYS.length) {
-    errors.push(
-      `Registry declares ${presentKeys.length} of ${V17_WORKSTREAM_KEYS.length} v1.7 workstream keys; partial adoption is not allowed.`
-    );
-    return;
-  }
-
-  const { surfaces, sideEffectModules, acknowledgements, existingTestFiles } = contract;
-  const gatedFeatures = collectGatedFeatures(surfaces, sideEffectModules);
+  const gatedFeatures = collectGatedFeatures(contract.surfaces, contract.sideEffectModules);
 
   for (const featureKey of V17_WORKSTREAM_KEYS) {
     const definition = registry[featureKey];
-
-    if (definition.temporary !== true) {
-      errors.push(`v1.7 workstream "${featureKey}" must remain temporary until production promotion.`);
-    }
-
-    for (const target of ['local', 'beta', 'staging', 'production']) {
-      if (definition.exposure?.[target] !== false) {
-        errors.push(`v1.7 workstream "${featureKey}" must stay disabled on target "${target}" until adoption enables it.`);
-      }
-    }
-
-    if (gatedFeatures.has(featureKey)) {
-      if (hasPerFeatureTestFile(featureKey, existingTestFiles)) continue;
-      if (hasValidAcknowledgement(featureKey, acknowledgements)) continue;
-      errors.push(
-        `v1.7 workstream "${featureKey}" is gated but has no exposure test coverage or acknowledgement.`
-      );
-      continue;
-    }
-
-    if (!hasValidAcknowledgement(featureKey, acknowledgements)) {
-      errors.push(
-        `v1.7 workstream "${featureKey}" has no gated surfaces yet and requires a valid acknowledgement in src/config/featureExposure.acknowledgements.json.`
-      );
-    }
+    validateV17WorkstreamLifecycle(featureKey, definition, errors);
+    validateV17WorkstreamCoverage(featureKey, gatedFeatures, contract, errors);
   }
 }

--- a/scripts/lib/feature-exposure-policy.mjs
+++ b/scripts/lib/feature-exposure-policy.mjs
@@ -10,7 +10,7 @@ import {
   validateClientServerExposureMatrices,
   validateClientServerRegistryAlignment,
 } from './feature-exposure-policy-alignment.mjs';
-import { validateExposureTestContract } from './feature-exposure-policy-contract.mjs';
+import { validateExposureTestContract, validateV17WorkstreamAdoption } from './feature-exposure-policy-contract.mjs';
 
 /**
  * @typedef {{ ok: true }} PolicyOk
@@ -162,6 +162,11 @@ export function evaluateFeatureExposurePolicy(registry, surfaces, options = {}) 
   validateClientServerRegistryAlignment(registry, serverRegistry, errors);
   validateClientServerExposureMatrices(registry, serverRegistry, errors);
   validateExposureTestContract(
+    { surfaces, sideEffectModules, acknowledgements, existingTestFiles },
+    errors
+  );
+  validateV17WorkstreamAdoption(
+    registry,
     { surfaces, sideEffectModules, acknowledgements, existingTestFiles },
     errors
   );

--- a/scripts/lib/feature-exposure-policy.mjs
+++ b/scripts/lib/feature-exposure-policy.mjs
@@ -152,6 +152,7 @@ export function evaluateFeatureExposurePolicy(registry, surfaces, options = {}) 
     sideEffectModules = {},
     acknowledgements = {},
     existingTestFiles = [],
+    requireV17WorkstreamRegistry = false,
   } = normalizedOptions;
 
   const errors = [];
@@ -168,7 +169,8 @@ export function evaluateFeatureExposurePolicy(registry, surfaces, options = {}) 
   validateV17WorkstreamAdoption(
     registry,
     { surfaces, sideEffectModules, acknowledgements, existingTestFiles },
-    errors
+    errors,
+    { requireV17WorkstreamRegistry }
   );
   validateProductionSafety(registry, errors);
   return createPolicyResult(errors);

--- a/scripts/lib/feature-exposure-policy.test.mjs
+++ b/scripts/lib/feature-exposure-policy.test.mjs
@@ -27,6 +27,24 @@ const validRegistry = {
 
 const emptySurfaces = { gatedRoutes: [], navigationItems: [] };
 
+const v17WorkstreamRegistry = {
+  autoTstm: { exposure: { ...ALL_OFF }, owner: 'WxboySuper', addedDate: '2026-06-20', temporary: true, removalCondition: 'Enable on beta.', serverBacked: true, serverCapabilityKey: 'TSTM_GENERATION_ENABLED', trackingIssue: 427 },
+  forecastWorkflowV2: { exposure: { ...ALL_OFF }, owner: 'WxboySuper', addedDate: '2026-06-20', temporary: true, removalCondition: 'Remove after v2.', serverBacked: false, trackingIssue: 429 },
+  verificationRelaunch: { exposure: { ...ALL_OFF }, owner: 'WxboySuper', addedDate: '2026-06-20', temporary: true, removalCondition: 'Remove after relaunch.', serverBacked: false, trackingIssue: 430 },
+  customProducts: { exposure: { ...ALL_OFF }, owner: 'WxboySuper', addedDate: '2026-06-20', temporary: true, removalCondition: 'Remove after ship.', serverBacked: false, trackingIssue: 431 },
+  tropicalWorkspace: { exposure: { ...ALL_OFF }, owner: 'WxboySuper', addedDate: '2026-06-20', temporary: true, removalCondition: 'Keep disabled.', serverBacked: false, trackingIssue: 432 },
+  collaborationRoom: { exposure: { ...ALL_OFF }, owner: 'WxboySuper', addedDate: '2026-06-20', temporary: true, removalCondition: 'Remove after ship.', serverBacked: false, trackingIssue: 433 },
+};
+
+const v17Acknowledgements = {
+  autoTstm: { reason: 'Covered by exemplar exposure tests', trackingIssue: 529 },
+  tropicalWorkspace: { reason: 'Covered by route and nav tests', trackingIssue: 529 },
+  collaborationRoom: { reason: 'Covered by route and nav tests', trackingIssue: 529 },
+  forecastWorkflowV2: { reason: 'Registry-only adoption acknowledgement', trackingIssue: 530 },
+  verificationRelaunch: { reason: 'Registry-only adoption acknowledgement', trackingIssue: 530 },
+  customProducts: { reason: 'Registry-only adoption acknowledgement', trackingIssue: 530 },
+};
+
 /** Asserts that a policy input fails with every expected message pattern. */
 function assertPolicyErrors(registry, patterns, surfaces = emptySurfaces, options = {}) {
   const normalizedOptions = Array.isArray(options) ? { serverCapabilityKeys: options } : options;
@@ -295,6 +313,9 @@ describe('feature exposure policy', () => {
         autoTstm: { reason: 'Covered by FeatureBoundary.test.tsx', trackingIssue: 427 },
         tropicalWorkspace: { reason: 'Covered by buildFeatureGatedRoutes.test.tsx', trackingIssue: 432 },
         collaborationRoom: { reason: 'Covered by buildFeatureGatedRoutes.test.tsx', trackingIssue: 433 },
+        forecastWorkflowV2: { reason: 'Registry-only adoption acknowledgement', trackingIssue: 530 },
+        verificationRelaunch: { reason: 'Registry-only adoption acknowledgement', trackingIssue: 530 },
+        customProducts: { reason: 'Registry-only adoption acknowledgement', trackingIssue: 530 },
       },
     });
     assert.equal(result.ok, true);
@@ -396,5 +417,32 @@ describe('feature exposure policy', () => {
       existingTestFiles: ['src/features/betaFeature.exposure.test.ts'],
     });
     assert.equal(result.ok, true);
+  });
+
+  it('fails when a registry-only v1.7 workstream lacks acknowledgement', () => {
+    const { forecastWorkflowV2, ...withoutWorkflow } = v17WorkstreamRegistry;
+    const registry = {
+      ...withoutWorkflow,
+      forecastWorkflowV2,
+    };
+    const acknowledgements = { ...v17Acknowledgements };
+    delete acknowledgements.forecastWorkflowV2;
+
+    assertPolicyErrors(registry, [/forecastWorkflowV2.*requires a valid acknowledgement/], emptySurfaces, {
+      acknowledgements,
+    });
+  });
+
+  it('fails when a v1.7 workstream is enabled on beta prematurely', () => {
+    const registry = {
+      ...v17WorkstreamRegistry,
+      customProducts: {
+        ...v17WorkstreamRegistry.customProducts,
+        exposure: { ...ALL_OFF, beta: true },
+      },
+    };
+    assertPolicyErrors(registry, [/customProducts.*disabled on target "beta"/], emptySurfaces, {
+      acknowledgements: v17Acknowledgements,
+    });
   });
 });

--- a/scripts/lib/feature-exposure-policy.test.mjs
+++ b/scripts/lib/feature-exposure-policy.test.mjs
@@ -441,8 +441,46 @@ describe('feature exposure policy', () => {
         exposure: { ...ALL_OFF, beta: true },
       },
     };
-    assertPolicyErrors(registry, [/customProducts.*disabled on target "beta"/], emptySurfaces, {
+    assertPolicyErrors(registry, [/customProducts.*betaEnablementApproved/], emptySurfaces, {
       acknowledgements: v17Acknowledgements,
     });
+  });
+
+  it('fails when all v1.7 workstream keys are removed from the registry', () => {
+    const registry = {
+      coreFeature: validRegistry.coreFeature,
+    };
+    const result = evaluateFeatureExposurePolicy(registry, emptySurfaces, {
+      requireV17WorkstreamRegistry: true,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((error) => /missing all 6 required v1\.7 workstream keys/.test(error)));
+  });
+
+  it('passes when a v1.7 workstream enables beta with explicit approval', () => {
+    const registry = {
+      ...v17WorkstreamRegistry,
+      autoTstm: {
+        ...v17WorkstreamRegistry.autoTstm,
+        exposure: { ...ALL_OFF, beta: true },
+      },
+    };
+    const acknowledgements = {
+      ...v17Acknowledgements,
+      autoTstm: { ...v17Acknowledgements.autoTstm, betaEnablementApproved: true },
+    };
+    const result = evaluateFeatureExposurePolicy(registry, emptySurfaces, {
+      acknowledgements,
+      serverCapabilityKeys: ['TSTM_GENERATION_ENABLED'],
+      serverRegistry: {
+        autoTstm: {
+          serverCapabilityKey: 'TSTM_GENERATION_ENABLED',
+          exposure: { ...ALL_OFF, beta: true },
+        },
+      },
+      sideEffectModules: { autoTstm: ['../utils/tstmGeneration'] },
+      existingTestFiles: ['server/testing/autoTstm.exposure.test.js'],
+    });
+    assert.equal(result.ok, true);
   });
 });

--- a/scripts/run-exposure-suite.mjs
+++ b/scripts/run-exposure-suite.mjs
@@ -10,6 +10,7 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const CLIENT_EXPOSURE_TESTS = [
   'src/testing/featureExposure/exemplar.exposure.test.tsx',
   'src/testing/featureExposure/targetMatrix.test.ts',
+  'src/config/v17WorkstreamAdoption.exposure.test.ts',
   'src/routing/buildFeatureGatedRoutes.test.tsx',
   'src/config/featureNavigation.test.ts',
   'src/features/FeatureBoundary.test.tsx',

--- a/scripts/validate-feature-exposure.integration.test.mjs
+++ b/scripts/validate-feature-exposure.integration.test.mjs
@@ -31,6 +31,7 @@ describe('validate-feature-exposure integration', () => {
         sideEffectModules: inputs.sideEffectModules,
         acknowledgements: inputs.acknowledgements,
         existingTestFiles: inputs.existingTestFiles,
+        requireV17WorkstreamRegistry: true,
       }
     );
     assert.equal(result.ok, true, result.ok ? '' : result.errors.join('\n'));

--- a/scripts/validate-feature-exposure.mjs
+++ b/scripts/validate-feature-exposure.mjs
@@ -106,6 +106,7 @@ function main() {
       sideEffectModules,
       acknowledgements,
       existingTestFiles,
+      requireV17WorkstreamRegistry: true,
     }
   );
 

--- a/scripts/validate-promotion-exposure-pr.mjs
+++ b/scripts/validate-promotion-exposure-pr.mjs
@@ -49,6 +49,7 @@ function evaluateHeadPolicy(inputs) {
       sideEffectModules: inputs.sideEffectModules,
       acknowledgements: inputs.acknowledgements,
       existingTestFiles: inputs.existingTestFiles,
+      requireV17WorkstreamRegistry: true,
     }
   );
 }

--- a/src/config/featureExposure.acknowledgements.json
+++ b/src/config/featureExposure.acknowledgements.json
@@ -10,5 +10,17 @@
   "collaborationRoom": {
     "reason": "Route and navigation gating covered by src/testing/featureExposure/exemplar.exposure.test.tsx and src/routing/buildFeatureGatedRoutes.test.tsx",
     "trackingIssue": 529
+  },
+  "forecastWorkflowV2": {
+    "reason": "Registry-only until workflow v2 surfaces merge; adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",
+    "trackingIssue": 530
+  },
+  "verificationRelaunch": {
+    "reason": "Registry-only until verification relaunch surfaces merge; core /verification is separate; adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",
+    "trackingIssue": 530
+  },
+  "customProducts": {
+    "reason": "Registry-only until custom product surfaces merge; adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",
+    "trackingIssue": 530
   }
 }

--- a/src/config/v17WorkstreamAdoption.exposure.test.ts
+++ b/src/config/v17WorkstreamAdoption.exposure.test.ts
@@ -1,0 +1,54 @@
+import { BUILD_TARGETS } from './buildTarget';
+import {
+  FEATURE_EXPOSURE_REGISTRY,
+  getFeatureExposure,
+  isFeatureExposedOnTarget,
+  type FeatureKey,
+} from './featureExposure';
+
+/** Canonical v1.7 workstream keys — keep aligned with featureExposure.test.ts and CI policy. */
+export const V17_WORKSTREAM_KEYS = [
+  'autoTstm',
+  'forecastWorkflowV2',
+  'verificationRelaunch',
+  'customProducts',
+  'tropicalWorkspace',
+  'collaborationRoom',
+] as const satisfies readonly FeatureKey[];
+
+type V17WorkstreamKey = (typeof V17_WORKSTREAM_KEYS)[number];
+
+describe('v1.7 workstream adoption contract', () => {
+  test.each(V17_WORKSTREAM_KEYS)('%s stays disabled on every build target', (feature) => {
+    for (const target of BUILD_TARGETS) {
+      expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
+      expect(FEATURE_EXPOSURE_REGISTRY[feature].exposure[target]).toBe(false);
+    }
+  });
+
+  test.each(V17_WORKSTREAM_KEYS)('%s declares required lifecycle metadata', (feature) => {
+    const definition = getFeatureExposure(feature);
+
+    expect(definition.temporary).toBe(true);
+    expect(definition.removalCondition.trim().length).toBeGreaterThan(0);
+    expect(definition.trackingIssue).toBeGreaterThan(0);
+    expect(definition.owner.trim().length).toBeGreaterThan(0);
+    expect(definition.addedDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('only autoTstm is server-backed among v1.7 workstreams', () => {
+    for (const feature of V17_WORKSTREAM_KEYS) {
+      const definition = getFeatureExposure(feature);
+      if (feature === 'autoTstm') {
+        expect(definition.serverBacked).toBe(true);
+        expect(definition.serverCapabilityKey).toBe('TSTM_GENERATION_ENABLED');
+      } else {
+        expect(definition.serverBacked).toBe(false);
+        expect(definition.serverCapabilityKey).toBeUndefined();
+      }
+    }
+  });
+});
+
+/** Exported for policy alignment tests that import the canonical key list. */
+export type { V17WorkstreamKey };


### PR DESCRIPTION
## Summary

- Add the v1.7 workstream adoption manifest (`docs/feature-exposure-workstreams.md`) mapping all six registry keys to gates, tests, and beta-enablement records.
- Close registry-only adoption gaps for `forecastWorkflowV2`, `verificationRelaunch`, and `customProducts` with acknowledgements and `v17WorkstreamAdoption.exposure.test.ts`.
- Extend CI policy with `validateV17WorkstreamAdoption` so partial or undocumented v1.7 adoption fails deterministically.
- Add smoke assertions that `/tropical` and `/collaborate` stay unreachable while disabled.
- Cross-link workstream tracker issues (#427–#433) with registry keys and FND-14 blocker.

Closes #530

## Test plan

- [x] `pnpm test:exposure`
- [x] `pnpm validate:feature-exposure`
- [x] `node --test scripts/lib/feature-exposure-policy.test.mjs scripts/validate-feature-exposure.integration.test.mjs`
- [x] `pnpm exposure:report` — all six v1.7 keys listed under Disabled
- [x] `pnpm run build`
- [x] `pnpm exec playwright test e2e/smoke.spec.ts`
- [ ] Sentry disabled-module check on beta deploy (manual; local smoke runs without DSN)
