### PR TITLE
fix(#452): Address PR #664 review feedback on workflow serialization

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #664 follow-up
+
+- Address Greptile and CodeScene review feedback from prematurely merged #664: preserve legacy grouping data via `migrateLegacyForecastToSerializedPackage`, remove dead helpers, add typed `cycleMetadata` on `GFCForecastSaveData`, and reduce serialization complexity.
+
 ### PR #664
 
 - Added backward-compatible cycle and workflow serialization with v2 metadata support

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,7 +4,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #664 follow-up
+### PR #670
 
 - Address Greptile and CodeScene review feedback from prematurely merged #664: preserve legacy grouping data via `migrateLegacyForecastToSerializedPackage`, remove dead helpers, add typed `cycleMetadata` on `GFCForecastSaveData`, and reduce serialization complexity.
 

--- a/src/types/outlooks.ts
+++ b/src/types/outlooks.ts
@@ -218,6 +218,9 @@ export interface GFCForecastSaveData {
     currentDay: DayType;
     cycleDate: string;
   };
+
+  /** Optional v2 workflow cycle metadata embedded in v1.0.0 saves. */
+  cycleMetadata?: import('./workflow').CycleMetadata;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -114,13 +114,9 @@ export const serializeForecast = (
       currentDay: forecastCycle.currentDay,
       cycleDate: forecastCycle.cycleDate
     },
-    mapView
+    mapView,
+    ...(cycleMetadata ? { cycleMetadata } : {}),
   };
-
-  // Embed v2 workflow metadata when provided
-  if (cycleMetadata) {
-    (result as GFCForecastSaveData & { cycleMetadata?: CycleMetadata }).cycleMetadata = cycleMetadata;
-  }
 
   return result;
 };

--- a/src/utils/workflowSerialization.test.ts
+++ b/src/utils/workflowSerialization.test.ts
@@ -302,6 +302,39 @@ describe('workflowSerialization', () => {
       );
       expect(serialized.cycles[0].groupingData['day4-8-v1']?.data['day4-8']).toEqual([['15%', []]]);
     });
+
+    test('keeps first day4-8 entry when multiple legacy days map to day4-8', () => {
+      const legacy = makeLegacySaveData();
+      if (legacy.forecastCycle) {
+        legacy.forecastCycle.days[4] = {
+          day: 4,
+          data: { 'day4-8': [['15%', []]] },
+          metadata: {
+            issueDate: '2026-04-21',
+            validDate: '2026-04-24',
+            issuanceTime: '0600',
+            lowProbabilityOutlooks: [],
+          },
+        };
+        legacy.forecastCycle.days[5] = {
+          day: 5,
+          data: { 'day4-8': [['30%', []]] },
+          metadata: {
+            issueDate: '2026-04-21',
+            validDate: '2026-04-25',
+            issuanceTime: '0600',
+            lowProbabilityOutlooks: [],
+          },
+        };
+      }
+
+      const serialized = migrateLegacyForecastToSerializedPackage(legacy);
+      const day48Grouping = serialized.cycles[0].groupings.find(({ grouping }) => grouping === 'day4-8');
+
+      expect(day48Grouping?.day).toBe(4);
+      expect(serialized.cycles[0].groupingData['day4-8-v1']?.day).toBe(4);
+      expect(serialized.cycles[0].groupingData['day4-8-v1']?.data['day4-8']).toEqual([['15%', []]]);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/utils/workflowSerialization.test.ts
+++ b/src/utils/workflowSerialization.test.ts
@@ -2,6 +2,7 @@ import {
   serializeWorkflowPackage,
   deserializeWorkflowPackage,
   migrateLegacyForecastToWorkflowPackage,
+  migrateLegacyForecastToSerializedPackage,
   validateWorkflowPackage,
 } from './workflowSerialization';
 import type {
@@ -289,10 +290,17 @@ describe('workflowSerialization', () => {
           },
         };
       }
-      const pkg = migrateLegacyForecastToWorkflowPackage(legacy);
+      const serialized = migrateLegacyForecastToSerializedPackage(legacy);
 
-      // Should have 3 outlook versions (days 1, 2, 4)
-      expect(pkg.cycles[0].outlookVersions).toHaveLength(3);
+      expect(serialized.cycles[0].outlookVersions).toHaveLength(3);
+      expect(serialized.cycles[0].groupings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ grouping: 'day1', day: 1 }),
+          expect.objectContaining({ grouping: 'day2', day: 2 }),
+          expect.objectContaining({ grouping: 'day4-8', day: 4 }),
+        ]),
+      );
+      expect(serialized.cycles[0].groupingData['day4-8-v1']?.data['day4-8']).toEqual([['15%', []]]);
     });
   });
 

