### PR TITLE
[Port][Conflicts] Move deploy feature switches to config files → beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,11 @@ jobs:
           node-version: '24.x'
 
       - name: Validate release automation unit tests
+<<<<<<< HEAD
         run: node --test scripts/lib/package-version.test.mjs scripts/lib/bump-beta-after-main-release.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/port-targets.test.mjs scripts/lib/port-conflicts.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/pr-ci-label-state.test.mjs scripts/lib/github-paginate.test.mjs scripts/lib/changelog.test.mjs scripts/lib/beta-changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs scripts/lib/stale-branch-report.test.mjs
+=======
+        run: node --test scripts/lib/package-version.test.mjs scripts/lib/bump-beta-after-main-release.test.mjs scripts/lib/deployment-config.test.mjs scripts/lib/branch-policy.test.mjs scripts/lib/port-pr-policy.test.mjs scripts/lib/port-targets.test.mjs scripts/lib/port-conflicts.test.mjs scripts/lib/version-bump.test.mjs scripts/lib/glob-match.test.mjs scripts/lib/pr-labels.test.mjs scripts/lib/pr-ci-label-state.test.mjs scripts/lib/github-paginate.test.mjs scripts/lib/changelog.test.mjs scripts/lib/beta-changelog.test.mjs scripts/lib/dependabot-changelog.test.mjs scripts/lib/production-release.test.mjs
+>>>>>>> 6cd6509 (fix: move deploy feature switches to config)
 
       - name: Validate package version for target branch
         env:

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -170,6 +170,7 @@ jobs:
           SENTRY_ENVIRONMENT=beta
           SENTRY_RELEASE=graphical-forecast-creator@${{ steps.app_version.outputs.value }}
           EOF
+          node scripts/write-deployment-env.mjs deploy/beta-deployment-config.json >> beta-server.env
           rsync -avz beta-server.env root@${{ secrets.BETA_SSH_HOST }}:/opt/gfc-beta-analytics/.env
 
       - name: Install analytics dependencies and restart

--- a/.github/workflows/deploy-main-to-vps.yml
+++ b/.github/workflows/deploy-main-to-vps.yml
@@ -246,6 +246,7 @@ jobs:
           SENTRY_ENVIRONMENT=production
           SENTRY_RELEASE=graphical-forecast-creator@${{ steps.app_version.outputs.sentry_release }}
           EOF
+          node scripts/write-deployment-env.mjs deploy/production-deployment-config.json >> prod-server.env
           cat > staging-server.env <<EOF
           PORT=3008
           LOG_DIR=/opt/gfc-staging-analytics/logs
@@ -271,6 +272,7 @@ jobs:
           SENTRY_ENVIRONMENT=staging
           SENTRY_RELEASE=graphical-forecast-creator@${{ steps.app_version.outputs.sentry_release }}
           EOF
+          node scripts/write-deployment-env.mjs deploy/beta-deployment-config.json >> staging-server.env
 
       - name: Deploy live release (full)
         if: steps.manifest.outputs.skip != 'true' && steps.manifest.outputs.action == 'live'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - **Production deploy supply chain:** Use `pnpm install --frozen-lockfile` in the production deploy workflow so builds cannot silently resolve new dependency versions at deploy time.
 
 ### Changed
+- **Deploy feature config:** Move server-backed feature switches into `deploy/beta-deployment-config.json` and `deploy/production-deployment-config.json`, with deploy workflows appending the target config into analytics env files.
 - **Deploy env:** Add explicit `SERVER_TARGET` values to beta, staging, and production analytics server deploy env files.
 - **Deploy triggers:** Run **Deploy Beta** on beta prerelease publish and **Deploy Production** on stable release publish (one deploy per version bump; merge pushes no longer trigger VPS deploys).
 

--- a/deploy/beta-deployment-config.json
+++ b/deploy/beta-deployment-config.json
@@ -1,0 +1,6 @@
+{
+  "serverEnv": {
+    "TSTM_GENERATION_ENABLED": "true",
+    "TSTM_INGESTION_ENABLED": "true"
+  }
+}

--- a/deploy/production-deployment-config.json
+++ b/deploy/production-deployment-config.json
@@ -1,0 +1,6 @@
+{
+  "serverEnv": {
+    "TSTM_GENERATION_ENABLED": "false",
+    "TSTM_INGESTION_ENABLED": "false"
+  }
+}

--- a/docs/hosted-rollout.md
+++ b/docs/hosted-rollout.md
@@ -60,6 +60,15 @@ bash /opt/gfc-analytics/current/release/promote-release.sh
 3. Smoke **staging-gfc** (beta access guard, same as beta-gfc).
 4. At `rolloutAt`, cron promotes; live banner switches via `write-live-alert-banner.mjs`.
 
