### PR TITLE
feat(tstm): harden cached Auto-TSTM API and operational limits

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,13 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #<N>
+
+- Harden cached Auto-TSTM API: public read policy, rate limits on `GET /api/tstm/latest` and `GET /api/tstm/status`, structured stale/unavailable error reasons, and operational cache health (TSTM-04, #475).
+- Align ingestion cache schema with client response validation (`forecastHours`, `warnings`).
+- Extend Auto-TSTM server/client tests and exposure contracts for the latest and status routes.
+- Document Auto-TSTM operational behavior in `docs/auto-tstm-operations.md`.
+
 ### PR #647
 
 - Reduce redundant Turf feature collection allocation in Auto-Categorical hatching and cumulative risk generation (PERF-04, #589).

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -6,7 +6,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ### PR #648
 
-- Harden cached Auto-TSTM API: public read policy, rate limits on `GET /api/tstm/latest` and `GET /api/tstm/status`, structured stale/unavailable error reasons, and operational cache health (TSTM-04, #475).
+- Harden cached Auto-TSTM API: public read policy, rate limits on `GET /api/tstm/latest` and `GET /api/tstm/status`, structured stale/unavailable/corrupt error reasons, and operational cache health (TSTM-04, #475).
 - Align ingestion cache schema with client response validation (`forecastHours`, `warnings`).
 - Extend Auto-TSTM server/client tests and exposure contracts for the latest and status routes.
 - Document Auto-TSTM operational behavior in `docs/auto-tstm-operations.md`.

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,7 +4,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #<N>
+### PR #648
 
 - Harden cached Auto-TSTM API: public read policy, rate limits on `GET /api/tstm/latest` and `GET /api/tstm/status`, structured stale/unavailable error reasons, and operational cache health (TSTM-04, #475).
 - Align ingestion cache schema with client response validation (`forecastHours`, `warnings`).

--- a/docs/auto-tstm-operations.md
+++ b/docs/auto-tstm-operations.md
@@ -1,0 +1,77 @@
+# Auto-TSTM operations
+
+Operational notes for the cached Auto-TSTM server API introduced in TSTM-03 (#474) and hardened in TSTM-04 (#475).
+
+## Public read policy
+
+Auto-TSTM routes are **unauthenticated** and intended for public read once the deployment exposes the capability:
+
+| Route | Method | Auth | Work when disabled |
+| --- | --- | --- | --- |
+| `/api/tstm/latest` | GET | None | Capability gate returns `404` before cache reads |
+| `/api/tstm/status` | GET | None | Capability gate returns `404` before cache reads |
+| `/api/tstm/generate` | POST | None | Capability gate returns `404` before Python worker spawn |
+| `/api/capabilities/status` | GET | None | Always available; lists exposed server capabilities |
+
+Disabled routes perform **no expensive work** (no generator spawn, no cache reads beyond the gate).
+
+Registry exposure (`autoTstm.exposure.*`) and deployment env (`TSTM_GENERATION_ENABLED=true`) must both be enabled before routes accept traffic. Emergency disable overrides are documented in [emergency-feature-disable.md](./emergency-feature-disable.md).
+
+## Rate limits
+
+| Route | Limit |
+| --- | --- |
+| `GET /api/tstm/latest` | 120 requests / minute / client |
+| `GET /api/tstm/status` | 120 requests / minute / client |
+| `POST /api/tstm/generate` | 2 requests / minute / client |
+| `GET /api/capabilities/status` | 120 requests / minute / client |
+
+Generate requests also accept at most **4 KB** JSON bodies.
+
+## Structured errors
+
+Cached read failures return sanitized JSON with a machine-readable `reason`:
+
+| `reason` | Meaning | Typical HTTP status |
+| --- | --- | --- |
+| `cache_miss` | No cached entry for the requested day/period | `404` |
+| `cache_stale` | Cache exists but is past its valid window | `404` |
+| `unavailable` | Generator or upstream guidance is temporarily down | `503` |
+
+Capability-disabled responses use the standard gate body and **do not** include internal `reason` codes.
+
+Responses never include filesystem paths, Python stderr, stack traces, or other internal details.
+
+## Operational health
+
+`GET /api/tstm/status` returns a public-safe summary:
+
+- `ingestionEnabled` — whether `TSTM_INGESTION_ENABLED=true` on this process
+- `cache.day1` / `cache.day2` — per-period availability with `available`, `stale`, `reason`, `run`, and `ingestedAt` when known
+
+Use this endpoint (or server logs prefixed with `[tstm-ingest]`) to confirm ingestion health. Expected ingestion skips log at **info** level and do not report to Sentry.
+
+## Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `TSTM_GENERATION_ENABLED` | Deployment capability switch (`true` to allow gated routes) |
+| `TSTM_INGESTION_ENABLED` | Start the scheduled ingestion loop |
+| `TSTM_INGESTION_INTERVAL_MS` | Poll interval (default 30 minutes) |
+| `TSTM_CACHE_DIR` | Cache root (default `server/cache/tstm`) |
+| `TSTM_GENERATION_TIMEOUT_MS` | Python worker timeout |
+| `SERVER_TARGET` | Cache partition (`local`, `beta`, `staging`, `production`) |
+| `EMERGENCY_DISABLED_CAPABILITIES` | Immediate disable override (see emergency runbook) |
+
+## Client behavior
+
+`requestLatestTstmData()` in `src/utils/tstmGeneration.ts`:
+
+- Returns parsed guidance on success
+- Returns `null` for expected `cache_miss`, `cache_stale`, and disabled responses (no thrown errors, no Sentry noise)
+- Marks the server capability unavailable when the standard disabled gate message is returned
+
+## Related docs
+
+- [feature-exposure-workstreams.md](./feature-exposure-workstreams.md) — Auto-TSTM registry and beta enablement criteria
+- [emergency-feature-disable.md](./emergency-feature-disable.md) — incident disable runbook

--- a/docs/auto-tstm-operations.md
+++ b/docs/auto-tstm-operations.md
@@ -36,6 +36,7 @@ Cached read failures return sanitized JSON with a machine-readable `reason`:
 | --- | --- | --- |
 | `cache_miss` | No cached entry for the requested day/period | `404` |
 | `cache_stale` | Cache exists but is past its valid window | `404` |
+| `cache_corrupt` | Cache file exists but is unreadable or invalid | `404` |
 | `unavailable` | Generator or upstream guidance is temporarily down | `503` |
 
 Capability-disabled responses use the standard gate body and **do not** include internal `reason` codes.
@@ -47,7 +48,7 @@ Responses never include filesystem paths, Python stderr, stack traces, or other 
 `GET /api/tstm/status` returns a public-safe summary:
 
 - `ingestionEnabled` — whether `TSTM_INGESTION_ENABLED=true` on this process
-- `cache.day1` / `cache.day2` — per-period availability with `available`, `stale`, `reason`, `run`, and `ingestedAt` when known
+- `cache.day1` / `cache.day2` — per-period availability with `available`, `stale`, `reason`, `run`, `ingestedAt`, and `effectiveEnd` when known
 
 Use this endpoint (or server logs prefixed with `[tstm-ingest]`) to confirm ingestion health. Expected ingestion skips log at **info** level and do not report to Sentry.
 

--- a/docs/feature-exposure-workstreams.md
+++ b/docs/feature-exposure-workstreams.md
@@ -31,6 +31,7 @@ Initial exposure matrix for every row above: `local`, `beta`, `staging`, and `pr
 - **Registry:** `temporary: true`, `serverBacked: true`, `serverCapabilityKey: TSTM_GENERATION_ENABLED`
 - **Gates:** `FEATURE_SIDE_EFFECT_MODULES.autoTstm`, `ServerBackedFeatureBoundary`, `server/tstm.js` capability gate
 - **Tests:** `src/testing/featureExposure/exemplar.exposure.test.tsx`, `server/testing/autoTstm.exposure.test.js`
+- **Ops:** [auto-tstm-operations.md](./auto-tstm-operations.md)
 - **Beta enablement:** tracker #427; first enable PR: TBD (flip `exposure.beta` after TSTM-03+ surfaces ship and disabled-side-effect tests pass)
 
 ### Forecast workflow v2 (`forecastWorkflowV2`, #429)

--- a/server/lib/tstmApiErrors.js
+++ b/server/lib/tstmApiErrors.js
@@ -4,6 +4,7 @@
 const TSTM_ERROR_REASON = {
   CACHE_MISS: 'cache_miss',
   CACHE_STALE: 'cache_stale',
+  CACHE_CORRUPT: 'cache_corrupt',
   UNAVAILABLE: 'unavailable',
 };
 

--- a/server/lib/tstmApiErrors.js
+++ b/server/lib/tstmApiErrors.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/** Machine-readable reasons for cached Auto-TSTM API responses. */
+const TSTM_ERROR_REASON = {
+  CACHE_MISS: 'cache_miss',
+  CACHE_STALE: 'cache_stale',
+  UNAVAILABLE: 'unavailable',
+};
+
+/** Sends a sanitized JSON error without internal implementation details. */
+const sendTstmApiError = (res, status, error, reason) => {
+  const body = { error };
+  if (reason) {
+    body.reason = reason;
+  }
+  res.status(status).json(body);
+};
+
+module.exports = {
+  TSTM_ERROR_REASON,
+  sendTstmApiError,
+};

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "main": "analytics.js",
   "scripts": {
     "start": "node analytics.js",
-    "test": "node --test billing-stripe-period.test.js qs-dos.test.js lib/serverTarget.test.js lib/featureCapabilities.test.js server-stack.test.js tstm.test.js testing/featureExposureHarness.test.js testing/autoTstm.exposure.test.js lib/capabilityStatus.test.js"
+    "test": "node --test billing-stripe-period.test.js qs-dos.test.js lib/serverTarget.test.js lib/featureCapabilities.test.js server-stack.test.js tstm.test.js tstm-ingestion.test.js testing/featureExposureHarness.test.js testing/autoTstm.exposure.test.js lib/capabilityStatus.test.js"
   },
   "dependencies": {
     "@sentry/node": "^10.62.0",

--- a/server/testing/autoTstm.exposure.test.js
+++ b/server/testing/autoTstm.exposure.test.js
@@ -23,6 +23,11 @@ const getGenerateUrl = (server) => {
   return `http://127.0.0.1:${address.port}/api/tstm/generate`;
 };
 
+const getLatestUrl = (server, query = '') => {
+  const address = server.address();
+  return `http://127.0.0.1:${address.port}/api/tstm/latest${query}`;
+};
+
 const postGenerateRequest = (server) =>
   fetch(getGenerateUrl(server), {
     method: 'POST',
@@ -55,9 +60,44 @@ const assertGenerateRouteRejectsWithoutWork = async ({ env, routeOptions = {}, e
   }
 };
 
+/** Asserts the latest route rejects without invoking the generator. */
+const assertLatestRouteRejectsWithoutWork = async ({ env, routeOptions = {}, expectedBody }) => {
+  let calls = 0;
+  const server = await startServer(
+    env,
+    async () => {
+      calls += 1;
+      return {};
+    },
+    routeOptions
+  );
+
+  try {
+    const response = await fetch(getLatestUrl(server, '?day=1&period=full'));
+    const assert = require('node:assert/strict');
+    assert.equal(response.status, 404);
+    if (expectedBody) {
+      assert.deepEqual(await response.json(), expectedBody);
+    }
+    assert.equal(calls, 0);
+  } finally {
+    server.close();
+  }
+};
+
 describe('autoTstm exposure contract', () => {
   it('rejects generate requests for registry-disabled fixtures', async () => {
     await assertGenerateRouteRejectsWithoutWork({
+      env: disabledCapabilityStatusFixtures.registry_disabled.env,
+      routeOptions: disabledCapabilityStatusFixtures.registry_disabled.routeOptions,
+      expectedBody: {
+        error: 'Auto-TSTM is not enabled on this deployment.',
+      },
+    });
+  });
+
+  it('rejects latest requests for registry-disabled fixtures', async () => {
+    await assertLatestRouteRejectsWithoutWork({
       env: disabledCapabilityStatusFixtures.registry_disabled.env,
       routeOptions: disabledCapabilityStatusFixtures.registry_disabled.routeOptions,
       expectedBody: {
@@ -72,8 +112,24 @@ describe('autoTstm exposure contract', () => {
     });
   });
 
+  it('rejects latest requests when only deployment env is enabled', async () => {
+    await assertLatestRouteRejectsWithoutWork({
+      env: { TSTM_GENERATION_ENABLED: 'true' },
+    });
+  });
+
   it('rejects generate requests for emergency-disabled fixtures', async () => {
     await assertGenerateRouteRejectsWithoutWork({
+      env: disabledCapabilityStatusFixtures.emergency_disabled.env,
+      routeOptions: disabledCapabilityStatusFixtures.emergency_disabled.routeOptions,
+      expectedBody: {
+        error: 'Auto-TSTM is not enabled on this deployment.',
+      },
+    });
+  });
+
+  it('rejects latest requests for emergency-disabled fixtures', async () => {
+    await assertLatestRouteRejectsWithoutWork({
       env: disabledCapabilityStatusFixtures.emergency_disabled.env,
       routeOptions: disabledCapabilityStatusFixtures.emergency_disabled.routeOptions,
       expectedBody: {

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -22,14 +22,31 @@ const cacheDir = (target, env = process.env) =>
 const cacheFilePath = (target, day, period, env = process.env) =>
   path.join(cacheDir(target, env), `day${day}`, `${period}.json`);
 
+/** Reads cache and reports miss, corrupt, or hit without exposing internal paths. */
+const readCacheState = (target, day, period, env = process.env) => {
+  if (!isValidPeriod(period)) {
+    return { state: 'miss' };
+  }
+
+  const filePath = cacheFilePath(target, day, period, env);
+  if (!fs.existsSync(filePath)) {
+    return { state: 'miss' };
+  }
+
+  try {
+    return {
+      state: 'hit',
+      data: JSON.parse(fs.readFileSync(filePath, 'utf8')),
+    };
+  } catch {
+    return { state: 'corrupt' };
+  }
+};
+
 /** Reads cached TSTM data for a target/day/period. Returns null on any error. */
 const readCache = (target, day, period, env = process.env) => {
-  if (!isValidPeriod(period)) return null;
-  try {
-    return JSON.parse(fs.readFileSync(cacheFilePath(target, day, period, env), 'utf8'));
-  } catch {
-    return null;
-  }
+  const entry = readCacheState(target, day, period, env);
+  return entry.state === 'hit' ? entry.data : null;
 };
 
 /** Atomically writes TSTM data to the cache (write-to-temp, then rename). */
@@ -134,8 +151,8 @@ const getTstmCacheHealth = (target, env = process.env, now = Date.now()) => {
     cache[dayKey] = {};
 
     for (const period of VALID_PERIODS) {
-      const cached = readCache(target, day, period, env);
-      if (!cached) {
+      const entry = readCacheState(target, day, period, env);
+      if (entry.state === 'miss') {
         cache[dayKey][period] = {
           available: false,
           reason: 'cache_miss',
@@ -143,6 +160,15 @@ const getTstmCacheHealth = (target, env = process.env, now = Date.now()) => {
         continue;
       }
 
+      if (entry.state === 'corrupt') {
+        cache[dayKey][period] = {
+          available: false,
+          reason: 'cache_corrupt',
+        };
+        continue;
+      }
+
+      const cached = entry.data;
       if (isCacheExpired(cached, now)) {
         cache[dayKey][period] = {
           available: false,
@@ -150,6 +176,7 @@ const getTstmCacheHealth = (target, env = process.env, now = Date.now()) => {
           reason: 'cache_stale',
           run: cached.run,
           ingestedAt: cached.ingestedAt,
+          effectiveEnd: cached.effectiveEnd,
         };
         continue;
       }
@@ -257,6 +284,7 @@ module.exports = {
   isValidPeriod,
   isRunComplete,
   readCache,
+  readCacheState,
   runIngestionCycle,
   startIngestionLoop,
   SUPPORTED_DAYS,

--- a/server/tstm-ingestion.js
+++ b/server/tstm-ingestion.js
@@ -116,12 +116,59 @@ const buildCacheData = (result, day, period) => ({
   features: result.features,
   effectiveStart: result.effectiveStart,
   effectiveEnd: result.effectiveEnd,
+  forecastHours: Array.isArray(result.forecastHours) ? result.forecastHours : [],
+  warnings: Array.isArray(result.warnings) ? result.warnings : [],
   thresholds: result.thresholds,
   generatedAt: result.generatedAt,
   ingestedAt: new Date().toISOString(),
   complete: true,
   domain: result.domain || 'conus',
 });
+
+/** Summarizes cache availability for each supported day and period. */
+const getTstmCacheHealth = (target, env = process.env, now = Date.now()) => {
+  const cache = {};
+
+  for (const day of SUPPORTED_DAYS) {
+    const dayKey = `day${day}`;
+    cache[dayKey] = {};
+
+    for (const period of VALID_PERIODS) {
+      const cached = readCache(target, day, period, env);
+      if (!cached) {
+        cache[dayKey][period] = {
+          available: false,
+          reason: 'cache_miss',
+        };
+        continue;
+      }
+
+      if (isCacheExpired(cached, now)) {
+        cache[dayKey][period] = {
+          available: false,
+          stale: true,
+          reason: 'cache_stale',
+          run: cached.run,
+          ingestedAt: cached.ingestedAt,
+        };
+        continue;
+      }
+
+      cache[dayKey][period] = {
+        available: true,
+        stale: false,
+        run: cached.run,
+        ingestedAt: cached.ingestedAt,
+        effectiveEnd: cached.effectiveEnd,
+      };
+    }
+  }
+
+  return {
+    ingestionEnabled: env.TSTM_INGESTION_ENABLED === 'true',
+    cache,
+  };
+};
 
 /**
  * Runs a single ingestion cycle: checks each candidate run, spawns the
@@ -151,7 +198,7 @@ const runIngestionCycle = async (options = {}) => {
       writeCache({ target, day, period, data: buildCacheData(result, day, period), env });
       log.info?.(`[tstm-ingest] run ${run} day ${day} cached (${result.features.length} features)`);
     } catch (err) {
-      log.error?.(`[tstm-ingest] run ${run} day ${day} failed: ${err.message}`);
+      log.info?.(`[tstm-ingest] run ${run} day ${day} skipped: ${err.message}`);
     }
   }
 };
@@ -197,6 +244,7 @@ const startIngestionLoop = (options = {}) => {
 };
 
 module.exports = {
+  buildCacheData,
   cacheDir,
   cacheFilePath,
   computeCandidateRuns,
@@ -204,6 +252,7 @@ module.exports = {
   DEFAULT_BUFFER_HOURS,
   DEFAULT_EXPIRATION_HOURS,
   DEFAULT_INGESTION_INTERVAL_MS,
+  getTstmCacheHealth,
   isCacheExpired,
   isValidPeriod,
   isRunComplete,

--- a/server/tstm-ingestion.test.js
+++ b/server/tstm-ingestion.test.js
@@ -7,9 +7,11 @@ const os = require('os');
 const path = require('path');
 
 const {
+  buildCacheData,
   cacheFilePath,
   computeCandidateRuns,
   deleteCache,
+  getTstmCacheHealth,
   isCacheExpired,
   isRunComplete,
   readCache,
@@ -289,6 +291,61 @@ describe('tstm-ingestion', () => {
       assert.ok(callCount >= 1);
 
       stop();
+    });
+  });
+
+  describe('buildCacheData', () => {
+    it('persists forecastHours and warnings for client parsing', () => {
+      const cached = buildCacheData({
+        run: '2026-06-13T12:00:00Z',
+        features: SAMPLE_CACHE_DATA.features,
+        effectiveStart: '2026-06-13T06:00:00Z',
+        effectiveEnd: '2026-06-14T12:00:00Z',
+        forecastHours: [12, 24],
+        warnings: ['sample warning'],
+        thresholds: SAMPLE_CACHE_DATA.thresholds,
+        generatedAt: '2026-06-13T14:05:00Z',
+      }, 1, 'full');
+
+      assert.deepEqual(cached.forecastHours, [12, 24]);
+      assert.deepEqual(cached.warnings, ['sample warning']);
+    });
+  });
+
+  describe('getTstmCacheHealth', () => {
+    let dir;
+    beforeEach(() => { dir = tmpDir(); });
+    afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+    it('distinguishes available, stale, and missing cache entries', () => {
+      const env = { TSTM_CACHE_DIR: dir, TSTM_INGESTION_ENABLED: 'true' };
+      writeCache({
+        target: 'beta',
+        day: 1,
+        period: 'full',
+        data: {
+          ...SAMPLE_CACHE_DATA,
+          effectiveEnd: '2099-01-01T00:00:00Z',
+        },
+        env,
+      });
+      writeCache({
+        target: 'beta',
+        day: 2,
+        period: 'full',
+        data: {
+          ...SAMPLE_CACHE_DATA,
+          day: 2,
+          effectiveEnd: '2020-01-01T00:00:00Z',
+        },
+        env,
+      });
+
+      const health = getTstmCacheHealth('beta', env);
+      assert.equal(health.ingestionEnabled, true);
+      assert.equal(health.cache.day1.full.available, true);
+      assert.equal(health.cache.day2.full.reason, 'cache_stale');
+      assert.equal(health.cache.day1['4hr'].reason, 'cache_miss');
     });
   });
 });

--- a/server/tstm-ingestion.test.js
+++ b/server/tstm-ingestion.test.js
@@ -15,6 +15,7 @@ const {
   isCacheExpired,
   isRunComplete,
   readCache,
+  readCacheState,
   runIngestionCycle,
   startIngestionLoop,
   writeCache,
@@ -345,7 +346,40 @@ describe('tstm-ingestion', () => {
       assert.equal(health.ingestionEnabled, true);
       assert.equal(health.cache.day1.full.available, true);
       assert.equal(health.cache.day2.full.reason, 'cache_stale');
+      assert.equal(health.cache.day2.full.effectiveEnd, '2020-01-01T00:00:00Z');
       assert.equal(health.cache.day1['4hr'].reason, 'cache_miss');
+    });
+
+    it('reports corrupt cache separately from a true miss', () => {
+      const env = { TSTM_CACHE_DIR: dir };
+      const corruptPath = cacheFilePath('beta', 1, 'full', env);
+      fs.mkdirSync(path.dirname(corruptPath), { recursive: true });
+      fs.writeFileSync(corruptPath, '{not-json', 'utf8');
+
+      const health = getTstmCacheHealth('beta', env);
+      assert.equal(health.cache.day1.full.reason, 'cache_corrupt');
+      assert.equal(health.cache.day2.full.reason, 'cache_miss');
+    });
+  });
+
+  describe('readCacheState', () => {
+    let dir;
+    beforeEach(() => { dir = tmpDir(); });
+    afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+    it('distinguishes miss, corrupt, and hit states', () => {
+      const env = { TSTM_CACHE_DIR: dir };
+      assert.deepEqual(readCacheState('beta', 1, 'full', env), { state: 'miss' });
+
+      const corruptPath = cacheFilePath('beta', 1, 'full', env);
+      fs.mkdirSync(path.dirname(corruptPath), { recursive: true });
+      fs.writeFileSync(corruptPath, 'not-json', 'utf8');
+      assert.deepEqual(readCacheState('beta', 1, 'full', env), { state: 'corrupt' });
+
+      writeCache({ target: 'beta', day: 1, period: 'full', data: SAMPLE_CACHE_DATA, env });
+      const hit = readCacheState('beta', 1, 'full', env);
+      assert.equal(hit.state, 'hit');
+      assert.equal(hit.data.run, SAMPLE_CACHE_DATA.run);
     });
   });
 });

--- a/server/tstm.js
+++ b/server/tstm.js
@@ -11,7 +11,7 @@ const {
   getTstmCacheHealth,
   isCacheExpired,
   isValidPeriod,
-  readCache,
+  readCacheState,
   startIngestionLoop,
 } = require('./tstm-ingestion');
 
@@ -150,8 +150,8 @@ const handleLatestRequest = (env, target) => (req, res) => {
     res.status(400).json({ error: 'period must be full, 4hr, or 1hr.' });
     return;
   }
-  const cached = readCache(target, day, period, env);
-  if (!cached) {
+  const entry = readCacheState(target, day, period, env);
+  if (entry.state === 'miss') {
     sendTstmApiError(
       res,
       404,
@@ -160,6 +160,16 @@ const handleLatestRequest = (env, target) => (req, res) => {
     );
     return;
   }
+  if (entry.state === 'corrupt') {
+    sendTstmApiError(
+      res,
+      404,
+      'Cached TSTM data is unavailable.',
+      TSTM_ERROR_REASON.CACHE_CORRUPT,
+    );
+    return;
+  }
+  const cached = entry.data;
   if (isCacheExpired(cached)) {
     sendTstmApiError(
       res,

--- a/server/tstm.js
+++ b/server/tstm.js
@@ -6,12 +6,28 @@ const os = require('os');
 const path = require('path');
 
 const { createServerCapabilityGate, isServerCapabilityEnabled } = require('./lib/featureCapabilities');
-const { isCacheExpired, isValidPeriod, readCache, startIngestionLoop } = require('./tstm-ingestion');
+const { sendTstmApiError, TSTM_ERROR_REASON } = require('./lib/tstmApiErrors');
+const {
+  getTstmCacheHealth,
+  isCacheExpired,
+  isValidPeriod,
+  readCache,
+  startIngestionLoop,
+} = require('./tstm-ingestion');
 
 const DEFAULT_TIMEOUT_MS = 480000;
 const MAX_STDERR_LENGTH = 2000;
 const MAX_STDOUT_LENGTH = 4 * 1024 * 1024;
 const TSTM_CAPABILITY_KEY = 'TSTM_GENERATION_ENABLED';
+const TSTM_READ_RATE_LIMIT_MAX = 120;
+
+/** Creates the shared read rate limiter for cached Auto-TSTM GET routes. */
+const createTstmReadRateLimit = (rateLimit, options = {}) => rateLimit({
+  windowMs: 60 * 1000,
+  max: options.max ?? TSTM_READ_RATE_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 /** Returns true when Auto-TSTM is exposed on this deployment target and capability env. */
 const isTstmGenerationEnabled = (env = process.env, options = {}) =>
@@ -136,14 +152,29 @@ const handleLatestRequest = (env, target) => (req, res) => {
   }
   const cached = readCache(target, day, period, env);
   if (!cached) {
-    res.status(404).json({ error: 'No cached TSTM data available.' });
+    sendTstmApiError(
+      res,
+      404,
+      'No cached TSTM data available.',
+      TSTM_ERROR_REASON.CACHE_MISS,
+    );
     return;
   }
   if (isCacheExpired(cached)) {
-    res.status(404).json({ error: 'Cached TSTM data has expired.' });
+    sendTstmApiError(
+      res,
+      404,
+      'Cached TSTM data has expired.',
+      TSTM_ERROR_REASON.CACHE_STALE,
+    );
     return;
   }
   res.json(cached);
+};
+
+/** Handles GET /api/tstm/status — public operational cache health. */
+const handleStatusRequest = (env, target) => (_req, res) => {
+  res.json(getTstmCacheHealth(target, env));
 };
 
 /** Registers the preserved endpoint in a fail-closed, default-off state. */
@@ -157,6 +188,7 @@ const registerTstmRoutes = (app, express, options = {}) => {
     standardHeaders: true,
     legacyHeaders: false,
   });
+  const readLimiter = options.readRateLimit || createTstmReadRateLimit(rateLimit, options.readRateLimitOptions);
   const capabilityOptions = {
     env,
     exposureOverride: options.exposureOverride,
@@ -177,7 +209,12 @@ const registerTstmRoutes = (app, express, options = {}) => {
       try {
         res.json(await runGenerator(payload));
       } catch {
-        res.status(503).json({ error: 'Auto-TSTM guidance is temporarily unavailable.' });
+        sendTstmApiError(
+          res,
+          503,
+          'Auto-TSTM guidance is temporarily unavailable.',
+          TSTM_ERROR_REASON.UNAVAILABLE,
+        );
       }
     },
   );
@@ -187,7 +224,14 @@ const registerTstmRoutes = (app, express, options = {}) => {
   app.get(
     '/api/tstm/latest',
     createServerCapabilityGate(TSTM_CAPABILITY_KEY, capabilityOptions),
+    readLimiter,
     handleLatestRequest(env, target),
+  );
+  app.get(
+    '/api/tstm/status',
+    createServerCapabilityGate(TSTM_CAPABILITY_KEY, capabilityOptions),
+    readLimiter,
+    handleStatusRequest(env, target),
   );
 };
 
@@ -207,10 +251,14 @@ const registerTstmIngestion = (app, express, options = {}) => {
 
 module.exports = {
   createGenerationPayload,
+  createTstmReadRateLimit,
+  handleLatestRequest,
+  handleStatusRequest,
   isSupportedDay,
   isTstmGenerationEnabled,
   registerTstmIngestion,
   registerTstmRoutes,
   runTstmGenerator,
+  TSTM_READ_RATE_LIMIT_MAX,
   validatePayload,
 };

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -138,6 +138,7 @@ describe('Auto-TSTM server foundation', () => {
       assert.equal(response.status, 503);
       assert.deepEqual(await response.json(), {
         error: 'Auto-TSTM guidance is temporarily unavailable.',
+        reason: 'unavailable',
       });
     } finally {
       server.close();
@@ -198,24 +199,7 @@ describe('Auto-TSTM server foundation', () => {
 describe('GET /api/tstm/latest', () => {
   let tmpDir;
   beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tstm-latest-test-')); });
-  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true   });
-});
-
-describe('registerTstmIngestion', () => {
-  it('returns null when capability is not enabled', () => {
-    const result = registerTstmIngestion({}, express, {
-      env: { TSTM_INGESTION_ENABLED: 'true' },
-    });
-    assert.equal(result, null);
-  });
-
-  it('returns null when TSTM_INGESTION_ENABLED is not set', () => {
-    const result = registerTstmIngestion({}, express, {
-      env: { TSTM_GENERATION_ENABLED: 'true' },
-    });
-    assert.equal(result, null);
-  });
-});
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
   const SAMPLE_CACHED = {
     run: '2026-06-13T12:00:00Z',
@@ -265,6 +249,10 @@ describe('registerTstmIngestion', () => {
     try {
       const res = await fetch(getLatestUrl(server, '?day=1'));
       assert.equal(res.status, 404);
+      assert.deepEqual(await res.json(), {
+        error: 'No cached TSTM data available.',
+        reason: 'cache_miss',
+      });
     } finally {
       server.close();
     }
@@ -311,7 +299,123 @@ describe('registerTstmIngestion', () => {
       const res = await fetch(getLatestUrl(server, '?day=1'));
       assert.equal(res.status, 404);
       const body = await res.json();
+      assert.equal(body.reason, 'cache_stale');
       assert.ok(body.error.includes('expired'));
+    } finally {
+      server.close();
+    }
+  });
+
+  it('rate limits repeated latest requests', async () => {
+    const cacheDir = path.join(tmpDir, 'local', 'day1');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
+
+    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
+    const rateLimit = require('express-rate-limit');
+    const server = await startLatestServer(env, {
+      ...allTargetsEnabledRouteOptions(),
+      readRateLimit: rateLimit({
+        windowMs: 60 * 1000,
+        limit: 1,
+        standardHeaders: true,
+        legacyHeaders: false,
+      }),
+    });
+    try {
+      const url = getLatestUrl(server, '?day=1&period=full');
+      const first = await fetch(url);
+      const second = await fetch(url);
+      assert.equal(first.status, 200);
+      assert.equal(second.status, 429);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe('registerTstmIngestion', () => {
+  it('returns null when capability is not enabled', () => {
+    const result = registerTstmIngestion({}, express, {
+      env: { TSTM_INGESTION_ENABLED: 'true' },
+    });
+    assert.equal(result, null);
+  });
+
+  it('returns null when TSTM_INGESTION_ENABLED is not set', () => {
+    const result = registerTstmIngestion({}, express, {
+      env: { TSTM_GENERATION_ENABLED: 'true' },
+    });
+    assert.equal(result, null);
+  });
+});
+
+describe('GET /api/tstm/status', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tstm-status-test-')); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  const SAMPLE_CACHED = {
+    run: '2026-06-13T12:00:00Z',
+    day: 1,
+    period: 'full',
+    features: [{ type: 'Feature', id: 't-0', geometry: { type: 'Polygon', coordinates: [[[-100, 30], [-99, 30], [-99, 31], [-100, 31], [-100, 30]]] }, properties: {} }],
+    effectiveStart: '2026-06-13T06:00:00Z',
+    effectiveEnd: '2099-01-01T00:00:00Z',
+    forecastHours: [24],
+    warnings: [],
+    ingestedAt: '2026-06-13T14:05:12Z',
+    complete: true,
+  };
+
+  const startStatusServer = (env, routeOptions = {}) => {
+    const app = express();
+    registerTstmRoutes(app, express, { env, runGenerator: async () => ({}), ...routeOptions });
+    return new Promise((resolve, reject) => {
+      const server = app.listen(0, '127.0.0.1', () => resolve(server));
+      server.on('error', reject);
+    });
+  };
+
+  const getStatusUrl = (server) => {
+    const { port } = server.address();
+    return `http://127.0.0.1:${port}/api/tstm/status`;
+  };
+
+  it('reports cache miss and available entries without leaking internals', async () => {
+    const cacheDir = path.join(tmpDir, 'local', 'day1');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
+
+    const env = {
+      TSTM_GENERATION_ENABLED: 'true',
+      TSTM_CACHE_DIR: tmpDir,
+      TSTM_INGESTION_ENABLED: 'true',
+    };
+    const server = await startStatusServer(env, allTargetsEnabledRouteOptions());
+    try {
+      const res = await fetch(getStatusUrl(server));
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.ingestionEnabled, true);
+      assert.equal(body.cache.day1.full.available, true);
+      assert.equal(body.cache.day2.full.reason, 'cache_miss');
+      assert.equal(JSON.stringify(body).includes(tmpDir), false);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 404 when capability is disabled without reading cache', async () => {
+    const cacheDir = path.join(tmpDir, 'local', 'day1');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
+
+    const env = { TSTM_CACHE_DIR: tmpDir };
+    const server = await startStatusServer(env);
+    try {
+      const res = await fetch(getStatusUrl(server));
+      assert.equal(res.status, 404);
     } finally {
       server.close();
     }

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -48,6 +48,60 @@ const postGenerateRequest = (server) =>
     body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
   });
 
+const SAMPLE_CACHED_ROUTE = {
+  run: '2026-06-13T12:00:00Z',
+  day: 1,
+  period: 'full',
+  features: [{ type: 'Feature', id: 't-0', geometry: { type: 'Polygon', coordinates: [[[-100, 30], [-99, 30], [-99, 31], [-100, 31], [-100, 30]]] }, properties: {} }],
+  effectiveStart: '2026-06-13T06:00:00Z',
+  effectiveEnd: '2099-01-01T00:00:00Z',
+  forecastHours: [24],
+  warnings: [],
+  ingestedAt: '2026-06-13T14:05:12Z',
+  complete: true,
+};
+
+const writeDay1FullCache = (tmpDir, data = SAMPLE_CACHED_ROUTE) => {
+  const cacheDir = path.join(tmpDir, 'local', 'day1');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(data));
+};
+
+const startTstmRoutesServer = (env, routeOptions = {}) => {
+  const app = express();
+  registerTstmRoutes(app, express, { env, runGenerator: async () => ({}), ...routeOptions });
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+    server.on('error', reject);
+  });
+};
+
+const getTstmRouteUrl = (server, routePath, query = '') => {
+  const { port } = server.address();
+  return `http://127.0.0.1:${port}${routePath}${query}`;
+};
+
+/** Fetches a TSTM route and always closes the ephemeral test server. */
+const withTstmRouteResponse = async ({
+  tmpDir,
+  env,
+  routeOptions = allTargetsEnabledRouteOptions(),
+  cache,
+  routePath,
+  query = '',
+}, runAssertion) => {
+  if (cache !== undefined) {
+    writeDay1FullCache(tmpDir, cache);
+  }
+  const server = await startTstmRoutesServer(env, routeOptions);
+  try {
+    const response = await fetch(getTstmRouteUrl(server, routePath, query));
+    await runAssertion(response);
+  } finally {
+    server.close();
+  }
+};
+
 /** Asserts a disabled generate route returns 404 without invoking the generator. */
 const assertGenerateRouteRejectsWithoutWork = async ({ env, routeOptions = {}, expectedBody }) => {
   let calls = 0;
@@ -201,129 +255,95 @@ describe('GET /api/tstm/latest', () => {
   beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tstm-latest-test-')); });
   afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
-  const SAMPLE_CACHED = {
-    run: '2026-06-13T12:00:00Z',
-    day: 1,
-    period: 'full',
-    features: [{ type: 'Feature', id: 't-0', geometry: { type: 'Polygon', coordinates: [[[-100, 30], [-99, 30], [-99, 31], [-100, 31], [-100, 30]]] }, properties: {} }],
-    effectiveStart: '2026-06-13T06:00:00Z',
-    effectiveEnd: '2099-01-01T00:00:00Z',
-    complete: true,
-  };
-
-  const startLatestServer = (env, routeOptions = {}) => {
-    const app = express();
-    registerTstmRoutes(app, express, { env, runGenerator: async () => ({}), ...routeOptions });
-    return new Promise((resolve, reject) => {
-      const server = app.listen(0, '127.0.0.1', () => resolve(server));
-      server.on('error', reject);
-    });
-  };
-
-  const getLatestUrl = (server, query = '') => {
-    const { port } = server.address();
-    return `http://127.0.0.1:${port}/api/tstm/latest${query}`;
-  };
-
   it('returns cached data when available', async () => {
-    const cacheDir = path.join(tmpDir, 'local', 'day1');
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
-
-    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
-    const server = await startLatestServer(env, allTargetsEnabledRouteOptions());
-    try {
-      const res = await fetch(getLatestUrl(server, '?day=1&period=full'));
+    await withTstmRouteResponse({
+      tmpDir,
+      env: { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir },
+      cache: SAMPLE_CACHED_ROUTE,
+      routePath: '/api/tstm/latest',
+      query: '?day=1&period=full',
+    }, async (res) => {
       assert.equal(res.status, 200);
       const body = await res.json();
       assert.equal(body.run, '2026-06-13T12:00:00Z');
       assert.equal(body.features.length, 1);
-    } finally {
-      server.close();
-    }
+    });
   });
 
   it('returns 404 when no cache exists', async () => {
-    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
-    const server = await startLatestServer(env, allTargetsEnabledRouteOptions());
-    try {
-      const res = await fetch(getLatestUrl(server, '?day=1'));
+    await withTstmRouteResponse({
+      tmpDir,
+      env: { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir },
+      routePath: '/api/tstm/latest',
+      query: '?day=1',
+    }, async (res) => {
       assert.equal(res.status, 404);
       assert.deepEqual(await res.json(), {
         error: 'No cached TSTM data available.',
         reason: 'cache_miss',
       });
-    } finally {
-      server.close();
-    }
+    });
   });
 
   it('returns 400 for invalid day parameter', async () => {
-    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
-    const server = await startLatestServer(env, allTargetsEnabledRouteOptions());
-    try {
-      const res = await fetch(getLatestUrl(server, '?day=3'));
+    await withTstmRouteResponse({
+      tmpDir,
+      env: { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir },
+      routePath: '/api/tstm/latest',
+      query: '?day=3',
+    }, async (res) => {
       assert.equal(res.status, 400);
-    } finally {
-      server.close();
-    }
+    });
   });
 
   it('returns 404 when capability is disabled', async () => {
-    const cacheDir = path.join(tmpDir, 'local', 'day1');
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
-
-    const env = { TSTM_CACHE_DIR: tmpDir };
-    const server = await startLatestServer(env);
-    try {
-      const res = await fetch(getLatestUrl(server, '?day=1'));
+    await withTstmRouteResponse({
+      tmpDir,
+      env: { TSTM_CACHE_DIR: tmpDir },
+      cache: SAMPLE_CACHED_ROUTE,
+      routeOptions: {},
+      routePath: '/api/tstm/latest',
+      query: '?day=1',
+    }, async (res) => {
       assert.equal(res.status, 404);
-    } finally {
-      server.close();
-    }
+    });
   });
 
   it('returns 404 when cached data has expired', async () => {
-    const expired = {
-      ...SAMPLE_CACHED,
-      effectiveEnd: '2026-06-13T12:00:00Z',
-    };
-    const cacheDir = path.join(tmpDir, 'local', 'day1');
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(expired));
-
-    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
-    const server = await startLatestServer(env, allTargetsEnabledRouteOptions());
-    try {
-      const res = await fetch(getLatestUrl(server, '?day=1'));
+    await withTstmRouteResponse({
+      tmpDir,
+      env: { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir },
+      cache: {
+        ...SAMPLE_CACHED_ROUTE,
+        effectiveEnd: '2026-06-13T12:00:00Z',
+      },
+      routePath: '/api/tstm/latest',
+      query: '?day=1',
+    }, async (res) => {
       assert.equal(res.status, 404);
       const body = await res.json();
       assert.equal(body.reason, 'cache_stale');
       assert.ok(body.error.includes('expired'));
-    } finally {
-      server.close();
-    }
+    });
   });
 
   it('rate limits repeated latest requests', async () => {
-    const cacheDir = path.join(tmpDir, 'local', 'day1');
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
-
-    const env = { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir };
     const rateLimit = require('express-rate-limit');
-    const server = await startLatestServer(env, {
-      ...allTargetsEnabledRouteOptions(),
-      readRateLimit: rateLimit({
-        windowMs: 60 * 1000,
-        limit: 1,
-        standardHeaders: true,
-        legacyHeaders: false,
-      }),
-    });
+    writeDay1FullCache(tmpDir, SAMPLE_CACHED_ROUTE);
+    const server = await startTstmRoutesServer(
+      { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir },
+      {
+        ...allTargetsEnabledRouteOptions(),
+        readRateLimit: rateLimit({
+          windowMs: 60 * 1000,
+          limit: 1,
+          standardHeaders: true,
+          legacyHeaders: false,
+        }),
+      },
+    );
     try {
-      const url = getLatestUrl(server, '?day=1&period=full');
+      const url = getTstmRouteUrl(server, '/api/tstm/latest', '?day=1&period=full');
       const first = await fetch(url);
       const second = await fetch(url);
       assert.equal(first.status, 200);
@@ -355,69 +375,35 @@ describe('GET /api/tstm/status', () => {
   beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tstm-status-test-')); });
   afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
-  const SAMPLE_CACHED = {
-    run: '2026-06-13T12:00:00Z',
-    day: 1,
-    period: 'full',
-    features: [{ type: 'Feature', id: 't-0', geometry: { type: 'Polygon', coordinates: [[[-100, 30], [-99, 30], [-99, 31], [-100, 31], [-100, 30]]] }, properties: {} }],
-    effectiveStart: '2026-06-13T06:00:00Z',
-    effectiveEnd: '2099-01-01T00:00:00Z',
-    forecastHours: [24],
-    warnings: [],
-    ingestedAt: '2026-06-13T14:05:12Z',
-    complete: true,
-  };
-
-  const startStatusServer = (env, routeOptions = {}) => {
-    const app = express();
-    registerTstmRoutes(app, express, { env, runGenerator: async () => ({}), ...routeOptions });
-    return new Promise((resolve, reject) => {
-      const server = app.listen(0, '127.0.0.1', () => resolve(server));
-      server.on('error', reject);
-    });
-  };
-
-  const getStatusUrl = (server) => {
-    const { port } = server.address();
-    return `http://127.0.0.1:${port}/api/tstm/status`;
-  };
-
   it('reports cache miss and available entries without leaking internals', async () => {
-    const cacheDir = path.join(tmpDir, 'local', 'day1');
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
-
-    const env = {
-      TSTM_GENERATION_ENABLED: 'true',
-      TSTM_CACHE_DIR: tmpDir,
-      TSTM_INGESTION_ENABLED: 'true',
-    };
-    const server = await startStatusServer(env, allTargetsEnabledRouteOptions());
-    try {
-      const res = await fetch(getStatusUrl(server));
+    await withTstmRouteResponse({
+      tmpDir,
+      env: {
+        TSTM_GENERATION_ENABLED: 'true',
+        TSTM_CACHE_DIR: tmpDir,
+        TSTM_INGESTION_ENABLED: 'true',
+      },
+      cache: SAMPLE_CACHED_ROUTE,
+      routePath: '/api/tstm/status',
+    }, async (res) => {
       assert.equal(res.status, 200);
       const body = await res.json();
       assert.equal(body.ingestionEnabled, true);
       assert.equal(body.cache.day1.full.available, true);
       assert.equal(body.cache.day2.full.reason, 'cache_miss');
       assert.equal(JSON.stringify(body).includes(tmpDir), false);
-    } finally {
-      server.close();
-    }
+    });
   });
 
   it('returns 404 when capability is disabled without reading cache', async () => {
-    const cacheDir = path.join(tmpDir, 'local', 'day1');
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(path.join(cacheDir, 'full.json'), JSON.stringify(SAMPLE_CACHED));
-
-    const env = { TSTM_CACHE_DIR: tmpDir };
-    const server = await startStatusServer(env);
-    try {
-      const res = await fetch(getStatusUrl(server));
+    await withTstmRouteResponse({
+      tmpDir,
+      env: { TSTM_CACHE_DIR: tmpDir },
+      cache: SAMPLE_CACHED_ROUTE,
+      routeOptions: {},
+      routePath: '/api/tstm/status',
+    }, async (res) => {
       assert.equal(res.status, 404);
-    } finally {
-      server.close();
-    }
+    });
   });
 });

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -285,6 +285,25 @@ describe('GET /api/tstm/latest', () => {
     });
   });
 
+  it('returns 404 when cache file is corrupt', async () => {
+    const corruptPath = path.join(tmpDir, 'local', 'day1', 'full.json');
+    fs.mkdirSync(path.dirname(corruptPath), { recursive: true });
+    fs.writeFileSync(corruptPath, '{not-json', 'utf8');
+
+    await withTstmRouteResponse({
+      tmpDir,
+      env: { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir },
+      routePath: '/api/tstm/latest',
+      query: '?day=1&period=full',
+    }, async (res) => {
+      assert.equal(res.status, 404);
+      assert.deepEqual(await res.json(), {
+        error: 'Cached TSTM data is unavailable.',
+        reason: 'cache_corrupt',
+      });
+    });
+  });
+
   it('returns 400 for invalid day parameter', async () => {
     await withTstmRouteResponse({
       tmpDir,

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -5,6 +5,8 @@ import {
   isCurrentTstmRequest,
   normalizeGeneratedTstmFeatures,
   parseTstmGenerationResponse,
+  readTstmLatestFailureReason,
+  requestLatestTstmData,
   requestTstmGeneration,
 } from './tstmGeneration';
 import {
@@ -148,6 +150,68 @@ describe('tstmGeneration utilities', () => {
         .resolves.toMatchObject({ features: [] });
       await expect(requestTstmGeneration({ day: 1, cycleDate: '2026-06-13' }))
         .rejects.toThrow(/not enabled/);
+      expect(
+        isServerCapabilityAvailable('TSTM_GENERATION_ENABLED', {
+          loaded: true,
+          capabilities: {
+            TSTM_GENERATION_ENABLED: {
+              available: true,
+              reason: 'available',
+            },
+          },
+        })
+      ).toBe(false);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('reads structured latest failure reasons from API payloads', () => {
+    expect(readTstmLatestFailureReason({ reason: 'cache_miss' })).toBe('cache_miss');
+    expect(readTstmLatestFailureReason({ reason: 'cache_stale' })).toBe('cache_stale');
+    expect(readTstmLatestFailureReason({ reason: 'unavailable' })).toBe('unavailable');
+    expect(readTstmLatestFailureReason({ reason: 'internal_path' })).toBeNull();
+  });
+
+  test('returns cached guidance and handles expected latest outages without throwing', async () => {
+    const originalFetch = global.fetch;
+    const cachedPayload = {
+      features: [{
+        type: 'Feature',
+        geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+        properties: {},
+      }],
+      run: '2026-06-13T12:00:00Z',
+      forecastHours: [24],
+      effectiveStart: '2026-06-13T12:00:00Z',
+      effectiveEnd: '2026-06-14T12:00:00Z',
+      warnings: [],
+    };
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => cachedPayload,
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'No cached TSTM data available.', reason: 'cache_miss' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'Cached TSTM data has expired.', reason: 'cache_stale' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'Auto-TSTM is not enabled on this deployment.' }),
+      }) as jest.Mock;
+    try {
+      await expect(requestLatestTstmData(1)).resolves.toMatchObject({ run: '2026-06-13T12:00:00Z' });
+      await expect(requestLatestTstmData(1)).resolves.toBeNull();
+      await expect(requestLatestTstmData(1)).resolves.toBeNull();
+      await expect(requestLatestTstmData(1)).resolves.toBeNull();
       expect(
         isServerCapabilityAvailable('TSTM_GENERATION_ENABLED', {
           loaded: true,

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -169,6 +169,7 @@ describe('tstmGeneration utilities', () => {
   test('reads structured latest failure reasons from API payloads', () => {
     expect(readTstmLatestFailureReason({ reason: 'cache_miss' })).toBe('cache_miss');
     expect(readTstmLatestFailureReason({ reason: 'cache_stale' })).toBe('cache_stale');
+    expect(readTstmLatestFailureReason({ reason: 'cache_corrupt' })).toBe('cache_corrupt');
     expect(readTstmLatestFailureReason({ reason: 'unavailable' })).toBe('unavailable');
     expect(readTstmLatestFailureReason({ reason: 'internal_path' })).toBeNull();
   });

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -169,31 +169,11 @@ export const requestTstmGeneration = async (
 
 const TSTM_LATEST_ENDPOINT = '/api/tstm/latest';
 
-export type TstmLatestFailureReason = 'cache_miss' | 'cache_stale' | 'unavailable';
-
-/** Reads a machine-readable reason from a cached Auto-TSTM API error payload. */
-export const readTstmLatestFailureReason = (payload: unknown): TstmLatestFailureReason | null => {
-  if (!payload || typeof payload !== 'object') {
-    return null;
-  }
-
-  const reason = (payload as { reason?: unknown }).reason;
-  if (reason === 'cache_miss' || reason === 'cache_stale' || reason === 'unavailable') {
-    return reason;
-  }
-
-  return null;
-};
-
-/** Requests the latest pre-cached TSTM data for a given day and period. */
-export const requestLatestTstmData = async (
-  day: DayType,
-  period = 'full',
-  signal?: AbortSignal
-): Promise<TstmGenerationResponse | null> => {
-  if (!canGenerateTstmForDay(day)) return null;
-  const response = await fetch(`${TSTM_LATEST_ENDPOINT}?day=${day}&period=${period}`, { signal });
-  const payload = await response.json().catch(() => null);
+/** Resolves a latest-route response into guidance or an expected null result. */
+const finishLatestTstmRequest = (
+  response: Response,
+  payload: unknown
+): TstmGenerationResponse | null => {
   if (!response.ok) {
     const error = readTstmGenerationErrorMessage(payload);
     if (error) {
@@ -207,4 +187,19 @@ export const requestLatestTstmData = async (
   } catch {
     return null;
   }
+};
+
+export type { TstmLatestFailureReason } from './tstmLatestErrors';
+export { readTstmLatestFailureReason } from './tstmLatestErrors';
+
+/** Requests the latest pre-cached TSTM data for a given day and period. */
+export const requestLatestTstmData = async (
+  day: DayType,
+  period = 'full',
+  signal?: AbortSignal
+): Promise<TstmGenerationResponse | null> => {
+  if (!canGenerateTstmForDay(day)) return null;
+  const response = await fetch(`${TSTM_LATEST_ENDPOINT}?day=${day}&period=${period}`, { signal });
+  const payload = await response.json().catch(() => null);
+  return finishLatestTstmRequest(response, payload);
 };

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -169,6 +169,22 @@ export const requestTstmGeneration = async (
 
 const TSTM_LATEST_ENDPOINT = '/api/tstm/latest';
 
+export type TstmLatestFailureReason = 'cache_miss' | 'cache_stale' | 'unavailable';
+
+/** Reads a machine-readable reason from a cached Auto-TSTM API error payload. */
+export const readTstmLatestFailureReason = (payload: unknown): TstmLatestFailureReason | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const reason = (payload as { reason?: unknown }).reason;
+  if (reason === 'cache_miss' || reason === 'cache_stale' || reason === 'unavailable') {
+    return reason;
+  }
+
+  return null;
+};
+
 /** Requests the latest pre-cached TSTM data for a given day and period. */
 export const requestLatestTstmData = async (
   day: DayType,
@@ -177,8 +193,14 @@ export const requestLatestTstmData = async (
 ): Promise<TstmGenerationResponse | null> => {
   if (!canGenerateTstmForDay(day)) return null;
   const response = await fetch(`${TSTM_LATEST_ENDPOINT}?day=${day}&period=${period}`, { signal });
-  if (!response.ok) return null;
   const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error = readTstmGenerationErrorMessage(payload);
+    if (error) {
+      handleDisabledTstmCapability(response, error);
+    }
+    return null;
+  }
   if (!payload) return null;
   try {
     return parseTstmGenerationResponse(payload);

--- a/src/utils/tstmLatestErrors.ts
+++ b/src/utils/tstmLatestErrors.ts
@@ -1,0 +1,25 @@
+export type TstmLatestFailureReason = 'cache_miss' | 'cache_stale' | 'unavailable';
+
+const VALID_LATEST_FAILURE_REASONS: readonly TstmLatestFailureReason[] = [
+  'cache_miss',
+  'cache_stale',
+  'unavailable',
+];
+
+/** Returns true when a string matches a cached Auto-TSTM failure reason. */
+const isTstmLatestFailureReason = (value: string): value is TstmLatestFailureReason =>
+  VALID_LATEST_FAILURE_REASONS.includes(value as TstmLatestFailureReason);
+
+/** Reads a machine-readable reason from a cached Auto-TSTM API error payload. */
+export const readTstmLatestFailureReason = (payload: unknown): TstmLatestFailureReason | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const reason = (payload as { reason?: unknown }).reason;
+  if (typeof reason !== 'string' || !isTstmLatestFailureReason(reason)) {
+    return null;
+  }
+
+  return reason;
+};

--- a/src/utils/tstmLatestErrors.ts
+++ b/src/utils/tstmLatestErrors.ts
@@ -1,8 +1,9 @@
-export type TstmLatestFailureReason = 'cache_miss' | 'cache_stale' | 'unavailable';
+export type TstmLatestFailureReason = 'cache_miss' | 'cache_stale' | 'cache_corrupt' | 'unavailable';
 
 const VALID_LATEST_FAILURE_REASONS: readonly TstmLatestFailureReason[] = [
   'cache_miss',
   'cache_stale',
+  'cache_corrupt',
   'unavailable',
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the cached Auto-TSTM read path delivered in TSTM-03 (PR #646) for beta operational use.

Closes #475 (TSTM-04).

## Changes

- **Public read policy:** Document unauthenticated, capability-gated access for `GET /api/tstm/latest` and new `GET /api/tstm/status` (no work when disabled).
- **Rate limits:** 120 req/min on cached read routes (matches `/api/capabilities/status` precedent).
- **Structured errors:** `cache_miss`, `cache_stale`, and `unavailable` reasons on sanitized API responses.
- **Operational health:** `GET /api/tstm/status` reports per-day/period cache availability without leaking internal paths.
- **Cache schema:** Ingestion cache now stores `forecastHours` and `warnings` so `requestLatestTstmData()` can parse cached payloads.
- **Expected outage noise:** Ingestion skips log at info; client latest helper returns `null` for expected failures without throwing.
- **Tests:** Server latest/status/rate-limit coverage, exposure contracts for latest route, client `requestLatestTstmData` tests, `tstm-ingestion.test.js` in CI script.
- **Docs:** `docs/auto-tstm-operations.md`

## Out of scope

- No `autoTstm.exposure.beta` flip
- No forecast editor UI wiring

## Verification

- [x] `cd server && npm test`
- [x] `pnpm test -- --runTestsByPath src/utils/tstmGeneration.test.ts`
- [x] `pnpm test:exposure`
- [x] `pnpm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2875d0c7-405a-4b45-ae1d-4d39c2a9453a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2875d0c7-405a-4b45-ae1d-4d39c2a9453a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

