### PR TITLE
fix(#598): Require auth for cloud_cycle_saved and cache premium count

### DIFF
--- a/server/metrics.js
+++ b/server/metrics.js
@@ -69,10 +69,13 @@ let premiumSubscriptionsCache = {
   value: null,
   expiresAt: 0,
 };
+let pendingPremiumCount = null;
 
+/** Returns true when the premium subscriptions cache has a fresh value. */
 const hasFreshPremiumCache = () =>
   premiumSubscriptionsCache.value !== null && Date.now() < premiumSubscriptionsCache.expiresAt;
 
+/** Stores a premium subscription count in the cache with a TTL. */
 const cachePremiumSubscriptions = (value) => {
   premiumSubscriptionsCache = {
     value,
@@ -313,14 +316,26 @@ const countPremiumSubscriptions = async () => {
     return premiumSubscriptionsCache.value;
   }
 
-  const snapshot = await db
+  if (pendingPremiumCount) {
+    return pendingPremiumCount;
+  }
+
+  pendingPremiumCount = db
     .collection('userEntitlements')
     .where('billingStatus', 'in', ['active', 'trialing'])
-    .get();
+    .get()
+    .then((snapshot) => {
+      const count = snapshot.size;
+      cachePremiumSubscriptions(count);
+      pendingPremiumCount = null;
+      return count;
+    })
+    .catch((err) => {
+      pendingPremiumCount = null;
+      throw err;
+    });
 
-  const count = snapshot.size;
-  cachePremiumSubscriptions(count);
-  return count;
+  return pendingPremiumCount;
 };
 
 /** Returns the current total number of hosted accounts that have profile docs in Firestore. */
@@ -659,6 +674,15 @@ const createAdminMetricsSummary = (dailyMetrics, liveSummary = {}) => {
   };
 };
 
+/** Returns true when the event requires authentication but the token is missing, sending a 401 if so. */
+const requireAuthForExpensiveEvents = (eventType, decodedToken, res) => {
+  if (eventType === 'cloud_cycle_saved' && !decodedToken) {
+    res.status(401).json({ error: 'Authentication required for cloud save metrics.' });
+    return true;
+  }
+  return false;
+};
+
 /** Handles client product-metric events while gracefully no-oping when hosted metrics are unavailable. */
 const handleMetricEvent = async (req, res) => {
   if (!hasFirebaseAdminConfig()) {
@@ -675,10 +699,7 @@ const handleMetricEvent = async (req, res) => {
   const installationId = readInstallationId(req.body?.installationId);
   const decodedToken = await verifyRequestUser(req);
 
-  if (eventType === 'cloud_cycle_saved' && !decodedToken) {
-    res.status(401).json({ error: 'Authentication required for cloud save metrics.' });
-    return;
-  }
+  if (requireAuthForExpensiveEvents(eventType, decodedToken, res)) return;
 
   await recordMetricEvent({
     eventType,

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -64,6 +64,21 @@ let storageBytesCache = {
   value: null,
   expiresAt: 0,
 };
+const PREMIUM_CACHE_TTL_MS = 5 * 60 * 1000;
+let premiumSubscriptionsCache = {
+  value: null,
+  expiresAt: 0,
+};
+
+const hasFreshPremiumCache = () =>
+  premiumSubscriptionsCache.value !== null && Date.now() < premiumSubscriptionsCache.expiresAt;
+
+const cachePremiumSubscriptions = (value) => {
+  premiumSubscriptionsCache = {
+    value,
+    expiresAt: Date.now() + PREMIUM_CACHE_TTL_MS,
+  };
+};
 
 /** True when the storage-footprint cache is still valid for reuse. */
 const hasFreshStorageCache = () =>
@@ -294,12 +309,18 @@ const countPremiumSubscriptions = async () => {
     return 0;
   }
 
+  if (hasFreshPremiumCache()) {
+    return premiumSubscriptionsCache.value;
+  }
+
   const snapshot = await db
     .collection('userEntitlements')
     .where('billingStatus', 'in', ['active', 'trialing'])
     .get();
 
-  return snapshot.size;
+  const count = snapshot.size;
+  cachePremiumSubscriptions(count);
+  return count;
 };
 
 /** Returns the current total number of hosted accounts that have profile docs in Firestore. */
@@ -653,6 +674,11 @@ const handleMetricEvent = async (req, res) => {
 
   const installationId = readInstallationId(req.body?.installationId);
   const decodedToken = await verifyRequestUser(req);
+
+  if (eventType === 'cloud_cycle_saved' && !decodedToken) {
+    res.status(401).json({ error: 'Authentication required for cloud save metrics.' });
+    return;
+  }
 
   await recordMetricEvent({
     eventType,


### PR DESCRIPTION
## Problem

The Sentry tunnel rate limiter runs **after** `express.raw()` parses the request body. A flood of oversized requests allocates up to 2 MB of memory each before being rejected, making it a memory-exhaustion vector.

## Fix

1. **server/sentry-tunnel.js** — Swap middleware order so `tunnelRateLimit` runs before `express.raw()`. Over-limit clients are now rejected with 429 immediately — no body is read, no memory allocated.

2. **server/nginx.conf / server/nginx-staging.conf** — Add dedicated `location = /api/sentry-tunnel` blocks before the catch-all `location /api/`. These enforce `client_max_body_size 100k` and `limit_except POST { deny all; }` at the nginx layer, providing defense-in-depth before requests even reach Node.

## Changelog
- Fixed resource exhaustion vulnerability in Sentry tunnel by moving rate limit before body parsing
- Added nginx-level body size limit (100k) for the Sentry tunnel endpoint
