### PR TITLE
Enable Auto-TSTM beta testing

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -145,6 +145,15 @@ jobs:
 
       - name: Write beta analytics env file
         run: |
+          current_emergency_disabled_capabilities="$(
+            ssh -o StrictHostKeyChecking=yes root@${{ secrets.BETA_SSH_HOST }} \
+              "grep -E '^EMERGENCY_DISABLED_CAPABILITIES=' /opt/gfc-beta-analytics/.env 2>/dev/null | tail -n 1 | cut -d= -f2-"
+          )"
+          current_tstm_ingestion_enabled="$(
+            ssh -o StrictHostKeyChecking=yes root@${{ secrets.BETA_SSH_HOST }} \
+              "grep -E '^TSTM_INGESTION_ENABLED=' /opt/gfc-beta-analytics/.env 2>/dev/null | tail -n 1 | cut -d= -f2-"
+          )"
+
           cat > beta-server.env <<EOF
           PORT=3007
           LOG_DIR=/opt/gfc-beta-analytics/logs
@@ -170,6 +179,14 @@ jobs:
           SENTRY_ENVIRONMENT=beta
           SENTRY_RELEASE=graphical-forecast-creator@${{ steps.app_version.outputs.value }}
           EOF
+          if [ -n "$current_emergency_disabled_capabilities" ]; then
+            echo "Preserving active EMERGENCY_DISABLED_CAPABILITIES from beta analytics .env"
+            echo "EMERGENCY_DISABLED_CAPABILITIES=${current_emergency_disabled_capabilities}" >> beta-server.env
+          fi
+          if [ "$current_tstm_ingestion_enabled" = "false" ]; then
+            echo "Preserving emergency TSTM_INGESTION_ENABLED=false from beta analytics .env"
+            echo "TSTM_INGESTION_ENABLED=false" >> beta-server.env
+          fi
           node scripts/write-deployment-env.mjs deploy/beta-deployment-config.json >> beta-server.env
           rsync -avz beta-server.env root@${{ secrets.BETA_SSH_HOST }}:/opt/gfc-beta-analytics/.env
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -9,6 +9,11 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 - Port deployment feature-switch config from #651: add per-target config files under `deploy/` and wire beta, staging, and production analytics env generation through the checked-out deploy ref.
 - Harden deployment config validation for newline injection, path traversal, and readable CLI errors.
 
