### PR TITLE
[Port] Sentry noise filters to beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Deploy reliability:** Harden beta and production VPS deploy workflows against flaky `ssh-keyscan` host-key discovery with pinned known-host secrets, retries, deploy concurrency, and explicit `StrictHostKeyChecking` on SSH/rsync.
+<<<<<<< HEAD
+=======
+- **GFC-WEB-H/J Sentry noise:** Filter the known OpenLayers canvas renderer `requestAnimationFrame` noise before it reaches Sentry while preserving actionable application TypeErrors.
+- **GFC-WEB-K/F/E Sentry noise:** Filter no-stack browser `NetworkError`/`AbortError` promise-rejection noise before it reaches Sentry while preserving actionable exceptions.
+>>>>>>> 2b13234 (fix: filter OpenLayers render-frame noise)
 
 ### Added
 - **Explicit build targets:** Define and validate local, beta, staging, and production frontend build targets while preserving the existing beta access gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Deploy reliability:** Harden beta and production VPS deploy workflows against flaky `ssh-keyscan` host-key discovery with pinned known-host secrets, retries, deploy concurrency, and explicit `StrictHostKeyChecking` on SSH/rsync.
-<<<<<<< HEAD
-=======
 - **GFC-WEB-H/J Sentry noise:** Filter the known OpenLayers canvas renderer `requestAnimationFrame` noise before it reaches Sentry while preserving actionable application TypeErrors.
 - **GFC-WEB-K/F/E Sentry noise:** Filter no-stack browser `NetworkError`/`AbortError` promise-rejection noise before it reaches Sentry while preserving actionable exceptions.
->>>>>>> 2b13234 (fix: filter OpenLayers render-frame noise)
 
 ### Added
 - **Explicit build targets:** Define and validate local, beta, staging, and production frontend build targets while preserving the existing beta access gate.

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -45,6 +45,7 @@ describe('instrument', () => {
           sendDefaultPii: false,
           enableLogs: true,
           normalizeDepth: 10,
+          beforeSend: expect.any(Function),
           tracesSampleRate: 0.1,
           tracePropagationTargets: expect.arrayContaining([
             'localhost',
@@ -58,8 +59,6 @@ describe('instrument', () => {
       expect(initCall.integrations).toHaveLength(1);
     });
   });
-<<<<<<< HEAD
-=======
 
   const createOpenLayersCanvasEvent = (
     value: string,
@@ -148,6 +147,17 @@ describe('instrument', () => {
     });
   });
 
+  it('drops matching request lifecycle noise from message-only events', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = { message: 'A network error occurred.' };
+
+      expect(beforeSend(event, {})).toBeNull();
+    });
+  });
+
   it('keeps unrelated application errors', () => {
     jest.isolateModules(() => {
       globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
@@ -158,5 +168,4 @@ describe('instrument', () => {
       expect(beforeSend(event, {})).toBe(event);
     });
   });
->>>>>>> 2b13234 (fix: filter OpenLayers render-frame noise)
 });

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -83,6 +83,7 @@ describe('instrument', () => {
   it.each([
     ["Safari/WebKit observed shape", "null is not an object (evaluating 'a.canvas')"],
     ["Safari/WebKit alternate minified name", "null is not an object (evaluating 'b.canvas')"],
+    ["Safari/WebKit two-character minified name", "null is not an object (evaluating 'ab.canvas')"],
   ])('drops OpenLayers canvas render-frame noise: %s', (_label, message) => {
     jest.isolateModules(() => {
       globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -58,4 +58,105 @@ describe('instrument', () => {
       expect(initCall.integrations).toHaveLength(1);
     });
   });
+<<<<<<< HEAD
+=======
+
+  const createOpenLayersCanvasEvent = (
+    value: string,
+    mechanismType = 'auto.browser.browserapierrors.requestAnimationFrame'
+  ) => ({
+    exception: {
+      values: [
+        {
+          value,
+          mechanism: {
+            type: mechanismType,
+            handled: false,
+          },
+          stacktrace: {
+            frames: [{ filename: 'assets/index-BmG6v9Rh.js', function: 'n' }],
+          },
+        },
+      ],
+    },
+  });
+
+  it.each([
+    ["Safari/WebKit observed shape", "null is not an object (evaluating 'a.canvas')"],
+    ["Safari/WebKit alternate minified name", "null is not an object (evaluating 'b.canvas')"],
+  ])('drops OpenLayers canvas render-frame noise: %s', (_label, message) => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createOpenLayersCanvasEvent(message);
+
+      expect(beforeSend(event, {})).toBeNull();
+    });
+  });
+
+  it('keeps matching canvas TypeErrors when they come from application frames', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createOpenLayersCanvasEvent(
+        "null is not an object (evaluating 'a.canvas')",
+        'auto.browser.global_handlers.onerror'
+      );
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
+  });
+
+  const createRequestLifecycleEvent = (value: string, withStack = false) => ({
+    exception: {
+      values: [
+        {
+          value,
+          stacktrace: withStack
+            ? { frames: [{ filename: 'src/lib/openFreeMap.ts', function: 'loadStyle' }] }
+            : undefined,
+        },
+      ],
+    },
+  });
+
+  it.each([
+    ['GFC-WEB-K NetworkError', 'A network error occurred.'],
+    ['GFC-WEB-F wrapped NetworkError', 'NetworkError: A network error occurred.'],
+    ['GFC-WEB-E wrapped AbortError', 'AbortError: The user aborted a request.'],
+    ['bare AbortError variant', 'The user aborted a request.'],
+  ])('drops no-stack request lifecycle noise: %s', (_label, message) => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+
+      expect(beforeSend(createRequestLifecycleEvent(message), {})).toBeNull();
+    });
+  });
+
+  it('keeps matching request lifecycle errors with stack frames', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createRequestLifecycleEvent('A network error occurred.', true);
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
+  });
+
+  it('keeps unrelated application errors', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createRequestLifecycleEvent('Cannot read properties of undefined');
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
+  });
+>>>>>>> 2b13234 (fix: filter OpenLayers render-frame noise)
 });

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -11,6 +11,19 @@ declare const __GFC_SENTRY_DSN__: string;
 declare const __GFC_SENTRY_ENVIRONMENT__: string;
 declare const __GFC_APP_VERSION__: string;
 