--- a/src/utils/workflowSerialization.ts
+++ b/src/utils/workflowSerialization.ts
@@ -1,7 +1,6 @@
 import type {
   Package,
   CycleMetadata,
-  WorkflowMetadata,
   WorkflowPackageMetadata,
   CycleId,
   WorkflowId,
@@ -13,12 +12,8 @@ import type {
   SerializedOutlookVersionData,
 } from '../types/workflow';
 import type {
-  ForecastCycle,
   GFCForecastSaveData,
   DayType,
-  OutlookDay,
-  OutlookType,
-  SerializedOutlookData,
   DiscussionData,
 } from '../types/outlooks';
 import { WORKFLOW_SCHEMA_VERSION } from '../types/workflow';
@@ -40,12 +35,115 @@ const dayToGrouping = (day: DayType): Grouping => {
 const makeCycleId = (workflowId: WorkflowId, cycleDate: string): CycleId =>
   `WF-${workflowId}-${cycleDate}`;
 
-// ---------------------------------------------------------------------------
-// Helpers: Map ↔ Array
-// ---------------------------------------------------------------------------
+const getLegacyDayEntries = (
+  legacyData: GFCForecastSaveData,
+): Array<{ day: DayType; savedDay: NonNullable<NonNullable<GFCForecastSaveData['forecastCycle']>['days']>[DayType] }> => {
+  if (!legacyData.forecastCycle?.days) {
+    return [];
+  }
 
-const mapToArray = <K, V>(m: Map<K, V>): [K, V][] =>
-  m instanceof Map ? Array.from(m.entries()) : [];
+  return (Object.values(legacyData.forecastCycle.days) as Array<NonNullable<NonNullable<GFCForecastSaveData['forecastCycle']>['days']>[DayType]>)
+    .filter((savedDay): savedDay is NonNullable<typeof savedDay> => Boolean(savedDay))
+    .map((savedDay) => ({ day: savedDay.day, savedDay }));
+};
+
+const toCycleMetadata = (serializedCycle: SerializedCycle): CycleMetadata => ({
+  id: serializedCycle.id,
+  workflowId: serializedCycle.workflowId,
+  cycleDate: serializedCycle.cycleDate,
+  status: serializedCycle.status,
+  outlookVersions: serializedCycle.outlookVersions,
+  createdAt: serializedCycle.createdAt,
+  updatedAt: serializedCycle.updatedAt,
+});
+
+const buildOutlookVersions = (
+  legacyData: GFCForecastSaveData,
+  createdAt: string,
+): OutlookVersion[] => {
+  const outlookVersions: OutlookVersion[] = [];
+  let versionCounter = 1;
+
+  getLegacyDayEntries(legacyData).forEach(({ day }) => {
+    outlookVersions.push({
+      version: versionCounter++,
+      status: 'completed',
+      createdAt,
+    });
+  });
+
+  if (outlookVersions.length === 0) {
+    outlookVersions.push({
+      version: 1,
+      status: 'completed',
+      createdAt,
+    });
+  }
+
+  return outlookVersions;
+};
+
+const buildGroupingData = (
+  legacyData: GFCForecastSaveData,
+): Record<string, SerializedOutlookVersionData> => {
+  const groupingData: Record<string, SerializedOutlookVersionData> = {};
+
+  getLegacyDayEntries(legacyData).forEach(({ day, savedDay }) => {
+    const grouping = dayToGrouping(day);
+    groupingData[`${grouping}-v1`] = {
+      day,
+      data: savedDay.data,
+      metadata: {
+        issueDate: savedDay.metadata.issueDate,
+        validDate: savedDay.metadata.validDate,
+        issuanceTime: savedDay.metadata.issuanceTime,
+        lowProbabilityOutlooks: savedDay.metadata.lowProbabilityOutlooks,
+      },
+      discussion: (savedDay as { discussion?: DiscussionData }).discussion,
+    };
+  });
+
+  return groupingData;
+};
+
+const buildGroupings = (legacyData: GFCForecastSaveData): { grouping: Grouping; day: DayType }[] => {
+  const seenGroupings = new Set<string>();
+  const groupings: { grouping: Grouping; day: DayType }[] = [];
+
+  getLegacyDayEntries(legacyData).forEach(({ day }) => {
+    const grouping = dayToGrouping(day);
+    if (seenGroupings.has(grouping)) {
+      return;
+    }
+
+    seenGroupings.add(grouping);
+    groupings.push({ grouping, day });
+  });
+
+  return groupings;
+};
+
+const isWorkflowPackageMetadata = (value: unknown): value is WorkflowPackageMetadata => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const metadata = value as Partial<WorkflowPackageMetadata>;
+  return typeof metadata.workflowId === 'string' && typeof metadata.cycleId === 'string';
+};
+
+const isSerializedCycle = (value: unknown): value is SerializedCycle => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const cycle = value as Partial<SerializedCycle>;
+  return (
+    typeof cycle.id === 'string' &&
+    typeof cycle.workflowId === 'string' &&
+    Array.isArray(cycle.outlookVersions)
+  );
+};
 
 // ---------------------------------------------------------------------------
 // serializeWorkflowPackage
