### PR TITLE
fix(#599): Move Sentry tunnel rate limit before body parsing

### DIFF
--- a/server/nginx-staging.conf
+++ b/server/nginx-staging.conf
@@ -31,6 +31,17 @@ server {
         limit_except POST { deny all; }
     }
 
+    # ── Sentry tunnel — proxy browser envelopes past ad blockers ──────────
+    location = /api/sentry-tunnel {
+        proxy_pass          http://127.0.0.1:3008/api/sentry-tunnel;
+        proxy_set_header    Host              $host;
+        proxy_set_header    X-Forwarded-For   $remote_addr;
+        proxy_set_header    X-Real-IP         $remote_addr;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        client_max_body_size 100k;
+        limit_except POST { deny all; }
+    }
+
     location /api/ {
         proxy_pass          http://127.0.0.1:3008;
         proxy_set_header    Host              $host;

--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -35,6 +35,17 @@ server {
         limit_except POST { deny all; }
     }
 
+    # ── Sentry tunnel — proxy browser envelopes past ad blockers ──────────
+    location = /api/sentry-tunnel {
+        proxy_pass          http://127.0.0.1:3006/api/sentry-tunnel;
+        proxy_set_header    Host              $host;
+        proxy_set_header    X-Forwarded-For   $remote_addr;
+        proxy_set_header    X-Real-IP         $remote_addr;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        client_max_body_size 100k;
+        limit_except POST { deny all; }
+    }
+
     location /api/ {
         proxy_pass          http://127.0.0.1:3006;
         proxy_set_header    Host              $host;

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -86,7 +86,7 @@ function registerSentryTunnelRoutes(app, express, rateLimit) {
   app.post(
     '/api/sentry-tunnel',
     tunnelRateLimit,
-    express.raw({ type: () => true, limit: '2mb' }),
+    express.raw({ type: () => true, limit: '150kb' }),
     async (req, res) => {
       try {
         const envelopeBody = req.body;

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -85,8 +85,8 @@ function registerSentryTunnelRoutes(app, express, rateLimit) {
 
   app.post(
     '/api/sentry-tunnel',
-    express.raw({ type: () => true, limit: '2mb' }),
     tunnelRateLimit,
+    express.raw({ type: () => true, limit: '2mb' }),
     async (req, res) => {
       try {
         const envelopeBody = req.body;

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -86,7 +86,7 @@ function registerSentryTunnelRoutes(app, express, rateLimit) {
   app.post(
     '/api/sentry-tunnel',
     tunnelRateLimit,
-    express.raw({ type: () => true, limit: '150kb' }),
+    express.raw({ type: () => true, limit: '100kb' }),
     async (req, res) => {
       try {
         const envelopeBody = req.body;


### PR DESCRIPTION
## Problem

The Sentry tunnel rate limiter runs **after** `express.raw()e parses the request body. A flood of oversized requests allocates up to 2 MB of memory each before being rejected, making it a memory-exhaustion vector.

## Fix

1. **server/sentry-tunnel.js** — Swap middleware order so `tunnelRateLimit` runs before `express.raw()`. Over-limit clients are now rejected with 429 immediately — no body is read, no memory allocated. Reduced Express body limit from 2mb to 150kb to align with nginx layer.

2. **server/nginx.conf / server/nginx-staging.conf** — Add dedicated `location = /api/sentry-tunnel` blocks before the catch-all `location /api/`. These enforce `client_max_body_size 100k` and `limit_except POST { deny all; }` at the nginx layer, providing defense-in-depth before requests even reach Node.

## Changelog
- Fixed resource exhaustion vulnerability in Sentry tunnel by moving rate limit before body parsing
- Added nginx-level body size limit (100k) for the Sentry tunnel endpoint

Fixes #599 