### PR TITLE
feat(workflow): add cycle and workflow entry, resume, new outlook, and update actions (WF-04)

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,15 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #680
+
+- Implement WF-04: cycle and workflow entry, resume, new outlook, and update actions
+- Add Redux actions: `startBlankCycle`, `resumeIncompleteCycle`, `createOutlookUpdate`, `startFromPreviousCycle`
+- Add `WorkflowActions` dropdown component with Start Blank, Create Update, and Start from Previous options
+- Add `outlookVersionSnapshots` state for tracking versioned outlook data within cycles
+- Add workflow template constants and `useWorkflowActions` hook
+- All new code gated behind `forecastWorkflowV2` feature flag (currently ALL_TARGETS_OFF)
+
 ### PR #670
 
 - Address Greptile and CodeScene review feedback from prematurely merged #664: preserve legacy grouping data via `migrateLegacyForecastToSerializedPackage`, remove dead helpers, add typed `cycleMetadata` on `GFCForecastSaveData`, and reduce serialization complexity.

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -18,6 +18,7 @@ import {
   Upload,
   Wrench,
 } from 'lucide-react';
+import { WorkflowActions } from '../WorkflowActions/WorkflowActions';
 import { Button } from '../ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import {
@@ -958,6 +959,9 @@ const TabbedToolbarToolsTab: React.FC<{
               ))}
             </div>
           ) : null}
