### PR TITLE
fix(#597): Remove request-controlled Origin from billing base URL

### DIFF
--- a/server/billing-config.js
+++ b/server/billing-config.js
@@ -20,10 +20,8 @@ const parseDateEnv = (value) => {
 const getAnnualPromoPriceId = () => process.env.STRIPE_PRICE_ANNUAL_PROMO || '';
 
 /** Returns the public base URL used for Stripe return links. */
-const getBaseUrl = (req) =>
-  process.env.APP_BASE_URL ||
-  req.headers.origin ||
-  'http://127.0.0.1:3000';
+const getBaseUrl = () =>
+  process.env.APP_BASE_URL || 'http://127.0.0.1:3000';
 
 /** True when the annual intro pricing window is currently active. */
 const isAnnualPromoActive = () => {
@@ -72,10 +70,11 @@ const getBillingRuntimeConfig = () => {
       monthlyPriceId &&
       annualPlan.annualPriceId
   );
+  const hasBaseUrl = Boolean(process.env.APP_BASE_URL);
 
   return {
     billingEnabled,
-    checkoutEnabled: billingEnabled && hasFirebaseAdminConfig(),
+    checkoutEnabled: billingEnabled && hasFirebaseAdminConfig() && hasBaseUrl,
     annualPromoActive: annualPlan.annualPromoActive,
     monthlyDisplayPrice: MONTHLY_DISPLAY_PRICE,
     annualDisplayPrice: annualPlan.annualDisplayPrice,

--- a/server/billing-config.js
+++ b/server/billing-config.js
@@ -74,6 +74,7 @@ const getBillingRuntimeConfig = () => {
 
   return {
     billingEnabled,
+    hasBaseUrl,
     checkoutEnabled: billingEnabled && hasFirebaseAdminConfig() && hasBaseUrl,
     annualPromoActive: annualPlan.annualPromoActive,
     monthlyDisplayPrice: MONTHLY_DISPLAY_PRICE,

--- a/server/billing-config.test.js
+++ b/server/billing-config.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { getBaseUrl, getBillingRuntimeConfig } = require('./billing-config');
+
+describe('getBaseUrl', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.APP_BASE_URL;
+  });
+
+  it('returns APP_BASE_URL when set', () => {
+    process.env.APP_BASE_URL = 'https://gfc.weatherboysuper.com';
+    assert.equal(getBaseUrl(), 'https://gfc.weatherboysuper.com');
+  });
+
+  it('falls back to localhost when APP_BASE_URL is absent', () => {
+    assert.equal(getBaseUrl(), 'http://127.0.0.1:3000');
+  });
+
+  it('does not accept request headers as a fallback', () => {
+    assert.equal(getBaseUrl(), 'http://127.0.0.1:3000');
+  });
+});
+
+describe('getBillingRuntimeConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_PRICE_MONTHLY;
+    delete process.env.STRIPE_PRICE_ANNUAL_STANDARD;
+    delete process.env.STRIPE_PRICE_ANNUAL_PROMO;
+    delete process.env.APP_BASE_URL;
+    delete process.env.FIREBASE_ADMIN_PROJECT_ID;
+    delete process.env.FIREBASE_ADMIN_CLIENT_EMAIL;
+    delete process.env.FIREBASE_ADMIN_PRIVATE_KEY;
+  });
+
+  it('checkoutEnabled is false when APP_BASE_URL is missing', () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+    process.env.STRIPE_PRICE_MONTHLY = 'price_monthly';
+    process.env.STRIPE_PRICE_ANNUAL_STANDARD = 'price_annual';
+    process.env.FIREBASE_ADMIN_PROJECT_ID = 'project';
+    process.env.FIREBASE_ADMIN_CLIENT_EMAIL = 'email@test.com';
+    process.env.FIREBASE_ADMIN_PRIVATE_KEY = 'key';
+
+    const config = getBillingRuntimeConfig();
+    assert.equal(config.billingEnabled, true);
+    assert.equal(config.checkoutEnabled, false);
+  });
+
+  it('checkoutEnabled is true when all config including APP_BASE_URL is present', () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+    process.env.STRIPE_PRICE_MONTHLY = 'price_monthly';
+    process.env.STRIPE_PRICE_ANNUAL_STANDARD = 'price_annual';
+    process.env.APP_BASE_URL = 'https://gfc.weatherboysuper.com';
+    process.env.FIREBASE_ADMIN_PROJECT_ID = 'project';
+    process.env.FIREBASE_ADMIN_CLIENT_EMAIL = 'email@test.com';
+    process.env.FIREBASE_ADMIN_PRIVATE_KEY = 'key';
+
+    const config = getBillingRuntimeConfig();
+    assert.equal(config.billingEnabled, true);
+    assert.equal(config.checkoutEnabled, true);
+  });
+});

--- a/server/billing-config.test.js
+++ b/server/billing-config.test.js
@@ -23,7 +23,8 @@ describe('getBaseUrl', () => {
     assert.equal(getBaseUrl(), 'http://127.0.0.1:3000');
   });
 
-  it('does not accept request headers as a fallback', () => {
+  it('never derives the base URL from request headers because getBaseUrl is env-only', () => {
+    assert.equal(getBaseUrl.length, 0);
     assert.equal(getBaseUrl(), 'http://127.0.0.1:3000');
   });
 });

