### PR TITLE
fix: filter GFC-WEB-H/J render-frame noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Deploy reliability:** Harden beta and production VPS deploy workflows against flaky `ssh-keyscan` host-key discovery with pinned known-host secrets, retries, deploy concurrency, and explicit `StrictHostKeyChecking` on SSH/rsync.
+- **GFC-WEB-H/J Sentry noise:** Filter the known OpenLayers canvas renderer `requestAnimationFrame` noise before it reaches Sentry while preserving actionable application TypeErrors.
 - **GFC-WEB-K/F/E Sentry noise:** Filter no-stack browser `NetworkError`/`AbortError` promise-rejection noise before it reaches Sentry while preserving actionable exceptions.
 
 ### Added

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -60,6 +60,54 @@ describe('instrument', () => {
     });
   });
 
+  const createOpenLayersCanvasEvent = (
+    value: string,
+    mechanismType = 'auto.browser.browserapierrors.requestAnimationFrame'
+  ) => ({
+    exception: {
+      values: [
+        {
+          value,
+          mechanism: {
+            type: mechanismType,
+            handled: false,
+          },
+          stacktrace: {
+            frames: [{ filename: 'assets/index-BmG6v9Rh.js', function: 'n' }],
+          },
+        },
+      ],
+    },
+  });
+
+  it.each([
+    ["Safari/WebKit observed shape", "null is not an object (evaluating 'a.canvas')"],
+    ["Safari/WebKit alternate minified name", "null is not an object (evaluating 'b.canvas')"],
+  ])('drops OpenLayers canvas render-frame noise: %s', (_label, message) => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createOpenLayersCanvasEvent(message);
+
+      expect(beforeSend(event, {})).toBeNull();
+    });
+  });
+
+  it('keeps matching canvas TypeErrors when they come from application frames', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createOpenLayersCanvasEvent(
+        "null is not an object (evaluating 'a.canvas')",
+        'auto.browser.global_handlers.onerror'
+      );
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
+  });
+
   const createRequestLifecycleEvent = (value: string, withStack = false) => ({
     exception: {
       values: [

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -12,7 +12,12 @@ declare const __GFC_SENTRY_DSN__: string;
 declare const __GFC_SENTRY_ENVIRONMENT__: string;
 declare const __GFC_APP_VERSION__: string;
 
-const IGNORED_ERROR_MESSAGES = [
+type SentryExceptionValue = NonNullable<NonNullable<Event['exception']>['values']>[number];
+
+const OPENLAYERS_CANVAS_MESSAGE = /^null is not an object \(evaluating '[a-z]\.canvas'\)$/i;
+const REQUEST_ANIMATION_FRAME_MECHANISM = 'auto.browser.browserapierrors.requestAnimationFrame';
+
+const REQUEST_LIFECYCLE_MESSAGES = [
   /^(NetworkError: )?A network error occurred\.?$/i,
   /^(AbortError: )?The user aborted a request\.?$/i,
 ];
@@ -40,14 +45,30 @@ function getEnvironment(): string {
   return configured.trim() || 'production';
 }
 
+/** True when Sentry captured stack frames for an exception value. */
+function hasStackFrames(value: SentryExceptionValue): boolean {
+  return (value.stacktrace?.frames?.length ?? 0) > 0;
+}
+
+/** True for the OpenLayers Safari canvas renderer noise from requestAnimationFrame. */
+function isOpenLayersCanvasNoise(value: SentryExceptionValue): boolean {
+  return (
+    OPENLAYERS_CANVAS_MESSAGE.test(value.value ?? '') &&
+    value.mechanism?.type === REQUEST_ANIMATION_FRAME_MECHANISM &&
+    value.mechanism.handled === false
+  );
+}
+
 /** Drops no-stack request lifecycle noise while preserving actionable stacked errors. */
 export function beforeSend(event: Event, _hint: EventHint): Event | null {
   const values = event.exception?.values ?? [];
   const message = values[0]?.value ?? event.message ?? '';
-  const hasStackFrames = values.some((value) => (value.stacktrace?.frames?.length ?? 0) > 0);
-  const isIgnoredRequestNoise = IGNORED_ERROR_MESSAGES.some((pattern) => pattern.test(message));
+  const hasAnyStackFrames = values.some(hasStackFrames);
+  const isIgnoredRequestNoise = REQUEST_LIFECYCLE_MESSAGES.some((pattern) => pattern.test(message));
 
-  return isIgnoredRequestNoise && !hasStackFrames ? null : event;
+  return (isIgnoredRequestNoise && !hasAnyStackFrames) || values.some(isOpenLayersCanvasNoise)
+    ? null
+    : event;
 }
 
 /** Initializes Sentry when a DSN is present. No-op in local dev without a DSN. */


### PR DESCRIPTION
## Summary

- Filter the known OpenLayers canvas renderer `requestAnimationFrame` TypeError before Sentry sends it.
- Keep similar TypeErrors when they come from application frames so actionable errors still report.
- Add focused coverage for the GFC-WEB-H/J event shape and guardrails.

## Sentry

- Fixes noisy production issues `GFC-WEB-H` and `GFC-WEB-J`.
- Observed `GFC-WEB-H` issue `7588062526`, release `graphical-forecast-creator@1.6.14`, environment `production`, URL `/forecast`.
- Observed `GFC-WEB-J` issue `7588062548`, release `graphical-forecast-creator@1.6.14`, environment `production`, URL `/forecast`.
- Both issues showed `TypeError: null is not an object (evaluating 'a.canvas')` from `ol/renderer/canvas/Layer.js` `useContainer` under `auto.browser.browserapierrors.requestAnimationFrame`.

## Changelog

- Filter known OpenLayers canvas renderer `requestAnimationFrame` noise before it reaches Sentry while preserving actionable application TypeErrors.

## Verification

- `.\node_modules\.bin\jest.cmd --runTestsByPath src/instrument.test.ts`
- `$env:SENTRY_AUTH_TOKEN=''; .\node_modules\.bin\vite.cmd build`

## Notes

- Local build verification clears `SENTRY_AUTH_TOKEN` because the read-only investigation token cannot create Sentry releases or upload source maps.