+          <div className="tabbed-integrated-toolbar__action-group flex flex-wrap items-center gap-2 border-r border-border/70 pr-3">
+            <WorkflowActions />
+          </div>
           <div className="tabbed-integrated-toolbar__action-group flex flex-wrap items-center gap-2">
             {destructiveItems.map((item) => (
               <TabbedToolbarActionTile key={item.key} item={item} />

--- a/src/components/WorkflowActions/WorkflowActions.tsx
+++ b/src/components/WorkflowActions/WorkflowActions.tsx
@@ -27,7 +27,6 @@ import { cn } from '../../lib/utils';
 import { isFeatureExposed } from '../../config/featureExposure';
 import { 
   startBlankCycle, 
-  resumeIncompleteCycle, 
   createOutlookUpdate,
   startFromPreviousCycle,
   selectWorkflowMetadata,
@@ -42,8 +41,93 @@ interface WorkflowActionsProps {
   className?: string;
 }
 
+/** Modal for selecting a workflow template when starting a new cycle. */
+const StartNewWorkflowModal: React.FC<{
+  templates: WorkflowMetadata[];
+  onSelect: (template?: WorkflowMetadata) => void;
+  onClose: () => void;
+}> = ({ templates, onSelect, onClose }) => {
+  const [selectedTemplate, setSelectedTemplate] = useState<WorkflowMetadata | null>(null);
+  
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background rounded-lg shadow-lg p-6 w-96 max-h-[80vh] overflow-y-auto">
+        <h2 className="text-lg font-semibold mb-4">Start New Workflow</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Select a workflow template for your new forecast cycle.
+        </p>
+        
+        <div className="space-y-2">
+          {templates.map((template) => (
+            <button
+              key={template.id}
+              onClick={() => setSelectedTemplate(template)}
+              className={cn(
+                'w-full text-left p-3 rounded-lg border transition-colors',
+                selectedTemplate?.id === template.id
+                  ? 'border-violet-500 bg-violet-500/10'
+                  : 'border-border hover:border-violet-300'
+              )}
+            >
+              <div className="font-medium">{template.label}</div>
+              <div className="text-xs text-muted-foreground">
+                Groupings: {template.groupings.join(', ')}
+              </div>
+            </button>
+          ))}
+        </div>
+        
+        <div className="flex justify-end gap-2 mt-6">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => onSelect(selectedTemplate || undefined)}>
+            Start Cycle
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/** Modal for selecting a previous cycle to base a new cycle on. */
+const StartFromPreviousModal: React.FC<{
+  onSelect: (sourceCycleId: string) => void;
+  onClose: () => void;
+}> = ({ onClose }) => {
+  // This is a placeholder - in a real implementation, this would show
+  // a list of saved cycles from the cycle history
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background rounded-lg shadow-lg p-6 w-96">
+        <h2 className="text-lg font-semibold mb-4">Start from Previous Cycle</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Select a previous cycle to use as a base for your new forecast.
+        </p>
+        
+        <div className="text-center py-8 text-muted-foreground">
+          <Calendar className="h-12 w-12 mx-auto mb-2 opacity-50" />
+          <p>Cycle history integration coming soon.</p>
+          <p className="text-xs mt-1">
+            Use the History action to load a previous cycle, then create an update.
+          </p>
+        </div>
+        
+        <div className="flex justify-end gap-2 mt-6">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled>
+            Select Cycle
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 /** Workflow actions dropdown menu for the forecast editor toolbar. */
-export const WorkflowActions: React.FC<WorkflowActionsProps> = ({ className }) => {
+export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
   const dispatch = useDispatch();
   const [showStartNewModal, setShowStartNewModal] = useState(false);
   const [showStartFromPreviousModal, setShowStartFromPreviousModal] = useState(false);
@@ -61,6 +145,7 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = ({ className }) =
     return null;
   }
   
+  /** Handle starting a blank cycle with optional workflow template. */
   const handleStartBlank = (template?: WorkflowMetadata) => {
     dispatch(startBlankCycle({ 
       workflowTemplate: template,
@@ -69,18 +154,14 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = ({ className }) =
     setShowStartNewModal(false);
   };
   
-  const handleResumeIncomplete = () => {
-    // For now, we'll use the existing history modal
-    // This action will be integrated with the history modal in the future
-    console.log('Resume incomplete - integrate with history modal');
-  };
-  
+  /** Handle creating a new outlook version within the current cycle. */
   const handleCreateUpdate = () => {
     if (isInProgress && hasOutlookData) {
       dispatch(createOutlookUpdate({}));
     }
   };
   
+  /** Handle starting a new cycle derived from a previous cycle. */
   const handleStartFromPrevious = (sourceCycleId: string) => {
     dispatch(startFromPreviousCycle({
       sourceCycleId,
@@ -128,7 +209,7 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = ({ className }) =
             </div>
           </DropdownMenuItem>
           
-          <DropdownMenuItem onClick={handleResumeIncomplete}>
+          <DropdownMenuItem onClick={() => {}}>
             <RotateCcw className="h-4 w-4 mr-2" />
             <div>
               <div className="font-medium">Continue Incomplete</div>
@@ -185,91 +266,6 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = ({ className }) =
         />
       )}
     </>
-  );
-};
-
-/** Modal for selecting a workflow template when starting a new cycle. */
-const StartNewWorkflowModal: React.FC<{
-  templates: WorkflowMetadata[];
-  onSelect: (template?: WorkflowMetadata) => void;
-  onClose: () => void;
-}> = ({ templates, onSelect, onClose }) => {
-  const [selectedTemplate, setSelectedTemplate] = useState<WorkflowMetadata | null>(null);
-  
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-background rounded-lg shadow-lg p-6 w-96 max-h-[80vh] overflow-y-auto">
-        <h2 className="text-lg font-semibold mb-4">Start New Workflow</h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          Select a workflow template for your new forecast cycle.
-        </p>
-        
-        <div className="space-y-2">
-          {templates.map((template) => (
-            <button
-              key={template.id}
-              onClick={() => setSelectedTemplate(template)}
-              className={cn(
-                'w-full text-left p-3 rounded-lg border transition-colors',
-                selectedTemplate?.id === template.id
-                  ? 'border-violet-500 bg-violet-500/10'
-                  : 'border-border hover:border-violet-300'
-              )}
-            >
-              <div className="font-medium">{template.label}</div>
-              <div className="text-xs text-muted-foreground">
-                Groupings: {template.groupings.join(', ')}
-              </div>
-            </button>
-          ))}
-        </div>
-        
-        <div className="flex justify-end gap-2 mt-6">
-          <Button variant="outline" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button onClick={() => onSelect(selectedTemplate || undefined)}>
-            Start Cycle
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-/** Modal for selecting a previous cycle to base a new cycle on. */
-const StartFromPreviousModal: React.FC<{
-  onSelect: (sourceCycleId: string) => void;
-  onClose: () => void;
-}> = ({ onSelect, onClose }) => {
-  // This is a placeholder - in a real implementation, this would show
-  // a list of saved cycles from the cycle history
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-background rounded-lg shadow-lg p-6 w-96">
-        <h2 className="text-lg font-semibold mb-4">Start from Previous Cycle</h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          Select a previous cycle to use as a base for your new forecast.
-        </p>
-        
-        <div className="text-center py-8 text-muted-foreground">
-          <Calendar className="h-12 w-12 mx-auto mb-2 opacity-50" />
-          <p>Cycle history integration coming soon.</p>
-          <p className="text-xs mt-1">
-            Use the History action to load a previous cycle, then create an update.
-          </p>
-        </div>
-        
-        <div className="flex justify-end gap-2 mt-6">
-          <Button variant="outline" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button disabled>
-            Select Cycle
-          </Button>
-        </div>
-      </div>
-    </div>
   );
 };
 

--- a/src/components/WorkflowActions/WorkflowActions.tsx
+++ b/src/components/WorkflowActions/WorkflowActions.tsx
@@ -17,11 +17,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '../ui/tooltip';
 import { cn } from '../../lib/utils';
 import { isFeatureExposed } from '../../config/featureExposure';
 import { 
@@ -125,6 +120,26 @@ const StartFromPreviousModal: React.FC<{
   );
 };
 
+/** Trigger button for the workflow actions dropdown. */
+const WorkflowActionsTrigger: React.FC = () => (
+  <DropdownMenuTrigger asChild>
+    <Button
+      variant="outline"
+      className={cn(
+        'tabbed-integrated-toolbar__action-tile h-10 shrink-0 justify-start rounded-xl px-2.5 text-left text-xs',
+        'bg-background',
+        'tabbed-integrated-toolbar__action-tile--primary'
+      )}
+    >
+      <span className="tabbed-integrated-toolbar__action-icon rounded-lg p-1.5 bg-violet-500/15 text-violet-700">
+        <Workflow className="h-4 w-4" />
+      </span>
+      <span className="font-semibold">Workflow</span>
+      <ChevronDown className="h-3 w-3 ml-1 opacity-50" />
+    </Button>
+  </DropdownMenuTrigger>
+);
+
 /** Workflow actions dropdown menu for the forecast editor toolbar. */
 export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
   const dispatch = useDispatch();
@@ -170,75 +185,51 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
   };
   
   return (
-    <>
-      <DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                className={cn(
-                  'tabbed-integrated-toolbar__action-tile h-10 shrink-0 justify-start rounded-xl px-2.5 text-left text-xs',
-                  'bg-background',
-                  'tabbed-integrated-toolbar__action-tile--primary'
-                )}
-              >
-                <span className="tabbed-integrated-toolbar__action-icon rounded-lg p-1.5 bg-violet-500/15 text-violet-700">
-                  <Workflow className="h-4 w-4" />
-                </span>
-                <span className="font-semibold">Workflow</span>
-                <ChevronDown className="h-3 w-3 ml-1 opacity-50" />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Workflow actions for cycle management</p>
-          </TooltipContent>
-        </Tooltip>
+    <DropdownMenu>
+      <WorkflowActionsTrigger />
+      
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Workflow Actions</DropdownMenuLabel>
+        <DropdownMenuSeparator />
         
-        <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuLabel>Workflow Actions</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          
-          <DropdownMenuItem onClick={() => setShowStartNewModal(true)}>
-            <Play className="h-4 w-4 mr-2" />
-            <div>
-              <div className="font-medium">Start Blank</div>
-              <div className="text-xs text-muted-foreground">Begin a new empty cycle</div>
+        <DropdownMenuItem onClick={() => setShowStartNewModal(true)}>
+          <Play className="h-4 w-4 mr-2" />
+          <div>
+            <div className="font-medium">Start Blank</div>
+            <div className="text-xs text-muted-foreground">Begin a new empty cycle</div>
+          </div>
+        </DropdownMenuItem>
+        
+        <DropdownMenuSeparator />
+        
+        <DropdownMenuItem 
+          onClick={handleCreateUpdate}
+          disabled={!isInProgress || !hasOutlookData}
+        >
+          <RefreshCw className="h-4 w-4 mr-2" />
+          <div>
+            <div className="font-medium">Create Update</div>
+            <div className="text-xs text-muted-foreground">
+              New outlook version (v{currentVersionNumber + 1})
             </div>
-          </DropdownMenuItem>
-          
-          <DropdownMenuSeparator />
-          
-          <DropdownMenuItem 
-            onClick={handleCreateUpdate}
-            disabled={!isInProgress || !hasOutlookData}
-          >
-            <RefreshCw className="h-4 w-4 mr-2" />
-            <div>
-              <div className="font-medium">Create Update</div>
-              <div className="text-xs text-muted-foreground">
-                New outlook version (v{currentVersionNumber + 1})
-              </div>
-            </div>
-          </DropdownMenuItem>
-          
-          <DropdownMenuItem onClick={() => setShowStartFromPreviousModal(true)}>
-            <GitBranch className="h-4 w-4 mr-2" />
-            <div>
-              <div className="font-medium">Start from Previous</div>
-              <div className="text-xs text-muted-foreground">Base on an existing cycle</div>
-            </div>
-          </DropdownMenuItem>
-          
-          <DropdownMenuSeparator />
-          
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            Current: {workflowTemplate?.label || 'No workflow'} 
-            {workflowMetadata && ` • v${currentVersionNumber}`}
-          </DropdownMenuLabel>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          </div>
+        </DropdownMenuItem>
+        
+        <DropdownMenuItem onClick={() => setShowStartFromPreviousModal(true)}>
+          <GitBranch className="h-4 w-4 mr-2" />
+          <div>
+            <div className="font-medium">Start from Previous</div>
+            <div className="text-xs text-muted-foreground">Base on an existing cycle</div>
+          </div>
+        </DropdownMenuItem>
+        
+        <DropdownMenuSeparator />
+        
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          Current: {workflowTemplate?.label || 'No workflow'} 
+          {workflowMetadata && ` • v${currentVersionNumber}`}
+        </DropdownMenuLabel>
+      </DropdownMenuContent>
       
       {/* Start New Modal */}
       {showStartNewModal && (
@@ -256,7 +247,7 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
           onClose={() => setShowStartFromPreviousModal(false)}
         />
       )}
-    </>
+    </DropdownMenu>
   );
 };
 

--- a/src/components/WorkflowActions/WorkflowActions.tsx
+++ b/src/components/WorkflowActions/WorkflowActions.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
 import {
   Workflow,
   Play,
@@ -18,18 +17,9 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { cn } from '../../lib/utils';
-import { isFeatureExposed } from '../../config/featureExposure';
-import { 
-  startBlankCycle, 
-  createOutlookUpdate,
-  startFromPreviousCycle,
-  selectWorkflowMetadata,
-  selectWorkflowTemplate,
-  selectOutlookVersionSnapshots,
-  selectCurrentVersionNumber,
-} from '../../store/forecastSlice';
 import type { WorkflowMetadata } from '../../types/workflow';
 import { DEFAULT_WORKFLOW_TEMPLATES } from './workflowTemplates';
+import { useWorkflowActions } from './useWorkflowActions';
 
 interface WorkflowActionsProps {
   className?: string;
@@ -41,7 +31,7 @@ const StartNewWorkflowModal: React.FC<{
   onSelect: (template?: WorkflowMetadata) => void;
   onClose: () => void;
 }> = ({ templates, onSelect, onClose }) => {
-  const [selectedTemplate, setSelectedTemplate] = useState<WorkflowMetadata | null>(null);
+  const [selectedTemplate, setSelectedTemplate] = React.useState<WorkflowMetadata | null>(null);
   
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -88,37 +78,33 @@ const StartNewWorkflowModal: React.FC<{
 const StartFromPreviousModal: React.FC<{
   onSelect: (sourceCycleId: string) => void;
   onClose: () => void;
-}> = ({ onClose }) => {
-  // This is a placeholder - in a real implementation, this would show
-  // a list of saved cycles from the cycle history
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-background rounded-lg shadow-lg p-6 w-96">
-        <h2 className="text-lg font-semibold mb-4">Start from Previous Cycle</h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          Select a previous cycle to use as a base for your new forecast.
+}> = ({ onClose }) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div className="bg-background rounded-lg shadow-lg p-6 w-96">
+      <h2 className="text-lg font-semibold mb-4">Start from Previous Cycle</h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        Select a previous cycle to use as a base for your new forecast.
+      </p>
+      
+      <div className="text-center py-8 text-muted-foreground">
+        <Calendar className="h-12 w-12 mx-auto mb-2 opacity-50" />
+        <p>Cycle history integration coming soon.</p>
+        <p className="text-xs mt-1">
+          Use the History action to load a previous cycle, then create an update.
         </p>
-        
-        <div className="text-center py-8 text-muted-foreground">
-          <Calendar className="h-12 w-12 mx-auto mb-2 opacity-50" />
-          <p>Cycle history integration coming soon.</p>
-          <p className="text-xs mt-1">
-            Use the History action to load a previous cycle, then create an update.
-          </p>
-        </div>
-        
-        <div className="flex justify-end gap-2 mt-6">
-          <Button variant="outline" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button disabled>
-            Select Cycle
-          </Button>
-        </div>
+      </div>
+      
+      <div className="flex justify-end gap-2 mt-6">
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button disabled>
+          Select Cycle
+        </Button>
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 /** Trigger button for the workflow actions dropdown. */
 const WorkflowActionsTrigger: React.FC = () => (
@@ -140,100 +126,94 @@ const WorkflowActionsTrigger: React.FC = () => (
   </DropdownMenuTrigger>
 );
 
+/** Renders the workflow dropdown menu body. */
+const WorkflowMenuContent: React.FC<{
+  isInProgress: boolean;
+  hasVersionHistory: boolean;
+  currentVersionNumber: number;
+  workflowTemplate: WorkflowMetadata | null | undefined;
+  workflowMetadata: { status: string } | undefined;
+  onStartBlank: () => void;
+  onCreateUpdate: () => void;
+  onStartFromPrevious: () => void;
+}> = ({
+  isInProgress,
+  hasVersionHistory,
+  currentVersionNumber,
+  workflowTemplate,
+  workflowMetadata,
+  onStartBlank,
+  onCreateUpdate,
+  onStartFromPrevious,
+}) => (
+  <DropdownMenuContent align="end" className="w-56">
+    <DropdownMenuLabel>Workflow Actions</DropdownMenuLabel>
+    <DropdownMenuSeparator />
+    
+    <DropdownMenuItem onClick={onStartBlank}>
+      <Play className="h-4 w-4 mr-2" />
+      <span className="font-medium">Start Blank</span>
+    </DropdownMenuItem>
+    
+    <DropdownMenuSeparator />
+    
+    <DropdownMenuItem 
+      onClick={onCreateUpdate}
+      disabled={!isInProgress || !hasVersionHistory}
+    >
+      <RefreshCw className="h-4 w-4 mr-2" />
+      <span className="font-medium">Create Update (v{currentVersionNumber + 1})</span>
+    </DropdownMenuItem>
+    
+    <DropdownMenuItem onClick={onStartFromPrevious}>
+      <GitBranch className="h-4 w-4 mr-2" />
+      <span className="font-medium">Start from Previous</span>
+    </DropdownMenuItem>
+    
+    <DropdownMenuSeparator />
+    
+    <DropdownMenuLabel className="text-xs text-muted-foreground">
+      Current: {workflowTemplate?.label ?? 'No workflow'} 
+      {workflowMetadata != null && ` • v${currentVersionNumber}`}
+    </DropdownMenuLabel>
+  </DropdownMenuContent>
+);
+
 /** Workflow actions dropdown menu for the forecast editor toolbar. */
 export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
-  const dispatch = useDispatch();
-  const [showStartNewModal, setShowStartNewModal] = useState(false);
-  const [showStartFromPreviousModal, setShowStartFromPreviousModal] = useState(false);
-  
-  const workflowMetadata = useSelector(selectWorkflowMetadata);
-  const workflowTemplate = useSelector(selectWorkflowTemplate);
-  const outlookVersionSnapshots = useSelector(selectOutlookVersionSnapshots);
-  const currentVersionNumber = useSelector(selectCurrentVersionNumber);
-  
-  const isWorkflowMode = isFeatureExposed('forecastWorkflowV2');
-  const isInProgress = workflowMetadata?.status === 'in-progress';
-  const hasOutlookData = outlookVersionSnapshots.length > 0 || currentVersionNumber > 1;
-  
-  if (!isWorkflowMode) {
+  const actions = useWorkflowActions();
+
+  if (!actions.isWorkflowMode) {
     return null;
   }
-  
-  /** Handle starting a blank cycle with optional workflow template. */
-  const handleStartBlank = (template?: WorkflowMetadata) => {
-    dispatch(startBlankCycle({ 
-      workflowTemplate: template,
-      cycleDate: new Date().toISOString().split('T')[0],
-    }));
-    setShowStartNewModal(false);
-  };
-  
-  /** Handle creating a new outlook version within the current cycle. */
-  const handleCreateUpdate = () => {
-    if (isInProgress && hasOutlookData) {
-      dispatch(createOutlookUpdate());
-    }
-  };
-  
-  /** Handle starting a new cycle derived from a previous cycle. */
-  const handleStartFromPrevious = (sourceCycleId: string) => {
-    dispatch(startFromPreviousCycle({
-      sourceCycleId,
-      workflowTemplate: workflowTemplate || undefined,
-    }));
-    setShowStartFromPreviousModal(false);
-  };
-  
+
   return (
     <DropdownMenu>
       <WorkflowActionsTrigger />
       
-      <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuLabel>Workflow Actions</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        
-        <DropdownMenuItem onClick={() => setShowStartNewModal(true)}>
-          <Play className="h-4 w-4 mr-2" />
-          <span className="font-medium">Start Blank</span>
-        </DropdownMenuItem>
-        
-        <DropdownMenuSeparator />
-        
-        <DropdownMenuItem 
-          onClick={handleCreateUpdate}
-          disabled={!isInProgress || !hasOutlookData}
-        >
-          <RefreshCw className="h-4 w-4 mr-2" />
-          <span className="font-medium">Create Update (v{currentVersionNumber + 1})</span>
-        </DropdownMenuItem>
-        
-        <DropdownMenuItem onClick={() => setShowStartFromPreviousModal(true)}>
-          <GitBranch className="h-4 w-4 mr-2" />
-          <span className="font-medium">Start from Previous</span>
-        </DropdownMenuItem>
-        
-        <DropdownMenuSeparator />
-        
-        <DropdownMenuLabel className="text-xs text-muted-foreground">
-          Current: {workflowTemplate?.label || 'No workflow'} 
-          {workflowMetadata && ` • v${currentVersionNumber}`}
-        </DropdownMenuLabel>
-      </DropdownMenuContent>
+      <WorkflowMenuContent
+        isInProgress={actions.isInProgress}
+        hasVersionHistory={actions.hasVersionHistory}
+        currentVersionNumber={actions.currentVersionNumber}
+        workflowTemplate={actions.workflowTemplate}
+        workflowMetadata={actions.workflowMetadata}
+        onStartBlank={() => actions.setShowStartNewModal(true)}
+        onCreateUpdate={actions.handleCreateUpdate}
+        onStartFromPrevious={() => actions.setShowStartFromPreviousModal(true)}
+      />
       
-      {/* Start New Modal */}
-      {showStartNewModal && (
+      {actions.showStartNewModal && (
         <StartNewWorkflowModal
           templates={DEFAULT_WORKFLOW_TEMPLATES}
-          onSelect={handleStartBlank}
-          onClose={() => setShowStartNewModal(false)}
+          onSelect={actions.handleStartBlank}
+          onClose={() => actions.setShowStartNewModal(false)}
         />
       )}
       
-      {/* Start from Previous Modal */}
-      {showStartFromPreviousModal && (
+      {actions.showStartFromPreviousModal && (
         <StartFromPreviousModal
-          onSelect={handleStartFromPrevious}
-          onClose={() => setShowStartFromPreviousModal(false)}
+          onSelect={actions.handleStartFromPrevious}
+          onClose={() => actions.setShowStartFromPreviousModal(false)}
         />
       )}
     </DropdownMenu>

--- a/src/components/WorkflowActions/WorkflowActions.tsx
+++ b/src/components/WorkflowActions/WorkflowActions.tsx
@@ -128,7 +128,6 @@ const WorkflowActionsTrigger: React.FC = () => (
 
 /** Renders the workflow dropdown menu body. */
 const WorkflowMenuContent: React.FC<{
-  isInProgress: boolean;
   canCreateUpdate: boolean;
   currentVersionNumber: number;
   workflowTemplate: WorkflowMetadata | null | undefined;
@@ -137,7 +136,6 @@ const WorkflowMenuContent: React.FC<{
   onCreateUpdate: () => void;
   onStartFromPrevious: () => void;
 }> = ({
-  isInProgress,
   canCreateUpdate,
   currentVersionNumber,
   workflowTemplate,
@@ -192,7 +190,6 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
       <WorkflowActionsTrigger />
       
       <WorkflowMenuContent
-        isInProgress={actions.isInProgress}
         canCreateUpdate={actions.canCreateUpdate}
         currentVersionNumber={actions.currentVersionNumber}
         workflowTemplate={actions.workflowTemplate}

--- a/src/components/WorkflowActions/WorkflowActions.tsx
+++ b/src/components/WorkflowActions/WorkflowActions.tsx
@@ -1,0 +1,276 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Workflow,
+  Play,
+  RotateCcw,
+  RefreshCw,
+  GitBranch,
+  Calendar,
+  ChevronDown,
+} from 'lucide-react';
+import { Button } from '../ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '../ui/tooltip';
+import { cn } from '../../lib/utils';
+import { isFeatureExposed } from '../../config/featureExposure';
+import { 
+  startBlankCycle, 
+  resumeIncompleteCycle, 
+  createOutlookUpdate,
+  startFromPreviousCycle,
+  selectWorkflowMetadata,
+  selectWorkflowTemplate,
+  selectOutlookVersionSnapshots,
+  selectCurrentVersionNumber,
+} from '../../store/forecastSlice';
+import type { WorkflowMetadata } from '../../types/workflow';
+import { DEFAULT_WORKFLOW_TEMPLATES } from './workflowTemplates';
+
+interface WorkflowActionsProps {
+  className?: string;
+}
+
+/** Workflow actions dropdown menu for the forecast editor toolbar. */
+export const WorkflowActions: React.FC<WorkflowActionsProps> = ({ className }) => {
+  const dispatch = useDispatch();
+  const [showStartNewModal, setShowStartNewModal] = useState(false);
+  const [showStartFromPreviousModal, setShowStartFromPreviousModal] = useState(false);
+  
+  const workflowMetadata = useSelector(selectWorkflowMetadata);
+  const workflowTemplate = useSelector(selectWorkflowTemplate);
+  const outlookVersionSnapshots = useSelector(selectOutlookVersionSnapshots);
+  const currentVersionNumber = useSelector(selectCurrentVersionNumber);
+  
+  const isWorkflowMode = isFeatureExposed('forecastWorkflowV2');
+  const isInProgress = workflowMetadata?.status === 'in-progress';
+  const hasOutlookData = outlookVersionSnapshots.length > 0 || currentVersionNumber > 1;
+  
+  if (!isWorkflowMode) {
+    return null;
+  }
+  
+  const handleStartBlank = (template?: WorkflowMetadata) => {
+    dispatch(startBlankCycle({ 
+      workflowTemplate: template,
+      cycleDate: new Date().toISOString().split('T')[0],
+    }));
+    setShowStartNewModal(false);
+  };
+  
+  const handleResumeIncomplete = () => {
+    // For now, we'll use the existing history modal
+    // This action will be integrated with the history modal in the future
+    console.log('Resume incomplete - integrate with history modal');
+  };
+  
+  const handleCreateUpdate = () => {
+    if (isInProgress && hasOutlookData) {
+      dispatch(createOutlookUpdate({}));
+    }
+  };
+  
+  const handleStartFromPrevious = (sourceCycleId: string) => {
+    dispatch(startFromPreviousCycle({
+      sourceCycleId,
+      workflowTemplate: workflowTemplate || undefined,
+    }));
+    setShowStartFromPreviousModal(false);
+  };
+  
+  return (
+    <>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className={cn(
+                  'tabbed-integrated-toolbar__action-tile h-10 shrink-0 justify-start rounded-xl px-2.5 text-left text-xs',
+                  'bg-background',
+                  'tabbed-integrated-toolbar__action-tile--primary'
+                )}
+              >
+                <span className="tabbed-integrated-toolbar__action-icon rounded-lg p-1.5 bg-violet-500/15 text-violet-700">
+                  <Workflow className="h-4 w-4" />
+                </span>
+                <span className="font-semibold">Workflow</span>
+                <ChevronDown className="h-3 w-3 ml-1 opacity-50" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Workflow actions for cycle management</p>
+          </TooltipContent>
+        </Tooltip>
+        
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuLabel>Workflow Actions</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          
+          <DropdownMenuItem onClick={() => setShowStartNewModal(true)}>
+            <Play className="h-4 w-4 mr-2" />
+            <div>
+              <div className="font-medium">Start Blank</div>
+              <div className="text-xs text-muted-foreground">Begin a new empty cycle</div>
+            </div>
+          </DropdownMenuItem>
+          
+          <DropdownMenuItem onClick={handleResumeIncomplete}>
+            <RotateCcw className="h-4 w-4 mr-2" />
+            <div>
+              <div className="font-medium">Continue Incomplete</div>
+              <div className="text-xs text-muted-foreground">Resume a saved cycle</div>
+            </div>
+          </DropdownMenuItem>
+          
+          <DropdownMenuSeparator />
+          
+          <DropdownMenuItem 
+            onClick={handleCreateUpdate}
+            disabled={!isInProgress || !hasOutlookData}
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            <div>
+              <div className="font-medium">Create Update</div>
+              <div className="text-xs text-muted-foreground">
+                New outlook version (v{currentVersionNumber + 1})
+              </div>
+            </div>
+          </DropdownMenuItem>
+          
+          <DropdownMenuItem onClick={() => setShowStartFromPreviousModal(true)}>
+            <GitBranch className="h-4 w-4 mr-2" />
+            <div>
+              <div className="font-medium">Start from Previous</div>
+              <div className="text-xs text-muted-foreground">Base on an existing cycle</div>
+            </div>
+          </DropdownMenuItem>
+          
+          <DropdownMenuSeparator />
+          
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            Current: {workflowTemplate?.label || 'No workflow'} 
+            {workflowMetadata && ` • v${currentVersionNumber}`}
+          </DropdownMenuLabel>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      
+      {/* Start New Modal */}
+      {showStartNewModal && (
+        <StartNewWorkflowModal
+          templates={DEFAULT_WORKFLOW_TEMPLATES}
+          onSelect={handleStartBlank}
+          onClose={() => setShowStartNewModal(false)}
+        />
+      )}
+      
+      {/* Start from Previous Modal */}
+      {showStartFromPreviousModal && (
+        <StartFromPreviousModal
+          onSelect={handleStartFromPrevious}
+          onClose={() => setShowStartFromPreviousModal(false)}
+        />
+      )}
+    </>
+  );
+};
+
+/** Modal for selecting a workflow template when starting a new cycle. */
+const StartNewWorkflowModal: React.FC<{
+  templates: WorkflowMetadata[];
+  onSelect: (template?: WorkflowMetadata) => void;
+  onClose: () => void;
+}> = ({ templates, onSelect, onClose }) => {
+  const [selectedTemplate, setSelectedTemplate] = useState<WorkflowMetadata | null>(null);
+  
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background rounded-lg shadow-lg p-6 w-96 max-h-[80vh] overflow-y-auto">
+        <h2 className="text-lg font-semibold mb-4">Start New Workflow</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Select a workflow template for your new forecast cycle.
+        </p>
+        
+        <div className="space-y-2">
+          {templates.map((template) => (
+            <button
+              key={template.id}
+              onClick={() => setSelectedTemplate(template)}
+              className={cn(
+                'w-full text-left p-3 rounded-lg border transition-colors',
+                selectedTemplate?.id === template.id
+                  ? 'border-violet-500 bg-violet-500/10'
+                  : 'border-border hover:border-violet-300'
+              )}
+            >
+              <div className="font-medium">{template.label}</div>
+              <div className="text-xs text-muted-foreground">
+                Groupings: {template.groupings.join(', ')}
+              </div>
+            </button>
+          ))}
+        </div>
+        
+        <div className="flex justify-end gap-2 mt-6">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => onSelect(selectedTemplate || undefined)}>
+            Start Cycle
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/** Modal for selecting a previous cycle to base a new cycle on. */
+const StartFromPreviousModal: React.FC<{
+  onSelect: (sourceCycleId: string) => void;
+  onClose: () => void;
+}> = ({ onSelect, onClose }) => {
+  // This is a placeholder - in a real implementation, this would show
+  // a list of saved cycles from the cycle history
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background rounded-lg shadow-lg p-6 w-96">
+        <h2 className="text-lg font-semibold mb-4">Start from Previous Cycle</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Select a previous cycle to use as a base for your new forecast.
+        </p>
+        
+        <div className="text-center py-8 text-muted-foreground">
+          <Calendar className="h-12 w-12 mx-auto mb-2 opacity-50" />
+          <p>Cycle history integration coming soon.</p>
+          <p className="text-xs mt-1">
+            Use the History action to load a previous cycle, then create an update.
+          </p>
+        </div>
+        
+        <div className="flex justify-end gap-2 mt-6">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled>
+            Select Cycle
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowActions;

--- a/src/components/WorkflowActions/WorkflowActions.tsx
+++ b/src/components/WorkflowActions/WorkflowActions.tsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   Workflow,
   Play,
-  RotateCcw,
   RefreshCw,
   GitBranch,
   Calendar,
@@ -157,7 +156,7 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
   /** Handle creating a new outlook version within the current cycle. */
   const handleCreateUpdate = () => {
     if (isInProgress && hasOutlookData) {
-      dispatch(createOutlookUpdate({}));
+      dispatch(createOutlookUpdate());
     }
   };
   
@@ -206,14 +205,6 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
             <div>
               <div className="font-medium">Start Blank</div>
               <div className="text-xs text-muted-foreground">Begin a new empty cycle</div>
-            </div>
-          </DropdownMenuItem>
-          
-          <DropdownMenuItem onClick={() => {}}>
-            <RotateCcw className="h-4 w-4 mr-2" />
-            <div>
-              <div className="font-medium">Continue Incomplete</div>
-              <div className="text-xs text-muted-foreground">Resume a saved cycle</div>
             </div>
           </DropdownMenuItem>
           

--- a/src/components/WorkflowActions/WorkflowActions.tsx
+++ b/src/components/WorkflowActions/WorkflowActions.tsx
@@ -194,10 +194,7 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
         
         <DropdownMenuItem onClick={() => setShowStartNewModal(true)}>
           <Play className="h-4 w-4 mr-2" />
-          <div>
-            <div className="font-medium">Start Blank</div>
-            <div className="text-xs text-muted-foreground">Begin a new empty cycle</div>
-          </div>
+          <span className="font-medium">Start Blank</span>
         </DropdownMenuItem>
         
         <DropdownMenuSeparator />
@@ -207,20 +204,12 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
           disabled={!isInProgress || !hasOutlookData}
         >
           <RefreshCw className="h-4 w-4 mr-2" />
-          <div>
-            <div className="font-medium">Create Update</div>
-            <div className="text-xs text-muted-foreground">
-              New outlook version (v{currentVersionNumber + 1})
-            </div>
-          </div>
+          <span className="font-medium">Create Update (v{currentVersionNumber + 1})</span>
         </DropdownMenuItem>
         
         <DropdownMenuItem onClick={() => setShowStartFromPreviousModal(true)}>
           <GitBranch className="h-4 w-4 mr-2" />
-          <div>
-            <div className="font-medium">Start from Previous</div>
-            <div className="text-xs text-muted-foreground">Base on an existing cycle</div>
-          </div>
+          <span className="font-medium">Start from Previous</span>
         </DropdownMenuItem>
         
         <DropdownMenuSeparator />

--- a/src/components/WorkflowActions/WorkflowActions.tsx
+++ b/src/components/WorkflowActions/WorkflowActions.tsx
@@ -129,7 +129,7 @@ const WorkflowActionsTrigger: React.FC = () => (
 /** Renders the workflow dropdown menu body. */
 const WorkflowMenuContent: React.FC<{
   isInProgress: boolean;
-  hasVersionHistory: boolean;
+  canCreateUpdate: boolean;
   currentVersionNumber: number;
   workflowTemplate: WorkflowMetadata | null | undefined;
   workflowMetadata: { status: string } | undefined;
@@ -138,7 +138,7 @@ const WorkflowMenuContent: React.FC<{
   onStartFromPrevious: () => void;
 }> = ({
   isInProgress,
-  hasVersionHistory,
+  canCreateUpdate,
   currentVersionNumber,
   workflowTemplate,
   workflowMetadata,
@@ -159,7 +159,7 @@ const WorkflowMenuContent: React.FC<{
     
     <DropdownMenuItem 
       onClick={onCreateUpdate}
-      disabled={!isInProgress || !hasVersionHistory}
+      disabled={!canCreateUpdate}
     >
       <RefreshCw className="h-4 w-4 mr-2" />
       <span className="font-medium">Create Update (v{currentVersionNumber + 1})</span>
@@ -193,7 +193,7 @@ export const WorkflowActions: React.FC<WorkflowActionsProps> = () => {
       
       <WorkflowMenuContent
         isInProgress={actions.isInProgress}
-        hasVersionHistory={actions.hasVersionHistory}
+        canCreateUpdate={actions.canCreateUpdate}
         currentVersionNumber={actions.currentVersionNumber}
         workflowTemplate={actions.workflowTemplate}
         workflowMetadata={actions.workflowMetadata}

--- a/src/components/WorkflowActions/useWorkflowActions.ts
+++ b/src/components/WorkflowActions/useWorkflowActions.ts
@@ -27,6 +27,7 @@ export function useWorkflowActions() {
   const isInProgress = workflowMetadata?.status === 'in-progress';
   const hasVersionHistory = outlookVersionSnapshots.length > 0 || currentVersionNumber > 1;
 
+  /** Handle starting a blank cycle with optional workflow template. */
   const handleStartBlank = (template?: WorkflowMetadata) => {
     dispatch(startBlankCycle({ 
       workflowTemplate: template,
@@ -35,12 +36,14 @@ export function useWorkflowActions() {
     setShowStartNewModal(false);
   };
 
+  /** Handle creating a new outlook version within the current cycle. */
   const handleCreateUpdate = () => {
     if (isInProgress && hasVersionHistory) {
       dispatch(createOutlookUpdate());
     }
   };
 
+  /** Handle starting a new cycle derived from a previous cycle. */
   const handleStartFromPrevious = (sourceCycleId: string) => {
     dispatch(startFromPreviousCycle({
       sourceCycleId,

--- a/src/components/WorkflowActions/useWorkflowActions.ts
+++ b/src/components/WorkflowActions/useWorkflowActions.ts
@@ -26,6 +26,9 @@ export function useWorkflowActions() {
   const isWorkflowMode = isFeatureExposed('forecastWorkflowV2');
   const isInProgress = workflowMetadata?.status === 'in-progress';
   const hasVersionHistory = outlookVersionSnapshots.length > 0 || currentVersionNumber > 1;
+  // Allow creating an update when in workflow mode and either version history exists
+  // or the current version is in-progress (user has started working)
+  const canCreateUpdate = isInProgress && (hasVersionHistory || workflowMetadata?.outlookVersions.some(v => v.status === 'in-progress'));
 
   /** Handle starting a blank cycle with optional workflow template. */
   const handleStartBlank = (template?: WorkflowMetadata) => {
@@ -38,7 +41,7 @@ export function useWorkflowActions() {
 
   /** Handle creating a new outlook version within the current cycle. */
   const handleCreateUpdate = () => {
-    if (isInProgress && hasVersionHistory) {
+    if (canCreateUpdate) {
       dispatch(createOutlookUpdate());
     }
   };
@@ -55,7 +58,7 @@ export function useWorkflowActions() {
   return {
     isWorkflowMode,
     isInProgress,
-    hasVersionHistory,
+    canCreateUpdate,
     currentVersionNumber,
     workflowMetadata,
     workflowTemplate,

--- a/src/components/WorkflowActions/useWorkflowActions.ts
+++ b/src/components/WorkflowActions/useWorkflowActions.ts
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { isFeatureExposed } from '../../config/featureExposure';
+import { 
+  startBlankCycle, 
+  createOutlookUpdate,
+  startFromPreviousCycle,
+  selectWorkflowMetadata,
+  selectWorkflowTemplate,
+  selectOutlookVersionSnapshots,
+  selectCurrentVersionNumber,
+} from '../../store/forecastSlice';
+import type { WorkflowMetadata } from '../../types/workflow';
+
+/** Encapsulates workflow action state and dispatch logic. */
+export function useWorkflowActions() {
+  const dispatch = useDispatch();
+  const [showStartNewModal, setShowStartNewModal] = useState(false);
+  const [showStartFromPreviousModal, setShowStartFromPreviousModal] = useState(false);
+
+  const workflowMetadata = useSelector(selectWorkflowMetadata);
+  const workflowTemplate = useSelector(selectWorkflowTemplate);
+  const outlookVersionSnapshots = useSelector(selectOutlookVersionSnapshots);
+  const currentVersionNumber = useSelector(selectCurrentVersionNumber);
+
+  const isWorkflowMode = isFeatureExposed('forecastWorkflowV2');
+  const isInProgress = workflowMetadata?.status === 'in-progress';
+  const hasVersionHistory = outlookVersionSnapshots.length > 0 || currentVersionNumber > 1;
+
+  const handleStartBlank = (template?: WorkflowMetadata) => {
+    dispatch(startBlankCycle({ 
+      workflowTemplate: template,
+      cycleDate: new Date().toISOString().split('T')[0],
+    }));
+    setShowStartNewModal(false);
+  };
+
+  const handleCreateUpdate = () => {
+    if (isInProgress && hasVersionHistory) {
+      dispatch(createOutlookUpdate());
+    }
+  };
+
+  const handleStartFromPrevious = (sourceCycleId: string) => {
+    dispatch(startFromPreviousCycle({
+      sourceCycleId,
+      workflowTemplate: workflowTemplate || undefined,
+    }));
+    setShowStartFromPreviousModal(false);
+  };
+
+  return {
+    isWorkflowMode,
+    isInProgress,
+    hasVersionHistory,
+    currentVersionNumber,
+    workflowMetadata,
+    workflowTemplate,
+    showStartNewModal,
+    setShowStartNewModal,
+    showStartFromPreviousModal,
+    setShowStartFromPreviousModal,
+    handleStartBlank,
+    handleCreateUpdate,
+    handleStartFromPrevious,
+  };
+}

--- a/src/components/WorkflowActions/workflowTemplates.ts
+++ b/src/components/WorkflowActions/workflowTemplates.ts
@@ -1,0 +1,34 @@
+import type { WorkflowMetadata } from '../../types/workflow';
+
+/** Default workflow templates for forecast cycles. */
+export const DEFAULT_WORKFLOW_TEMPLATES: WorkflowMetadata[] = [
+  {
+    id: 'severe-day1',
+    label: 'Severe Convective Day 1',
+    groupings: ['day1'],
+  },
+  {
+    id: 'severe-day2',
+    label: 'Severe Convective Day 2',
+    groupings: ['day2'],
+  },
+  {
+    id: 'severe-day3',
+    label: 'Severe Convective Day 3',
+    groupings: ['day3'],
+  },
+  {
+    id: 'severe-day4-8',
+    label: 'Severe Convective Days 4-8',
+    groupings: ['day4-8'],
+  },
+  {
+    id: 'convective-outlook',
+    label: 'Convective Outlook (Full)',
+    groupings: ['day1', 'day2', 'day3', 'day4-8'],
+  },
+];
+
+/** Returns a workflow template by ID, or undefined if not found. */
+export const getWorkflowTemplateById = (id: string): WorkflowMetadata | undefined =>
+  DEFAULT_WORKFLOW_TEMPLATES.find((template) => template.id === id);

--- a/src/store/forecastSlice.test.ts
+++ b/src/store/forecastSlice.test.ts
@@ -1,5 +1,6 @@
 import type { Feature, Polygon } from 'geojson';
 import type { DayType } from '../types/outlooks';
+import type { WorkflowMetadata } from '../types/workflow';
 import reducer, {
   addFeature,
   applyAutoCategoricalSync,
@@ -20,6 +21,11 @@ import reducer, {
   markAsSaved,
   omitDay,
   validateCompletion,
+  startBlankCycle,
+  resumeIncompleteCycle,
+  createOutlookUpdate,
+  startFromPreviousCycle,
+  saveCurrentCycle,
 } from './forecastSlice';
 
 const createPolygon = (offset: number): Polygon => ({
@@ -547,5 +553,149 @@ describe('forecastSlice undo/redo', () => {
     expect(nextState.forecastCycle.omittedDayReasons).toEqual({ 3: 'No severe weather expected' });
     expect(nextState.isSaved).toBe(false);
     expect(nextState.completionValidation.omittedDays).toEqual({});
+  });
+
+  describe('WF-04: Workflow entry, resume, update, and base-cycle actions', () => {
+    const testWorkflowTemplate: WorkflowMetadata = {
+      id: 'severe-day1',
+      label: 'Severe Convective Day 1',
+      groupings: ['day1'],
+    };
+
+    describe('startBlankCycle', () => {
+      it('starts a blank cycle without workflow metadata', () => {
+        const state = reducer(undefined, startBlankCycle({}));
+        
+        expect(state.forecastCycle.days[1]).toBeDefined();
+        expect(state.forecastCycle.currentDay).toBe(1);
+        expect(state.isSaved).toBe(false);
+        expect(state.outlookVersionSnapshots).toEqual([]);
+        expect(state.workflowMetadata).toBeUndefined();
+        expect(state.workflowTemplate).toBeUndefined();
+      });
+
+      it('starts a blank cycle with workflow metadata', () => {
+        const state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+          cycleDate: '2026-07-04',
+        }));
+        
+        expect(state.forecastCycle.cycleDate).toBe('2026-07-04');
+        expect(state.workflowTemplate).toEqual(testWorkflowTemplate);
+        expect(state.workflowMetadata).toBeDefined();
+        expect(state.workflowMetadata?.workflowId).toBe('severe-day1');
+        expect(state.workflowMetadata?.cycleDate).toBe('2026-07-04');
+        expect(state.workflowMetadata?.status).toBe('in-progress');
+        expect(state.workflowMetadata?.outlookVersions).toHaveLength(1);
+        expect(state.workflowMetadata?.outlookVersions[0].version).toBe(1);
+        expect(state.workflowMetadata?.outlookVersions[0].status).toBe('in-progress');
+      });
+    });
+
+    describe('resumeIncompleteCycle', () => {
+      it('resumes a saved cycle and restores workflow metadata', () => {
+        // First create a saved cycle with workflow metadata
+        let state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        state = reducer(state, markAsSaved());
+        state = reducer(state, saveCurrentCycle({ label: 'Test Cycle' }));
+        
+        const savedCycleId = state.savedCycles[0].id;
+        
+        // Reset to a new cycle
+        state = reducer(state, resetForecasts());
+        expect(state.workflowMetadata).toBeUndefined();
+        
+        // Resume the saved cycle
+        state = reducer(state, resumeIncompleteCycle({ cycleId: savedCycleId }));
+        
+        expect(state.workflowMetadata).toBeDefined();
+        expect(state.workflowMetadata?.workflowId).toBe('severe-day1');
+        expect(state.isSaved).toBe(true);
+        expect(state.outlookVersionSnapshots).toEqual([]);
+      });
+
+      it('does nothing if cycle ID is not found', () => {
+        const initialState = reducer(undefined, startBlankCycle({}));
+        const state = reducer(initialState, resumeIncompleteCycle({ cycleId: 'nonexistent' }));
+        
+        expect(state).toEqual(initialState);
+      });
+    });
+
+    describe('createOutlookUpdate', () => {
+      it('creates a new outlook version within the current cycle', () => {
+        // Start a workflow cycle
+        let state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        
+        expect(state.workflowMetadata?.outlookVersions).toHaveLength(1);
+        expect(state.workflowMetadata?.outlookVersions[0].version).toBe(1);
+        
+        // Create an update
+        state = reducer(state, createOutlookUpdate({}));
+        
+        expect(state.workflowMetadata?.outlookVersions).toHaveLength(2);
+        expect(state.workflowMetadata?.outlookVersions[0].status).toBe('completed');
+        expect(state.workflowMetadata?.outlookVersions[1].version).toBe(2);
+        expect(state.workflowMetadata?.outlookVersions[1].status).toBe('in-progress');
+        expect(state.workflowMetadata?.outlookVersions[1].derivedFrom).toBe(1);
+        expect(state.isSaved).toBe(false);
+      });
+
+      it('creates multiple updates incrementing version numbers', () => {
+        let state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        
+        state = reducer(state, createOutlookUpdate({}));
+        state = reducer(state, createOutlookUpdate({}));
+        state = reducer(state, createOutlookUpdate({}));
+        
+        expect(state.workflowMetadata?.outlookVersions).toHaveLength(4);
+        expect(state.workflowMetadata?.outlookVersions[3].version).toBe(4);
+        expect(state.workflowMetadata?.outlookVersions[3].derivedFrom).toBe(3);
+      });
+    });
+
+    describe('startFromPreviousCycle', () => {
+      it('creates a new cycle derived from a previous cycle', () => {
+        // Create and save a cycle with workflow metadata
+        let state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        state = reducer(state, markAsSaved());
+        state = reducer(state, saveCurrentCycle({ label: 'Previous Cycle' }));
+        
+        const previousCycleId = state.savedCycles[0].id;
+        
+        // Start a new cycle from the previous one
+        state = reducer(state, startFromPreviousCycle({
+          sourceCycleId: previousCycleId,
+          newCycleDate: '2026-07-05',
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        
+        expect(state.forecastCycle.cycleDate).toBe('2026-07-05');
+        expect(state.forecastCycle.currentDay).toBe(1);
+        expect(state.workflowMetadata).toBeDefined();
+        expect(state.workflowMetadata?.workflowId).toBe('severe-day1');
+        expect(state.workflowMetadata?.cycleDate).toBe('2026-07-05');
+        expect(state.workflowMetadata?.status).toBe('in-progress');
+        expect(state.isSaved).toBe(false);
+        expect(state.outlookVersionSnapshots).toEqual([]);
+      });
+
+      it('does nothing if source cycle ID is not found', () => {
+        const initialState = reducer(undefined, startBlankCycle({}));
+        const state = reducer(initialState, startFromPreviousCycle({
+          sourceCycleId: 'nonexistent',
+        }));
+        
+        expect(state).toEqual(initialState);
+      });
+    });
   });
 });

--- a/src/store/forecastSlice.test.ts
+++ b/src/store/forecastSlice.test.ts
@@ -635,7 +635,7 @@ describe('forecastSlice undo/redo', () => {
         expect(state.workflowMetadata?.outlookVersions[0].version).toBe(1);
         
         // Create an update
-        state = reducer(state, createOutlookUpdate({}));
+        state = reducer(state, createOutlookUpdate());
         
         expect(state.workflowMetadata?.outlookVersions).toHaveLength(2);
         expect(state.workflowMetadata?.outlookVersions[0].status).toBe('completed');
@@ -650,9 +650,9 @@ describe('forecastSlice undo/redo', () => {
           workflowTemplate: testWorkflowTemplate,
         }));
         
-        state = reducer(state, createOutlookUpdate({}));
-        state = reducer(state, createOutlookUpdate({}));
-        state = reducer(state, createOutlookUpdate({}));
+        state = reducer(state, createOutlookUpdate());
+        state = reducer(state, createOutlookUpdate());
+        state = reducer(state, createOutlookUpdate());
         
         expect(state.workflowMetadata?.outlookVersions).toHaveLength(4);
         expect(state.workflowMetadata?.outlookVersions[3].version).toBe(4);

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1,7 +1,7 @@
 import '../immerSetup';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { OutlookData, OutlookType, DrawingState, ForecastCycle, DayType, OutlookDay, DiscussionData, Probability } from '../types/outlooks';
-import type { CycleMetadata, WorkflowMetadata, Package, CycleValidationResult } from '../types/workflow';
+import type { CycleMetadata, WorkflowMetadata, Package, CycleValidationResult, OutlookVersion } from '../types/workflow';
 import { normalizeForecastCycle } from '../utils/outlookMapCoercion';
 import type { Feature } from 'geojson';
 import { RootState } from './index'; // Need RootState for selectors
@@ -48,6 +48,8 @@ export interface ForecastState {
     showCompletionModal: boolean;
     omittedDays: Partial<Record<DayType, string>>;
   };
+  /** v2 outlook version snapshots for the active cycle (used for same-cycle updates). */
+  outlookVersionSnapshots: OutlookVersionSnapshot[];
 }
 
 interface ForecastDaySnapshot {
@@ -64,6 +66,16 @@ interface ForecastHistoryEntry {
 interface ForecastHistoryStacks {
   undoStack: ForecastHistoryEntry[];
   redoStack: ForecastHistoryEntry[];
+}
+
+/** Stores a snapshot of outlook data for a specific version within a cycle. */
+interface OutlookVersionSnapshot {
+  /** Version number within the cycle. */
+  version: number;
+  /** Snapshot of day data for this version. */
+  days: Partial<Record<DayType, OutlookDay>>;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
 }
 
 type DayBucket = 'day12' | 'day3' | 'day48';
@@ -181,7 +193,8 @@ const initialState: ForecastState = {
     lastResult: null,
     showCompletionModal: false,
     omittedDays: {},
-  }
+  },
+  outlookVersionSnapshots: [],
 };
 
 // Helpers to keep reducers small and testable
@@ -694,6 +707,9 @@ export const forecastSlice = createSlice({
 
       state.forecastCycle = newCycle;
       state.isSaved = false;
+      state.outlookVersionSnapshots = [];
+      state.workflowMetadata = undefined;
+      state.workflowTemplate = undefined;
     },
 
     markAsSaved: (state) => {
@@ -705,6 +721,7 @@ export const forecastSlice = createSlice({
       state.forecastCycle = action.payload;
       clearHistory(state);
       state.isSaved = true;
+      state.outlookVersionSnapshots = [];
     },
 
     // Legacy import support (Single day) -> Import into CURRENT day
@@ -766,6 +783,7 @@ export const forecastSlice = createSlice({
         label: action.payload.label,
         forecastCycle: forecastCycleSnapshot,
         stats: countForecastMetrics(forecastCycleSnapshot),
+        workflowMetadata: state.workflowMetadata ? { ...state.workflowMetadata } : undefined,
       };
       state.savedCycles.push(savedCycle);
       state.isSaved = true;
@@ -778,6 +796,12 @@ export const forecastSlice = createSlice({
         state.forecastCycle = cloneForecastCycle(normalizeForecastCycle(savedCycle.forecastCycle));
         clearHistory(state);
         state.isSaved = true;
+        state.outlookVersionSnapshots = [];
+        
+        // Restore workflow metadata if present
+        if (savedCycle.workflowMetadata) {
+          state.workflowMetadata = savedCycle.workflowMetadata;
+        }
       }
     },
 
@@ -875,6 +899,7 @@ export const forecastSlice = createSlice({
       }
       clearHistory(state);
       state.isSaved = true;
+      state.outlookVersionSnapshots = [];
     },
 
     // Completion validation (WF-03)
@@ -914,6 +939,156 @@ export const forecastSlice = createSlice({
 
     clearOmittedDays: (state) => {
       state.completionValidation.omittedDays = {};
+    },
+
+    // WF-04: Workflow entry, resume, update, and base-cycle actions
+
+    /** Start a new blank cycle with optional workflow metadata. */
+    startBlankCycle: (state, action: PayloadAction<{
+      workflowTemplate?: WorkflowMetadata;
+      cycleDate?: string;
+    }>) => {
+      const { workflowTemplate, cycleDate } = action.payload;
+      clearHistory(state);
+      localStorage.removeItem('forecastData');
+      const today = cycleDate || getLocalCalendarDate();
+      const newCycle: ForecastCycle = {
+        days: { 1: createEmptyOutlook(1) },
+        currentDay: 1,
+        cycleDate: today
+      };
+      state.forecastCycle = newCycle;
+      state.isSaved = false;
+      state.outlookVersionSnapshots = [];
+      
+      if (workflowTemplate) {
+        state.workflowTemplate = workflowTemplate;
+        // Create initial cycle metadata
+        const now = new Date().toISOString();
+        state.workflowMetadata = {
+          id: `WF-${workflowTemplate.id}-${today}`,
+          workflowId: workflowTemplate.id,
+          cycleDate: today,
+          status: 'in-progress',
+          outlookVersions: [{
+            version: 1,
+            status: 'in-progress',
+            createdAt: now,
+          }],
+          createdAt: now,
+          updatedAt: now,
+        };
+      }
+    },
+
+    /** Resume an incomplete cycle from a saved snapshot, restoring workflow metadata. */
+    resumeIncompleteCycle: (state, action: PayloadAction<{ cycleId: string }>) => {
+      const { cycleId } = action.payload;
+      const savedCycle = state.savedCycles.find((c) => c.id === cycleId);
+      if (!savedCycle) return;
+
+      clearHistory(state);
+      // Deep clone the forecast cycle to avoid shared references
+      state.forecastCycle = JSON.parse(JSON.stringify(savedCycle.forecastCycle));
+      state.isSaved = true;
+      state.outlookVersionSnapshots = [];
+      
+      // Restore workflow metadata if present
+      if (savedCycle.workflowMetadata) {
+        state.workflowMetadata = savedCycle.workflowMetadata;
+      }
+    },
+
+    /** Create a new outlook version within the current cycle (same-cycle update). */
+    createOutlookUpdate: (state, action: PayloadAction<{ versionLabel?: string }>) => {
+      const { versionLabel } = action.payload;
+      const now = new Date().toISOString();
+      
+      // Determine the next version number
+      const currentVersions = state.workflowMetadata?.outlookVersions || [];
+      const nextVersion = currentVersions.length > 0 
+        ? Math.max(...currentVersions.map(v => v.version)) + 1 
+        : 1;
+      
+      // Snapshot the current day data before creating the update
+      const currentDay = state.forecastCycle.currentDay;
+      const currentDayData = state.forecastCycle.days[currentDay];
+      
+      if (currentDayData) {
+        // Store a snapshot of the current version
+        state.outlookVersionSnapshots.push({
+          version: nextVersion - 1, // Snapshot the previous version
+          days: { [currentDay]: JSON.parse(JSON.stringify(currentDayData)) },
+          createdAt: now,
+        });
+      }
+      
+      // Mark previous versions as completed
+      if (state.workflowMetadata) {
+        state.workflowMetadata.outlookVersions.forEach(v => {
+          if (v.status === 'in-progress') {
+            v.status = 'completed';
+          }
+        });
+        
+        // Add new version
+        state.workflowMetadata.outlookVersions.push({
+          version: nextVersion,
+          status: 'in-progress',
+          derivedFrom: nextVersion - 1,
+          createdAt: now,
+        });
+        
+        state.workflowMetadata.updatedAt = now;
+      }
+      
+      state.isSaved = false;
+    },
+
+    /** Start a new cycle derived from a previous cycle. */
+    startFromPreviousCycle: (state, action: PayloadAction<{
+      sourceCycleId: string;
+      newCycleDate?: string;
+      workflowTemplate?: WorkflowMetadata;
+    }>) => {
+      const { sourceCycleId, newCycleDate, workflowTemplate } = action.payload;
+      
+      // Find the source cycle in saved cycles
+      const sourceCycle = state.savedCycles.find(c => c.id === sourceCycleId);
+      if (!sourceCycle) return;
+      
+      const now = new Date().toISOString();
+      const targetDate = newCycleDate || getLocalCalendarDate();
+      
+      // Create a new cycle derived from the source
+      clearHistory(state);
+      state.forecastCycle = JSON.parse(JSON.stringify(sourceCycle.forecastCycle));
+      state.forecastCycle.cycleDate = targetDate;
+      state.forecastCycle.currentDay = 1;
+      state.isSaved = false;
+      state.outlookVersionSnapshots = [];
+      
+      // Set workflow metadata with derivedFromCycleId
+      const workflowId = workflowTemplate?.id || sourceCycle.workflowMetadata?.workflowId || 'default';
+      state.workflowMetadata = {
+        id: `WF-${workflowId}-${targetDate}`,
+        workflowId,
+        cycleDate: targetDate,
+        status: 'in-progress',
+        outlookVersions: [{
+          version: 1,
+          status: 'in-progress',
+          createdAt: now,
+        }],
+        createdAt: now,
+        updatedAt: now,
+      };
+      
+      if (workflowTemplate) {
+        state.workflowTemplate = workflowTemplate;
+      } else if (state.workflowTemplate) {
+        // Keep existing template if not provided
+      }
     },
   }
 });
@@ -956,6 +1131,10 @@ export const {
   completeCycle,
   completeWithOmissions,
   clearOmittedDays,
+  startBlankCycle,
+  resumeIncompleteCycle,
+  createOutlookUpdate,
+  startFromPreviousCycle,
 } = forecastSlice.actions;
 
 /** Selects the full forecast slice. */
@@ -1006,5 +1185,24 @@ export const selectShowCompletionModal = (state: RootState) =>
 /** Selects the omitted days map. */
 export const selectOmittedDays = (state: RootState) =>
   state.forecast.completionValidation.omittedDays;
+
+/** Selects the workflow metadata for the active cycle. */
+export const selectWorkflowMetadata = (state: RootState) =>
+  state.forecast.workflowMetadata;
+
+/** Selects the workflow template metadata. */
+export const selectWorkflowTemplate = (state: RootState) =>
+  state.forecast.workflowTemplate;
+
+/** Selects the outlook version snapshots for the active cycle. */
+export const selectOutlookVersionSnapshots = (state: RootState) =>
+  state.forecast.outlookVersionSnapshots;
+
+/** Selects the current version number for the active cycle. */
+export const selectCurrentVersionNumber = (state: RootState) => {
+  const metadata = state.forecast.workflowMetadata;
+  if (!metadata || metadata.outlookVersions.length === 0) return 1;
+  return Math.max(...metadata.outlookVersions.map(v => v.version));
+};
 
 export default forecastSlice.reducer;

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -10,6 +10,7 @@ import { countForecastMetrics } from '../utils/forecastMetrics';
 import { getLocalCalendarDate } from '../utils/localDate';
 import { areTstmFeaturesEqual } from '../utils/tstmGeneration';
 import { validateCycleCompletion } from '../utils/completionValidation';
+import { getWorkflowTemplateById } from '../components/WorkflowActions/workflowTemplates';
 
 export interface SavedCycleStats {
   forecastDays: number;
@@ -732,6 +733,9 @@ export const forecastSlice = createSlice({
       clearHistory(state);
       state.isSaved = true;
       state.outlookVersionSnapshots = [];
+      // Clear workflow state when importing a plain forecast cycle
+      state.workflowMetadata = undefined;
+      state.workflowTemplate = undefined;
     },
 
     // Legacy import support (Single day) -> Import into CURRENT day
@@ -812,7 +816,7 @@ export const forecastSlice = createSlice({
         if (savedCycle.workflowMetadata) {
           state.workflowMetadata = savedCycle.workflowMetadata;
           // Restore the workflow template from the workflowId
-          state.workflowTemplate = {
+          state.workflowTemplate = getWorkflowTemplateById(savedCycle.workflowMetadata.workflowId) || {
             id: savedCycle.workflowMetadata.workflowId,
             label: savedCycle.workflowMetadata.workflowId,
             groupings: [],
@@ -1023,8 +1027,7 @@ export const forecastSlice = createSlice({
       if (savedCycle.workflowMetadata) {
         state.workflowMetadata = savedCycle.workflowMetadata;
         // Restore the workflow template from the workflowId
-        // Create a minimal template if the full template isn't available
-        state.workflowTemplate = {
+        state.workflowTemplate = getWorkflowTemplateById(savedCycle.workflowMetadata.workflowId) || {
           id: savedCycle.workflowMetadata.workflowId,
           label: savedCycle.workflowMetadata.workflowId,
           groupings: [],

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -320,16 +320,6 @@ const cloneEntries = (map?: Map<string, Feature[]>): Map<string, Feature[]> | un
   ]));
 };
 
-/** Deep-clones OutlookData preserving Map-backed outlook maps. */
-const cloneOutlookData = (data: OutlookData): OutlookData => ({
-  tornado: cloneEntries(data.tornado),
-  wind: cloneEntries(data.wind),
-  hail: cloneEntries(data.hail),
-  totalSevere: cloneEntries(data.totalSevere),
-  categorical: cloneEntries(data.categorical),
-  'day4-8': cloneEntries(data['day4-8']),
-});
-
 /** Copies only the outlook types allowed by the source/target day compatibility rules. */
 const copyCompatibleOutlooks = (
   sourceData: OutlookData,

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -808,9 +808,18 @@ export const forecastSlice = createSlice({
         state.isSaved = true;
         state.outlookVersionSnapshots = [];
         
-        // Restore workflow metadata if present
+        // Restore or clear workflow metadata
         if (savedCycle.workflowMetadata) {
           state.workflowMetadata = savedCycle.workflowMetadata;
+          // Restore the workflow template from the workflowId
+          state.workflowTemplate = {
+            id: savedCycle.workflowMetadata.workflowId,
+            label: savedCycle.workflowMetadata.workflowId,
+            groupings: [],
+          };
+        } else {
+          state.workflowMetadata = undefined;
+          state.workflowTemplate = undefined;
         }
       }
     },

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -950,7 +950,11 @@ export const forecastSlice = createSlice({
     }>) => {
       const { workflowTemplate, cycleDate } = action.payload;
       clearHistory(state);
-      localStorage.removeItem('forecastData');
+      try {
+        localStorage.removeItem('forecastData');
+      } catch {
+        // Ignore localStorage errors
+      }
       const today = cycleDate || getLocalCalendarDate();
       const newCycle: ForecastCycle = {
         days: { 1: createEmptyOutlook(1) },
@@ -988,14 +992,16 @@ export const forecastSlice = createSlice({
       if (!savedCycle) return;
 
       clearHistory(state);
-      // Deep clone the forecast cycle to avoid shared references
-      state.forecastCycle = JSON.parse(JSON.stringify(savedCycle.forecastCycle));
+      state.forecastCycle = cloneForecastCycle(normalizeForecastCycle(savedCycle.forecastCycle));
       state.isSaved = true;
       state.outlookVersionSnapshots = [];
       
-      // Restore workflow metadata if present
+      // Restore or clear workflow metadata
       if (savedCycle.workflowMetadata) {
         state.workflowMetadata = savedCycle.workflowMetadata;
+      } else {
+        state.workflowMetadata = undefined;
+        state.workflowTemplate = undefined;
       }
     },
 
@@ -1061,7 +1067,7 @@ export const forecastSlice = createSlice({
       
       // Create a new cycle derived from the source
       clearHistory(state);
-      state.forecastCycle = JSON.parse(JSON.stringify(sourceCycle.forecastCycle));
+      state.forecastCycle = cloneForecastCycle(normalizeForecastCycle(sourceCycle.forecastCycle));
       state.forecastCycle.cycleDate = targetDate;
       state.forecastCycle.currentDay = 1;
       state.isSaved = false;

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -914,7 +914,7 @@ export const forecastSlice = createSlice({
         state.workflowMetadata = pkg.cycles[0];
       }
       if (pkg.metadata) {
-        state.workflowTemplate = {
+        state.workflowTemplate = getWorkflowTemplateById(pkg.metadata.workflowId) || {
           id: pkg.metadata.workflowId,
           label: pkg.metadata.workflowId,
           groupings: [],

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1013,6 +1013,13 @@ export const forecastSlice = createSlice({
       // Restore or clear workflow metadata
       if (savedCycle.workflowMetadata) {
         state.workflowMetadata = savedCycle.workflowMetadata;
+        // Restore the workflow template from the workflowId
+        // Create a minimal template if the full template isn't available
+        state.workflowTemplate = {
+          id: savedCycle.workflowMetadata.workflowId,
+          label: savedCycle.workflowMetadata.workflowId,
+          groupings: [],
+        };
       } else {
         state.workflowMetadata = undefined;
         state.workflowTemplate = undefined;

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1,7 +1,7 @@
 import '../immerSetup';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { OutlookData, OutlookType, DrawingState, ForecastCycle, DayType, OutlookDay, DiscussionData, Probability } from '../types/outlooks';
-import type { CycleMetadata, WorkflowMetadata, Package, CycleValidationResult, OutlookVersion } from '../types/workflow';
+import type { CycleMetadata, WorkflowMetadata, Package, CycleValidationResult } from '../types/workflow';
 import { normalizeForecastCycle } from '../utils/outlookMapCoercion';
 import type { Feature } from 'geojson';
 import { RootState } from './index'; // Need RootState for selectors
@@ -1001,7 +1001,6 @@ export const forecastSlice = createSlice({
 
     /** Create a new outlook version within the current cycle (same-cycle update). */
     createOutlookUpdate: (state, action: PayloadAction<{ versionLabel?: string }>) => {
-      const { versionLabel } = action.payload;
       const now = new Date().toISOString();
       
       // Determine the next version number

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1000,7 +1000,7 @@ export const forecastSlice = createSlice({
     },
 
     /** Create a new outlook version within the current cycle (same-cycle update). */
-    createOutlookUpdate: (state, action: PayloadAction<{ versionLabel?: string }>) => {
+    createOutlookUpdate: (state) => {
       const now = new Date().toISOString();
       
       // Determine the next version number

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -992,6 +992,10 @@ export const forecastSlice = createSlice({
           createdAt: now,
           updatedAt: now,
         };
+      } else {
+        // Clear stale workflow state when starting without a template
+        state.workflowTemplate = undefined;
+        state.workflowMetadata = undefined;
       }
     },
 

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -96,6 +96,31 @@ const ALL_OUTLOOK_TYPES: OutlookType[] = [
   'day4-8',
 ];
 const DIRECT_DAY12_COPY_TYPES: OutlookType[] = ['tornado', 'wind', 'hail', 'categorical'];
+
+/** Resolves the workflow ID from template or cycle metadata, falling back to 'default'. */
+const resolveWorkflowId = (
+  template?: WorkflowMetadata,
+  cycleMetadata?: CycleMetadata,
+): string => template?.id || cycleMetadata?.workflowId || 'default';
+
+/** Creates initial CycleMetadata for a new cycle. */
+const createInitialCycleMetadata = (
+  workflowId: string,
+  cycleDate: string,
+  now: string,
+): CycleMetadata => ({
+  id: `WF-${workflowId}-${cycleDate}`,
+  workflowId,
+  cycleDate,
+  status: 'in-progress',
+  outlookVersions: [{
+    version: 1,
+    status: 'in-progress',
+    createdAt: now,
+  }],
+  createdAt: now,
+  updatedAt: now,
+});
 const COPY_FEATURE_RULES: Record<DayBucket, Record<DayBucket, CopyFeatureRule[]>> = {
   day12: {
     day12: DIRECT_DAY12_COPY_TYPES.map((type) => ({ sourceType: type, targetType: type })),
@@ -1112,26 +1137,11 @@ export const forecastSlice = createSlice({
       state.outlookVersionSnapshots = [];
       
       // Set workflow metadata with derivedFromCycleId
-      const workflowId = workflowTemplate?.id || sourceCycle.workflowMetadata?.workflowId || 'default';
-      state.workflowMetadata = {
-        id: `WF-${workflowId}-${targetDate}`,
-        workflowId,
-        cycleDate: targetDate,
-        status: 'in-progress',
-        outlookVersions: [{
-          version: 1,
-          status: 'in-progress',
-          createdAt: now,
-        }],
-        createdAt: now,
-        updatedAt: now,
-      };
+      const workflowId = resolveWorkflowId(workflowTemplate, sourceCycle.workflowMetadata);
+      state.workflowMetadata = createInitialCycleMetadata(workflowId, targetDate, now);
       
-      if (workflowTemplate) {
-        state.workflowTemplate = workflowTemplate;
-      } else if (state.workflowTemplate) {
-        // Keep existing template if not provided
-      }
+      // Restore or set workflow template
+      state.workflowTemplate = workflowTemplate || getWorkflowTemplateById(workflowId) || undefined;
     },
   }
 });

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -294,6 +294,16 @@ const cloneEntries = (map?: Map<string, Feature[]>): Map<string, Feature[]> | un
   ]));
 };
 
+/** Deep-clones OutlookData preserving Map-backed outlook maps. */
+const cloneOutlookData = (data: OutlookData): OutlookData => ({
+  tornado: cloneEntries(data.tornado),
+  wind: cloneEntries(data.wind),
+  hail: cloneEntries(data.hail),
+  totalSevere: cloneEntries(data.totalSevere),
+  categorical: cloneEntries(data.categorical),
+  'day4-8': cloneEntries(data['day4-8']),
+});
+
 /** Copies only the outlook types allowed by the source/target day compatibility rules. */
 const copyCompatibleOutlooks = (
   sourceData: OutlookData,
@@ -1020,10 +1030,15 @@ export const forecastSlice = createSlice({
       const currentDayData = state.forecastCycle.days[currentDay];
       
       if (currentDayData) {
-        // Store a snapshot of the current version
+        // Store a snapshot of the current version, preserving Map-backed outlook data
         state.outlookVersionSnapshots.push({
           version: nextVersion - 1, // Snapshot the previous version
-          days: { [currentDay]: JSON.parse(JSON.stringify(currentDayData)) },
+          days: { 
+            [currentDay]: {
+              ...currentDayData,
+              data: cloneOutlookData(currentDayData.data),
+            } 
+          },
           createdAt: now,
         });
       }


### PR DESCRIPTION
## Summary

Implement WF-04: Build cycle and workflow entry, resume, new outlook, and update actions.

## Changes

### Redux Actions
- `startBlankCycle` - Start a new blank cycle with optional workflow metadata

esumeIncompleteCycle - Resume a saved cycle and restore workflow metadata
- `createOutlookUpdate` - Create a new outlook version within the same cycle
- `startFromPreviousCycle` - Start a new cycle derived from a previous cycle

### UI Components
- WorkflowActions component with dropdown menu for workflow operations
- Integrated into IntegratedToolbar Tools tab (feature-gated behind `forecastWorkflowV2`)
- Default workflow templates for forecast cycles (Severe Convective Day 1-3, Days 4-8, Full Outlook)

### State Management
- Added `outlookVersionSnapshots` field to `ForecastState` for tracking versioned outlook data
- Added selectors: `selectWorkflowMetadata`, `selectWorkflowTemplate, `selectOutlookVersionSnapshots`, `selectCurrentVersionNumber`
- Updated `saveCurrentCycle` to persist workflow metadata
- Updated `loadSavedCycle` to restore workflow metadata
- Updated `presetForecasts`, `importForecastCycle`, `importWorkflowPackage` to clear outlook version snapshots

### Tests
- Added comprehensive unit tests for all new Redux actions
- All existing tests continue to pass

## Acceptance Criteria

- [x] Actions have distinct metadata and copy
- [x] New outlook does not mutate prior work
- [x] Updates stay in the current cycle

## Verification

- [x] Added focused unit/component tests
- [x] Run affected tests and build
- [ ] Add responsive E2E coverage for user-facing flows (follow-up)

## Feature exposure

Workflow gate; beta first. Feature-gated behind `forecastWorkflowV2`.

Closes #454