@@ -60,26 +158,17 @@ const mapToArray = <K, V>(m: Map<K, V>): [K, V][] =>
 export const serializeWorkflowPackage = (
   pkg: Package,
 ): SerializedWorkflowPackage => {
-  const serializedCycles: SerializedCycle[] = pkg.cycles.map((cycle) => {
-    // Build groupings from outlookVersions + metadata — this is a passthrough
-    // since the runtime Package does not yet carry per-cycle grouping data;
-    // callers who need richer grouping info should populate it on the Package
-    // before calling this function. For now we emit an empty groupings array
-    // and let the consumer reconstruct from the cycle metadata.
-    const groupings: { grouping: Grouping; day: DayType }[] = [];
-
-    return {
-      id: cycle.id,
-      workflowId: cycle.workflowId,
-      cycleDate: cycle.cycleDate,
-      status: cycle.status,
-      outlookVersions: cycle.outlookVersions,
-      createdAt: cycle.createdAt,
-      updatedAt: cycle.updatedAt,
-      groupings,
-      groupingData: {},
-    };
-  });
+  const serializedCycles: SerializedCycle[] = pkg.cycles.map((cycle) => ({
+    id: cycle.id,
+    workflowId: cycle.workflowId,
+    cycleDate: cycle.cycleDate,
+    status: cycle.status,
+    outlookVersions: cycle.outlookVersions,
+    createdAt: cycle.createdAt,
+    updatedAt: cycle.updatedAt,
+    groupings: [],
+    groupingData: {},
+  }));
 
   return {
     schemaVersion: WORKFLOW_SCHEMA_VERSION,
@@ -96,121 +185,41 @@ export const serializeWorkflowPackage = (
 /**
  * Rehydrates a `SerializedWorkflowPackage` back into a runtime `Package`.
  *
- * This is a near-passthrough: the serialized format already mirrors the
- * runtime `Package` shape, so the main work is ensuring correct typing.
+ * Grouping payloads remain in the serialized shape until WF-02+ attaches them
+ * to runtime cycles.
  */
 export const deserializeWorkflowPackage = (
   data: SerializedWorkflowPackage,
-): Package => {
-  const cycles: CycleMetadata[] = data.cycles.map((sc) => ({
-    id: sc.id,
-    workflowId: sc.workflowId,
-    cycleDate: sc.cycleDate,
-    status: sc.status,
-    outlookVersions: sc.outlookVersions,
-    createdAt: sc.createdAt,
-    updatedAt: sc.updatedAt,
-  }));
-
-  return {
-    metadata: data.metadata,
-    cycles,
-  };
-};
+): Package => ({
+  metadata: data.metadata,
+  cycles: data.cycles.map(toCycleMetadata),
+});
 
 // ---------------------------------------------------------------------------
 // migrateLegacyForecastToWorkflowPackage
 // ---------------------------------------------------------------------------
 
 /**
- * Converts a legacy `GFCForecastSaveData` (v0.5.0 / v1.0.0) into a v2
- * `Package` suitable for import into the workflow system.
- *
- * @param legacyData  The persisted v0.5.0/v1.0.0 forecast save data.
- * @param workflowId  Optional workflow ID; defaults to `'default'`.
- * @returns A fully-populated `Package` with one cycle.
+ * Converts legacy forecast save data into a fully populated serialized package.
  */
-export const migrateLegacyForecastToWorkflowPackage = (
+export const migrateLegacyForecastToSerializedPackage = (
   legacyData: GFCForecastSaveData,
   workflowId: WorkflowId = DEFAULT_WORKFLOW_ID,
-): Package => {
+): SerializedWorkflowPackage => {
   const cycleDate = legacyData.forecastCycle?.cycleDate ?? new Date().toISOString().split('T')[0];
   const now = new Date().toISOString();
   const cycleId = makeCycleId(workflowId, cycleDate);
-
-  // Determine status — completed if all days exist and have data
   const status: CycleStatus = 'in-progress';
-
-  // Build outlook versions — one version per existing day
-  const outlookVersions: OutlookVersion[] = [];
-  let versionCounter = 1;
-
-  if (legacyData.forecastCycle?.days) {
-    const dayKeys = Object.keys(legacyData.forecastCycle.days) as unknown as DayType[];
-    dayKeys.forEach((day) => {
-      if (legacyData.forecastCycle!.days[day]) {
-        outlookVersions.push({
-          version: versionCounter++,
-          status: 'completed',
-          createdAt: now,
-        });
-      }
-    });
-  }
-
-  // If no outlook versions were created, add a single default one
-  if (outlookVersions.length === 0) {
-    outlookVersions.push({
-      version: 1,
-      status: 'completed',
-      createdAt: now,
-    });
-  }
-
-  // Build grouping data from the legacy days
-  const groupingData: Record<string, SerializedOutlookVersionData> = {};
-  if (legacyData.forecastCycle?.days) {
-    const dayKeys = Object.keys(legacyData.forecastCycle.days) as unknown as DayType[];
-    dayKeys.forEach((day) => {
-      const savedDay = legacyData.forecastCycle!.days[day];
-      if (savedDay) {
-        const grouping = dayToGrouping(day);
-        const key = `${grouping}-v1`;
-        groupingData[key] = {
-          day,
-          data: savedDay.data,
-          metadata: {
-            issueDate: savedDay.metadata.issueDate,
-            validDate: savedDay.metadata.validDate,
-            issuanceTime: savedDay.metadata.issuanceTime,
-            lowProbabilityOutlooks: savedDay.metadata.lowProbabilityOutlooks,
-          },
-          discussion: (savedDay as { discussion?: DiscussionData }).discussion,
-        };
-      }
-    });
-  }
-
-  // Build groupings list (unique)
-  const seenGroupings = new Set<string>();
-  const groupings: { grouping: Grouping; day: DayType }[] = [];
-  if (legacyData.forecastCycle?.days) {
-    const dayKeys = Object.keys(legacyData.forecastCycle.days) as unknown as DayType[];
-    dayKeys.forEach((day) => {
-      const grouping = dayToGrouping(day);
-      if (!seenGroupings.has(grouping)) {
-        seenGroupings.add(grouping);
-        groupings.push({ grouping, day });
-      }
-    });
-  }
+  const groupingData = buildGroupingData(legacyData);
+  const groupings = buildGroupings(legacyData);
+  const outlookVersions = buildOutlookVersions(legacyData, now);
 
   const metadata: WorkflowPackageMetadata = {
     workflowId,
     cycleId,
     version: 1,
     status,
-    includesDiscussions: Object.values(groupingData).some((g) => g.discussion !== undefined),
+    includesDiscussions: Object.values(groupingData).some((grouping) => grouping.discussion !== undefined),
     includesStyleSnapshots: false,
   };
 
@@ -227,18 +236,23 @@ export const migrateLegacyForecastToWorkflowPackage = (
   };
 
   return {
+    schemaVersion: WORKFLOW_SCHEMA_VERSION,
+    version: '1',
     metadata,
-    cycles: [{
-      id: cycleId,
-      workflowId,
-      cycleDate,
-      status,
-      outlookVersions,
-      createdAt: now,
-      updatedAt: now,
-    }],
+    cycles: [serializedCycle],
   };
 };
+
+/**
+ * Converts a legacy `GFCForecastSaveData` (v0.5.0 / v1.0.0) into a v2
+ * `Package` suitable for import into the workflow system.
+ */
+export const migrateLegacyForecastToWorkflowPackage = (
+  legacyData: GFCForecastSaveData,
+  workflowId: WorkflowId = DEFAULT_WORKFLOW_ID,
+): Package => deserializeWorkflowPackage(
+  migrateLegacyForecastToSerializedPackage(legacyData, workflowId),
+);
 
 // ---------------------------------------------------------------------------
 // validateWorkflowPackage
@@ -251,17 +265,17 @@ export const migrateLegacyForecastToWorkflowPackage = (
 export const validateWorkflowPackage = (
   data: unknown,
 ): data is SerializedWorkflowPackage => {
-  if (typeof data !== 'object' || data === null) return false;
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
 
   const candidate = data as Partial<SerializedWorkflowPackage>;
 
   return (
     typeof candidate.schemaVersion === 'string' &&
     typeof candidate.version === 'string' &&
-    typeof candidate.metadata === 'object' &&
-    candidate.metadata !== null &&
-    typeof (candidate.metadata as Partial<WorkflowPackageMetadata>).workflowId === 'string' &&
-    typeof (candidate.metadata as Partial<WorkflowPackageMetadata>).cycleId === 'string' &&
-    Array.isArray(candidate.cycles)
+    isWorkflowPackageMetadata(candidate.metadata) &&
+    Array.isArray(candidate.cycles) &&
+    candidate.cycles.every(isSerializedCycle)
   );
 };

--- a/src/utils/workflowSerialization.ts
+++ b/src/utils/workflowSerialization.ts
@@ -35,6 +35,7 @@ const dayToGrouping = (day: DayType): Grouping => {
 const makeCycleId = (workflowId: WorkflowId, cycleDate: string): CycleId =>
   `WF-${workflowId}-${cycleDate}`;
 
+/** Returns populated legacy day entries in stable iteration order. */
 const getLegacyDayEntries = (
   legacyData: GFCForecastSaveData,
 ): Array<{ day: DayType; savedDay: NonNullable<NonNullable<GFCForecastSaveData['forecastCycle']>['days']>[DayType] }> => {
@@ -47,6 +48,7 @@ const getLegacyDayEntries = (
     .map((savedDay) => ({ day: savedDay.day, savedDay }));
 };
 
+/** Maps a serialized cycle into runtime cycle metadata. */
 const toCycleMetadata = (serializedCycle: SerializedCycle): CycleMetadata => ({
   id: serializedCycle.id,
   workflowId: serializedCycle.workflowId,
@@ -57,6 +59,7 @@ const toCycleMetadata = (serializedCycle: SerializedCycle): CycleMetadata => ({
   updatedAt: serializedCycle.updatedAt,
 });
 
+/** Builds one completed outlook version per legacy day entry. */
 const buildOutlookVersions = (
   legacyData: GFCForecastSaveData,
   createdAt: string,
@@ -64,7 +67,7 @@ const buildOutlookVersions = (
   const outlookVersions: OutlookVersion[] = [];
   let versionCounter = 1;
 
-  getLegacyDayEntries(legacyData).forEach(({ day }) => {
+  getLegacyDayEntries(legacyData).forEach(() => {
     outlookVersions.push({
       version: versionCounter++,
       status: 'completed',
@@ -83,6 +86,7 @@ const buildOutlookVersions = (
   return outlookVersions;
 };
 
+/** Builds grouping payloads keyed by grouping version, keeping the first day per grouping. */
 const buildGroupingData = (
   legacyData: GFCForecastSaveData,
 ): Record<string, SerializedOutlookVersionData> => {
@@ -90,7 +94,12 @@ const buildGroupingData = (
 
   getLegacyDayEntries(legacyData).forEach(({ day, savedDay }) => {
     const grouping = dayToGrouping(day);
-    groupingData[`${grouping}-v1`] = {
+    const groupingKey = `${grouping}-v1`;
+    if (groupingData[groupingKey]) {
+      return;
+    }
+
+    groupingData[groupingKey] = {
       day,
       data: savedDay.data,
       metadata: {
@@ -106,6 +115,7 @@ const buildGroupingData = (
   return groupingData;
 };
 
+/** Builds unique grouping entries, keeping the first day per grouping. */
 const buildGroupings = (legacyData: GFCForecastSaveData): { grouping: Grouping; day: DayType }[] => {
   const seenGroupings = new Set<string>();
   const groupings: { grouping: Grouping; day: DayType }[] = [];
@@ -123,6 +133,7 @@ const buildGroupings = (legacyData: GFCForecastSaveData): { grouping: Grouping; 
   return groupings;
 };
 
+/** Type guard for serialized workflow package metadata. */
 const isWorkflowPackageMetadata = (value: unknown): value is WorkflowPackageMetadata => {
   if (typeof value !== 'object' || value === null) {
     return false;
@@ -132,6 +143,7 @@ const isWorkflowPackageMetadata = (value: unknown): value is WorkflowPackageMeta
   return typeof metadata.workflowId === 'string' && typeof metadata.cycleId === 'string';
 };
 
+/** Type guard for serialized cycle payloads. */
 const isSerializedCycle = (value: unknown): value is SerializedCycle => {
   if (typeof value !== 'object' || value === null) {
     return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to prematurely merged #664. Instead of reverting (#667 was closed), this PR addresses the Greptile/CodeScene/DeepSource review feedback left on #664 before merge.

## Changes

- Preserve legacy grouping data via new `migrateLegacyForecastToSerializedPackage` export; migration now routes through serialized form instead of discarding `groupings` / `groupingData`.
- Remove dead `mapToArray` helper and unused imports from `workflowSerialization.ts`.
- Add optional typed `cycleMetadata` field to `GFCForecastSaveData` (removes unsafe cast in `serializeForecast`).
- Refactor migration/validation helpers to reduce cyclomatic complexity flagged by CodeScene.
- Extend tests to assert day4-8 grouping data survives migration.

## Context

- Source PR: #664 (merged to `beta` without human review)
- Revert PR #667 was closed in favor of this follow-up approach

## Verification

- `pnpm test -- --runTestsByPath src/utils/workflowSerialization.test.ts` — 23/23 passing

**Do not merge until human review.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76f1ba98-3d86-40f4-b2e7-a76ce7b4f52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76f1ba98-3d86-40f4-b2e7-a76ce7b4f52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

Fixes #452

