### PR TITLE
[WF-01] Define cycle, workflow, outlook version, and package schemas

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,12 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #660
+
+- Define workflow v2 schema types: stable cycle/workflow IDs, cycle and outlook status enums, outlook versioning with derivation tracking, standard and custom groupings, workflow/cycle/package metadata, and schema version constant (WF-01, #451).
+- Add 27 focused unit tests covering all type definitions and acceptance criteria.
+- Re-export new types from `outlooks.ts` for backward compatibility.
+
 ### PR #655
 
 - Move Monitor UI and map components under `src/monitor/components` so Monitor domain logic and implementation components share one feature-owned area.

--- a/src/types/outlooks.ts
+++ b/src/types/outlooks.ts
@@ -219,3 +219,24 @@ export interface GFCForecastSaveData {
     cycleDate: string;
   };
 }
+
+// ---------------------------------------------------------------------------
+// Workflow v2 re-exports (issue #451 / WF-01)
+// ---------------------------------------------------------------------------
+
+export type {
+  WorkflowId,
+  CycleId,
+  CycleStatus,
+  OutlookStatus,
+  OutlookVersion,
+  StandardGrouping,
+  CustomGrouping,
+  Grouping,
+  WorkflowMetadata,
+  CycleMetadata,
+  WorkflowPackageMetadata,
+  Package,
+} from './workflow';
+
+export { WORKFLOW_SCHEMA_VERSION } from './workflow';

--- a/src/types/outlooks.ts
+++ b/src/types/outlooks.ts
@@ -239,4 +239,4 @@ export type {
   Package,
 } from './workflow';
 
-export { WORKFLOW_SCHEMA_VERSION } from './workflow';
+export { WORKFLOW_SCHEMA_VERSION, createCustomGrouping } from './workflow';