+### PR #650
+
+- Add Auto-TSTM beta tester plans, including a short step-by-step test, a full forecast test, and copy-ready report templates.
+- Document that beta deployment enables Auto-TSTM generation and ingestion through `deploy/beta-deployment-config.json`.
+
 ### PR #649
 
 - Integrate Auto-TSTM preview, apply, cancel, and stale-result protection in the forecast editor (TSTM-05, #476).

--- a/docs/auto-tstm-beta-test-plans.md
+++ b/docs/auto-tstm-beta-test-plans.md
@@ -1,0 +1,206 @@
+# Auto-TSTM beta test plans
+
+Auto-TSTM is available on beta for early user testing as of July 1, 2026. These plans are written for beta testers who are exercising the feature from the hosted beta app, not for CI or local development.
+
+Use the [Auto-TSTM operations guide](./auto-tstm-operations.md) for API behavior, cache health, and emergency-disable details.
+
+## Feature under test
+
+Auto-TSTM adds cached general thunderstorm guidance to the Forecast editor:
+
+1. Open the Forecast editor.
+2. Use **Day 1** or **Day 2**.
+3. Open the **Tools** tab.
+4. Select **Auto-TSTM**.
+5. Review the preview layer.
+6. Use **Apply** to commit the guidance or **Cancel** to discard it.
+
+Auto-TSTM should be unavailable on unsupported forecast days and should never apply guidance without an explicit tester action.
+
+## Tester report format
+
+Ask testers to include:
+
+- Tester name or handle
+- Date and local time tested
+- Device and browser
+- Desktop, tablet, phone portrait, or phone landscape
+- Forecast day tested
+- Whether Auto-TSTM preview loaded, applied, or failed
+- Screenshots or screen recording for any visual issue
+- Steps to reproduce anything unexpected
+- Whether the issue blocks normal forecast creation
+
+## Plan 1: 15-minute beta smoke test
+
+Goal: prove the feature can be found, previewed, cancelled, applied, and used on common devices without breaking the forecast workflow.
+
+Recommended testers: broad beta group.
+
+Recommended coverage:
+
+- One desktop browser
+- One mobile phone in portrait
+- One mobile phone in landscape, if possible
+
+### Steps
+
+1. Open the beta app and enter the Forecast editor.
+2. Confirm the map loads and the normal toolbar tabs are usable.
+3. Select **Day 1**.
+4. Open **Tools** and confirm **Auto-TSTM** is visible.
+5. Open **Auto-TSTM**.
+6. Confirm a preview dialog appears.
+7. Confirm the map remains visible and usable behind or around the preview.
+8. Select **Cancel**.
+9. Confirm the preview closes and the forecast does not change.
+10. Reopen **Auto-TSTM** on **Day 1**.
+11. Select **Apply**.
+12. Confirm the general thunderstorm area is added to the forecast.
+13. Use undo once.
+14. Confirm the Auto-TSTM-applied area is removed by the undo action.
+15. Switch to **Day 2** and repeat preview plus cancel.
+16. Switch to **Day 3**.
+17. Open **Tools** and confirm Auto-TSTM is disabled or clearly unavailable.
+
+### Pass goals
+
+- Auto-TSTM is discoverable from the Tools tab.
+- Preview opens for Day 1 and Day 2 when cached guidance is available.
+- Cancel leaves the forecast unchanged.
+- Apply adds only the previewed TSTM guidance.
+- Undo removes the applied Auto-TSTM guidance in one action.
+- Day 3 and later do not allow Auto-TSTM.
+- No toolbar, map control, legend, credit, warning badge, or modal overlap blocks the workflow.
+
+### Failures to report immediately
+
+- Auto-TSTM is missing on Day 1 or Day 2 when the tester has beta access.
+- Apply happens automatically before the tester selects **Apply**.
+- Cancel still changes the forecast.
+- Undo fails to remove the applied Auto-TSTM guidance.
+- The mobile layout hides the map or makes Tools unreachable.
+- Any crash, blank map, or repeated loading state.
+
+## Plan 2: 45-minute workflow and quality pass
+
+Goal: test Auto-TSTM as part of realistic forecast creation and compare the generated guidance against forecaster judgment.
+
+Recommended testers: experienced beta testers, forecasters, and anyone comfortable filing detailed feedback.
+
+Recommended coverage:
+
+- At least one fresh forecast cycle
+- Day 1 and Day 2
+- Desktop plus one constrained viewport, preferably phone landscape
+
+### Setup
+
+Before opening Auto-TSTM, create a normal forecast workspace:
+
+1. Start or load a forecast cycle.
+2. Pan and zoom to the area of interest.
+3. Add at least one manual categorical or hazard area that should remain separate from Auto-TSTM.
+4. Save or export a before screenshot if the tester can.
+
+### Preview quality
+
+1. Open **Tools**.
+2. Open **Auto-TSTM** for **Day 1**.
+3. Compare the previewed area against current forecast reasoning.
+4. Check whether the preview location, size, and shape are plausible.
+5. Check whether the preview styling is visibly separate from already-applied forecast geometry.
+6. Close with **Cancel**.
+7. Confirm the manual forecast work is unchanged.
+
+Pass goals:
+
+- Preview styling is understandable and does not look like committed forecast geometry.
+- The preview does not obscure critical map context.
+- Existing manual forecast areas remain unchanged after cancel.
+- Any unavailable-data message is understandable and does not create Sentry-style technical noise for testers.
+
+### Apply behavior
+
+1. Reopen **Auto-TSTM** for **Day 1**.
+2. Select **Apply**.
+3. Confirm the applied TSTM area appears as committed forecast geometry.
+4. Confirm existing manually drawn areas still exist.
+5. Save the forecast, reload the page, and confirm the applied TSTM area persists if this workflow normally persists other drawn geometry for the tester.
+6. Use undo and redo around the Auto-TSTM apply action.
+
+Pass goals:
+
+- Apply commits the guidance once.
+- Apply does not duplicate geometry when the tester presses the action once.
+- Manual geometry is preserved.
+- Save, reload, undo, and redo behave the same way they do for normal drawing operations.
+
+### Context switching
+
+1. Open Auto-TSTM on **Day 1**.
+2. While preview is loading or visible, switch forecast day if the UI allows it.
+3. Return to **Day 1** and **Day 2**.
+4. Confirm stale previews do not apply to the wrong day.
+5. Repeat after changing map zoom or active forecast context.
+
+Pass goals:
+
+- Day 1 guidance does not apply to Day 2.
+- Day 2 guidance does not apply to Day 1.
+- Late-loading previews do not mutate the forecast after the tester has moved to another context.
+- The panel can be reopened after switching contexts.
+
+### Responsive layout
+
+Run the core preview and apply flow on a phone-sized viewport:
+
+1. Phone portrait.
+2. Phone landscape.
+3. A narrow desktop window, if possible.
+
+Pass goals:
+
+- Navbar does not overflow.
+- The map remains visible.
+- Bottom toolbar tabs are reachable.
+- Tools and Auto-TSTM controls are reachable without awkward two-direction scrolling.
+- Floating map controls do not collide with the Auto-TSTM panel, legend, credits, or warning badge.
+- Touch targets are large enough to use confidently.
+
+## Optional operator check
+
+This section is for maintainers, not general beta testers.
+
+Use the public beta API to confirm cached guidance health before sending testers into the feature:
+
+```powershell
+curl https://beta-gfc.weatherboysuper.com/api/capabilities/status
+curl "https://beta-gfc.weatherboysuper.com/api/tstm/status"
+curl "https://beta-gfc.weatherboysuper.com/api/tstm/latest?day=1&period=full"
+curl "https://beta-gfc.weatherboysuper.com/api/tstm/latest?day=2&period=full"
+```
+
+Expected result:
+
+- Capabilities report Auto-TSTM available on beta.
+- Status reports Day 1 and Day 2 cache availability or a clear public-safe reason.
+- Latest responses return GeoJSON-like feature payloads when cache is available.
+- Disabled, stale, missing, or unavailable states return public-safe error messages without internal paths, stack traces, or stderr.
+
+## Triage labels
+
+Suggested labels when filing tester findings:
+
+- `Component: Forecast`
+- `Component: Map`
+- `Component: UI`
+- `quality`
+- `e2e-validated` only after a maintainer reproduces and verifies a fix
+
+Use the highest severity that matches the impact:
+
+- **Blocking:** crash, blank map, data loss, wrong-day apply, or Apply/Cancel mutating the wrong state.
+- **High:** mobile workflow cannot be completed, Auto-TSTM unavailable when expected, or saved forecast state is wrong.
+- **Medium:** confusing preview state, poor generated shape quality, duplicate geometry, or undo/redo inconsistency.
+- **Low:** copy, styling, or minor layout polish that does not block testing.

--- a/docs/auto-tstm-beta-test-plans.md
+++ b/docs/auto-tstm-beta-test-plans.md
@@ -31,7 +31,7 @@ Ask testers to include:
 - Steps to reproduce anything unexpected
 - Whether the issue blocks normal forecast creation
 
-## Plan 1: 15-minute beta smoke test
+## Plan 1: Short beta test
 
 Goal: prove the feature can be found, previewed, cancelled, applied, and used on common devices without breaking the forecast workflow.
 
@@ -82,7 +82,7 @@ Recommended coverage:
 - The mobile layout hides the map or makes Tools unreachable.
 - Any crash, blank map, or repeated loading state.
 
-## Plan 2: 45-minute workflow and quality pass
+## Plan 2: Full forecast test
 
 Goal: test Auto-TSTM as part of realistic forecast creation and compare the generated guidance against forecaster judgment.
 
@@ -174,7 +174,7 @@ This section is for maintainers, not general beta testers.
 
 Use the public beta API to confirm cached guidance health before sending testers into the feature:
 
-```powershell
+```sh
 curl https://beta-gfc.weatherboysuper.com/api/capabilities/status
 curl "https://beta-gfc.weatherboysuper.com/api/tstm/status"
 curl "https://beta-gfc.weatherboysuper.com/api/tstm/latest?day=1&period=full"

--- a/docs/auto-tstm-beta-tester-post.md
+++ b/docs/auto-tstm-beta-tester-post.md
@@ -1,0 +1,54 @@
+# Auto-TSTM beta tester instructions
+
+Auto-TSTM is ready for beta testing. Please test it on the beta site from the Forecast editor.
+
+## Short Test
+
+1. Open the beta app.
+2. Go to the Forecast editor.
+3. Select Day 1.
+4. Open the Tools tab.
+5. Open Auto-TSTM.
+6. Confirm a preview appears on the map.
+7. Press Cancel.
+8. Confirm nothing was added to the forecast.
+9. Open Auto-TSTM again.
+10. Press Apply.
+11. Confirm the TSTM area was added.
+12. Use undo.
+13. Confirm the TSTM area was removed.
+14. Switch to Day 2 and make sure Auto-TSTM can open there too.
+15. Switch to Day 3 and make sure Auto-TSTM is disabled or unavailable.
+
+## Full Forecast Test
+
+Use Auto-TSTM in your next real forecast. Treat it like a normal part of your workflow:
+
+- Start a forecast the way you normally would.
+- Open Auto-TSTM on Day 1 or Day 2.
+- Review the preview before applying it.
+- Apply it only if it makes sense for your forecast.
+- Keep editing, saving, exporting, or undoing like normal.
+- Report whether Auto-TSTM helped, got in the way, or produced guidance that looked wrong.
+
+## Bug Report Format
+
+- Device and browser:
+- Forecast day:
+- What went wrong:
+- What you expected:
+- Steps to reproduce:
+- Screenshot or screen recording:
+- Did it block your forecast? yes/no
+
+## General Report Format
+
+- Device and browser:
+- Test used: Short Test or Full Forecast Test
+- Did the preview load? yes/no
+- Did Apply work? yes/no
+- Did Cancel leave the forecast unchanged? yes/no
+- Did undo work after Apply? yes/no
+- Did the guidance look reasonable? yes/no/unsure
+- Anything confusing or awkward:
+- Overall: ready / needs work / not sure

--- a/docs/auto-tstm-operations.md
+++ b/docs/auto-tstm-operations.md
@@ -74,7 +74,7 @@ Use this endpoint (or server logs prefixed with `[tstm-ingest]`) to confirm inge
 
 ### Preview / apply flow (TSTM-05)
 
-On beta builds with `autoTstm` exposure enabled and the beta analytics deployment setting `TSTM_GENERATION_ENABLED=true`:
+On beta builds with `autoTstm` exposure enabled and `TSTM_GENERATION_ENABLED=true` supplied by `deploy/beta-deployment-config.json`:
 
 1. Forecast editor **Tools** tab exposes **Auto-TSTM** behind `ServerBackedFeatureBoundary`.
 2. Opening the panel fetches `GET /api/tstm/latest` for the active Day 1/2 context.

--- a/docs/auto-tstm-operations.md
+++ b/docs/auto-tstm-operations.md
@@ -74,7 +74,7 @@ Use this endpoint (or server logs prefixed with `[tstm-ingest]`) to confirm inge
 
 ### Preview / apply flow (TSTM-05)
 
-On beta builds with `autoTstm` exposure enabled:
+On beta builds with `autoTstm` exposure enabled and the beta analytics deployment setting `TSTM_GENERATION_ENABLED=true`:
 
 1. Forecast editor **Tools** tab exposes **Auto-TSTM** behind `ServerBackedFeatureBoundary`.
 2. Opening the panel fetches `GET /api/tstm/latest` for the active Day 1/2 context.
@@ -87,5 +87,6 @@ Controls stay absent when registry exposure or the server capability gate is off
 ## Related docs
 
 - [auto-tstm-beta-test-plans.md](./auto-tstm-beta-test-plans.md) — beta tester smoke and workflow plans
+- [auto-tstm-beta-tester-post.md](./auto-tstm-beta-tester-post.md) — concise copy-ready tester instructions
 - [feature-exposure-workstreams.md](./feature-exposure-workstreams.md) — Auto-TSTM registry and beta enablement criteria
 - [emergency-feature-disable.md](./emergency-feature-disable.md) — incident disable runbook

--- a/docs/auto-tstm-operations.md
+++ b/docs/auto-tstm-operations.md
@@ -86,5 +86,6 @@ Controls stay absent when registry exposure or the server capability gate is off
 
 ## Related docs
 
+- [auto-tstm-beta-test-plans.md](./auto-tstm-beta-test-plans.md) — beta tester smoke and workflow plans
 - [feature-exposure-workstreams.md](./feature-exposure-workstreams.md) — Auto-TSTM registry and beta enablement criteria
 - [emergency-feature-disable.md](./emergency-feature-disable.md) — incident disable runbook

--- a/docs/emergency-feature-disable.md
+++ b/docs/emergency-feature-disable.md
@@ -33,6 +33,8 @@ No frontend rebuild or redeploy is required.
 
 Use this when the incident is caused by the background ingestion loop itself, such as upstream rate limiting, disk growth, runaway polling, or repeated cache writes. Route disable alone prevents user-triggered generation but does not keep a running ingestion loop from polling after restart.
 
+The beta deploy workflow preserves an active `TSTM_INGESTION_ENABLED=false` value and any existing `EMERGENCY_DISABLED_CAPABILITIES` value from `/opt/gfc-beta-analytics/.env` when it writes a fresh env file. This keeps an in-flight emergency stop from being silently undone by a hotfix deployment. After the incident is resolved, complete the rollback steps below so future deployments resume normal ingestion.
+
 1. SSH to the beta analytics host.
 2. Edit `/opt/gfc-beta-analytics/.env`.
 3. Set:
@@ -99,6 +101,7 @@ Already-open beta sessions should stop showing server-backed controls after the 
 3. Restart `gfc-beta-analytics` with pm2.
 4. Re-run the verification commands and confirm `"available": true` when registry exposure and `TSTM_GENERATION_ENABLED=true` are both in effect.
 5. Confirm `GET /api/tstm/status` reports `"ingestionEnabled": true` when ingestion should be running.
+6. If a hotfix deployed during the incident, confirm `/opt/gfc-beta-analytics/.env` no longer carries the preserved emergency values.
 
 ## Ownership and audit
 

--- a/docs/emergency-feature-disable.md
+++ b/docs/emergency-feature-disable.md
@@ -10,7 +10,7 @@ Use this when a server-backed beta capability must be turned off immediately wit
 
 Normal rollout still comes from the checked-in registry in `src/config/featureExposure.ts` plus deployment env switches such as `TSTM_GENERATION_ENABLED=true`.
 
-## Activation (beta)
+## Disable Auto-TSTM routes (beta)
 
 1. SSH to the beta analytics host.
 2. Edit `/opt/gfc-beta-analytics/.env`.
@@ -26,6 +26,46 @@ EMERGENCY_DISABLED_CAPABILITIES=TSTM_GENERATION_ENABLED
 cd /opt/gfc-beta-analytics
 pm2 restart gfc-beta-analytics
 ```
+
+No frontend rebuild or redeploy is required.
+
+## Stop Auto-TSTM ingestion (beta)
+
+Use this when the incident is caused by the background ingestion loop itself, such as upstream rate limiting, disk growth, runaway polling, or repeated cache writes. Route disable alone prevents user-triggered generation but does not keep a running ingestion loop from polling after restart.
+
+1. SSH to the beta analytics host.
+2. Edit `/opt/gfc-beta-analytics/.env`.
+3. Set:
+
+```bash
+TSTM_INGESTION_ENABLED=false
+```
+
+4. If user-facing Auto-TSTM should also be hidden while ingestion is stopped, add or keep:
+
+```bash
+EMERGENCY_DISABLED_CAPABILITIES=TSTM_GENERATION_ENABLED
+```
+
+5. Restart the analytics process so the scheduled loop is not registered:
+
+```bash
+cd /opt/gfc-beta-analytics
+pm2 restart gfc-beta-analytics
+```
+
+6. Confirm the process restarted cleanly:
+
+```bash
+pm2 status gfc-beta-analytics
+pm2 logs gfc-beta-analytics --lines 100
+```
+
+Expected results:
+
+- No new `[tstm-ingest]` polling or cache-write log lines appear after restart.
+- `GET /api/tstm/status` reports `"ingestionEnabled": false`.
+- If `EMERGENCY_DISABLED_CAPABILITIES=TSTM_GENERATION_ENABLED` is also set, `/api/capabilities/status` reports `"available": false` with `"reason": "emergency_disabled"`.
 
 No frontend rebuild or redeploy is required.
 
@@ -55,8 +95,10 @@ Already-open beta sessions should stop showing server-backed controls after the 
 ## Rollback
 
 1. Remove `EMERGENCY_DISABLED_CAPABILITIES` from `/opt/gfc-beta-analytics/.env`, or set it to an empty value.
-2. Restart `gfc-beta-analytics` with pm2.
-3. Re-run the verification commands and confirm `"available": true` when registry exposure and `TSTM_GENERATION_ENABLED=true` are both in effect.
+2. If ingestion was stopped, restore `TSTM_INGESTION_ENABLED=true`.
+3. Restart `gfc-beta-analytics` with pm2.
+4. Re-run the verification commands and confirm `"available": true` when registry exposure and `TSTM_GENERATION_ENABLED=true` are both in effect.
+5. Confirm `GET /api/tstm/status` reports `"ingestionEnabled": true` when ingestion should be running.
 
 ## Ownership and audit
 
@@ -82,6 +124,7 @@ Manual server drill (requires registry exposure on the target):
 ```powershell
 $env:SERVER_TARGET='beta'
 $env:TSTM_GENERATION_ENABLED='true'
+$env:TSTM_INGESTION_ENABLED='false'
 $env:EMERGENCY_DISABLED_CAPABILITIES='TSTM_GENERATION_ENABLED'
 node server/analytics.js
 ```
@@ -95,8 +138,8 @@ curl -X POST http://127.0.0.1:3006/api/tstm/generate `
   -d '{"day":1,"cycleDate":"2026-06-13"}'
 ```
 
-4. Confirm the status payload includes `TSTM_GENERATION_ENABLED` with reason `emergency_disabled`, the generate route returns `404`, and no Python worker starts.
-5. Remove the env var, restart the server, and confirm normal disabled/enabled behavior resumes according to the registry matrix.
+4. Confirm the status payload includes `TSTM_GENERATION_ENABLED` with reason `emergency_disabled`, `/api/tstm/status` reports `"ingestionEnabled": false`, the generate route returns `404`, and no Python worker starts.
+5. Remove the emergency env var, restore `TSTM_INGESTION_ENABLED=true` if needed, restart the server, and confirm normal disabled/enabled behavior resumes according to the registry matrix.
 
 ## Public status endpoint security
 


### PR DESCRIPTION
## Summary

- Add Auto-TSTM beta tester documentation, including the full internal test plan and a concise copy-ready tester post.
- Enable beta Auto-TSTM through the deployment-config process introduced by #651 and ported by #653:
  - `deploy/beta-deployment-config.json` supplies `TSTM_GENERATION_ENABLED=true`
  - `deploy/beta-deployment-config.json` supplies `TSTM_INGESTION_ENABLED=true`
- Preserve active beta emergency disables across hotfix deploys by reading the current beta analytics `.env` before appending deployment config values.
- Link the tester docs from the Auto-TSTM operations guide and record the beta changelog entry.

## Server/Feature Governance

- Client and server exposure registries already expose `autoTstm` on `beta`.
- This PR now relies on the checked-out deployment config file for normal beta feature switches instead of hardcoding Auto-TSTM flags in the workflow.
- The emergency runbook documents both route disable and ingestion stop paths.

## Verification

- `git diff --check origin/beta...HEAD`
- `node --test scripts/lib/deployment-config.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-targets.test.mjs scripts/lib/port-pr-policy.test.mjs`
- `node scripts/write-deployment-env.mjs deploy/beta-deployment-config.json`
- `node scripts/write-deployment-env.mjs deploy/production-deployment-config.json`
