### PR TITLE
[Port] fix: filter Sentry request lifecycle noise to beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Deploy reliability:** Harden beta and production VPS deploy workflows against flaky `ssh-keyscan` host-key discovery with pinned known-host secrets, retries, deploy concurrency, and explicit `StrictHostKeyChecking` on SSH/rsync.
+- **GFC-WEB-K/F/E Sentry noise:** Filter no-stack browser `NetworkError`/`AbortError` promise-rejection noise before it reaches Sentry while preserving actionable exceptions.
 
 ### Added
 - **Explicit build targets:** Define and validate local, beta, staging, and production frontend build targets while preserving the existing beta access gate.

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -45,6 +45,7 @@ describe('instrument', () => {
           sendDefaultPii: false,
           enableLogs: true,
           normalizeDepth: 10,
+          beforeSend: expect.any(Function),
           tracesSampleRate: 0.1,
           tracePropagationTargets: expect.arrayContaining([
             'localhost',
@@ -56,6 +57,56 @@ describe('instrument', () => {
       );
       const initCall = (Sentry.init as jest.Mock).mock.calls[0][0];
       expect(initCall.integrations).toHaveLength(1);
+    });
+  });
+
+  const createRequestLifecycleEvent = (value: string, withStack = false) => ({
+    exception: {
+      values: [
+        {
+          value,
+          stacktrace: withStack
+            ? { frames: [{ filename: 'src/lib/openFreeMap.ts', function: 'loadStyle' }] }
+            : undefined,
+        },
+      ],
+    },
+  });
+
+  it.each([
+    ['GFC-WEB-K NetworkError', 'A network error occurred.'],
+    ['GFC-WEB-F wrapped NetworkError', 'NetworkError: A network error occurred.'],
+    ['GFC-WEB-E wrapped AbortError', 'AbortError: The user aborted a request.'],
+    ['bare AbortError variant', 'The user aborted a request.'],
+  ])('drops no-stack request lifecycle noise: %s', (_label, message) => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+
+      expect(beforeSend(createRequestLifecycleEvent(message), {})).toBeNull();
+    });
+  });
+
+  it('keeps matching request lifecycle errors with stack frames', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createRequestLifecycleEvent('A network error occurred.', true);
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
+  });
+
+  it('keeps unrelated application errors', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createRequestLifecycleEvent('Cannot read properties of undefined');
+
+      expect(beforeSend(event, {})).toBe(event);
     });
   });
 });

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react';
+import type { Event, EventHint } from '@sentry/react';
 import React from 'react';
 import {
   useLocation,
@@ -10,6 +11,11 @@ import {
 declare const __GFC_SENTRY_DSN__: string;
 declare const __GFC_SENTRY_ENVIRONMENT__: string;
 declare const __GFC_APP_VERSION__: string;
+
+const IGNORED_ERROR_MESSAGES = [
+  /^(NetworkError: )?A network error occurred\.?$/i,
+  /^(AbortError: )?The user aborted a request\.?$/i,
+];
 
 /** Returns the Sentry DSN baked in at build time, or an empty string when monitoring is off. */
 function getSentryDsn(): string {
@@ -34,6 +40,16 @@ function getEnvironment(): string {
   return configured.trim() || 'production';
 }
 
+/** Drops no-stack request lifecycle noise while preserving actionable stacked errors. */
+export function beforeSend(event: Event, _hint: EventHint): Event | null {
+  const values = event.exception?.values ?? [];
+  const message = values[0]?.value ?? event.message ?? '';
+  const hasStackFrames = values.some((value) => (value.stacktrace?.frames?.length ?? 0) > 0);
+  const isIgnoredRequestNoise = IGNORED_ERROR_MESSAGES.some((pattern) => pattern.test(message));
+
+  return isIgnoredRequestNoise && !hasStackFrames ? null : event;
+}
+
 /** Initializes Sentry when a DSN is present. No-op in local dev without a DSN. */
 export function initSentry(): void {
   if (!isSentryEnabled()) {
@@ -48,6 +64,7 @@ export function initSentry(): void {
     sendDefaultPii: false,
     enableLogs: true,
     normalizeDepth: 10,
+    beforeSend,
     integrations: [
       Sentry.reactRouterV7BrowserTracingIntegration({
         useEffect: React.useEffect,


### PR DESCRIPTION
Automated port of the original commits from PR #656 into `beta` after merge into `main`.