+<<<<<<< HEAD
+=======
+type SentryExceptionValue = NonNullable<NonNullable<Event['exception']>['values']>[number];
+
+const OPENLAYERS_CANVAS_MESSAGE = /^null is not an object \(evaluating '[a-z]\.canvas'\)$/i;
+const REQUEST_ANIMATION_FRAME_MECHANISM = 'auto.browser.browserapierrors.requestAnimationFrame';
+
+const REQUEST_LIFECYCLE_MESSAGES = [
+  /^(NetworkError: )?A network error occurred\.?$/i,
+  /^(AbortError: )?The user aborted a request\.?$/i,
+];
+
+>>>>>>> 2b13234 (fix: filter OpenLayers render-frame noise)
 /** Returns the Sentry DSN baked in at build time, or an empty string when monitoring is off. */
 function getSentryDsn(): string {
   return typeof __GFC_SENTRY_DSN__ !== 'undefined' ? __GFC_SENTRY_DSN__ : '';
@@ -34,6 +47,35 @@ function getEnvironment(): string {
   return configured.trim() || 'production';
 }
 
+<<<<<<< HEAD
+=======
+/** True when Sentry captured stack frames for an exception value. */
+function hasStackFrames(value: SentryExceptionValue): boolean {
+  return (value.stacktrace?.frames?.length ?? 0) > 0;
+}
+
+/** True for the OpenLayers Safari canvas renderer noise from requestAnimationFrame. */
+function isOpenLayersCanvasNoise(value: SentryExceptionValue): boolean {
+  return (
+    OPENLAYERS_CANVAS_MESSAGE.test(value.value ?? '') &&
+    value.mechanism?.type === REQUEST_ANIMATION_FRAME_MECHANISM &&
+    value.mechanism.handled === false
+  );
+}
+
+/** Drops no-stack request lifecycle noise while preserving actionable stacked errors. */
+export function beforeSend(event: Event, _hint: EventHint): Event | null {
+  const values = event.exception?.values ?? [];
+  const message = values[0]?.value ?? event.message ?? '';
+  const hasAnyStackFrames = values.some(hasStackFrames);
+  const isIgnoredRequestNoise = REQUEST_LIFECYCLE_MESSAGES.some((pattern) => pattern.test(message));
+
+  return (isIgnoredRequestNoise && !hasAnyStackFrames) || values.some(isOpenLayersCanvasNoise)
+    ? null
+    : event;
+}
+
+>>>>>>> 2b13234 (fix: filter OpenLayers render-frame noise)
 /** Initializes Sentry when a DSN is present. No-op in local dev without a DSN. */
 export function initSentry(): void {
   if (!isSentryEnabled()) {

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -14,7 +14,7 @@ declare const __GFC_APP_VERSION__: string;
 
 type SentryExceptionValue = NonNullable<NonNullable<Event['exception']>['values']>[number];
 
-const OPENLAYERS_CANVAS_MESSAGE = /^null is not an object \(evaluating '[a-z]\.canvas'\)$/i;
+const OPENLAYERS_CANVAS_MESSAGE = /^null is not an object \(evaluating '[a-z]{1,2}\.canvas'\)$/i;
 const REQUEST_ANIMATION_FRAME_MECHANISM = 'auto.browser.browserapierrors.requestAnimationFrame';
 
 const REQUEST_LIFECYCLE_MESSAGES = [

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react';
+import type { Event, EventHint } from '@sentry/react';
 import React from 'react';
 import {
   useLocation,
@@ -11,8 +12,6 @@ declare const __GFC_SENTRY_DSN__: string;
 declare const __GFC_SENTRY_ENVIRONMENT__: string;
 declare const __GFC_APP_VERSION__: string;
 
-<<<<<<< HEAD
-=======
 type SentryExceptionValue = NonNullable<NonNullable<Event['exception']>['values']>[number];
 
 const OPENLAYERS_CANVAS_MESSAGE = /^null is not an object \(evaluating '[a-z]\.canvas'\)$/i;
@@ -23,7 +22,6 @@ const REQUEST_LIFECYCLE_MESSAGES = [
   /^(AbortError: )?The user aborted a request\.?$/i,
 ];
 
->>>>>>> 2b13234 (fix: filter OpenLayers render-frame noise)
 /** Returns the Sentry DSN baked in at build time, or an empty string when monitoring is off. */
 function getSentryDsn(): string {
   return typeof __GFC_SENTRY_DSN__ !== 'undefined' ? __GFC_SENTRY_DSN__ : '';
@@ -47,8 +45,6 @@ function getEnvironment(): string {
   return configured.trim() || 'production';
 }
 
-<<<<<<< HEAD
-=======
 /** True when Sentry captured stack frames for an exception value. */
 function hasStackFrames(value: SentryExceptionValue): boolean {
   return (value.stacktrace?.frames?.length ?? 0) > 0;
@@ -75,7 +71,6 @@ export function beforeSend(event: Event, _hint: EventHint): Event | null {
     : event;
 }
 
->>>>>>> 2b13234 (fix: filter OpenLayers render-frame noise)
 /** Initializes Sentry when a DSN is present. No-op in local dev without a DSN. */
 export function initSentry(): void {
   if (!isSentryEnabled()) {
@@ -90,6 +85,7 @@ export function initSentry(): void {
     sendDefaultPii: false,
     enableLogs: true,
     normalizeDepth: 10,
+    beforeSend,
     integrations: [
       Sentry.reactRouterV7BrowserTracingIntegration({
         useEffect: React.useEffect,


### PR DESCRIPTION
## Summary
- Ports #656 and #657 to `beta` in one repaired port branch.
- Keeps the no-stack request lifecycle Sentry filter for GFC-WEB-K/F/E.
- Keeps the OpenLayers Safari canvas `requestAnimationFrame` Sentry filter for GFC-WEB-H/J.
- Adds regression coverage for exception-backed and message-only Sentry events.

## Verification
- `jest --runTestsByPath src/instrument.test.ts`
- `vite build` with local Sentry upload disabled
