### PR TITLE
perf: reduce Auto-Categorical Turf feature collection allocation (PERF-04)

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,11 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #647
+
+- Reduce redundant Turf feature collection allocation in Auto-Categorical hatching and cumulative risk generation (PERF-04, #589).
+- Extend Auto-Categorical tests for hatching splits, cumulative risk rings, and allocation regression coverage.
+
 ### PR #646
 
 - Add scheduled TSTM ingestion: periodic server-side discovery of new HREF runs with golden-copy caching that only replaces confirmed data (TSTM-03, #474).

--- a/src/hooks/__tests__/useAutoCategorical.test.ts
+++ b/src/hooks/__tests__/useAutoCategorical.test.ts
@@ -18,6 +18,15 @@ jest.mock('uuid', () => ({
   v4: () => mockUuid(),
 }));
 
+jest.mock('@turf/turf', () => {
+  const actual = jest.requireActual<typeof import('@turf/turf')>('@turf/turf');
+  return {
+    ...actual,
+    featureCollection: jest.fn((...args: Parameters<typeof actual.featureCollection>) =>
+      actual.featureCollection(...args)),
+  };
+});
+
 const makeFeature = (id: string): Feature<Polygon> => ({
   type: 'Feature',
   id,
@@ -232,12 +241,12 @@ describe('processOutlooksToCategorical', () => {
       categorical: new Map(),
     };
 
-    const featureCollectionSpy = jest.spyOn(turf, 'featureCollection');
+    const featureCollectionMock = turf.featureCollection as jest.MockedFunction<typeof turf.featureCollection>;
+    featureCollectionMock.mockClear();
     processDay12OutlooksToCategorical(outlooks);
 
     // Hatching unions may still allocate collections; intersect/difference should not per CIG iteration.
-    expect(featureCollectionSpy.mock.calls.length).toBeLessThanOrEqual(3);
-    featureCollectionSpy.mockRestore();
+    expect(featureCollectionMock.mock.calls.length).toBeLessThanOrEqual(3);
   });
 
   test('applies day 3 hatching and cumulative risk generation', () => {

--- a/src/hooks/__tests__/useAutoCategorical.test.ts
+++ b/src/hooks/__tests__/useAutoCategorical.test.ts
@@ -9,6 +9,7 @@ import useAutoCategorical, {
 } from '../useAutoCategorical';
 import { OutlookData } from '../../types/outlooks';
 import { Feature, Polygon } from 'geojson';
+import * as turf from '@turf/turf';
 import forecastReducer, { addFeature, undoLastEdit, updateFeature } from '../../store/forecastSlice';
 
 const mockUuid = jest.fn(() => 'mock-uuid');
@@ -42,6 +43,22 @@ const makeProbabilisticFeature = (id: string, offset: number): Feature<Polygon> 
     probability: '30%',
     isSignificant: false
   }
+});
+
+const makeSquare = (id: string, offset: number, size = 2): Feature<Polygon> => ({
+  type: 'Feature',
+  id,
+  geometry: {
+    type: 'Polygon',
+    coordinates: [[
+      [offset, offset],
+      [offset + size, offset],
+      [offset + size, offset + size],
+      [offset, offset + size],
+      [offset, offset],
+    ]],
+  },
+  properties: {},
 });
 
 const createStore = () => configureStore({
@@ -165,6 +182,84 @@ describe('processOutlooksToCategorical', () => {
 
     expect(processDay12OutlooksToCategorical(outlooks).length).toBeGreaterThan(0);
     expect(processOutlooksToCategorical(outlooks, 2).length).toBeGreaterThan(0);
+  });
+
+  test('maps hatching intersections to expected categorical risk levels', () => {
+    const outlooks: OutlookData = {
+      tornado: new Map(),
+      wind: new Map([
+        ['30%', [makeSquare('wind-prob', 0)]],
+        ['CIG1', [makeSquare('wind-hatch', 0)]],
+      ]),
+      hail: new Map(),
+      categorical: new Map(),
+    };
+
+    const result = processDay12OutlooksToCategorical(outlooks);
+    expect(result.some((feature) => feature.properties?.probability === 'ENH')).toBe(true);
+  });
+
+  test('builds cumulative categorical rings that include lower-tier geometry', () => {
+    const outlooks: OutlookData = {
+      tornado: new Map(),
+      wind: new Map([
+        ['5%', [makeSquare('wind-mrgl', 0)]],
+        ['30%', [makeSquare('wind-slgt', 4)]],
+      ]),
+      hail: new Map(),
+      categorical: new Map(),
+    };
+
+    const result = processDay12OutlooksToCategorical(outlooks);
+    const marginal = result.find((feature) => feature.properties?.probability === 'MRGL');
+    const slight = result.find((feature) => feature.properties?.probability === 'SLGT');
+
+    expect(marginal).toBeDefined();
+    expect(slight).toBeDefined();
+    expect(turf.booleanContains(marginal as Feature<Polygon>, slight as Feature<Polygon>)).toBe(true);
+  });
+
+  test('avoids redundant turf.featureCollection calls in hatching loops', () => {
+    const outlooks: OutlookData = {
+      tornado: new Map(),
+      wind: new Map([
+        ['30%', [makeSquare('wind-prob', 0)]],
+        ['CIG3', [makeSquare('wind-cig3', 0)]],
+        ['CIG2', [makeSquare('wind-cig2', 0)]],
+        ['CIG1', [makeSquare('wind-cig1', 0)]],
+      ]),
+      hail: new Map(),
+      categorical: new Map(),
+    };
+
+    const featureCollectionSpy = jest.spyOn(turf, 'featureCollection');
+    processDay12OutlooksToCategorical(outlooks);
+
+    // Hatching unions may still allocate collections; intersect/difference should not per CIG iteration.
+    expect(featureCollectionSpy.mock.calls.length).toBeLessThanOrEqual(3);
+    featureCollectionSpy.mockRestore();
+  });
+
+  test('applies day 3 hatching and cumulative risk generation', () => {
+    const outlooks: OutlookData = {
+      tornado: new Map(),
+      wind: new Map(),
+      hail: new Map(),
+      categorical: new Map(),
+      totalSevere: new Map([
+        ['15%', [makeSquare('severe-prob', 0)]],
+        ['CIG1', [makeSquare('severe-hatch', 0)]],
+        ['5%', [makeSquare('severe-mrgl', 5)]],
+      ]),
+    };
+
+    const result = processDay3OutlooksToCategorical(outlooks);
+    expect(result.some((feature) => feature.properties?.probability === 'SLGT')).toBe(true);
+    expect(result.some((feature) => feature.properties?.probability === 'MRGL')).toBe(true);
+
+    const marginal = result.find((feature) => feature.properties?.probability === 'MRGL');
+    const slight = result.find((feature) => feature.properties?.probability === 'SLGT');
+    expect(turf.booleanContains(marginal as Feature<Polygon>, slight as Feature<Polygon>)).toBe(true);
   });
 
   // Since we use turf intersection, robust testing requires valid geometries and turf mocking or integration.

--- a/src/hooks/useAutoCategorical.ts
+++ b/src/hooks/useAutoCategorical.ts
@@ -228,7 +228,7 @@ export function processOutlooksToCategorical(outlooks: OutlookData, day: number 
 
 type PolygonOutlookFeature = Feature<Polygon | MultiPolygon>;
 
-/** Reusable two-feature collection for Turf v7 intersect/difference/union calls. */
+/** Builds a reusable two-feature collection shell for Turf v7 boolean ops. */
 const createPairFeatureCollection = (): turf.FeatureCollection<Polygon | MultiPolygon> => ({
   type: 'FeatureCollection',
   features: [
@@ -237,6 +237,7 @@ const createPairFeatureCollection = (): turf.FeatureCollection<Polygon | MultiPo
   ],
 });
 
+/** Assigns two polygon features into a reusable collection before Turf calls. */
 const setPairFeatures = (
   collection: turf.FeatureCollection<Polygon | MultiPolygon>,
   first: PolygonOutlookFeature,

--- a/src/hooks/useAutoCategorical.ts
+++ b/src/hooks/useAutoCategorical.ts
@@ -226,6 +226,28 @@ export function processOutlooksToCategorical(outlooks: OutlookData, day: number 
   return [];
 }
 
+type PolygonOutlookFeature = Feature<Polygon | MultiPolygon>;
+
+/** Reusable two-feature collection for Turf v7 intersect/difference/union calls. */
+const createPairFeatureCollection = (): turf.FeatureCollection<Polygon | MultiPolygon> => ({
+  type: 'FeatureCollection',
+  features: [
+    { type: 'Feature', geometry: { type: 'Polygon', coordinates: [] }, properties: {} },
+    { type: 'Feature', geometry: { type: 'Polygon', coordinates: [] }, properties: {} },
+  ],
+});
+
+const setPairFeatures = (
+  collection: turf.FeatureCollection<Polygon | MultiPolygon>,
+  first: PolygonOutlookFeature,
+  second: PolygonOutlookFeature,
+): void => {
+  collection.features[0] = first;
+  collection.features[1] = second;
+};
+
+const pairFeatureCollection = createPairFeatureCollection();
+
 // Helper to safely union a list of polygons
 const safeUnion = (features: Feature<Polygon | MultiPolygon>[]): Feature<Polygon | MultiPolygon> | null => {
   if (features.length === 0) return null;
@@ -233,7 +255,13 @@ const safeUnion = (features: Feature<Polygon | MultiPolygon>[]): Feature<Polygon
   
   try {
     // Turf v7: union takes a FeatureCollection
-    const fc = turf.featureCollection(features);
+    let fc: turf.FeatureCollection<Polygon | MultiPolygon>;
+    if (features.length === 2) {
+      setPairFeatures(pairFeatureCollection, features[0], features[1]);
+      fc = pairFeatureCollection;
+    } else {
+      fc = turf.featureCollection(features);
+    }
     const result = turf.union(fc);
     return result as Feature<Polygon | MultiPolygon>;
   } catch {
@@ -297,8 +325,6 @@ const buildCumulativeCategoricalFeatures = (
   return generatedFeatures;
 };
 
-type PolygonOutlookFeature = Feature<Polygon | MultiPolygon>;
-
 /** Narrows GeoJSON features to polygon geometries used in categorical generation. */
 const isPolygonOutlookFeature = (feature: GeoJSON.Feature): feature is PolygonOutlookFeature =>
   feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon';
@@ -354,6 +380,7 @@ const applyProbabilityFeaturesWithHatching = (
   probabilityFeatures.forEach((features, probStr) => {
     features.forEach((poly) => {
       let remainingPoly: PolygonOutlookFeature | null = poly;
+      const pairCollection = createPairFeatureCollection();
 
       cigLevels.forEach((cig) => {
         if (!remainingPoly) {
@@ -366,12 +393,12 @@ const applyProbabilityFeaturesWithHatching = (
         }
 
         try {
-          const intersection = turf.intersect(turf.featureCollection([remainingPoly, hatchRegion]));
+          setPairFeatures(pairCollection, remainingPoly, hatchRegion);
+          const intersection = turf.intersect(pairCollection);
           if (intersection) {
             onPiece(probStr, cig, intersection as PolygonOutlookFeature);
-            remainingPoly = turf.difference(
-              turf.featureCollection([remainingPoly, intersection as PolygonOutlookFeature]),
-            ) as PolygonOutlookFeature | null;
+            setPairFeatures(pairCollection, remainingPoly, intersection as PolygonOutlookFeature);
+            remainingPoly = turf.difference(pairCollection) as PolygonOutlookFeature | null;
           }
         } catch {
           // Ignore topology errors


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduce redundant `turf.featureCollection(...)` allocation in Auto-Categorical hatching and cumulative risk generation by reusing mutable two-feature collections for Turf v7 intersect/difference/union calls.

Fixes #589

## Changes

- Reuse a per-polygon pair collection in `applyProbabilityFeaturesWithHatching` instead of allocating two collections per CIG intersection.
- Reuse a shared pair collection in `safeUnion` when merging exactly two polygons.
- Extend Auto-Categorical tests for hatching risk mapping, cumulative risk rings, day 3 total severe behavior, and allocation regression coverage.

## Feature exposure

- [x] This PR does not change feature exposure
- [ ] This PR changes feature exposure (describe below)

## Temporary feature removal

- [x] N/A — no temporary features affected
- [ ] Temporary feature removal included (confirm `removalCondition` metadata is present in `src/config/featureExposure.ts`)

## Review requests

- [ ] Server-backed feature changes reviewed by server owner
- [ ] Security-sensitive feature changes flagged for security review

## Testing

- [x] Tests added/updated (if applicable)
- [x] Build passes (`pnpm run build`)
- Focused: `pnpm test -- --runTestsByPath src/hooks/__tests__/useAutoCategorical.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab0f83d5-633f-4482-b146-4402720700d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab0f83d5-633f-4482-b146-4402720700d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

