### PR TITLE
[Port] fix(#599): Move Sentry tunnel rate limit before body parsing to beta

### DIFF
--- a/server/nginx-staging.conf
+++ b/server/nginx-staging.conf
@@ -31,6 +31,17 @@ server {
         limit_except POST { deny all; }
     }
 
+    # ── Sentry tunnel — proxy browser envelopes past ad blockers ──────────
+    location = /api/sentry-tunnel {
+        proxy_pass          http://127.0.0.1:3008/api/sentry-tunnel;
+        proxy_set_header    Host              $host;
+        proxy_set_header    X-Forwarded-For   $remote_addr;
+        proxy_set_header    X-Real-IP         $remote_addr;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        client_max_body_size 100k;
+        limit_except POST { deny all; }
+    }
+
     location /api/ {
         proxy_pass          http://127.0.0.1:3008;
         proxy_set_header    Host              $host;

--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -35,6 +35,17 @@ server {
         limit_except POST { deny all; }
     }
 
+    # ── Sentry tunnel — proxy browser envelopes past ad blockers ──────────
+    location = /api/sentry-tunnel {
+        proxy_pass          http://127.0.0.1:3006/api/sentry-tunnel;
+        proxy_set_header    Host              $host;
+        proxy_set_header    X-Forwarded-For   $remote_addr;
+        proxy_set_header    X-Real-IP         $remote_addr;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        client_max_body_size 100k;
+        limit_except POST { deny all; }
+    }
+
     location /api/ {
         proxy_pass          http://127.0.0.1:3006;
         proxy_set_header    Host              $host;

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -86,7 +86,7 @@ function registerSentryTunnelRoutes(app, express, rateLimit) {
   app.post(
     '/api/sentry-tunnel',
     tunnelRateLimit,
-    express.raw({ type: () => true, limit: '2mb' }),
+    express.raw({ type: () => true, limit: '150kb' }),
     async (req, res) => {
       try {
         const envelopeBody = req.body;

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -85,8 +85,8 @@ function registerSentryTunnelRoutes(app, express, rateLimit) {
 
   app.post(
     '/api/sentry-tunnel',
-    express.raw({ type: () => true, limit: '2mb' }),
     tunnelRateLimit,
+    express.raw({ type: () => true, limit: '2mb' }),
     async (req, res) => {
       try {
         const envelopeBody = req.body;

--- a/server/sentry-tunnel.js
+++ b/server/sentry-tunnel.js
@@ -86,7 +86,7 @@ function registerSentryTunnelRoutes(app, express, rateLimit) {
   app.post(
     '/api/sentry-tunnel',
     tunnelRateLimit,
-    express.raw({ type: () => true, limit: '150kb' }),
+    express.raw({ type: () => true, limit: '100kb' }),
     async (req, res) => {
       try {
         const envelopeBody = req.body;


### PR DESCRIPTION
Automated port of the original commits from PR #668 into `beta` after merge into `main`.