--- a/src/types/workflow.test.ts
+++ b/src/types/workflow.test.ts
@@ -294,7 +294,7 @@ describe('Acceptance criteria validation', () => {
       status: 'completed-with-omissions',
       outlookVersions: [
         { version: 1, status: 'completed', createdAt: '2026-06-14T12:00:00Z' },
-        { version: 1, status: 'omitted', createdAt: '2026-06-14T12:00:00Z' },
+        { version: 2, status: 'omitted', createdAt: '2026-06-14T12:00:00Z' },
       ],
       createdAt: '2026-06-14T12:00:00Z',
       updatedAt: '2026-06-14T18:00:00Z',

--- a/src/types/workflow.test.ts
+++ b/src/types/workflow.test.ts
@@ -1,0 +1,305 @@
+import type {
+  WorkflowId,
+  CycleId,
+  CycleStatus,
+  OutlookStatus,
+  OutlookVersion,
+  StandardGrouping,
+  Grouping,
+  WorkflowMetadata,
+  CycleMetadata,
+  WorkflowPackageMetadata,
+  Package,
+} from './workflow';
+
+import { WORKFLOW_SCHEMA_VERSION } from './workflow';
+
+describe('WORKFLOW_SCHEMA_VERSION', () => {
+  it('is a valid semver string', () => {
+    expect(WORKFLOW_SCHEMA_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('is defined and non-empty', () => {
+    expect(WORKFLOW_SCHEMA_VERSION).toBeTruthy();
+  });
+});
+
+describe('CycleStatus', () => {
+  const validStatuses: CycleStatus[] = [
+    'in-progress',
+    'completed',
+    'completed-with-omissions',
+  ];
+
+  it.each(validStatuses)('includes "%s"', (status) => {
+    const cycle: CycleMetadata = {
+      id: 'WF-sev-20260613',
+      workflowId: 'severe-day1',
+      cycleDate: '2026-06-13',
+      status,
+      outlookVersions: [],
+      createdAt: '2026-06-13T12:00:00Z',
+      updatedAt: '2026-06-13T12:00:00Z',
+    };
+    expect(cycle.status).toBe(status);
+  });
+});
+
+describe('OutlookStatus', () => {
+  const validStatuses: OutlookStatus[] = [
+    'in-progress',
+    'completed',
+    'skipped',
+    'omitted',
+  ];
+
+  it.each(validStatuses)('includes "%s"', (status) => {
+    const version: OutlookVersion = {
+      version: 1,
+      status,
+      createdAt: '2026-06-13T12:00:00Z',
+    };
+    expect(version.status).toBe(status);
+  });
+});
+
+describe('OutlookVersion', () => {
+  it('supports original outlook (no derivedFrom)', () => {
+    const version: OutlookVersion = {
+      version: 1,
+      status: 'completed',
+      createdAt: '2026-06-13T12:00:00Z',
+    };
+    expect(version.derivedFrom).toBeUndefined();
+    expect(version.version).toBe(1);
+  });
+
+  it('supports derived outlook with parent reference', () => {
+    const original: OutlookVersion = {
+      version: 1,
+      status: 'completed',
+      createdAt: '2026-06-13T12:00:00Z',
+    };
+    const update: OutlookVersion = {
+      version: 2,
+      status: 'in-progress',
+      derivedFrom: original.version,
+      createdAt: '2026-06-13T15:00:00Z',
+    };
+    expect(update.derivedFrom).toBe(1);
+    expect(update.version).toBe(2);
+  });
+
+  it('distinguishes derived outlooks from originals', () => {
+    const original: OutlookVersion = {
+      version: 1,
+      status: 'completed',
+      createdAt: '2026-06-13T12:00:00Z',
+    };
+    const derived: OutlookVersion = {
+      version: 2,
+      status: 'in-progress',
+      derivedFrom: 1,
+      createdAt: '2026-06-13T16:00:00Z',
+    };
+
+    const isDerived = (v: OutlookVersion) => v.derivedFrom !== undefined;
+    expect(isDerived(original)).toBe(false);
+    expect(isDerived(derived)).toBe(true);
+  });
+});
+
+describe('StandardGrouping', () => {
+  const expected: StandardGrouping[] = ['day1', 'day2', 'day3', 'day4-8'];
+
+  it.each(expected)('includes "%s"', (grouping) => {
+    const workflow: WorkflowMetadata = {
+      id: 'severe-day1',
+      label: 'Severe Convective Day 1',
+      groupings: [grouping],
+    };
+    expect(workflow.groupings).toContain(grouping);
+  });
+});
+
+describe('Grouping', () => {
+  it('accepts standard groupings', () => {
+    const groupings: Grouping[] = ['day1', 'day2', 'day3', 'day4-8'];
+    expect(groupings).toHaveLength(4);
+  });
+
+  it('accepts custom groupings', () => {
+    const groupings: Grouping[] = ['day1', 'fire-weather', 'marine'];
+    expect(groupings).toContain('fire-weather');
+    expect(groupings).toContain('marine');
+  });
+});
+
+describe('WorkflowMetadata', () => {
+  it('can be constructed with standard groupings', () => {
+    const workflow: WorkflowMetadata = {
+      id: 'severe-day1',
+      label: 'Severe Convective Day 1',
+      groupings: ['day1'],
+    };
+    expect(workflow.id).toBe('severe-day1');
+    expect(workflow.groupings).toEqual(['day1']);
+  });
+});
+
+describe('CycleMetadata', () => {
+  it('supports all status states', () => {
+    const statuses: CycleStatus[] = [
+      'in-progress',
+      'completed',
+      'completed-with-omissions',
+    ];
+    for (const status of statuses) {
+      const cycle: CycleMetadata = {
+        id: `WF-test-${status}`,
+        workflowId: 'test',
+        cycleDate: '2026-06-13',
+        status,
+        outlookVersions: [],
+        createdAt: '2026-06-13T12:00:00Z',
+        updatedAt: '2026-06-13T12:00:00Z',
+      };
+      expect(cycle.status).toBe(status);
+    }
+  });
+
+  it('can hold multiple outlook versions', () => {
+    const versions: OutlookVersion[] = [
+      { version: 1, status: 'completed', createdAt: '2026-06-13T12:00:00Z' },
+      { version: 2, status: 'in-progress', derivedFrom: 1, createdAt: '2026-06-13T16:00:00Z' },
+    ];
+    const cycle: CycleMetadata = {
+      id: 'WF-sev-20260613',
+      workflowId: 'severe-day1',
+      cycleDate: '2026-06-13',
+      status: 'in-progress',
+      outlookVersions: versions,
+      createdAt: '2026-06-13T12:00:00Z',
+      updatedAt: '2026-06-13T16:00:00Z',
+    };
+    expect(cycle.outlookVersions).toHaveLength(2);
+    expect(cycle.outlookVersions[1].derivedFrom).toBe(1);
+  });
+});
+
+describe('WorkflowPackageMetadata', () => {
+  it('supports standalone cycle (no derivedFromCycleId)', () => {
+    const pkg: WorkflowPackageMetadata = {
+      workflowId: 'severe-day1',
+      cycleId: 'WF-sev-20260613',
+      version: 1,
+      status: 'completed',
+      includesDiscussions: false,
+      includesStyleSnapshots: true,
+    };
+    expect(pkg.derivedFromCycleId).toBeUndefined();
+  });
+
+  it('supports derived cycle with previous-cycle reference', () => {
+    const pkg: WorkflowPackageMetadata = {
+      workflowId: 'severe-day1',
+      cycleId: 'WF-sev-20260613-v2',
+      version: 2,
+      status: 'in-progress',
+      includesDiscussions: true,
+      includesStyleSnapshots: false,
+      derivedFromCycleId: 'WF-sev-20260613',
+    };
+    expect(pkg.derivedFromCycleId).toBe('WF-sev-20260613');
+  });
+});
+
+describe('Package', () => {
+  it('can be constructed with metadata and cycles', () => {
+    const pkg: Package = {
+      metadata: {
+        workflowId: 'severe-day1',
+        cycleId: 'WF-sev-20260613',
+        version: 1,
+        status: 'completed',
+        includesDiscussions: true,
+        includesStyleSnapshots: true,
+      },
+      cycles: [
+        {
+          id: 'WF-sev-20260613',
+          workflowId: 'severe-day1',
+          cycleDate: '2026-06-13',
+          status: 'completed',
+          outlookVersions: [
+            { version: 1, status: 'completed', createdAt: '2026-06-13T12:00:00Z' },
+          ],
+          createdAt: '2026-06-13T12:00:00Z',
+          updatedAt: '2026-06-13T18:00:00Z',
+        },
+      ],
+    };
+    expect(pkg.cycles).toHaveLength(1);
+    expect(pkg.metadata.status).toBe('completed');
+  });
+});
+
+describe('Acceptance criteria validation', () => {
+  it('updates remain inside a cycle (outlookVersion tracks within CycleMetadata)', () => {
+    const cycle: CycleMetadata = {
+      id: 'WF-sev-20260613',
+      workflowId: 'severe-day1',
+      cycleDate: '2026-06-13',
+      status: 'in-progress',
+      outlookVersions: [
+        { version: 1, status: 'completed', createdAt: '2026-06-13T12:00:00Z' },
+        { version: 2, status: 'in-progress', derivedFrom: 1, createdAt: '2026-06-13T16:00:00Z' },
+      ],
+      createdAt: '2026-06-13T12:00:00Z',
+      updatedAt: '2026-06-13T16:00:00Z',
+    };
+    // Both versions belong to the same cycle
+    expect(cycle.outlookVersions.every((v) => v.version >= 1)).toBe(true);
+    expect(cycle.outlookVersions[1].derivedFrom).toBe(1);
+  });
+
+  it('derived new outlooks are distinguishable via derivedFrom', () => {
+    const versions: OutlookVersion[] = [
+      { version: 1, status: 'completed', createdAt: '2026-06-13T12:00:00Z' },
+      { version: 2, status: 'in-progress', derivedFrom: 1, createdAt: '2026-06-13T16:00:00Z' },
+      { version: 3, status: 'skipped', derivedFrom: 2, createdAt: '2026-06-13T20:00:00Z' },
+    ];
+    const originals = versions.filter((v) => v.derivedFrom === undefined);
+    const derived = versions.filter((v) => v.derivedFrom !== undefined);
+    expect(originals).toHaveLength(1);
+    expect(derived).toHaveLength(2);
+    expect(derived[0].derivedFrom).toBe(1);
+    expect(derived[1].derivedFrom).toBe(2);
+  });
+
+  it('incomplete and completed-with-omissions states are supported', () => {
+    const incomplete: CycleMetadata = {
+      id: 'WF-sev-20260613',
+      workflowId: 'severe-day1',
+      cycleDate: '2026-06-13',
+      status: 'in-progress',
+      outlookVersions: [],
+      createdAt: '2026-06-13T12:00:00Z',
+      updatedAt: '2026-06-13T12:00:00Z',
+    };
+    const omissions: CycleMetadata = {
+      id: 'WF-sev-20260614',
+      workflowId: 'severe-day1',
+      cycleDate: '2026-06-14',
+      status: 'completed-with-omissions',
+      outlookVersions: [
+        { version: 1, status: 'completed', createdAt: '2026-06-14T12:00:00Z' },
+        { version: 1, status: 'omitted', createdAt: '2026-06-14T12:00:00Z' },
+      ],
+      createdAt: '2026-06-14T12:00:00Z',
+      updatedAt: '2026-06-14T18:00:00Z',
+    };
+    expect(incomplete.status).toBe('in-progress');
+    expect(omissions.status).toBe('completed-with-omissions');
+  });
+});

--- a/src/types/workflow.test.ts
+++ b/src/types/workflow.test.ts
@@ -12,7 +12,7 @@ import type {
   Package,
 } from './workflow';
 
-import { WORKFLOW_SCHEMA_VERSION } from './workflow';
+import { WORKFLOW_SCHEMA_VERSION, createCustomGrouping } from './workflow';
 
 describe('WORKFLOW_SCHEMA_VERSION', () => {
   it('is a valid semver string', () => {
@@ -129,7 +129,11 @@ describe('Grouping', () => {
   });
 
   it('accepts custom groupings', () => {
-    const groupings: Grouping[] = ['day1', 'fire-weather', 'marine'];
+    const groupings: Grouping[] = [
+      'day1',
+      createCustomGrouping('fire-weather'),
+      createCustomGrouping('marine'),
+    ];
     expect(groupings).toContain('fire-weather');
     expect(groupings).toContain('marine');
   });

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -64,6 +64,11 @@ export type OutlookStatus = 'in-progress' | 'completed' | 'skipped' | 'omitted';
  * When a forecaster issues an update (e.g. Day 1 1300Z → 1600Z), a new
  * `OutlookVersion` is appended. The `derivedFrom` field links the update
  * back to its parent, making lineage explicit.
+ *
+ * @note This type is grouping-agnostic — it does not indicate which
+ * grouping (day) a version belongs to. WF-02+ will attach grouping
+ * information via the cycle's workflow groupings. Consumers should not
+ * assume a 1:1 mapping between outlook versions and groupings.
  */
 export interface OutlookVersion {
   /** 1-based version number within the cycle. */
@@ -86,8 +91,8 @@ export interface OutlookVersion {
  */
 export type StandardGrouping = 'day1' | 'day2' | 'day3' | 'day4-8';
 
-/** User-defined grouping label. */
-export type CustomGrouping = string;
+/** User-defined grouping label. Branded to distinguish from standard groupings at the type level. */
+export type CustomGrouping = string & { readonly _brand: 'custom' };
 
 /** Union of standard and custom groupings. */
 export type Grouping = StandardGrouping | CustomGrouping;

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -94,6 +94,11 @@ export type StandardGrouping = 'day1' | 'day2' | 'day3' | 'day4-8';
 /** User-defined grouping label. Branded to distinguish from standard groupings at the type level. */
 export type CustomGrouping = string & { readonly _brand: 'custom' };
 
+/** Helper to construct a branded CustomGrouping from a plain string. */
+export function createCustomGrouping(value: string): CustomGrouping {
+  return value as CustomGrouping;
+}
+
 /** Union of standard and custom groupings. */
 export type Grouping = StandardGrouping | CustomGrouping;
 

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -1,0 +1,165 @@
+/**
+ * Workflow v2 schema definitions for forecast cycles, workflows,
+ * outlook versions, and package metadata.
+ *
+ * This is the foundational type layer for the v1.7 forecast workflow
+ * redesign (issue #429). Downstream issues WF-02 through WF-09 build
+ * on these schemas.
+ *
+ * @see https://github.com/WxboySuper/Graphical-Forecast-Creator/issues/451
+ */
+
+// ---------------------------------------------------------------------------
+// Schema version
+// ---------------------------------------------------------------------------
+
+/** Semver string for the workflow v2 type/schema surface. */
+export const WORKFLOW_SCHEMA_VERSION = '1.0.0' as const;
+
+// ---------------------------------------------------------------------------
+// Identifiers
+// ---------------------------------------------------------------------------
+
+/** Stable workflow identifier, e.g. `"severe-day1"`, `"convective-outlook"`. */
+export type WorkflowId = string;
+
+/**
+ * Stable cycle identifier.
+ * Convention: `"WF-<workflowId>-<cycleDate>"`, but format is opaque to the
+ * schema layer — consumers must not parse it.
+ */
+export type CycleId = string;
+
+// ---------------------------------------------------------------------------
+// Status enums
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle status of a forecast cycle.
+ *
+ * - `in-progress` — cycle has started but is not yet final.
+ * - `completed` — all required outlooks are final.
+ * - `completed-with-omissions` — forecaster explicitly acknowledged
+ *   missing outlooks (see WF-03).
+ */
+export type CycleStatus = 'in-progress' | 'completed' | 'completed-with-omissions';
+
+/**
+ * Lifecycle status of a single outlook within a cycle.
+ *
+ * - `in-progress` — outlook is being edited.
+ * - `completed` — outlook is final.
+ * - `skipped` — outlook was intentionally not drawn (e.g. no threat).
+ * - `omitted` — outlook was not addressed (acknowledged omission).
+ */
+export type OutlookStatus = 'in-progress' | 'completed' | 'skipped' | 'omitted';
+
+// ---------------------------------------------------------------------------
+// Outlook versions
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks a single revision of an outlook within the same cycle.
+ *
+ * When a forecaster issues an update (e.g. Day 1 1300Z → 1600Z), a new
+ * `OutlookVersion` is appended. The `derivedFrom` field links the update
+ * back to its parent, making lineage explicit.
+ */
+export interface OutlookVersion {
+  /** 1-based version number within the cycle. */
+  version: number;
+  /** Current lifecycle status. */
+  status: OutlookStatus;
+  /** Parent version this was derived from (`undefined` = original). */
+  derivedFrom?: number;
+  /** ISO-8601 timestamp of creation. */
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Groupings
+// ---------------------------------------------------------------------------
+
+/**
+ * Standard day-based groupings that map to SPC issuance cadence.
+ * Custom groupings are freeform strings chosen by the forecaster.
+ */
+export type StandardGrouping = 'day1' | 'day2' | 'day3' | 'day4-8';
+
+/** User-defined grouping label. */
+export type CustomGrouping = string;
+
+/** Union of standard and custom groupings. */
+export type Grouping = StandardGrouping | CustomGrouping;
+
+// ---------------------------------------------------------------------------
+// Workflow metadata
+// ---------------------------------------------------------------------------
+
+/** Describes a workflow template (e.g. "Severe Convective Day 1"). */
+export interface WorkflowMetadata {
+  /** Stable workflow identifier. */
+  id: WorkflowId;
+  /** Human-readable label shown in the UI. */
+  label: string;
+  /** Ordered groupings this workflow covers. */
+  groupings: Grouping[];
+}
+
+// ---------------------------------------------------------------------------
+// Cycle metadata
+// ---------------------------------------------------------------------------
+
+/** Metadata for a single forecast cycle. */
+export interface CycleMetadata {
+  /** Stable cycle identifier. */
+  id: CycleId;
+  /** Workflow this cycle belongs to. */
+  workflowId: WorkflowId;
+  /** ISO date string (YYYY-MM-DD) of the forecast cycle. */
+  cycleDate: string;
+  /** Current lifecycle status. */
+  status: CycleStatus;
+  /** Ordered list of outlook versions issued within this cycle. */
+  outlookVersions: OutlookVersion[];
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+  /** ISO-8601 last-updated timestamp. */
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Package metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Package-level metadata for exporting or persisting a complete
+ * workflow + cycle bundle.
+ */
+export interface WorkflowPackageMetadata {
+  /** Workflow identifier. */
+  workflowId: WorkflowId;
+  /** Cycle identifier. */
+  cycleId: CycleId;
+  /** Package-level version (distinct from `OutlookVersion.version`). */
+  version: number;
+  /** Cycle status at time of packaging. */
+  status: CycleStatus;
+  /** Whether the package includes discussion content. */
+  includesDiscussions: boolean;
+  /** Whether the package includes custom style snapshots. */
+  includesStyleSnapshots: boolean;
+  /**
+   * If this cycle was derived from a previous cycle, the source cycle ID.
+   * `undefined` when the cycle is standalone.
+   */
+  derivedFromCycleId?: CycleId;
+}
+
+/**
+ * A complete workflow package containing metadata and associated cycles.
+ */
+export interface Package {
+  metadata: WorkflowPackageMetadata;
+  cycles: CycleMetadata[];
+}


### PR DESCRIPTION
## [WF-01] Define cycle, workflow, outlook version, and package schemas

Closes #451

### What

Adds the foundational TypeScript type definitions for the v1.7 forecast workflow redesign:

- **Stable IDs:** `WorkflowId`, `CycleId` (opaque string identifiers)
- **Status enums:** `CycleStatus` (`in-progress`, `completed`, `completed-with-omissions`), `OutlookStatus` (`in-progress`, `completed`, `skipped`, `omitted`)
- **Outlook versions:** `OutlookVersion` with `derivedFrom` lineage tracking for same-cycle updates
- **Groupings:** `StandardGrouping` (`day1`–`day4-8`) + `CustomGrouping` (freeform)
- **Metadata:** `WorkflowMetadata`, `CycleMetadata` with full status and version tracking
- **Package metadata:** `WorkflowPackageMetadata`, `Package` with previous-cycle derivation support
- **Schema version:** `WORKFLOW_SCHEMA_VERSION = '1.0.0'`

All types are defined in a new `src/types/workflow.ts` file and re-exported from `src/types/outlooks.ts` for backward compatibility.

### Files changed

- `src/types/workflow.ts` — new type definitions
- `src/types/workflow.test.ts` — 27 focused unit tests
- `src/types/outlooks.ts` — re-exports added

### Verification

- [x] 27 new unit tests pass
- [x] 637/637 total tests pass (no regressions)
- [x] Production build succeeds