+## Deployment feature config
+
+Server-backed capability switches are reviewed in target deployment config files, not hard-coded in workflow env blocks:
+
+- `deploy/beta-deployment-config.json` controls beta deploys and staging preview analytics.
+- `deploy/production-deployment-config.json` controls production analytics.
+
+The workflow definitions live on `main`, but each deploy checks out the release ref before reading these config files. To enable or disable a server-backed feature, update the config file on the branch/tag that will be deployed.
+
 ## Hotfix / emergency
 
 Set `"action": "live"` in `deploy/production-release.json` for immediate full deploy (no staging).

--- a/scripts/lib/deployment-config.mjs
+++ b/scripts/lib/deployment-config.mjs
@@ -1,0 +1,47 @@
+const ENV_KEY_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const ENV_VALUE_PATTERN = /^[^\r\n]*$/;
+
+/** Returns true when value is a plain object map rather than an array or primitive. */
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Normalizes and validates deployment config JSON. */
+export function normalizeDeploymentConfig(config) {
+  if (!isPlainObject(config)) {
+    throw new Error('Deployment config must be a JSON object.');
+  }
+
+  const serverEnv = config.serverEnv;
+  if (!isPlainObject(serverEnv)) {
+    throw new Error('Deployment config must declare a serverEnv object.');
+  }
+
+  const normalizedServerEnv = {};
+  for (const [key, value] of Object.entries(serverEnv)) {
+    if (!ENV_KEY_PATTERN.test(key)) {
+      throw new Error(`Invalid serverEnv key ${JSON.stringify(key)}.`);
+    }
+
+    if (typeof value !== 'string') {
+      throw new Error(`serverEnv.${key} must be a string.`);
+    }
+
+    if (!ENV_VALUE_PATTERN.test(value)) {
+      throw new Error(`serverEnv.${key} must not contain line breaks.`);
+    }
+
+    normalizedServerEnv[key] = value;
+  }
+
+  return { serverEnv: normalizedServerEnv };
+}
+
+/** Renders env-file lines that can be appended to an analytics .env. */
+export function renderServerEnvFile(config) {
+  const normalized = normalizeDeploymentConfig(config);
+  return Object.entries(normalized.serverEnv)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+}

--- a/scripts/lib/deployment-config.test.mjs
+++ b/scripts/lib/deployment-config.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  normalizeDeploymentConfig,
+  renderServerEnvFile,
+} from './deployment-config.mjs';
+
+describe('deployment config', () => {
+  it('normalizes server env values', () => {
+    assert.deepEqual(
+      normalizeDeploymentConfig({
+        serverEnv: {
+          TSTM_GENERATION_ENABLED: 'true',
+          TSTM_INGESTION_ENABLED: 'false',
+        },
+      }),
+      {
+        serverEnv: {
+          TSTM_GENERATION_ENABLED: 'true',
+          TSTM_INGESTION_ENABLED: 'false',
+        },
+      }
+    );
+  });
+
+  it('renders deterministic workflow env file lines', () => {
+    assert.equal(
+      renderServerEnvFile({
+        serverEnv: {
+          TSTM_INGESTION_ENABLED: 'true',
+          TSTM_GENERATION_ENABLED: 'true',
+        },
+      }),
+      ['TSTM_GENERATION_ENABLED=true', 'TSTM_INGESTION_ENABLED=true'].join('\n')
+    );
+  });
+
+  it('rejects missing serverEnv config', () => {
+    assert.throws(() => normalizeDeploymentConfig({}), /serverEnv object/);
+  });
+
+  it('rejects invalid env keys and non-string values', () => {
+    assert.throws(
+      () => normalizeDeploymentConfig({ serverEnv: { 'bad-key': 'true' } }),
+      /Invalid serverEnv key/
+    );
+    assert.throws(
+      () => normalizeDeploymentConfig({ serverEnv: { TSTM_GENERATION_ENABLED: true } }),
+      /must be a string/
+    );
+  });
+
+  it('rejects values with line breaks', () => {
+    assert.throws(
+      () => normalizeDeploymentConfig({ serverEnv: { TSTM_GENERATION_ENABLED: 'true\nBAD=1' } }),
+      /line breaks/
+    );
+  });
+});

--- a/scripts/write-deployment-env.mjs
+++ b/scripts/write-deployment-env.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+/** Writes deployment server env overrides from one deploy/*-deployment-config.json file. */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { renderServerEnvFile } from './lib/deployment-config.mjs';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const relativeConfigPath = process.argv[2];
+
+if (!relativeConfigPath) {
+  console.error('Usage: node scripts/write-deployment-env.mjs <config-json>');
+  process.exit(1);
+}
+
+const configPath = resolve(ROOT, relativeConfigPath);
+const config = JSON.parse(readFileSync(configPath, 'utf8'));
+const output = renderServerEnvFile(config);
+
+if (output) {
+  process.stdout.write(`${output}\n`);
+}


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #651 — Move deploy feature switches to config files |
| Source branch | `fix/deployment-config` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `.github/workflows/ci.yml`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/651-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #651, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.