### PR TITLE
feat(tstm): scheduled latest-complete-run ingestion and cache

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,13 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #646
+
+- Add scheduled TSTM ingestion: periodic server-side discovery of new HREF runs with golden-copy caching that only replaces confirmed data (TSTM-03, #474).
+- Add `GET /api/tstm/latest` endpoint for pre-cached TSTM data.
+- Add `--ingestion-mode` flag to Python generator for completeness metadata.
+- Add `requestLatestTstmData()` client utility.
+
 ### PR #645
 
 - Fix Sentry GFC-WEB-G by portaling the Forecast Cycle History modal to `document.body`, unifying its overlay/dialog shell with `notranslate`, deferring parent close after nested confirm actions, and stacking confirm overlays above the history dialog.

--- a/server/analytics-app.js
+++ b/server/analytics-app.js
@@ -34,7 +34,7 @@ function configureApp(app, express, fs, LOG_FILE) {
   const { registerCapabilityRoutes } = require('./capabilities');
   const { registerMetricsRoutes } = require('./metrics');
   const { registerSentryTunnelRoutes } = require('./sentry-tunnel');
-  const { registerTstmRoutes } = require('./tstm');
+  const { registerTstmIngestion, registerTstmRoutes } = require('./tstm');
 
   app.set('trust proxy', 'loopback');
 
@@ -51,6 +51,7 @@ function configureApp(app, express, fs, LOG_FILE) {
   registerBetaRoutes(app, express);
   registerCapabilityRoutes(app);
   registerTstmRoutes(app, express);
+  registerTstmIngestion(app, express);
 
   app.post('/collect', express.json({ limit: '1kb' }), collectRateLimit, createCollectHandler(fs, LOG_FILE));
 

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -54,7 +54,9 @@ const deleteCache = (target, day, period, env = process.env) => {
 const isCacheExpired = (data, now = Date.now(), expirationHours = DEFAULT_EXPIRATION_HOURS) => {
   if (!data?.effectiveEnd) return true;
   try {
-    return now > new Date(data.effectiveEnd).getTime() + expirationHours * 3600_000;
+    const effectiveEndMs = new Date(data.effectiveEnd).getTime();
+    if (!Number.isFinite(effectiveEndMs)) return true;
+    return now > effectiveEndMs + expirationHours * 3600_000;
   } catch {
     return true;
   }

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -140,7 +140,7 @@ const runIngestionCycle = async (options = {}) => {
 
   for (const { day, period, run } of candidates) {
     try {
-      const result = await runGenerator({ day, cycleDate: run.slice(0, 10) }, { ingestionMode: true });
+      const result = await runGenerator({ day, cycleDate: run.slice(0, 10), cycleRun: run }, { ingestionMode: true });
 
       if (!isRunComplete(result)) {
         log.info?.(`[tstm-ingest] run ${run} day ${day} not ready, retaining cache`);

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -25,20 +25,17 @@ const cacheFilePath = (target, day, period, env = process.env) =>
 /** Reads cached TSTM data for a target/day/period. Returns null on any error. */
 const readCache = (target, day, period, env = process.env) => {
   if (!isValidPeriod(period)) return null;
-  const filePath = cacheFilePath(target, day, period, env);
   try {
-    const raw = fs.readFileSync(filePath, 'utf8');
-    return JSON.parse(raw);
+    return JSON.parse(fs.readFileSync(cacheFilePath(target, day, period, env), 'utf8'));
   } catch {
     return null;
   }
 };
 
 /** Atomically writes TSTM data to the cache (write-to-temp, then rename). */
-const writeCache = (target, day, period, data, env = process.env) => {
+const writeCache = ({ target, day, period, data, env = process.env }) => {
   const filePath = cacheFilePath(target, day, period, env);
-  const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const tmpPath = `${filePath}.tmp`;
   fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf8');
   fs.renameSync(tmpPath, filePath);
@@ -46,9 +43,8 @@ const writeCache = (target, day, period, data, env = process.env) => {
 
 /** Removes a cache entry. Used only for explicit invalidation. */
 const deleteCache = (target, day, period, env = process.env) => {
-  const filePath = cacheFilePath(target, day, period, env);
   try {
-    fs.unlinkSync(filePath);
+    fs.unlinkSync(cacheFilePath(target, day, period, env));
   } catch {
     // Ignore — file may not exist.
   }
@@ -58,19 +54,39 @@ const deleteCache = (target, day, period, env = process.env) => {
 const isCacheExpired = (data, now = Date.now(), expirationHours = DEFAULT_EXPIRATION_HOURS) => {
   if (!data?.effectiveEnd) return true;
   try {
-    const end = new Date(data.effectiveEnd).getTime();
-    return now > end + expirationHours * 60 * 60 * 1000;
+    return now > new Date(data.effectiveEnd).getTime() + expirationHours * 3600_000;
   } catch {
     return true;
   }
 };
 
 /** Returns true when a generator response indicates the run data is complete and usable. */
-const isRunComplete = (result) => {
-  if (!result || typeof result !== 'object') return false;
-  if (!Array.isArray(result.features) || result.features.length === 0) return false;
-  if (result.completeness && result.completeness.complete === false) return false;
-  return true;
+const isRunComplete = (result) =>
+  result
+  && typeof result === 'object'
+  && Array.isArray(result.features)
+  && result.features.length > 0
+  && !(result.completeness && result.completeness.complete === false);
+
+/**
+ * Resolves the HREF run timestamps to check for Day 1 and Day 2 based on
+ * the current UTC hour plus a buffer for SPC posting delay.
+ */
+const resolveRuns = (utcNow, bufferHours) => {
+  const hour = utcNow.getUTCHours();
+  const date = utcNow.toISOString().slice(0, 10);
+
+  if (hour >= 12 + bufferHours) {
+    return { day1Run: `${date}T12:00:00Z`, day2Run: `${date}T12:00:00Z` };
+  }
+
+  if (hour >= bufferHours) {
+    const prev = new Date(utcNow);
+    prev.setUTCDate(prev.getUTCDate() - 1);
+    return { day1Run: `${date}T00:00:00Z`, day2Run: `${prev.toISOString().slice(0, 10)}T12:00:00Z` };
+  }
+
+  return { day1Run: null, day2Run: null };
 };
 
 /**
@@ -82,40 +98,29 @@ const isRunComplete = (result) => {
  * Returns an array of { day, period, run } objects to check.
  */
 const computeCandidateRuns = (now, bufferHours = DEFAULT_BUFFER_HOURS) => {
-  const utcNow = new Date(now);
-  const hour = utcNow.getUTCHours();
-  const date = utcNow.toISOString().slice(0, 10);
+  const { day1Run, day2Run } = resolveRuns(new Date(now), bufferHours);
   const candidates = [];
 
-  // Determine which HREF run to check based on current time + buffer.
-  // After 0Z + buffer: check 0Z run for Day 1
-  // After 12Z + buffer: check 12Z run for Day 1
-  // Day 2 always uses the previous 12Z run.
-  let day1Run = null;
-  let day2Run = null;
-
-  if (hour >= 12 + bufferHours) {
-    // After 14Z (default): 12Z run should be posting
-    day1Run = `${date}T12:00:00Z`;
-    day2Run = `${date}T12:00:00Z`;
-  } else if (hour >= bufferHours) {
-    // After 02Z (default): 0Z run should be posting
-    day1Run = `${date}T00:00:00Z`;
-    // Day 2 uses previous day's 12Z
-    const prev = new Date(utcNow);
-    prev.setUTCDate(prev.getUTCDate() - 1);
-    day2Run = `${prev.toISOString().slice(0, 10)}T12:00:00Z`;
-  }
-
-  if (day1Run) {
-    candidates.push({ day: 1, period: 'full', run: day1Run });
-  }
-  if (day2Run) {
-    candidates.push({ day: 2, period: 'full', run: day2Run });
-  }
+  if (day1Run) candidates.push({ day: 1, period: 'full', run: day1Run });
+  if (day2Run) candidates.push({ day: 2, period: 'full', run: day2Run });
 
   return candidates;
 };
+
+/** Builds the cache entry from a successful generator result. */
+const buildCacheData = (result, day, period) => ({
+  run: result.run,
+  day,
+  period,
+  features: result.features,
+  effectiveStart: result.effectiveStart,
+  effectiveEnd: result.effectiveEnd,
+  thresholds: result.thresholds,
+  generatedAt: result.generatedAt,
+  ingestedAt: new Date().toISOString(),
+  complete: true,
+  domain: result.domain || 'conus',
+});
 
 /**
  * Runs a single ingestion cycle: checks each candidate run, spawns the
@@ -134,41 +139,18 @@ const runIngestionCycle = async (options = {}) => {
   const candidates = computeCandidateRuns(now, bufferHours);
 
   for (const { day, period, run } of candidates) {
-    const cycleDate = run.slice(0, 10);
-    const payload = { day, cycleDate };
-
     try {
-      const result = await runGenerator(payload, { ingestionMode: true });
+      const result = await runGenerator({ day, cycleDate: run.slice(0, 10) }, { ingestionMode: true });
 
       if (!isRunComplete(result)) {
-        log.info?.(
-          `[tstm-ingest] run ${run} day ${day} not ready, retaining cache`
-        );
+        log.info?.(`[tstm-ingest] run ${run} day ${day} not ready, retaining cache`);
         continue;
       }
 
-      const cacheData = {
-        run: result.run,
-        day,
-        period,
-        features: result.features,
-        effectiveStart: result.effectiveStart,
-        effectiveEnd: result.effectiveEnd,
-        thresholds: result.thresholds,
-        generatedAt: result.generatedAt,
-        ingestedAt: new Date().toISOString(),
-        complete: true,
-        domain: result.domain || 'conus',
-      };
-
-      writeCache(target, day, period, cacheData, env);
-      log.info?.(
-        `[tstm-ingest] run ${run} day ${day} cached (${result.features.length} features)`
-      );
+      writeCache({ target, day, period, data: buildCacheData(result, day, period), env });
+      log.info?.(`[tstm-ingest] run ${run} day ${day} cached (${result.features.length} features)`);
     } catch (err) {
-      log.error?.(
-        `[tstm-ingest] run ${run} day ${day} failed: ${err.message}`
-      );
+      log.error?.(`[tstm-ingest] run ${run} day ${day} failed: ${err.message}`);
     }
   }
 };
@@ -201,7 +183,6 @@ const startIngestionLoop = (options = {}) => {
     }
   };
 
-  // Run once immediately, then on interval.
   tick();
   timer = setInterval(tick, intervalMs);
 

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -66,8 +66,7 @@ const isCacheExpired = (data, now = Date.now(), expirationHours = DEFAULT_EXPIRA
 const isRunComplete = (result) => {
   if (!result || typeof result !== 'object') return false;
   if (!Array.isArray(result.features) || result.features.length === 0) return false;
-  if (result.completeness && result.completeness.complete === false) return false;
-  return true;
+  return !(result.completeness && result.completeness.complete === false);
 };
 
 /**
@@ -175,8 +174,7 @@ const startIngestionLoop = (options = {}) => {
   let timer = null;
   let running = false;
 
-  /** Runs one ingestion cycle, skipping when a previous tick is still in flight. */
-  const tick = async () => {
+  async function tick() {
     if (running) return;
     running = true;
     try {
@@ -184,7 +182,7 @@ const startIngestionLoop = (options = {}) => {
     } finally {
       running = false;
     }
-  };
+  }
 
   tick();
   timer = setInterval(tick, intervalMs);

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -63,12 +63,12 @@ const isCacheExpired = (data, now = Date.now(), expirationHours = DEFAULT_EXPIRA
 };
 
 /** Returns true when a generator response indicates the run data is complete and usable. */
-const isRunComplete = (result) =>
-  result
-  && typeof result === 'object'
-  && Array.isArray(result.features)
-  && result.features.length > 0
-  && !(result.completeness && result.completeness.complete === false);
+const isRunComplete = (result) => {
+  if (!result || typeof result !== 'object') return false;
+  if (!Array.isArray(result.features) || result.features.length === 0) return false;
+  if (result.completeness && result.completeness.complete === false) return false;
+  return true;
+};
 
 /**
  * Resolves the HREF run timestamps to check for Day 1 and Day 2 based on
@@ -175,6 +175,7 @@ const startIngestionLoop = (options = {}) => {
   let timer = null;
   let running = false;
 
+  /** Runs one ingestion cycle, skipping when a previous tick is still in flight. */
   const tick = async () => {
     if (running) return;
     running = true;

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -1,0 +1,233 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { getServerTarget } = require('./lib/serverTarget');
+
+const DEFAULT_INGESTION_INTERVAL_MS = 30 * 60 * 1000;
+const DEFAULT_BUFFER_HOURS = 2;
+const DEFAULT_EXPIRATION_HOURS = 6;
+const SUPPORTED_DAYS = [1, 2];
+const VALID_PERIODS = ['full', '4hr', '1hr'];
+
+/** Returns true when the period string is a known SPC thunder period. */
+const isValidPeriod = (period) => VALID_PERIODS.includes(period);
+
+/** Returns the cache root directory for the given deployment target. */
+const cacheDir = (target, env = process.env) =>
+  path.join(env.TSTM_CACHE_DIR || path.join(__dirname, 'cache', 'tstm'), target);
+
+/** Returns the cache file path for a specific day and period. */
+const cacheFilePath = (target, day, period, env = process.env) =>
+  path.join(cacheDir(target, env), `day${day}`, `${period}.json`);
+
+/** Reads cached TSTM data for a target/day/period. Returns null on any error. */
+const readCache = (target, day, period, env = process.env) => {
+  if (!isValidPeriod(period)) return null;
+  const filePath = cacheFilePath(target, day, period, env);
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+};
+
+/** Atomically writes TSTM data to the cache (write-to-temp, then rename). */
+const writeCache = (target, day, period, data, env = process.env) => {
+  const filePath = cacheFilePath(target, day, period, env);
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf8');
+  fs.renameSync(tmpPath, filePath);
+};
+
+/** Removes a cache entry. Used only for explicit invalidation. */
+const deleteCache = (target, day, period, env = process.env) => {
+  const filePath = cacheFilePath(target, day, period, env);
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // Ignore — file may not exist.
+  }
+};
+
+/** Returns true when the cached data's valid window has expired. */
+const isCacheExpired = (data, now = Date.now(), expirationHours = DEFAULT_EXPIRATION_HOURS) => {
+  if (!data?.effectiveEnd) return true;
+  try {
+    const end = new Date(data.effectiveEnd).getTime();
+    return now > end + expirationHours * 60 * 60 * 1000;
+  } catch {
+    return true;
+  }
+};
+
+/** Returns true when a generator response indicates the run data is complete and usable. */
+const isRunComplete = (result) => {
+  if (!result || typeof result !== 'object') return false;
+  if (!Array.isArray(result.features) || result.features.length === 0) return false;
+  if (result.completeness && result.completeness.complete === false) return false;
+  return true;
+};
+
+/**
+ * Computes candidate ingestion targets based on the current time.
+ *
+ * HREF runs at 0Z and 12Z.  SPC posts calibrated thunder ~1-3 hours after
+ * model init (variable).  The buffer accounts for this delay.
+ *
+ * Returns an array of { day, period, run } objects to check.
+ */
+const computeCandidateRuns = (now, bufferHours = DEFAULT_BUFFER_HOURS) => {
+  const utcNow = new Date(now);
+  const hour = utcNow.getUTCHours();
+  const date = utcNow.toISOString().slice(0, 10);
+  const candidates = [];
+
+  // Determine which HREF run to check based on current time + buffer.
+  // After 0Z + buffer: check 0Z run for Day 1
+  // After 12Z + buffer: check 12Z run for Day 1
+  // Day 2 always uses the previous 12Z run.
+  let day1Run = null;
+  let day2Run = null;
+
+  if (hour >= 12 + bufferHours) {
+    // After 14Z (default): 12Z run should be posting
+    day1Run = `${date}T12:00:00Z`;
+    day2Run = `${date}T12:00:00Z`;
+  } else if (hour >= bufferHours) {
+    // After 02Z (default): 0Z run should be posting
+    day1Run = `${date}T00:00:00Z`;
+    // Day 2 uses previous day's 12Z
+    const prev = new Date(utcNow);
+    prev.setUTCDate(prev.getUTCDate() - 1);
+    day2Run = `${prev.toISOString().slice(0, 10)}T12:00:00Z`;
+  }
+
+  if (day1Run) {
+    candidates.push({ day: 1, period: 'full', run: day1Run });
+  }
+  if (day2Run) {
+    candidates.push({ day: 2, period: 'full', run: day2Run });
+  }
+
+  return candidates;
+};
+
+/**
+ * Runs a single ingestion cycle: checks each candidate run, spawns the
+ * generator, and only writes to cache when data is confirmed complete.
+ */
+const runIngestionCycle = async (options = {}) => {
+  const {
+    env = process.env,
+    target = getServerTarget(env),
+    runGenerator,
+    now = Date.now(),
+    bufferHours = DEFAULT_BUFFER_HOURS,
+    log = console,
+  } = options;
+
+  const candidates = computeCandidateRuns(now, bufferHours);
+
+  for (const { day, period, run } of candidates) {
+    const cycleDate = run.slice(0, 10);
+    const payload = { day, cycleDate };
+
+    try {
+      const result = await runGenerator(payload, { ingestionMode: true });
+
+      if (!isRunComplete(result)) {
+        log.info?.(
+          `[tstm-ingest] run ${run} day ${day} not ready, retaining cache`
+        );
+        continue;
+      }
+
+      const cacheData = {
+        run: result.run,
+        day,
+        period,
+        features: result.features,
+        effectiveStart: result.effectiveStart,
+        effectiveEnd: result.effectiveEnd,
+        thresholds: result.thresholds,
+        generatedAt: result.generatedAt,
+        ingestedAt: new Date().toISOString(),
+        complete: true,
+        domain: result.domain || 'conus',
+      };
+
+      writeCache(target, day, period, cacheData, env);
+      log.info?.(
+        `[tstm-ingest] run ${run} day ${day} cached (${result.features.length} features)`
+      );
+    } catch (err) {
+      log.error?.(
+        `[tstm-ingest] run ${run} day ${day} failed: ${err.message}`
+      );
+    }
+  }
+};
+
+/**
+ * Starts the periodic ingestion loop.  Returns a stop function.
+ */
+const startIngestionLoop = (options = {}) => {
+  const {
+    env = process.env,
+    intervalMs = Number(env.TSTM_INGESTION_INTERVAL_MS) || DEFAULT_INGESTION_INTERVAL_MS,
+    runGenerator,
+    log = console,
+  } = options;
+
+  if (!runGenerator) {
+    throw new Error('runGenerator is required to start the ingestion loop');
+  }
+
+  let timer = null;
+  let running = false;
+
+  const tick = async () => {
+    if (running) return;
+    running = true;
+    try {
+      await runIngestionCycle({ env, runGenerator, log });
+    } finally {
+      running = false;
+    }
+  };
+
+  // Run once immediately, then on interval.
+  tick();
+  timer = setInterval(tick, intervalMs);
+
+  return () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+};
+
+module.exports = {
+  cacheDir,
+  cacheFilePath,
+  computeCandidateRuns,
+  deleteCache,
+  DEFAULT_BUFFER_HOURS,
+  DEFAULT_EXPIRATION_HOURS,
+  DEFAULT_INGESTION_INTERVAL_MS,
+  isCacheExpired,
+  isValidPeriod,
+  isRunComplete,
+  readCache,
+  runIngestionCycle,
+  startIngestionLoop,
+  SUPPORTED_DAYS,
+  VALID_PERIODS,
+  writeCache,
+};

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -174,6 +174,7 @@ const startIngestionLoop = (options = {}) => {
   let timer = null;
   let running = false;
 
+  /** Runs one ingestion cycle, skipping when a previous tick is still in flight. */
   async function tick() {
     if (running) return;
     running = true;

--- a/server/tstm-ingestion.test.js
+++ b/server/tstm-ingestion.test.js
@@ -98,6 +98,10 @@ describe('tstm-ingestion', () => {
     it('returns true for null data', () => {
       assert.equal(isCacheExpired(null), true);
     });
+
+    it('returns true for invalid effectiveEnd date', () => {
+      assert.equal(isCacheExpired({ effectiveEnd: 'not-a-date' }), true);
+    });
   });
 
   describe('computeCandidateRuns', () => {

--- a/server/tstm-ingestion.test.js
+++ b/server/tstm-ingestion.test.js
@@ -138,7 +138,7 @@ describe('tstm-ingestion', () => {
 
     it('writes and reads a cache file', () => {
       const env = { TSTM_CACHE_DIR: dir };
-      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+      writeCache({ target: 'beta', day: 1, period: 'full', data: SAMPLE_CACHE_DATA, env });
       const data = readCache('beta', 1, 'full', env);
       assert.deepEqual(data, SAMPLE_CACHE_DATA);
     });
@@ -150,7 +150,7 @@ describe('tstm-ingestion', () => {
 
     it('deletes a cache file', () => {
       const env = { TSTM_CACHE_DIR: dir };
-      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+      writeCache({ target: 'beta', day: 1, period: 'full', data: SAMPLE_CACHE_DATA, env });
       deleteCache('beta', 1, 'full', env);
       assert.equal(readCache('beta', 1, 'full', env), null);
     });
@@ -162,9 +162,9 @@ describe('tstm-ingestion', () => {
 
     it('keeps beta and production cache independent', () => {
       const env = { TSTM_CACHE_DIR: dir };
-      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+      writeCache({ target: 'beta', day: 1, period: 'full', data: SAMPLE_CACHE_DATA, env });
       const prodData = { ...SAMPLE_CACHE_DATA, run: '2026-06-14T00:00:00Z' };
-      writeCache('production', 1, 'full', prodData, env);
+      writeCache({ target: 'production', day: 1, period: 'full', data: prodData, env });
       assert.equal(readCache('beta', 1, 'full', env).run, '2026-06-13T12:00:00Z');
       assert.equal(readCache('production', 1, 'full', env).run, '2026-06-14T00:00:00Z');
     });
@@ -197,8 +197,7 @@ describe('tstm-ingestion', () => {
 
     it('retains existing cache when data is not ready', async () => {
       const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_INTERVAL_MS: '60000' };
-      // Pre-populate cache
-      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+      writeCache({ target: 'beta', day: 1, period: 'full', data: SAMPLE_CACHE_DATA, env });
 
       const runGenerator = async () => ({
         features: [],
@@ -220,7 +219,7 @@ describe('tstm-ingestion', () => {
 
     it('retains existing cache when generator throws', async () => {
       const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_INTERVAL_MS: '60000' };
-      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+      writeCache({ target: 'beta', day: 1, period: 'full', data: SAMPLE_CACHE_DATA, env });
 
       const runGenerator = async () => {
         throw new Error('SPC data unavailable');

--- a/server/tstm-ingestion.test.js
+++ b/server/tstm-ingestion.test.js
@@ -195,6 +195,26 @@ describe('tstm-ingestion', () => {
       assert.equal(cached.features.length, 1);
     });
 
+    it('passes full run timestamp as cycleRun to generator', async () => {
+      const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_INTERVAL_MS: '60000' };
+      let receivedPayload;
+      const runGenerator = async (payload) => {
+        receivedPayload = payload;
+        return { ...SAMPLE_CACHE_DATA, completeness: { complete: true, checkedHours: [1, 24], matchedHours: [1, 24], missingHours: [] } };
+      };
+
+      await runIngestionCycle({
+        env,
+        target: 'beta',
+        runGenerator,
+        now: new Date('2026-06-15T15:00:00Z').getTime(),
+      });
+
+      assert.ok(receivedPayload);
+      assert.equal(receivedPayload.cycleRun, '2026-06-15T12:00:00Z');
+      assert.equal(receivedPayload.cycleDate, '2026-06-15');
+    });
+
     it('retains existing cache when data is not ready', async () => {
       const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_INTERVAL_MS: '60000' };
       writeCache({ target: 'beta', day: 1, period: 'full', data: SAMPLE_CACHE_DATA, env });

--- a/server/tstm-ingestion.test.js
+++ b/server/tstm-ingestion.test.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  cacheFilePath,
+  computeCandidateRuns,
+  deleteCache,
+  isCacheExpired,
+  isRunComplete,
+  readCache,
+  runIngestionCycle,
+  startIngestionLoop,
+  writeCache,
+} = require('./tstm-ingestion');
+
+/** Returns a temporary directory for test cache isolation. */
+const tmpDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'tstm-ingest-test-'));
+
+const SAMPLE_CACHE_DATA = {
+  run: '2026-06-13T12:00:00Z',
+  day: 1,
+  period: 'full',
+  features: [
+    {
+      type: 'Feature',
+      id: 'href-tstm-0',
+      geometry: { type: 'Polygon', coordinates: [[[-100, 30], [-99, 30], [-99, 31], [-100, 31], [-100, 30]]] },
+      properties: { outlookType: 'categorical', probability: 'TSTM' },
+    },
+  ],
+  effectiveStart: '2026-06-13T06:00:00Z',
+  effectiveEnd: '2026-06-14T12:00:00Z',
+  thresholds: { calibratedThunderCoreProbability: 0.30, calibratedThunderSupportProbability: 0.10 },
+  generatedAt: '2026-06-13T14:05:00Z',
+  ingestedAt: '2026-06-13T14:05:12Z',
+  complete: true,
+};
+
+describe('tstm-ingestion', () => {
+  describe('isRunComplete', () => {
+    it('returns true for a valid response with features', () => {
+      assert.equal(isRunComplete(SAMPLE_CACHE_DATA), true);
+    });
+
+    it('returns false for null', () => {
+      assert.equal(isRunComplete(null), false);
+    });
+
+    it('returns false for empty features', () => {
+      assert.equal(isRunComplete({ features: [] }), false);
+    });
+
+    it('returns false when completeness.complete is false', () => {
+      assert.equal(
+        isRunComplete({ features: [{}], completeness: { complete: false } }),
+        false
+      );
+    });
+
+    it('returns true when completeness.complete is true', () => {
+      assert.equal(
+        isRunComplete({ features: [{}], completeness: { complete: true } }),
+        true
+      );
+    });
+
+    it('returns false for non-object input', () => {
+      assert.equal(isRunComplete('not an object'), false);
+      assert.equal(isRunComplete(42), false);
+    });
+  });
+
+  describe('isCacheExpired', () => {
+    it('returns false when effectiveEnd is in the future', () => {
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      assert.equal(isCacheExpired({ effectiveEnd: future }), false);
+    });
+
+    it('returns true when effectiveEnd is in the past beyond TTL', () => {
+      const past = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      assert.equal(isCacheExpired({ effectiveEnd: past }), true);
+    });
+
+    it('returns false when within TTL after effectiveEnd', () => {
+      const recentPast = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+      assert.equal(isCacheExpired({ effectiveEnd: recentPast }, Date.now(), 6), false);
+    });
+
+    it('returns true when effectiveEnd is missing', () => {
+      assert.equal(isCacheExpired({}), true);
+    });
+
+    it('returns true for null data', () => {
+      assert.equal(isCacheExpired(null), true);
+    });
+  });
+
+  describe('computeCandidateRuns', () => {
+    it('returns day 1 and day 2 after 12Z + buffer', () => {
+      // 15:00 UTC on 2026-06-15
+      const now = new Date('2026-06-15T15:00:00Z').getTime();
+      const candidates = computeCandidateRuns(now, 2);
+      assert.equal(candidates.length, 2);
+      assert.equal(candidates[0].day, 1);
+      assert.equal(candidates[0].run, '2026-06-15T12:00:00Z');
+      assert.equal(candidates[1].day, 2);
+      assert.equal(candidates[1].run, '2026-06-15T12:00:00Z');
+    });
+
+    it('returns day 1 (0Z) and day 2 (prev 12Z) after 0Z + buffer', () => {
+      // 05:00 UTC on 2026-06-15
+      const now = new Date('2026-06-15T05:00:00Z').getTime();
+      const candidates = computeCandidateRuns(now, 2);
+      assert.equal(candidates.length, 2);
+      assert.equal(candidates[0].day, 1);
+      assert.equal(candidates[0].run, '2026-06-15T00:00:00Z');
+      assert.equal(candidates[1].day, 2);
+      assert.equal(candidates[1].run, '2026-06-14T12:00:00Z');
+    });
+
+    it('returns empty before buffer window opens', () => {
+      // 00:30 UTC — before 0Z + 2h buffer
+      const now = new Date('2026-06-15T00:30:00Z').getTime();
+      const candidates = computeCandidateRuns(now, 2);
+      assert.equal(candidates.length, 0);
+    });
+  });
+
+  describe('cache read/write', () => {
+    let dir;
+    beforeEach(() => { dir = tmpDir(); });
+    afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+    it('writes and reads a cache file', () => {
+      const env = { TSTM_CACHE_DIR: dir };
+      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+      const data = readCache('beta', 1, 'full', env);
+      assert.deepEqual(data, SAMPLE_CACHE_DATA);
+    });
+
+    it('returns null when reading non-existent cache', () => {
+      const env = { TSTM_CACHE_DIR: dir };
+      assert.equal(readCache('beta', 1, 'full', env), null);
+    });
+
+    it('deletes a cache file', () => {
+      const env = { TSTM_CACHE_DIR: dir };
+      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+      deleteCache('beta', 1, 'full', env);
+      assert.equal(readCache('beta', 1, 'full', env), null);
+    });
+
+    it('delete is idempotent for missing files', () => {
+      const env = { TSTM_CACHE_DIR: dir };
+      deleteCache('beta', 1, 'full', env);
+    });
+
+    it('keeps beta and production cache independent', () => {
+      const env = { TSTM_CACHE_DIR: dir };
+      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+      const prodData = { ...SAMPLE_CACHE_DATA, run: '2026-06-14T00:00:00Z' };
+      writeCache('production', 1, 'full', prodData, env);
+      assert.equal(readCache('beta', 1, 'full', env).run, '2026-06-13T12:00:00Z');
+      assert.equal(readCache('production', 1, 'full', env).run, '2026-06-14T00:00:00Z');
+    });
+  });
+
+  describe('runIngestionCycle', () => {
+    let dir;
+    beforeEach(() => { dir = tmpDir(); });
+    afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+    it('writes cache when generator returns complete data', async () => {
+      const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_INTERVAL_MS: '60000' };
+      const runGenerator = async () => ({
+        ...SAMPLE_CACHE_DATA,
+        completeness: { complete: true, checkedHours: [1, 24], matchedHours: [1, 24], missingHours: [] },
+      });
+
+      await runIngestionCycle({
+        env,
+        target: 'beta',
+        runGenerator,
+        now: new Date('2026-06-15T15:00:00Z').getTime(),
+      });
+
+      const cached = readCache('beta', 1, 'full', env);
+      assert.ok(cached);
+      assert.equal(cached.complete, true);
+      assert.equal(cached.features.length, 1);
+    });
+
+    it('retains existing cache when data is not ready', async () => {
+      const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_INTERVAL_MS: '60000' };
+      // Pre-populate cache
+      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+
+      const runGenerator = async () => ({
+        features: [],
+        completeness: { complete: false, checkedHours: [1, 24], matchedHours: [], missingHours: [1, 24] },
+      });
+
+      await runIngestionCycle({
+        env,
+        target: 'beta',
+        runGenerator,
+        now: new Date('2026-06-15T15:00:00Z').getTime(),
+      });
+
+      // Cache should still be the original data
+      const cached = readCache('beta', 1, 'full', env);
+      assert.ok(cached);
+      assert.equal(cached.run, '2026-06-13T12:00:00Z');
+    });
+
+    it('retains existing cache when generator throws', async () => {
+      const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_INTERVAL_MS: '60000' };
+      writeCache('beta', 1, 'full', SAMPLE_CACHE_DATA, env);
+
+      const runGenerator = async () => {
+        throw new Error('SPC data unavailable');
+      };
+
+      await runIngestionCycle({
+        env,
+        target: 'beta',
+        runGenerator,
+        now: new Date('2026-06-15T15:00:00Z').getTime(),
+      });
+
+      const cached = readCache('beta', 1, 'full', env);
+      assert.ok(cached);
+      assert.equal(cached.run, '2026-06-13T12:00:00Z');
+    });
+  });
+
+  describe('startIngestionLoop', () => {
+    let dir;
+    beforeEach(() => { dir = tmpDir(); });
+    afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+    it('throws when runGenerator is missing', () => {
+      assert.throws(() => {
+        startIngestionLoop({ env: { TSTM_CACHE_DIR: dir } });
+      }, /runGenerator is required/);
+    });
+
+    it('starts and stops without error', async () => {
+      const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_INTERVAL_MS: '60000' };
+      let callCount = 0;
+      const runGenerator = async () => {
+        callCount += 1;
+        return SAMPLE_CACHE_DATA;
+      };
+
+      const stop = startIngestionLoop({ env, runGenerator, intervalMs: 50 });
+      assert.equal(typeof stop, 'function');
+
+      // Wait for at least one cycle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      assert.ok(callCount >= 1);
+
+      stop();
+    });
+  });
+});

--- a/server/tstm.js
+++ b/server/tstm.js
@@ -6,7 +6,7 @@ const os = require('os');
 const path = require('path');
 
 const { createServerCapabilityGate, isServerCapabilityEnabled } = require('./lib/featureCapabilities');
-const { isValidPeriod, readCache, startIngestionLoop } = require('./tstm-ingestion');
+const { isCacheExpired, isValidPeriod, readCache, startIngestionLoop } = require('./tstm-ingestion');
 
 const DEFAULT_TIMEOUT_MS = 480000;
 const MAX_STDERR_LENGTH = 2000;
@@ -139,6 +139,10 @@ const handleLatestRequest = (env, target) => (req, res) => {
     res.status(404).json({ error: 'No cached TSTM data available.' });
     return;
   }
+  if (isCacheExpired(cached)) {
+    res.status(404).json({ error: 'Cached TSTM data has expired.' });
+    return;
+  }
   res.json(cached);
 };
 
@@ -194,6 +198,7 @@ const registerTstmRoutes = (app, express, options = {}) => {
 const registerTstmIngestion = (app, express, options = {}) => {
   const env = options.env || process.env;
   if (env.TSTM_INGESTION_ENABLED !== 'true') return null;
+  if (!isTstmGenerationEnabled(env, options)) return null;
 
   const runGenerator = options.runGenerator || runTstmGenerator;
   const log = options.log || console;

--- a/server/tstm.js
+++ b/server/tstm.js
@@ -6,6 +6,7 @@ const os = require('os');
 const path = require('path');
 
 const { createServerCapabilityGate, isServerCapabilityEnabled } = require('./lib/featureCapabilities');
+const { isValidPeriod, readCache, startIngestionLoop } = require('./tstm-ingestion');
 
 const DEFAULT_TIMEOUT_MS = 480000;
 const MAX_STDERR_LENGTH = 2000;
@@ -54,7 +55,11 @@ const runTstmGenerator = (payload, options = {}) => new Promise((resolve, reject
   const spawnProcess = options.spawnProcess || spawn;
   const timeoutMs = Number(env.TSTM_GENERATION_TIMEOUT_MS || DEFAULT_TIMEOUT_MS);
   const script = path.join(__dirname, 'weather', 'generate_tstm.py');
-  const child = spawnProcess(getPythonCommand(env), [script], {
+  const args = [script];
+  if (options.ingestionMode) {
+    args.push('--ingestion-mode');
+  }
+  const child = spawnProcess(getPythonCommand(env), args, {
     cwd: __dirname,
     env: {
       ...env,
@@ -117,6 +122,26 @@ const validatePayload = (payload) => {
   return null;
 };
 
+/** Handles GET /api/tstm/latest — serves pre-cached ingestion data. */
+const handleLatestRequest = (env, target) => (req, res) => {
+  const day = Number(req.query.day);
+  if (!isSupportedDay(day)) {
+    res.status(400).json({ error: 'day must be 1 or 2.' });
+    return;
+  }
+  const period = typeof req.query.period === 'string' ? req.query.period : 'full';
+  if (!isValidPeriod(period)) {
+    res.status(400).json({ error: 'period must be full, 4hr, or 1hr.' });
+    return;
+  }
+  const cached = readCache(target, day, period, env);
+  if (!cached) {
+    res.status(404).json({ error: 'No cached TSTM data available.' });
+    return;
+  }
+  res.json(cached);
+};
+
 /** Registers the preserved endpoint in a fail-closed, default-off state. */
 const registerTstmRoutes = (app, express, options = {}) => {
   const env = options.env || process.env;
@@ -152,12 +177,34 @@ const registerTstmRoutes = (app, express, options = {}) => {
       }
     },
   );
+
+  const { getServerTarget: getTarget } = require('./lib/serverTarget');
+  const target = options.target || getTarget(env);
+  app.get(
+    '/api/tstm/latest',
+    createServerCapabilityGate(TSTM_CAPABILITY_KEY, capabilityOptions),
+    handleLatestRequest(env, target),
+  );
+};
+
+/**
+ * Starts the scheduled TSTM ingestion loop.  Only runs when
+ * TSTM_INGESTION_ENABLED=true and the capability gate allows it.
+ */
+const registerTstmIngestion = (app, express, options = {}) => {
+  const env = options.env || process.env;
+  if (env.TSTM_INGESTION_ENABLED !== 'true') return null;
+
+  const runGenerator = options.runGenerator || runTstmGenerator;
+  const log = options.log || console;
+  return startIngestionLoop({ env, runGenerator, log });
 };
 
 module.exports = {
   createGenerationPayload,
   isSupportedDay,
   isTstmGenerationEnabled,
+  registerTstmIngestion,
   registerTstmRoutes,
   runTstmGenerator,
   validatePayload,

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -1,9 +1,12 @@
 'use strict';
 
-const { describe, it } = require('node:test');
+const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const { PassThrough } = require('node:stream');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const express = require('express');
 const {
   createGenerationPayload,
@@ -169,5 +172,109 @@ describe('Auto-TSTM server foundation', () => {
       /TSTM_GENERATION_TIMEOUT/
     );
     assert.equal(killed, true);
+  });
+
+  it('passes --ingestion-mode flag when ingestionMode is set', async () => {
+    const child = createFakeChild();
+    let spawnedArgs;
+    runTstmGenerator(
+      { day: 1, cycleDate: '2026-06-13' },
+      {
+        spawnProcess: (_cmd, args) => {
+          spawnedArgs = args;
+          return child;
+        },
+        ingestionMode: true,
+      }
+    );
+    child.stdout.end('{}');
+    child.emit('close', 0);
+    await new Promise((r) => setTimeout(r, 10));
+    assert.ok(spawnedArgs.includes('--ingestion-mode'));
+  });
+});
+
+describe('GET /api/tstm/latest', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tstm-latest-test-')); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  const SAMPLE_CACHED = {
+    run: '2026-06-13T12:00:00Z',
+    day: 1,
+    period: 'full',
+    features: [{ type: 'Feature', id: 't-0', geometry: { type: 'Polygon', coordinates: [[[-100, 30], [-99, 30], [-99, 31], [-100, 31], [-100, 30]]] }, properties: {} }],
+    effectiveStart: '2026-06-13T06:00:00Z',
+    effectiveEnd: '2099-01-01T00:00:00Z',
+    complete: true,
+  };
+
+  const startLatestServer = (env, routeOptions = {}) => {
+    const app = express();
+    registerTstmRoutes(app, express, { env, runGenerator: async () => ({}), ...routeOptions });
+    return new Promise((resolve, reject) => {
+      const server = app.listen(0, '127.0.0.1', () => resolve(server));
+      server.on('error', reject);
+    });
+  };
+
+  const getLatestUrl = (server, query = '') => {
+    const { port } = server.address();
+    return `http://127.0.0.1:${port}/api/tstm/latest${query}`;
+  };
+
+  it('returns cached data when available', async () => {
+    const cacheDir = path.join(tmpDir, 'local', 'day1');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
+
+    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
+    const server = await startLatestServer(env, allTargetsEnabledRouteOptions());
+    try {
+      const res = await fetch(getLatestUrl(server, '?day=1&period=full'));
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.run, '2026-06-13T12:00:00Z');
+      assert.equal(body.features.length, 1);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 404 when no cache exists', async () => {
+    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
+    const server = await startLatestServer(env, allTargetsEnabledRouteOptions());
+    try {
+      const res = await fetch(getLatestUrl(server, '?day=1'));
+      assert.equal(res.status, 404);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 400 for invalid day parameter', async () => {
+    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
+    const server = await startLatestServer(env, allTargetsEnabledRouteOptions());
+    try {
+      const res = await fetch(getLatestUrl(server, '?day=3'));
+      assert.equal(res.status, 400);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 404 when capability is disabled', async () => {
+    const cacheDir = path.join(tmpDir, 'local', 'day1');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
+
+    const env = { TSTM_CACHE_DIR: tmpDir };
+    const server = await startLatestServer(env);
+    try {
+      const res = await fetch(getLatestUrl(server, '?day=1'));
+      assert.equal(res.status, 404);
+    } finally {
+      server.close();
+    }
   });
 });

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -11,6 +11,7 @@ const express = require('express');
 const {
   createGenerationPayload,
   isTstmGenerationEnabled,
+  registerTstmIngestion,
   registerTstmRoutes,
   runTstmGenerator,
   validatePayload,
@@ -197,7 +198,24 @@ describe('Auto-TSTM server foundation', () => {
 describe('GET /api/tstm/latest', () => {
   let tmpDir;
   beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tstm-latest-test-')); });
-  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true   });
+});
+
+describe('registerTstmIngestion', () => {
+  it('returns null when capability is not enabled', () => {
+    const result = registerTstmIngestion({}, express, {
+      env: { TSTM_INGESTION_ENABLED: 'true' },
+    });
+    assert.equal(result, null);
+  });
+
+  it('returns null when TSTM_INGESTION_ENABLED is not set', () => {
+    const result = registerTstmIngestion({}, express, {
+      env: { TSTM_GENERATION_ENABLED: 'true' },
+    });
+    assert.equal(result, null);
+  });
+});
 
   const SAMPLE_CACHED = {
     run: '2026-06-13T12:00:00Z',
@@ -273,6 +291,27 @@ describe('GET /api/tstm/latest', () => {
     try {
       const res = await fetch(getLatestUrl(server, '?day=1'));
       assert.equal(res.status, 404);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 404 when cached data has expired', async () => {
+    const expired = {
+      ...SAMPLE_CACHED,
+      effectiveEnd: '2026-06-13T12:00:00Z',
+    };
+    const cacheDir = path.join(tmpDir, 'local', 'day1');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(expired));
+
+    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
+    const server = await startLatestServer(env, allTargetsEnabledRouteOptions());
+    try {
+      const res = await fetch(getLatestUrl(server, '?day=1'));
+      assert.equal(res.status, 404);
+      const body = await res.json();
+      assert.ok(body.error.includes('expired'));
     } finally {
       server.close();
     }

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -621,21 +621,24 @@ def _build_completeness(
     ingestion_mode: bool,
     window: EffectiveWindow,
     features: list[dict[str, Any]],
-    matched_hours: list[int] | None = None,
-    warnings: list[str] | None = None,
+    ctx: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
-    """Build completeness metadata for ingestion mode, or None."""
+    """Build completeness metadata for ingestion mode, or None.
+
+    *ctx* may contain ``matched_hours`` (list[int]) and ``warnings`` (list[str]).
+    """
     if not ingestion_mode:
         return None
+    ctx = ctx or {}
     checked = window.forecast_hours
-    matched = matched_hours if matched_hours is not None else []
+    matched = ctx.get("matched_hours", [])
     missing = sorted(set(checked) - set(matched))
     return {
         "complete": len(features) > 0,
         "checkedHours": checked,
         "matchedHours": matched,
         "missingHours": missing,
-        "warnings": warnings or [],
+        "warnings": ctx.get("warnings", []),
     }
 
 
@@ -683,7 +686,8 @@ def build_response(payload: dict[str, Any], ingestion_mode: bool = False) -> dic
 
     response = response_payload(response_window, features, warnings, sources)
     completeness = _build_completeness(
-        ingestion_mode, window, features, matched_hours, warnings
+        ingestion_mode, window, features,
+        {"matched_hours": matched_hours, "warnings": warnings},
     )
     if completeness is not None:
         response["completeness"] = completeness

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -617,38 +617,60 @@ def mask_to_features(mask: np.ndarray, lat: np.ndarray, lon: np.ndarray) -> list
     return features
 
 
-def build_response(payload: dict[str, Any]) -> dict[str, Any]:
+def _build_completeness(
+    ingestion_mode: bool,
+    window: EffectiveWindow,
+    features: list[dict[str, Any]],
+    matched_hours: list[int] | None = None,
+    warnings: list[str] | None = None,
+) -> dict[str, Any] | None:
+    """Build completeness metadata for ingestion mode, or None."""
+    if not ingestion_mode:
+        return None
+    checked = window.forecast_hours
+    matched = matched_hours if matched_hours is not None else []
+    missing = sorted(set(checked) - set(matched))
+    return {
+        "complete": len(features) > 0,
+        "checkedHours": checked,
+        "matchedHours": matched,
+        "missingHours": missing,
+        "warnings": warnings or [],
+    }
+
+
+def build_response(payload: dict[str, Any], ingestion_mode: bool = False) -> dict[str, Any]:
     window = build_effective_window(payload)
     warnings: list[str] = []
+    features: list[dict[str, Any]] = []
+    matched_hours: list[int] = []
+    sources: dict[str, dict[str, Any] | None] = {}
+    response_window = window
 
     if not window.forecast_hours:
         warnings.append("The effective outlook window does not overlap HREF forecast hours 0-48.")
-        return response_payload(window, [], warnings, {})
-
-    print(
-        f"effective window {window.start.isoformat()} to {window.end.isoformat()} "
-        f"from HREF run {window.href_run.isoformat()} using hours {window.forecast_hours}",
-        file=sys.stderr,
-        flush=True,
-    )
-
-    calibrated_thunder, spc_warnings = fetch_spc_calibrated_thunder(window)
-    warnings.extend(spc_warnings)
-    if calibrated_thunder is not None:
-        lat, lon = get_lat_lon(calibrated_thunder.template)
-        probability = as_probability(calibrated_thunder.values)
-        final_mask = calibrated_thunder_mask(probability, grid_near_land_mask(lat, lon), lat, lon)
-        features = mask_to_features(final_mask, lat, lon)
-        response_window = replace(
-            window,
-            href_run=calibrated_thunder.run,
-            forecast_hours=calibrated_thunder.forecast_hours,
+    else:
+        print(
+            f"effective window {window.start.isoformat()} to {window.end.isoformat()} "
+            f"from HREF run {window.href_run.isoformat()} using hours {window.forecast_hours}",
+            file=sys.stderr,
+            flush=True,
         )
-        return response_payload(
-            response_window,
-            features,
-            warnings,
-            {
+
+        calibrated_thunder, spc_warnings = fetch_spc_calibrated_thunder(window)
+        warnings.extend(spc_warnings)
+        if calibrated_thunder is not None:
+            lat, lon = get_lat_lon(calibrated_thunder.template)
+            probability = as_probability(calibrated_thunder.values)
+            final_mask = calibrated_thunder_mask(probability, grid_near_land_mask(lat, lon), lat, lon)
+            features = mask_to_features(final_mask, lat, lon)
+            matched_hours = calibrated_thunder.forecast_hours
+            response_window = replace(
+                window,
+                href_run=calibrated_thunder.run,
+                forecast_hours=calibrated_thunder.forecast_hours,
+            )
+            sources = {
                 "calibratedThunder": {
                     "product": f"spc_hrefct_{calibrated_thunder.period}",
                     "search": "tstm",
@@ -657,10 +679,15 @@ def build_response(payload: dict[str, Any]) -> dict[str, Any]:
                     "forecastHours": ",".join(str(hour) for hour in calibrated_thunder.forecast_hours),
                     "url": calibrated_thunder.urls[0],
                 },
-            },
-        )
+            }
 
-    return response_payload(window, [], warnings, {})
+    response = response_payload(response_window, features, warnings, sources)
+    completeness = _build_completeness(
+        ingestion_mode, window, features, matched_hours, warnings
+    )
+    if completeness is not None:
+        response["completeness"] = completeness
+    return response
 
 
 def response_payload(
@@ -683,10 +710,21 @@ def response_payload(
     }
 
 
+def parse_args() -> tuple[dict[str, Any], bool]:
+    """Parse CLI arguments and stdin payload.
+
+    Returns (payload, ingestion_mode).  ``--ingestion-mode`` enables the
+    extended completeness metadata in the JSON output.
+    """
+    ingestion_mode = "--ingestion-mode" in sys.argv
+    payload = read_payload()
+    return payload, ingestion_mode
+
+
 def main() -> int:
     try:
-        payload = read_payload()
-        print(json.dumps(build_response(payload)))
+        payload, ingestion_mode = parse_args()
+        print(json.dumps(build_response(payload, ingestion_mode=ingestion_mode)))
         return 0
     except Exception as exc:
         print(str(exc), file=sys.stderr)

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -133,14 +133,19 @@ def build_effective_window(payload: dict[str, Any]) -> EffectiveWindow:
     valid_date = parse_iso_datetime(payload.get("validDate"))
     issue_hour, issue_minute = parse_issuance_time(payload.get("issuanceTime"))
 
+    cycle_run_raw = payload.get("cycleRun")
+    override_run = (
+        parse_iso_datetime(cycle_run_raw) if isinstance(cycle_run_raw, str) and cycle_run_raw else None
+    )
+
     if day == 1:
         start = valid_date or issue_date or cycle_start.replace(hour=issue_hour, minute=issue_minute)
         end = (cycle_start + timedelta(days=1)).replace(hour=12, minute=0)
-        href_run = previous_spc_cycle(start)
+        href_run = override_run or previous_spc_cycle(start)
     else:
         start = (cycle_start + timedelta(days=1)).replace(hour=12, minute=0)
         end = (cycle_start + timedelta(days=2)).replace(hour=12, minute=0)
-        href_run = cycle_start.replace(hour=12, minute=0)
+        href_run = override_run or cycle_start.replace(hour=12, minute=0)
 
     forecast_hours = build_forecast_hours(start, end, href_run)
 
@@ -634,7 +639,7 @@ def _build_completeness(
     matched = ctx.get("matched_hours", [])
     missing = sorted(set(checked) - set(matched))
     return {
-        "complete": len(features) > 0,
+        "complete": len(features) > 0 and not missing,
         "checkedHours": checked,
         "matchedHours": matched,
         "missingHours": missing,

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -691,7 +691,7 @@ def build_response(payload: dict[str, Any], ingestion_mode: bool = False) -> dic
 
     response = response_payload(response_window, features, warnings, sources)
     completeness = _build_completeness(
-        ingestion_mode, window, features,
+        ingestion_mode, response_window, features,
         {"matched_hours": matched_hours, "warnings": warnings},
     )
     if completeness is not None:

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -62,6 +62,7 @@ class SpcThunderSignal:
     run: datetime
     period: str
     forecast_hours: list[int]
+    loaded_hours: list[int]
     urls: list[str]
 
 
@@ -122,6 +123,31 @@ def build_forecast_hours(start: datetime, end: datetime, run: datetime) -> list[
     return forecast_hours
 
 
+def parse_cycle_run_override(payload: dict[str, Any]) -> datetime | None:
+    cycle_run_raw = payload.get("cycleRun")
+    if not isinstance(cycle_run_raw, str) or not cycle_run_raw:
+        return None
+    return parse_iso_datetime(cycle_run_raw)
+
+
+def day1_window_bounds(
+    cycle_start: datetime,
+    issue_date: datetime | None,
+    valid_date: datetime | None,
+    issue_hour: int,
+    issue_minute: int,
+) -> tuple[datetime, datetime]:
+    start = valid_date or issue_date or cycle_start.replace(hour=issue_hour, minute=issue_minute)
+    end = (cycle_start + timedelta(days=1)).replace(hour=12, minute=0)
+    return start, end
+
+
+def day2_window_bounds(cycle_start: datetime) -> tuple[datetime, datetime]:
+    start = (cycle_start + timedelta(days=1)).replace(hour=12, minute=0)
+    end = (cycle_start + timedelta(days=2)).replace(hour=12, minute=0)
+    return start, end
+
+
 def build_effective_window(payload: dict[str, Any]) -> EffectiveWindow:
     """Compute valid-time window and HREF run for Day 1 (→12Z) or Day 2 (12Z→12Z)."""
     day = int(payload.get("day", 0))
@@ -132,19 +158,13 @@ def build_effective_window(payload: dict[str, Any]) -> EffectiveWindow:
     issue_date = parse_iso_datetime(payload.get("issueDate"))
     valid_date = parse_iso_datetime(payload.get("validDate"))
     issue_hour, issue_minute = parse_issuance_time(payload.get("issuanceTime"))
-
-    cycle_run_raw = payload.get("cycleRun")
-    override_run = (
-        parse_iso_datetime(cycle_run_raw) if isinstance(cycle_run_raw, str) and cycle_run_raw else None
-    )
+    override_run = parse_cycle_run_override(payload)
 
     if day == 1:
-        start = valid_date or issue_date or cycle_start.replace(hour=issue_hour, minute=issue_minute)
-        end = (cycle_start + timedelta(days=1)).replace(hour=12, minute=0)
+        start, end = day1_window_bounds(cycle_start, issue_date, valid_date, issue_hour, issue_minute)
         href_run = override_run or previous_spc_cycle(start)
     else:
-        start = (cycle_start + timedelta(days=1)).replace(hour=12, minute=0)
-        end = (cycle_start + timedelta(days=2)).replace(hour=12, minute=0)
+        start, end = day2_window_bounds(cycle_start)
         href_run = override_run or cycle_start.replace(hour=12, minute=0)
 
     forecast_hours = build_forecast_hours(start, end, href_run)
@@ -319,6 +339,7 @@ def fetch_spc_period_for_window(window: EffectiveWindow, period: str) -> SpcThun
             run=window.href_run,
             period=period,
             forecast_hours=[end_hour],
+            loaded_hours=matched_hours,
             urls=urls,
         )
     return None
@@ -654,6 +675,7 @@ def build_response(payload: dict[str, Any], ingestion_mode: bool = False) -> dic
     matched_hours: list[int] = []
     sources: dict[str, dict[str, Any] | None] = {}
     response_window = window
+    calibrated_thunder: SpcThunderSignal | None = None
 
     if not window.forecast_hours:
         warnings.append("The effective outlook window does not overlap HREF forecast hours 0-48.")
@@ -672,7 +694,7 @@ def build_response(payload: dict[str, Any], ingestion_mode: bool = False) -> dic
             probability = as_probability(calibrated_thunder.values)
             final_mask = calibrated_thunder_mask(probability, grid_near_land_mask(lat, lon), lat, lon)
             features = mask_to_features(final_mask, lat, lon)
-            matched_hours = calibrated_thunder.forecast_hours
+            matched_hours = calibrated_thunder.loaded_hours
             response_window = replace(
                 window,
                 href_run=calibrated_thunder.run,
@@ -690,8 +712,12 @@ def build_response(payload: dict[str, Any], ingestion_mode: bool = False) -> dic
             }
 
     response = response_payload(response_window, features, warnings, sources)
+    completeness_window = window
+    if calibrated_thunder is not None:
+        checked_hours = spc_period_hours(window.forecast_hours[-1], calibrated_thunder.period)
+        completeness_window = replace(window, forecast_hours=checked_hours)
     completeness = _build_completeness(
-        ingestion_mode, response_window, features,
+        ingestion_mode, completeness_window, features,
         {"matched_hours": matched_hours, "warnings": warnings},
     )
     if completeness is not None:

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -134,9 +134,9 @@ def day1_window_bounds(
     cycle_start: datetime,
     issue_date: datetime | None,
     valid_date: datetime | None,
-    issue_hour: int,
-    issue_minute: int,
+    issuance: tuple[int, int],
 ) -> tuple[datetime, datetime]:
+    issue_hour, issue_minute = issuance
     start = valid_date or issue_date or cycle_start.replace(hour=issue_hour, minute=issue_minute)
     end = (cycle_start + timedelta(days=1)).replace(hour=12, minute=0)
     return start, end
@@ -161,7 +161,7 @@ def build_effective_window(payload: dict[str, Any]) -> EffectiveWindow:
     override_run = parse_cycle_run_override(payload)
 
     if day == 1:
-        start, end = day1_window_bounds(cycle_start, issue_date, valid_date, issue_hour, issue_minute)
+        start, end = day1_window_bounds(cycle_start, issue_date, valid_date, (issue_hour, issue_minute))
         href_run = override_run or previous_spc_cycle(start)
     else:
         start, end = day2_window_bounds(cycle_start)
@@ -714,8 +714,8 @@ def build_response(payload: dict[str, Any], ingestion_mode: bool = False) -> dic
     response = response_payload(response_window, features, warnings, sources)
     completeness_window = window
     if calibrated_thunder is not None:
-        checked_hours = spc_period_hours(window.forecast_hours[-1], calibrated_thunder.period)
-        completeness_window = replace(window, forecast_hours=checked_hours)
+        checked_hours = spc_period_hours(response_window.forecast_hours[-1], calibrated_thunder.period)
+        completeness_window = replace(response_window, forecast_hours=checked_hours)
     completeness = _build_completeness(
         ingestion_mode, completeness_window, features,
         {"matched_hours": matched_hours, "warnings": warnings},

--- a/server/weather/generate_tstm.py
+++ b/server/weather/generate_tstm.py
@@ -351,6 +351,18 @@ def spc_period_hours(end_hour: int, period: str) -> list[int]:
     return [end_hour] if offset is None else sorted({max(1, end_hour - offset), end_hour})
 
 
+def completeness_checked_hours(period: str, end_hour: int, matched_hours: list[int]) -> list[int]:
+    """Forecast hours that must match for ingestion completeness.
+
+    The ``full`` product is a single 24h accumulation GRIB, and the loader stops
+    after the first successful frame.  Shorter periods may require every candidate
+    frame listed by :func:`spc_period_hours`.
+    """
+    if period == "full":
+        return matched_hours
+    return spc_period_hours(end_hour, period)
+
+
 def combine_spc_arrays(arrays: list[np.ndarray]) -> np.ndarray:
     stacked = np.stack(arrays)
     if np.all(np.isnan(stacked)):
@@ -714,7 +726,12 @@ def build_response(payload: dict[str, Any], ingestion_mode: bool = False) -> dic
     response = response_payload(response_window, features, warnings, sources)
     completeness_window = window
     if calibrated_thunder is not None:
-        checked_hours = spc_period_hours(response_window.forecast_hours[-1], calibrated_thunder.period)
+        end_hour = response_window.forecast_hours[-1]
+        checked_hours = completeness_checked_hours(
+            calibrated_thunder.period,
+            end_hour,
+            matched_hours,
+        )
         completeness_window = replace(response_window, forecast_hours=checked_hours)
     completeness = _build_completeness(
         ingestion_mode, completeness_window, features,

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -197,6 +197,36 @@ class GenerateTstmTests(unittest.TestCase):
         self.assertTrue(completeness["complete"])
         self.assertEqual(completeness["missingHours"], [])
 
+    def test_build_completeness_spc_period_partial_marks_incomplete(self):
+        """Only loading the end-hour frame should not satisfy the full SPC period."""
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        end_hour = window.forecast_hours[-1]
+        checked_hours = generate_tstm.spc_period_hours(end_hour, "full")
+        completeness_window = generate_tstm.replace(window, forecast_hours=checked_hours)
+        completeness = generate_tstm._build_completeness(
+            True, completeness_window, [{"type": "Feature"}],
+            {"matched_hours": [end_hour], "warnings": []},
+        )
+        self.assertFalse(completeness["complete"])
+        self.assertNotEqual(completeness["missingHours"], [])
+
+    def test_build_completeness_spc_period_full_marks_complete(self):
+        """When every SPC period frame loads, completeness should pass."""
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        end_hour = window.forecast_hours[-1]
+        checked_hours = generate_tstm.spc_period_hours(end_hour, "full")
+        completeness_window = generate_tstm.replace(window, forecast_hours=checked_hours)
+        completeness = generate_tstm._build_completeness(
+            True, completeness_window, [{"type": "Feature"}],
+            {"matched_hours": checked_hours, "warnings": []},
+        )
+        self.assertTrue(completeness["complete"])
+        self.assertEqual(completeness["missingHours"], [])
+
     def test_cycle_run_override(self):
         """When cycleRun is provided, it overrides the derived href_run."""
         window = generate_tstm.build_effective_window(

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -173,6 +173,37 @@ class GenerateTstmTests(unittest.TestCase):
         finally:
             sys.argv = original
 
+    def test_build_completeness_partial_run_marks_incomplete(self):
+        """Partial runs with missing forecast hours should be marked incomplete."""
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        completeness = generate_tstm._build_completeness(
+            True, window, [{"type": "Feature"}],
+            {"matched_hours": [6, 9], "warnings": []},
+        )
+        self.assertFalse(completeness["complete"])
+        self.assertIn(12, completeness["missingHours"])
+
+    def test_build_completeness_full_run_marks_complete(self):
+        """When all checked hours are matched, complete is True."""
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        completeness = generate_tstm._build_completeness(
+            True, window, [{"type": "Feature"}],
+            {"matched_hours": list(window.forecast_hours), "warnings": []},
+        )
+        self.assertTrue(completeness["complete"])
+        self.assertEqual(completeness["missingHours"], [])
+
+    def test_cycle_run_override(self):
+        """When cycleRun is provided, it overrides the derived href_run."""
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-15", "cycleRun": "2026-06-15T12:00:00Z"}
+        )
+        self.assertEqual(window.href_run.hour, 12)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -126,6 +126,53 @@ class GenerateTstmTests(unittest.TestCase):
         response = generate_tstm.response_payload(window, [], [], {})
         self.assertEqual(response["thresholds"], generate_tstm.DEFAULT_THRESHOLDS)
 
+    def test_ingestion_mode_off_by_default(self):
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        response = generate_tstm.build_response(
+            {"day": 1, "cycleDate": "2026-06-13"}, ingestion_mode=False
+        )
+        self.assertNotIn("completeness", response)
+
+    def test_ingestion_mode_adds_completeness_when_no_forecast_hours(self):
+        """When ingestion_mode=True and no SPC data is found, completeness.complete is False."""
+        window = generate_tstm.build_effective_window(
+            {"day": 1, "cycleDate": "2026-06-13"}
+        )
+        # Simulate a response with no features (data unavailable)
+        response = generate_tstm.response_payload(window, [], ["No SPC data"], {})
+        response["completeness"] = {
+            "complete": False,
+            "checkedHours": window.forecast_hours,
+            "matchedHours": [],
+            "missingHours": window.forecast_hours,
+            "warnings": ["No SPC data"],
+        }
+        self.assertFalse(response["completeness"]["complete"])
+        self.assertEqual(response["completeness"]["missingHours"], window.forecast_hours)
+        self.assertEqual(len(response["features"]), 0)
+
+    def test_ingestion_mode_parse_args_flag(self):
+        import sys
+        original = sys.argv
+        try:
+            sys.argv = ["generate_tstm.py", "--ingestion-mode"]
+            payload, mode = generate_tstm.parse_args()
+            self.assertTrue(mode)
+        finally:
+            sys.argv = original
+
+    def test_ingestion_mode_parse_args_default(self):
+        import sys
+        original = sys.argv
+        try:
+            sys.argv = ["generate_tstm.py"]
+            payload, mode = generate_tstm.parse_args()
+            self.assertFalse(mode)
+        finally:
+            sys.argv = original
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -173,59 +173,85 @@ class GenerateTstmTests(unittest.TestCase):
         finally:
             sys.argv = original
 
-    def test_build_completeness_partial_run_marks_incomplete(self):
-        """Partial runs with missing forecast hours should be marked incomplete."""
-        window = generate_tstm.build_effective_window(
-            {"day": 1, "cycleDate": "2026-06-13"}
-        )
+    def _assert_completeness(
+        self,
+        completeness_window,
+        matched_hours: list[int],
+        *,
+        expect_complete: bool,
+        missing_assert=None,
+    ) -> None:
         completeness = generate_tstm._build_completeness(
-            True, window, [{"type": "Feature"}],
-            {"matched_hours": [6, 9], "warnings": []},
+            True,
+            completeness_window,
+            [{"type": "Feature"}],
+            {"matched_hours": matched_hours, "warnings": []},
         )
-        self.assertFalse(completeness["complete"])
-        self.assertIn(12, completeness["missingHours"])
+        self.assertEqual(completeness["complete"], expect_complete)
+        if missing_assert is not None:
+            missing_assert(completeness["missingHours"])
 
-    def test_build_completeness_full_run_marks_complete(self):
-        """When all checked hours are matched, complete is True."""
-        window = generate_tstm.build_effective_window(
-            {"day": 1, "cycleDate": "2026-06-13"}
-        )
-        completeness = generate_tstm._build_completeness(
-            True, window, [{"type": "Feature"}],
-            {"matched_hours": list(window.forecast_hours), "warnings": []},
-        )
-        self.assertTrue(completeness["complete"])
-        self.assertEqual(completeness["missingHours"], [])
-
-    def test_build_completeness_spc_period_partial_marks_incomplete(self):
-        """Only loading the end-hour frame should not satisfy the full SPC period."""
-        window = generate_tstm.build_effective_window(
-            {"day": 1, "cycleDate": "2026-06-13"}
-        )
+    def test_build_completeness_outcomes(self):
+        window = self._build_day1_window()
         end_hour = window.forecast_hours[-1]
         checked_hours = generate_tstm.spc_period_hours(end_hour, "full")
-        completeness_window = generate_tstm.replace(window, forecast_hours=checked_hours)
-        completeness = generate_tstm._build_completeness(
-            True, completeness_window, [{"type": "Feature"}],
-            {"matched_hours": [end_hour], "warnings": []},
-        )
-        self.assertFalse(completeness["complete"])
-        self.assertNotEqual(completeness["missingHours"], [])
+        spc_window = generate_tstm.replace(window, forecast_hours=checked_hours)
 
-    def test_build_completeness_spc_period_full_marks_complete(self):
-        """When every SPC period frame loads, completeness should pass."""
-        window = generate_tstm.build_effective_window(
-            {"day": 1, "cycleDate": "2026-06-13"}
+        cases = [
+            (
+                "partial href hours",
+                window,
+                [6, 9],
+                False,
+                lambda missing: self.assertIn(12, missing),
+            ),
+            (
+                "full href hours",
+                window,
+                list(window.forecast_hours),
+                True,
+                lambda missing: self.assertEqual(missing, []),
+            ),
+            (
+                "partial spc period",
+                spc_window,
+                [end_hour],
+                False,
+                lambda missing: self.assertNotEqual(missing, []),
+            ),
+            (
+                "full spc period",
+                spc_window,
+                checked_hours,
+                True,
+                lambda missing: self.assertEqual(missing, []),
+            ),
+        ]
+        for label, completeness_window, matched_hours, expect_complete, missing_assert in cases:
+            with self.subTest(label=label):
+                self._assert_completeness(
+                    completeness_window,
+                    matched_hours,
+                    expect_complete=expect_complete,
+                    missing_assert=missing_assert,
+                )
+
+    def test_build_completeness_uses_loaded_run_hours_for_fallback(self):
+        """Fallback SPC runs should compare against the loaded run's period hours."""
+        requested = self._build_day1_window(cycleRun="2026-06-13T12:00:00Z")
+        fallback = generate_tstm.replace(
+            requested,
+            href_run=datetime(2026, 6, 13, 0, tzinfo=timezone.utc),
+            forecast_hours=[24],
         )
-        end_hour = window.forecast_hours[-1]
-        checked_hours = generate_tstm.spc_period_hours(end_hour, "full")
-        completeness_window = generate_tstm.replace(window, forecast_hours=checked_hours)
-        completeness = generate_tstm._build_completeness(
-            True, completeness_window, [{"type": "Feature"}],
-            {"matched_hours": checked_hours, "warnings": []},
+        checked_hours = generate_tstm.spc_period_hours(fallback.forecast_hours[-1], "full")
+        completeness_window = generate_tstm.replace(fallback, forecast_hours=checked_hours)
+        self._assert_completeness(
+            completeness_window,
+            checked_hours,
+            expect_complete=True,
+            missing_assert=lambda missing: self.assertEqual(missing, []),
         )
-        self.assertTrue(completeness["complete"])
-        self.assertEqual(completeness["missingHours"], [])
 
     def test_cycle_run_override(self):
         """When cycleRun is provided, it overrides the derived href_run."""

--- a/server/weather/test_generate_tstm.py
+++ b/server/weather/test_generate_tstm.py
@@ -191,11 +191,22 @@ class GenerateTstmTests(unittest.TestCase):
         if missing_assert is not None:
             missing_assert(completeness["missingHours"])
 
+    def test_completeness_checked_hours_full_uses_loaded_frames(self):
+        self.assertEqual(
+            generate_tstm.completeness_checked_hours("full", 30, [7]),
+            [7],
+        )
+        self.assertEqual(
+            generate_tstm.completeness_checked_hours("4hr", 30, [27, 30]),
+            [27, 30],
+        )
+
     def test_build_completeness_outcomes(self):
         window = self._build_day1_window()
         end_hour = window.forecast_hours[-1]
-        checked_hours = generate_tstm.spc_period_hours(end_hour, "full")
-        spc_window = generate_tstm.replace(window, forecast_hours=checked_hours)
+        full_checked = generate_tstm.spc_period_hours(end_hour, "full")
+        four_hr_checked = generate_tstm.spc_period_hours(end_hour, "4hr")
+        four_hr_window = generate_tstm.replace(window, forecast_hours=four_hr_checked)
 
         cases = [
             (
@@ -213,16 +224,23 @@ class GenerateTstmTests(unittest.TestCase):
                 lambda missing: self.assertEqual(missing, []),
             ),
             (
-                "partial spc period",
-                spc_window,
+                "full period single loaded hour",
+                generate_tstm.replace(window, forecast_hours=[full_checked[0]]),
+                [full_checked[0]],
+                True,
+                lambda missing: self.assertEqual(missing, []),
+            ),
+            (
+                "partial 4hr period",
+                four_hr_window,
                 [end_hour],
                 False,
                 lambda missing: self.assertNotEqual(missing, []),
             ),
             (
-                "full spc period",
-                spc_window,
-                checked_hours,
+                "full 4hr period",
+                four_hr_window,
+                four_hr_checked,
                 True,
                 lambda missing: self.assertEqual(missing, []),
             ),
@@ -244,11 +262,11 @@ class GenerateTstmTests(unittest.TestCase):
             href_run=datetime(2026, 6, 13, 0, tzinfo=timezone.utc),
             forecast_hours=[24],
         )
-        checked_hours = generate_tstm.spc_period_hours(fallback.forecast_hours[-1], "full")
-        completeness_window = generate_tstm.replace(fallback, forecast_hours=checked_hours)
+        loaded_hour = generate_tstm.spc_period_hours(fallback.forecast_hours[-1], "full")[0]
+        completeness_window = generate_tstm.replace(fallback, forecast_hours=[loaded_hour])
         self._assert_completeness(
             completeness_window,
-            checked_hours,
+            [loaded_hour],
             expect_complete=True,
             missing_assert=lambda missing: self.assertEqual(missing, []),
         )

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -166,3 +166,23 @@ export const requestTstmGeneration = async (
   }
   return parseTstmGenerationResponse(payload);
 };
+
+const TSTM_LATEST_ENDPOINT = '/api/tstm/latest';
+
+/** Requests the latest pre-cached TSTM data for a given day and period. */
+export const requestLatestTstmData = async (
+  day: DayType,
+  period = 'full',
+  signal?: AbortSignal
+): Promise<TstmGenerationResponse | null> => {
+  if (!canGenerateTstmForDay(day)) return null;
+  const response = await fetch(`${TSTM_LATEST_ENDPOINT}?day=${day}&period=${period}`, { signal });
+  if (!response.ok) return null;
+  const payload = await response.json().catch(() => null);
+  if (!payload) return null;
+  try {
+    return parseTstmGenerationResponse(payload);
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Parent tracker

- #427

## What

Build a periodic ingestion loop that checks for new HREF runs, validates completeness via a new \--ingestion-mode\ flag in the Python generator, and caches normalized GeoJSON on the server. The cache is only replaced when the new run is confirmed available, preserving data continuity.

## Changes

### Python generator
- \--ingestion-mode\ flag adds \completeness\ metadata (complete/checkedHours/matchedHours/missingHours) to the JSON output

### Server ingestion
- \server/tstm-ingestion.js\ — scheduler, cache read/write/expire, completeness gate, candidate run computation
- \GET /api/tstm/latest?day=1&period=full\ — serves cached TSTM data
- \egisterTstmIngestion()\ — starts the loop when \TSTM_INGESTION_ENABLED=true\
- Ingestion mode support in \unTstmGenerator\

### Client
- \equestLatestTstmData(day, period)\ — fetches pre-cached data, returns null on miss

### Golden copy behavior
- Cache is only replaced when \completeness.complete === true\ AND \eatures.length > 0\
- Prior cache is retained on incomplete data or generator failure
- Cache expires after \ffectiveEnd + 6h\ TTL
- Beta/production caches are independent directories

## Verification

- 22/22 Python tests pass
- 37/37 Node.js TSTM tests pass (24 ingestion + 13 routes)
- 50/50 backend tests pass
- 584/584 frontend tests pass
- \pnpm run build\ succeeds