--- a/server/billing-config.test.js
+++ b/server/billing-config.test.js
@@ -4,13 +4,15 @@ const { describe, it, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
 const { getBaseUrl, getBillingRuntimeConfig } = require('./billing-config');
 
-describe('getBaseUrl', () => {
-  const originalEnv = process.env;
+const originalEnv = process.env;
 
-  beforeEach(() => {
-    process.env = { ...originalEnv };
-    delete process.env.APP_BASE_URL;
-  });
+function resetEnv(keys) {
+  process.env = { ...originalEnv };
+  for (const key of keys) delete process.env[key];
+}
+
+describe('getBaseUrl', () => {
+  beforeEach(() => resetEnv(['APP_BASE_URL']));
 
   it('returns APP_BASE_URL when set', () => {
     process.env.APP_BASE_URL = 'https://gfc.weatherboysuper.com';
@@ -27,19 +29,16 @@ describe('getBaseUrl', () => {
 });
 
 describe('getBillingRuntimeConfig', () => {
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    process.env = { ...originalEnv };
-    delete process.env.STRIPE_SECRET_KEY;
-    delete process.env.STRIPE_PRICE_MONTHLY;
-    delete process.env.STRIPE_PRICE_ANNUAL_STANDARD;
-    delete process.env.STRIPE_PRICE_ANNUAL_PROMO;
-    delete process.env.APP_BASE_URL;
-    delete process.env.FIREBASE_ADMIN_PROJECT_ID;
-    delete process.env.FIREBASE_ADMIN_CLIENT_EMAIL;
-    delete process.env.FIREBASE_ADMIN_PRIVATE_KEY;
-  });
+  beforeEach(() => resetEnv([
+    'STRIPE_SECRET_KEY',
+    'STRIPE_PRICE_MONTHLY',
+    'STRIPE_PRICE_ANNUAL_STANDARD',
+    'STRIPE_PRICE_ANNUAL_PROMO',
+    'APP_BASE_URL',
+    'FIREBASE_ADMIN_PROJECT_ID',
+    'FIREBASE_ADMIN_CLIENT_EMAIL',
+    'FIREBASE_ADMIN_PRIVATE_KEY',
+  ]));
 
   it('checkoutEnabled is false when APP_BASE_URL is missing', () => {
     process.env.STRIPE_SECRET_KEY = 'sk_test_fake';

--- a/server/billing.js
+++ b/server/billing.js
@@ -219,6 +219,8 @@ const verifyRequestUser = async (req, res) => {
 /** Creates the plan-specific Stripe checkout session for the verified user. */
 const isCheckoutAvailable = (stripe, billingConfig) => Boolean(stripe && billingConfig.checkoutEnabled);
 
+const isPortalAvailable = (stripe, billingConfig) => Boolean(stripe && billingConfig.hasBaseUrl);
+
 /** Resolves the Stripe price id for the selected billing plan. */
 const getCheckoutPriceId = (plan, billingConfig) => {
   if (plan === 'monthly') {
@@ -276,8 +278,9 @@ const handleCheckout = async (req, res) => {
 
 /** Opens the Stripe billing portal for a user who already has a customer record. */
 const handleBillingPortal = async (req, res) => {
+  const billingConfig = getBillingRuntimeConfig();
   const stripe = getStripeClient();
-  if (!stripe) {
+  if (!isPortalAvailable(stripe, billingConfig)) {
     res.status(503).json({ error: 'Billing is not available on this deployment yet.' });
     return;
   }

--- a/server/billing.js
+++ b/server/billing.js
@@ -256,7 +256,7 @@ const handleCheckout = async (req, res) => {
     return;
   }
 
-  const baseUrl = getBaseUrl(req);
+  const baseUrl = getBaseUrl();
   const metadata = createCheckoutMetadata(decodedToken.uid, plan);
   const session = await stripe.checkout.sessions.create({
     mode: 'subscription',
@@ -296,7 +296,7 @@ const handleBillingPortal = async (req, res) => {
 
   const portal = await stripe.billingPortal.sessions.create({
     customer: entitlementData.stripeCustomerId,
-    return_url: `${getBaseUrl(req)}/account`,
+    return_url: `${getBaseUrl()}/account`,
   });
 
   res.json({ url: portal.url });


### PR DESCRIPTION
## fix(#597): Remove request-controlled Origin from billing base URL

### Problem
`getBaseUrl(req)` fell back to `req.headers.origin` when `APP_BASE_URL` was unset, allowing an attacker to craft requests with a poisoned Origin header and redirect Stripe checkout/portal return URLs to an arbitrary domain (open redirect).

### Changes
- **`server/billing-config.js`** — Removed the `req` parameter from `getBaseUrl`; it now returns only `process.env.APP_BASE_URL` or the hardcoded localhost fallback. Added `hasBaseUrl` check so `checkoutEnabled` is `false` when `APP_BASE_URL` is not configured.
- **`server/billing.js`** — Updated both call sites (`handleCheckout`, `handleBillingPortal`) from `getBaseUrl(req)` to `getBaseUrl()`.
- **`server/billing-config.test.js`** — New test file covering `getBaseUrl` (no request-header fallback) and `getBillingRuntimeConfig` (`checkoutEnabled` gating on `APP_BASE_URL`).

### Test Results
- `npm test` (server): **8/8 pass**
- `node --test billing-config.test.js`: **5/5 pass**

## Changelog
- Fixed open redirect vulnerability in billing return URL by removing request-controlled Origin fallback from `getBaseUrl`
- Checkout is now disabled when `APP_BASE_URL` is not configured

Fixes #597 