### PR TITLE
[WF-04] Core workflow cycle state

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,14 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #682
+
+- Add reusable workflow templates for Day 1, Day 2, Day 3, Days 4-8, and Full Outlook workflows with persistent activation in localStorage.
+- Start workflow templates on the correct forecast day and support same-cycle updates plus start-from-previous-cycle behavior.
+- Preserve workflow metadata when loading workflow-ready `forecast_cycle.json` files.
+- Fix completion validation to respect the active workflow groupings and invalidate stale package completion when map or discussion content changes.
+- Prevent local session restore from overwriting in-progress unsaved forecast or discussion state.
+
 ### PR #681
 
 - Dependency: @radix-ui/react-dialog ^1.1.17 → ^1.1.18

--- a/src/components/ForecastWorkflow/workflowTemplates.ts
+++ b/src/components/ForecastWorkflow/workflowTemplates.ts
@@ -1,0 +1,34 @@
+import type { WorkflowMetadata } from '../../types/workflow';
+
+/** Default workflow templates for forecast cycles. */
+export const DEFAULT_WORKFLOW_TEMPLATES: WorkflowMetadata[] = [
+  {
+    id: 'severe-day1',
+    label: 'Severe Convective Day 1',
+    groupings: ['day1'],
+  },
+  {
+    id: 'severe-day2',
+    label: 'Severe Convective Day 2',
+    groupings: ['day2'],
+  },
+  {
+    id: 'severe-day3',
+    label: 'Severe Convective Day 3',
+    groupings: ['day3'],
+  },
+  {
+    id: 'severe-day4-8',
+    label: 'Severe Convective Days 4-8',
+    groupings: ['day4-8'],
+  },
+  {
+    id: 'convective-outlook',
+    label: 'Convective Outlook (Full)',
+    groupings: ['day1', 'day2', 'day3', 'day4-8'],
+  },
+];
+
+/** Returns a workflow template by ID, or undefined if not found. */
+export const getWorkflowTemplateById = (id: string): WorkflowMetadata | undefined =>
+  DEFAULT_WORKFLOW_TEMPLATES.find((template) => template.id === id);

--- a/src/components/ForecastWorkspace/forecastWorkspaceActions.test.tsx
+++ b/src/components/ForecastWorkspace/forecastWorkspaceActions.test.tsx
@@ -31,6 +31,7 @@ const setup = (overrides: Partial<Parameters<typeof useForecastWorkspaceActionHa
     mapRef: { current: { getView: jest.fn(() => ({ center: [1, 2], zoom: 7 })) } },
     addToast,
     forecastCycle,
+    cycleMetadata: undefined,
     currentDay: 3,
     canUndo: true,
     canRedo: false,
@@ -95,7 +96,7 @@ describe('useForecastWorkspaceActionHandlers', () => {
       await Promise.resolve();
     });
 
-    expect(downloadGfcPackage).toHaveBeenCalledWith(forecastCycle, { center: [1, 2], zoom: 7 });
+    expect(downloadGfcPackage).toHaveBeenCalledWith(forecastCycle, { center: [1, 2], zoom: 7 }, undefined);
     expect(first.addToast).toHaveBeenCalledWith('Package downloaded!', 'success');
     expect(first.setIsPackageDownloading).toHaveBeenLastCalledWith(false);
 
@@ -107,7 +108,7 @@ describe('useForecastWorkspaceActionHandlers', () => {
       await Promise.resolve();
     });
 
-    expect(downloadGfcPackage).toHaveBeenLastCalledWith(forecastCycle, { center: [39.8283, -98.5795], zoom: 4 });
+    expect(downloadGfcPackage).toHaveBeenLastCalledWith(forecastCycle, { center: [39.8283, -98.5795], zoom: 4 }, undefined);
     expect(second.addToast).toHaveBeenCalledWith('Failed to create package.', 'error');
   });
 });

--- a/src/components/ForecastWorkspace/forecastWorkspaceActions.tsx
+++ b/src/components/ForecastWorkspace/forecastWorkspaceActions.tsx
@@ -11,6 +11,7 @@ import {
 import type { ForecastMapHandle } from '../Map/ForecastMap';
 import type { AddToastFn } from '../Layout';
 import type { DayType, ForecastCycle } from '../../types/outlooks';
+import type { CycleMetadata } from '../../types/workflow';
 import { useDispatch } from 'react-redux';
 
 export interface ForecastWorkspaceActionParams {
@@ -19,6 +20,7 @@ export interface ForecastWorkspaceActionParams {
   mapRef: React.RefObject<ForecastMapHandle | null>;
   addToast: AddToastFn;
   forecastCycle: ForecastCycle;
+  cycleMetadata?: CycleMetadata;
   currentDay: DayType;
   canUndo: boolean;
   canRedo: boolean;
@@ -65,6 +67,7 @@ export const useForecastWorkspaceActionHandlers = ({
   mapRef,
   addToast,
   forecastCycle,
+  cycleMetadata,
   currentDay,
   canUndo,
   canRedo,
@@ -78,14 +81,14 @@ export const useForecastWorkspaceActionHandlers = ({
     setIsPackageDownloading(true);
     try {
       const mapView = mapRef.current?.getView() ?? ({ center: [39.8283, -98.5795] as [number, number], zoom: 4 });
-      await downloadGfcPackage(forecastCycle, mapView);
+      await downloadGfcPackage(forecastCycle, mapView, cycleMetadata);
       addToast('Package downloaded!', 'success');
     } catch {
       addToast('Failed to create package.', 'error');
     } finally {
       setIsPackageDownloading(false);
     }
-  }, [mapRef, forecastCycle, addToast, setIsPackageDownloading]);
+  }, [mapRef, forecastCycle, cycleMetadata, addToast, setIsPackageDownloading]);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = getSelectedFile(e);

--- a/src/components/ForecastWorkspace/useForecastWorkspaceController.tsx
+++ b/src/components/ForecastWorkspace/useForecastWorkspaceController.tsx
@@ -414,6 +414,7 @@ function useForecastWorkspaceCoreState(
   const forecastCycle = useSelector(selectForecastCycle);
   const { currentDay, days, cycleDate } = forecastCycle;
   const isSaved = useSelector((state: RootState) => state.forecast.isSaved);
+  const cycleMetadata = useSelector((state: RootState) => state.forecast.workflowMetadata);
   const canUndo = useSelector(selectCanUndo);
   const canRedo = useSelector(selectCanRedo);
   const ghostOutlookState = useSelector((state: RootState) => state.overlays.ghostOutlooks);
@@ -441,6 +442,7 @@ function useForecastWorkspaceCoreState(
   return {
     dispatch,
     forecastCycle,
+    cycleMetadata,
     currentDay,
     days,
     cycleDate,
@@ -476,6 +478,7 @@ function useForecastWorkspaceControllerArgs({
     mapRef,
     addToast,
     forecastCycle: core.forecastCycle,
+    cycleMetadata: core.cycleMetadata,
     currentDay: core.currentDay,
     canUndo: core.canUndo,
     canRedo: core.canRedo,

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -10,6 +10,7 @@ const LOCAL_STORAGE_KEY = 'forecastData';
 export const useAutoSave = () => {
   const forecastCycle = useSelector(selectForecastCycle);
   const mapView = useSelector((state: RootState) => state.forecast.currentMapView);
+  const workflowMetadata = useSelector((state: RootState) => state.forecast.workflowMetadata);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const isFirstRender = useRef(true);
 
@@ -25,7 +26,7 @@ export const useAutoSave = () => {
 
     timerRef.current = setTimeout(() => {
       try {
-        const data = serializeForecast(forecastCycle, mapView);
+        const data = serializeForecast(forecastCycle, mapView, workflowMetadata);
         localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(data));
       } catch {
         // Auto-save silently fails to avoid disrupting the user
@@ -37,5 +38,5 @@ export const useAutoSave = () => {
         clearTimeout(timerRef.current);
       }
     };
-  }, [forecastCycle, mapView]);
+  }, [forecastCycle, mapView, workflowMetadata]);
 };

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -90,14 +90,15 @@ export const useCloudSync = (
   const updateSyncState = cloud.updateSyncState;
   const forecastCycle = useSelector((state: RootState) => state.forecast.forecastCycle);
   const mapView = useSelector((state: RootState) => state.forecast.currentMapView);
-  
+  const workflowMetadata = useSelector((state: RootState) => state.forecast.workflowMetadata);
+
   const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSyncStateRef = useRef<string | null>(null);
 
   const canSync = Boolean(currentCloud) && premiumActive;
   const serializedPayload = useMemo(
-    () => serializeForecast(forecastCycle, mapView),
-    [forecastCycle, mapView]
+    () => serializeForecast(forecastCycle, mapView, workflowMetadata),
+    [forecastCycle, mapView, workflowMetadata]
   );
   const currentHash = useMemo(
     () => buildCloudSyncHash(serializedPayload),

--- a/src/hooks/useFileLoader.test.ts
+++ b/src/hooks/useFileLoader.test.ts
@@ -89,7 +89,7 @@ describe('createFileHandlers', () => {
     expect(mockExportForecastToJson).toHaveBeenCalledWith(forecastCycle, {
       center: [39.8283, -98.5795],
       zoom: 4,
-    });
+    }, undefined);
     expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'forecast/markAsSaved' }));
     expect(addToast).toHaveBeenCalledWith('Forecast exported to JSON!', 'success');
 

--- a/src/hooks/useFileLoader.ts
+++ b/src/hooks/useFileLoader.ts
@@ -2,13 +2,14 @@ import { exportForecastToJson, deserializeForecast, validateForecastData } from 
 import { markAsSaved, importForecastCycle, setWorkflowMetadata } from '../store/forecastSlice';
 import type { AddToastFn } from '../components/Layout';
 import type { Dispatch } from 'redux';
-import type { ForecastCycle } from '../types/outlooks';
+import type { CycleMetadata, ForecastCycle } from '../types/outlooks';
 
 /** Creates save and load file handler functions bound to the given toast notifier, Redux dispatch, and current forecast state. */
-export function createFileHandlers({ addToast, dispatch, forecastCycle }: {
+export function createFileHandlers({ addToast, dispatch, forecastCycle, cycleMetadata }: {
   addToast: AddToastFn;
   dispatch: Dispatch;
   forecastCycle: ForecastCycle;
+  cycleMetadata?: CycleMetadata;
 }) {
   const fileInputRef = { current: null as HTMLInputElement | null } as React.MutableRefObject<HTMLInputElement | null>;
 
@@ -57,10 +58,14 @@ export function createFileHandlers({ addToast, dispatch, forecastCycle }: {
   /** Serializes the current forecast cycle to a JSON file and downloads it, then marks the store as saved. */
   const handleSave = () => {
     try {
-      exportForecastToJson(forecastCycle, {
-        center: [39.8283, -98.5795],
-        zoom: 4,
-      });
+      exportForecastToJson(
+        forecastCycle,
+        {
+          center: [39.8283, -98.5795],
+          zoom: 4,
+        },
+        cycleMetadata,
+      );
       dispatch(markAsSaved());
       addToast('Forecast exported to JSON!', 'success');
     } catch {

--- a/src/hooks/useFileLoader.ts
+++ b/src/hooks/useFileLoader.ts
@@ -1,5 +1,5 @@
 import { exportForecastToJson, deserializeForecast, validateForecastData } from '../utils/fileUtils';
-import { markAsSaved, importForecastCycle } from '../store/forecastSlice';
+import { markAsSaved, importForecastCycle, setWorkflowMetadata } from '../store/forecastSlice';
 import type { AddToastFn } from '../components/Layout';
 import type { Dispatch } from 'redux';
 import type { ForecastCycle } from '../types/outlooks';
@@ -31,6 +31,9 @@ export function createFileHandlers({ addToast, dispatch, forecastCycle }: {
 
       const deserializedCycle = deserializeForecast(data);
       dispatch(importForecastCycle(deserializedCycle));
+      if (data.cycleMetadata) {
+        dispatch(setWorkflowMetadata(data.cycleMetadata));
+      }
       addToast('Forecast loaded successfully!', 'success');
     } catch {
       addToast('Error reading file.', 'error');

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -34,6 +34,7 @@ import themeReducer from '../store/themeSlice';
 import verificationReducer from '../store/verificationSlice';
 import monitorReducer from '../store/monitorSlice';
 import { serializeForecast } from '../utils/fileUtils';
+import type { Feature } from 'geojson';
 
 const mockAddToast = jest.fn();
 const mockUseAuth = jest.fn();
@@ -181,6 +182,30 @@ describe('ForecastPage layout selection', () => {
     renderForecastPage(store);
 
     expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('2%')?.[0].id).toBe('live-outlook');
+  });
+
+  test('restores the local autosave when the current cycle is empty', () => {
+    const store = createStore();
+    const cycleWithOutlook = { ...store.getState().forecast.forecastCycle };
+    const features = new Map<string, Feature[]>();
+    features.set('10%', [{
+      type: 'Feature',
+      id: 'autosave-outlook',
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      properties: { outlookType: 'tornado', probability: '10%', isSignificant: false },
+    } as Feature]);
+    cycleWithOutlook.days = {
+      1: {
+        data: { tornado: features, wind: new Map(), hail: new Map(), categorical: new Map(), totalSevere: new Map() } as never,
+        metadata: { lowProbabilityOutlooks: [] },
+      },
+    } as typeof cycleWithOutlook.days;
+    const autosavePayload = serializeForecast(cycleWithOutlook, { center: [0, 0], zoom: 0 });
+    localStorage.setItem('forecastData', JSON.stringify(autosavePayload));
+
+    renderForecastPage(store);
+
+    expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('10%')?.[0].id).toBe('autosave-outlook');
   });
 });
 

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -26,12 +26,14 @@ import ForecastPage, {
   writeStoredDayValue,
 } from './ForecastPage';
 import forecastReducer from '../store/forecastSlice';
+import { addFeature } from '../store/forecastSlice';
 import overlaysReducer from '../store/overlaysSlice';
 import stormReportsReducer from '../store/stormReportsSlice';
 import appModeReducer from '../store/appModeSlice';
 import themeReducer from '../store/themeSlice';
 import verificationReducer from '../store/verificationSlice';
 import monitorReducer from '../store/monitorSlice';
+import { serializeForecast } from '../utils/fileUtils';
 
 const mockAddToast = jest.fn();
 const mockUseAuth = jest.fn();
@@ -153,6 +155,32 @@ describe('ForecastPage layout selection', () => {
     const third = renderForecastPage(store);
     expect(screen.getByText('ForecastTabbedToolbarLayout Mock')).toBeInTheDocument();
     third.unmount();
+  });
+
+  test('does not overwrite active in-memory outlooks with an older local autosave on remount', () => {
+    const store = createStore();
+    const stalePayload = serializeForecast(store.getState().forecast.forecastCycle, { center: [39.8283, -98.5795], zoom: 4 });
+    localStorage.setItem('forecastData', JSON.stringify(stalePayload));
+
+    store.dispatch(addFeature({
+      feature: {
+        type: 'Feature',
+        id: 'live-outlook',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+        },
+        properties: {
+          outlookType: 'tornado',
+          probability: '2%',
+          isSignificant: false,
+        },
+      },
+    }));
+
+    renderForecastPage(store);
+
+    expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('2%')?.[0].id).toBe('live-outlook');
   });
 });
 

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -13,9 +13,9 @@ import {
   DialogTitle,
 } from '../components/ui/dialog';
 import { RootState } from '../store';
-import { 
-  importForecastCycle, 
-  markAsSaved, 
+import {
+  importForecastCycle,
+  markAsSaved,
   resetForecasts,
   saveCurrentCycle,
   setMapView,
@@ -29,6 +29,7 @@ import {
   setForecastDay,
   redoLastEdit,
   undoLastEdit,
+  setWorkflowMetadata,
 } from '../store/forecastSlice';
 import { OutlookType, Probability, DayType, GFCForecastSaveData } from '../types/outlooks';
 import { deserializeForecast, validateForecastData, exportForecastToJson, serializeForecast } from '../utils/fileUtils';
@@ -242,7 +243,10 @@ export const buildMapView = (ref: React.RefObject<ForecastMapHandle | null>) => 
 };
 
 interface LoadedForecastPayload {
-  rawData: { mapView?: { center: [number, number]; zoom: number } };
+  rawData: {
+    mapView?: { center: [number, number]; zoom: number };
+    cycleMetadata?: import('../types/workflow').CycleMetadata;
+  };
   deserializedCycle: ReturnType<typeof deserializeForecast>;
 }
 
@@ -295,6 +299,9 @@ const applyLoadedForecast = (
   mapRef: React.RefObject<ForecastMapHandle | null>
 ) => {
   dispatch(importForecastCycle(payload.deserializedCycle));
+  if (payload.rawData.cycleMetadata) {
+    dispatch(setWorkflowMetadata(payload.rawData.cycleMetadata));
+  }
 
   if (payload.rawData.mapView) {
     dispatch(setMapView(payload.rawData.mapView));
@@ -632,6 +639,9 @@ const restoreStoredForecastPayload = (
 ) => {
   const deserializedCycle = deserializeForecast(data);
   dispatch(importForecastCycle(deserializedCycle));
+  if (data.cycleMetadata) {
+    dispatch(setWorkflowMetadata(data.cycleMetadata));
+  }
 
   const rawData = data as LoadedForecastPayload['rawData'];
   if (rawData.mapView) {

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -1083,6 +1083,7 @@ const useCloudForecastActions = ({
   markCurrentStateSynced,
   saveCycle,
   userId,
+  workflowMetadata,
 }: {
   addToast: AddToastFn;
   currentMapView: RootState['forecast']['currentMapView'];
@@ -1091,6 +1092,7 @@ const useCloudForecastActions = ({
   markCurrentStateSynced: () => void;
   saveCycle: UseCloudCyclesResult['saveCycle'];
   userId: string | undefined;
+  workflowMetadata?: import('../types/workflow').CycleMetadata;
 }) => {
   const handleCloudCycleLoaded = useCallback(
     (cloudCycle: { id: string; label: string }) => {
@@ -1106,7 +1108,7 @@ const useCloudForecastActions = ({
         throw new Error('Sign in to save forecasts to the cloud.');
       }
 
-      const payload = serializeForecast(forecastCycle, currentMapView);
+      const payload = serializeForecast(forecastCycle, currentMapView, workflowMetadata);
       const stats = countForecastMetrics(forecastCycle);
       const success = await saveCycle(label, forecastCycle.cycleDate, stats, payload);
 
@@ -1117,7 +1119,7 @@ const useCloudForecastActions = ({
       markCurrentStateSynced();
       addToast(`Saved "${label}" to the cloud.`, 'success');
     },
-    [addToast, currentMapView, forecastCycle, markCurrentStateSynced, saveCycle, userId]
+    [addToast, currentMapView, forecastCycle, markCurrentStateSynced, saveCycle, userId, workflowMetadata]
   );
 
   return {
@@ -1198,6 +1200,7 @@ const useForecastPageWorkspace = ({
     markCurrentStateSynced,
     saveCycle,
     userId: user?.uid,
+    workflowMetadata,
   });
 
   const restoreComplete = useSessionRestore(dispatch, addToast, {

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -726,16 +726,18 @@ const restoreLocalSession = (
 const restoreAvailableSession = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
-  forecastCycle: ReturnType<typeof selectForecastCycle>,
-  isSaved: boolean,
-  onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
+  currentSession: {
+    forecastCycle: ReturnType<typeof selectForecastCycle>;
+    isSaved: boolean;
+    onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void;
+  }
 ) => {
-  const restoredCloudSession = restoreCloudSession(dispatch, addToast, onCloudCycleLoaded);
+  const restoredCloudSession = restoreCloudSession(dispatch, addToast, currentSession.onCloudCycleLoaded);
   if (restoredCloudSession) {
     return;
   }
 
-  restoreLocalSession(dispatch, addToast, { forecastCycle, isSaved });
+  restoreLocalSession(dispatch, addToast, currentSession);
 };
 
 /** Attempts to restore the last auto-saved forecast session from localStorage on mount. */
@@ -755,7 +757,11 @@ const useSessionRestore = (
 
   useEffect(() => {
     try {
-      restoreAvailableSession(dispatch, addToast, forecastCycle, isSaved, onCloudCycleLoadedRef.current);
+      restoreAvailableSession(dispatch, addToast, {
+        forecastCycle,
+        isSaved,
+        onCloudCycleLoaded: onCloudCycleLoadedRef.current,
+      });
     } catch {
       // Silently skip auto-load errors to avoid disrupting initial render
     } finally {

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -699,8 +699,14 @@ const restoreCloudSession = (
 /** Restores the last local auto-saved forecast when no cloud-loaded payload is pending. */
 const restoreLocalSession = (
   dispatch: ShortcutDispatch,
-  addToast: AddToastFn
+  addToast: AddToastFn,
+  forecastCycle: ReturnType<typeof selectForecastCycle>,
+  isSaved: boolean
 ): void => {
+  if (!isSaved || hasRolloverForecastData(forecastCycle) || cycleHasDiscussionContent(forecastCycle)) {
+    return;
+  }
+
   const data = parseStoredForecastPayload(localStorage.getItem('forecastData'));
   if (!data) {
     return;
@@ -714,6 +720,8 @@ const restoreLocalSession = (
 const restoreAvailableSession = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
+  forecastCycle: ReturnType<typeof selectForecastCycle>,
+  isSaved: boolean,
   onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
 ) => {
   const restoredCloudSession = restoreCloudSession(dispatch, addToast, onCloudCycleLoaded);
@@ -721,13 +729,15 @@ const restoreAvailableSession = (
     return;
   }
 
-  restoreLocalSession(dispatch, addToast);
+  restoreLocalSession(dispatch, addToast, forecastCycle, isSaved);
 };
 
 /** Attempts to restore the last auto-saved forecast session from localStorage on mount. */
 const useSessionRestore = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
+  forecastCycle: ReturnType<typeof selectForecastCycle>,
+  isSaved: boolean,
   onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
 ) => {
   const onCloudCycleLoadedRef = useRef(onCloudCycleLoaded);
@@ -739,13 +749,13 @@ const useSessionRestore = (
 
   useEffect(() => {
     try {
-      restoreAvailableSession(dispatch, addToast, onCloudCycleLoadedRef.current);
+      restoreAvailableSession(dispatch, addToast, forecastCycle, isSaved, onCloudCycleLoadedRef.current);
     } catch {
       // Silently skip auto-load errors to avoid disrupting initial render
     } finally {
       setRestoreComplete(true);
     }
-  }, [dispatch, addToast]);
+  }, [dispatch, addToast, forecastCycle, isSaved]);
 
   return restoreComplete;
 };
@@ -1166,7 +1176,7 @@ const useForecastPageWorkspace = ({
     userId: user?.uid,
   });
 
-  const restoreComplete = useSessionRestore(dispatch, addToast, handleCloudCycleLoaded);
+  const restoreComplete = useSessionRestore(dispatch, addToast, forecastCycle, isSaved, handleCloudCycleLoaded);
   useUnsavedChangesWarning(isSaved);
 
   const { handleSave, handleLoad } = useForecastFileActions(

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -744,22 +744,24 @@ const restoreAvailableSession = (
 const useSessionRestore = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
-  forecastCycle: ReturnType<typeof selectForecastCycle>,
-  isSaved: boolean,
-  onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
+  currentSession: {
+    forecastCycle: ReturnType<typeof selectForecastCycle>;
+    isSaved: boolean;
+    onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void;
+  }
 ) => {
-  const onCloudCycleLoadedRef = useRef(onCloudCycleLoaded);
+  const onCloudCycleLoadedRef = useRef(currentSession.onCloudCycleLoaded);
   const [restoreComplete, setRestoreComplete] = useState(false);
 
   useEffect(() => {
-    onCloudCycleLoadedRef.current = onCloudCycleLoaded;
-  }, [onCloudCycleLoaded]);
+    onCloudCycleLoadedRef.current = currentSession.onCloudCycleLoaded;
+  }, [currentSession.onCloudCycleLoaded]);
 
   useEffect(() => {
     try {
       restoreAvailableSession(dispatch, addToast, {
-        forecastCycle,
-        isSaved,
+        forecastCycle: currentSession.forecastCycle,
+        isSaved: currentSession.isSaved,
         onCloudCycleLoaded: onCloudCycleLoadedRef.current,
       });
     } catch {
@@ -767,7 +769,7 @@ const useSessionRestore = (
     } finally {
       setRestoreComplete(true);
     }
-  }, [dispatch, addToast, forecastCycle, isSaved]);
+  }, [dispatch, addToast, currentSession.forecastCycle, currentSession.isSaved]);
 
   return restoreComplete;
 };
@@ -1188,7 +1190,11 @@ const useForecastPageWorkspace = ({
     userId: user?.uid,
   });
 
-  const restoreComplete = useSessionRestore(dispatch, addToast, forecastCycle, isSaved, handleCloudCycleLoaded);
+  const restoreComplete = useSessionRestore(dispatch, addToast, {
+    forecastCycle,
+    isSaved,
+    onCloudCycleLoaded: handleCloudCycleLoaded,
+  });
   useUnsavedChangesWarning(isSaved);
 
   const { handleSave, handleLoad } = useForecastFileActions(

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -696,20 +696,19 @@ const restoreCloudSession = (
   return true;
 };
 
-/** Returns true when the current cycle should skip local auto-save restore (already saved, rolled over, or has discussion content). */
+/** Returns true when the current cycle already holds content (rolled over or discussion) that should not be clobbered by a local autosave restore. */
 const shouldSkipLocalRestore = (
-  isSaved: boolean,
   forecastCycle: ReturnType<typeof selectForecastCycle>
 ): boolean =>
-  !isSaved || hasRolloverForecastData(forecastCycle) || cycleHasDiscussionContent(forecastCycle);
+  hasRolloverForecastData(forecastCycle) || cycleHasDiscussionContent(forecastCycle);
 
 /** Restores the last local auto-saved forecast when no cloud-loaded payload is pending. */
 const restoreLocalSession = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
-  currentSession: { forecastCycle: ReturnType<typeof selectForecastCycle>; isSaved: boolean }
+  currentSession: { forecastCycle: ReturnType<typeof selectForecastCycle> }
 ): void => {
-  if (shouldSkipLocalRestore(currentSession.isSaved, currentSession.forecastCycle)) {
+  if (shouldSkipLocalRestore(currentSession.forecastCycle)) {
     return;
   }
 
@@ -728,7 +727,6 @@ const restoreAvailableSession = (
   addToast: AddToastFn,
   currentSession: {
     forecastCycle: ReturnType<typeof selectForecastCycle>;
-    isSaved: boolean;
     onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void;
   }
 ) => {
@@ -746,11 +744,11 @@ const useSessionRestore = (
   addToast: AddToastFn,
   currentSession: {
     forecastCycle: ReturnType<typeof selectForecastCycle>;
-    isSaved: boolean;
     onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void;
   }
 ) => {
   const onCloudCycleLoadedRef = useRef(currentSession.onCloudCycleLoaded);
+  const initialCycleRef = useRef(currentSession.forecastCycle);
   const [restoreComplete, setRestoreComplete] = useState(false);
 
   useEffect(() => {
@@ -760,8 +758,7 @@ const useSessionRestore = (
   useEffect(() => {
     try {
       restoreAvailableSession(dispatch, addToast, {
-        forecastCycle: currentSession.forecastCycle,
-        isSaved: currentSession.isSaved,
+        forecastCycle: initialCycleRef.current,
         onCloudCycleLoaded: onCloudCycleLoadedRef.current,
       });
     } catch {
@@ -769,7 +766,7 @@ const useSessionRestore = (
     } finally {
       setRestoreComplete(true);
     }
-  }, [dispatch, addToast, currentSession.forecastCycle, currentSession.isSaved]);
+  }, [dispatch, addToast]);
 
   return restoreComplete;
 };
@@ -1192,7 +1189,6 @@ const useForecastPageWorkspace = ({
 
   const restoreComplete = useSessionRestore(dispatch, addToast, {
     forecastCycle,
-    isSaved,
     onCloudCycleLoaded: handleCloudCycleLoaded,
   });
   useUnsavedChangesWarning(isSaved);

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -326,18 +326,19 @@ const useForecastSaveAction = (
   addToast: AddToastFn,
   forecastCycle: ReturnType<typeof selectForecastCycle>,
   mapRef: React.RefObject<ForecastMapHandle | null>,
-  user: ReturnType<typeof useAuth>['user']
+  user: ReturnType<typeof useAuth>['user'],
+  workflowMetadata?: import('../types/workflow').CycleMetadata
 ) => {
   return useCallback(() => {
     try {
-      exportForecastToJson(forecastCycle, buildMapView(mapRef));
+      exportForecastToJson(forecastCycle, buildMapView(mapRef), workflowMetadata);
       dispatch(markAsSaved());
       queueProductMetric({ event: 'cycle_saved', user });
       addToast('Forecast exported to JSON!', 'success');
     } catch {
       addToast('Error exporting forecast.', 'error');
     }
-  }, [forecastCycle, dispatch, addToast, mapRef, user]);
+  }, [forecastCycle, dispatch, addToast, mapRef, user, workflowMetadata]);
 };
 
 /** Returns a memoized async callback that parses and imports a forecast JSON file into Redux. */
@@ -1013,9 +1014,10 @@ const useForecastFileActions = (
   addToast: AddToastFn,
   forecastCycle: ReturnType<typeof selectForecastCycle>,
   mapRef: React.RefObject<ForecastMapHandle | null>,
-  user: ReturnType<typeof useAuth>['user']
+  user: ReturnType<typeof useAuth>['user'],
+  workflowMetadata?: import('../types/workflow').CycleMetadata
 ) => {
-  const handleSave = useForecastSaveAction(dispatch, addToast, forecastCycle, mapRef, user);
+  const handleSave = useForecastSaveAction(dispatch, addToast, forecastCycle, mapRef, user, workflowMetadata);
   const handleLoad = useForecastLoadAction(dispatch, addToast, mapRef);
 
   return { handleSave, handleLoad };
@@ -1173,6 +1175,7 @@ const useForecastPageWorkspace = ({
   const canRedo = useSelector(selectCanRedo);
   const emergencyMode = useSelector((state: RootState) => state.forecast.emergencyMode);
   const drawingState = useSelector((state: RootState) => state.forecast.drawingState);
+  const workflowMetadata = useSelector((state: RootState) => state.forecast.workflowMetadata);
   const { user } = useAuth();
   const { premiumActive, effectiveSource } = useEntitlement();
   const cloudCycles = useCloudCycles();
@@ -1208,7 +1211,8 @@ const useForecastPageWorkspace = ({
     addToast,
     forecastCycle,
     mapRef,
-    user
+    user,
+    workflowMetadata
   );
 
   useKeyboardShortcuts({

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -696,14 +696,20 @@ const restoreCloudSession = (
   return true;
 };
 
+/** Returns true when the current cycle should skip local auto-save restore (already saved, rolled over, or has discussion content). */
+const shouldSkipLocalRestore = (
+  isSaved: boolean,
+  forecastCycle: ReturnType<typeof selectForecastCycle>
+): boolean =>
+  !isSaved || hasRolloverForecastData(forecastCycle) || cycleHasDiscussionContent(forecastCycle);
+
 /** Restores the last local auto-saved forecast when no cloud-loaded payload is pending. */
 const restoreLocalSession = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
-  forecastCycle: ReturnType<typeof selectForecastCycle>,
-  isSaved: boolean
+  currentSession: { forecastCycle: ReturnType<typeof selectForecastCycle>; isSaved: boolean }
 ): void => {
-  if (!isSaved || hasRolloverForecastData(forecastCycle) || cycleHasDiscussionContent(forecastCycle)) {
+  if (shouldSkipLocalRestore(currentSession.isSaved, currentSession.forecastCycle)) {
     return;
   }
 
@@ -729,7 +735,7 @@ const restoreAvailableSession = (
     return;
   }
 
-  restoreLocalSession(dispatch, addToast, forecastCycle, isSaved);
+  restoreLocalSession(dispatch, addToast, { forecastCycle, isSaved });
 };
 
 /** Attempts to restore the last auto-saved forecast session from localStorage on mount. */

--- a/src/store/forecastSlice.test.ts
+++ b/src/store/forecastSlice.test.ts
@@ -1,5 +1,6 @@
 import type { Feature, Polygon } from 'geojson';
 import type { DayType } from '../types/outlooks';
+import type { WorkflowMetadata } from '../types/workflow';
 import reducer, {
   addFeature,
   applyAutoCategoricalSync,
@@ -20,6 +21,12 @@ import reducer, {
   markAsSaved,
   omitDay,
   validateCompletion,
+  startBlankCycle,
+  resumeIncompleteCycle,
+  createOutlookUpdate,
+  startFromPreviousCycle,
+  saveCurrentCycle,
+  updateDiscussion,
 } from './forecastSlice';
 
 const createPolygon = (offset: number): Polygon => ({
@@ -547,5 +554,272 @@ describe('forecastSlice undo/redo', () => {
     expect(nextState.forecastCycle.omittedDayReasons).toEqual({ 3: 'No severe weather expected' });
     expect(nextState.isSaved).toBe(false);
     expect(nextState.completionValidation.omittedDays).toEqual({});
+  });
+
+  it('invalidates completed package acknowledgement when an outlook is edited', () => {
+    let state = reducer(undefined, startBlankCycle({
+      workflowTemplate: { id: 'severe-day1', label: 'Severe Convective Day 1', groupings: ['day1'] },
+      cycleDate: '2026-07-04',
+    }));
+    state = reducer(state, addFeature({ feature: createBaseFeature('tor-1', 0, { outlookType: 'tornado', probability: '2%' }) }));
+    state = reducer(state, addFeature({ feature: createBaseFeature('wind-1', 2, { outlookType: 'wind', probability: '5%' }) }));
+    state = reducer(state, addFeature({ feature: createBaseFeature('hail-1', 4, { outlookType: 'hail', probability: '5%' }) }));
+    state = reducer(state, addFeature({ feature: createBaseFeature('cat-1', 6, { outlookType: 'categorical', probability: 'SLGT' }) }));
+    state = reducer(state, updateDiscussion({
+      day: 1,
+      discussion: {
+        mode: 'diy',
+        validStart: '2026-07-04T12:00',
+        validEnd: '2026-07-05T12:00',
+        forecasterName: 'Test',
+        diyContent: 'Severe storms possible.',
+        lastModified: '2026-07-04T12:00:00.000Z',
+      },
+    }));
+    state = reducer(state, validateCompletion());
+    state = reducer(state, completeCycle());
+
+    expect(state.forecastCycle.completionAcknowledgedAt).toEqual(expect.any(String));
+
+    state = reducer(state, removeFeature({
+      outlookType: 'tornado',
+      probability: '2%',
+      featureId: 'tor-1',
+    }));
+
+    expect(state.forecastCycle.completionAcknowledgedAt).toBeUndefined();
+
+    state = reducer(state, validateCompletion());
+
+    expect(state.completionValidation.lastResult?.isComplete).toBe(false);
+    expect(state.completionValidation.lastResult?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          day: 'day1',
+          outlookType: 'tornado',
+          type: 'missing-polygon',
+          severity: 'critical',
+        }),
+      ]),
+    );
+  });
+
+  describe('WF-04: Workflow entry, resume, update, and base-cycle actions', () => {
+    const testWorkflowTemplate: WorkflowMetadata = {
+      id: 'severe-day1',
+      label: 'Severe Convective Day 1',
+      groupings: ['day1'],
+    };
+
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    describe('startBlankCycle', () => {
+      it('starts a blank cycle without workflow metadata', () => {
+        const state = reducer(undefined, startBlankCycle({}));
+        
+        expect(state.forecastCycle.days[1]).toBeDefined();
+        expect(state.forecastCycle.currentDay).toBe(1);
+        expect(state.isSaved).toBe(false);
+        expect(state.outlookVersionSnapshots).toEqual([]);
+        expect(state.workflowMetadata).toBeUndefined();
+        expect(state.workflowTemplate).toBeUndefined();
+      });
+
+      it('starts a blank cycle with workflow metadata', () => {
+        const state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+          cycleDate: '2026-07-04',
+        }));
+        
+        expect(state.forecastCycle.cycleDate).toBe('2026-07-04');
+        expect(state.workflowTemplate).toEqual(testWorkflowTemplate);
+        expect(state.workflowMetadata).toBeDefined();
+        expect(state.workflowMetadata?.workflowId).toBe('severe-day1');
+        expect(state.workflowMetadata?.cycleDate).toBe('2026-07-04');
+        expect(state.workflowMetadata?.status).toBe('in-progress');
+        expect(state.workflowMetadata?.outlookVersions).toHaveLength(1);
+        expect(state.workflowMetadata?.outlookVersions[0].version).toBe(1);
+        expect(state.workflowMetadata?.outlookVersions[0].status).toBe('in-progress');
+        expect(state.isWorkflowActive).toBe(true);
+        expect(localStorage.getItem('gfc-active-forecast-workflow')).toBe('true');
+      });
+
+      it('starts workflow templates on their matching forecast day', () => {
+        const day2State = reducer(undefined, startBlankCycle({
+          workflowTemplate: { id: 'severe-day2', label: 'Severe Convective Day 2', groupings: ['day2'] },
+          cycleDate: '2026-07-04',
+        }));
+        const day48State = reducer(undefined, startBlankCycle({
+          workflowTemplate: { id: 'severe-day4-8', label: 'Severe Convective Days 4-8', groupings: ['day4-8'] },
+          cycleDate: '2026-07-04',
+        }));
+
+        expect(day2State.forecastCycle.currentDay).toBe(2);
+        expect(day2State.forecastCycle.days[2]).toBeDefined();
+        expect(day48State.forecastCycle.currentDay).toBe(4);
+        expect(day48State.forecastCycle.days[4]).toBeDefined();
+      });
+    });
+
+    it('validates completion against the active workflow groupings only', () => {
+      let state = reducer(undefined, startBlankCycle({
+        workflowTemplate: testWorkflowTemplate,
+        cycleDate: '2026-07-04',
+      }));
+
+      state = reducer(state, validateCompletion());
+
+      expect(state.completionValidation.lastResult?.missingGroupings).toEqual(['day1']);
+      expect(state.completionValidation.lastResult?.issues.every((issue) => issue.day === 'day1')).toBe(true);
+    });
+
+    describe('resumeIncompleteCycle', () => {
+      it('resumes a saved cycle and restores workflow metadata', () => {
+        // First create a saved cycle with workflow metadata
+        let state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        state = reducer(state, markAsSaved());
+        state = reducer(state, saveCurrentCycle({ label: 'Test Cycle' }));
+        
+        const savedCycleId = state.savedCycles[0].id;
+        
+        // Reset to a new cycle
+        state = reducer(state, resetForecasts());
+        expect(state.workflowMetadata).toBeUndefined();
+        
+        // Resume the saved cycle
+        state = reducer(state, resumeIncompleteCycle({ cycleId: savedCycleId }));
+        
+        expect(state.workflowMetadata).toBeDefined();
+        expect(state.workflowMetadata?.workflowId).toBe('severe-day1');
+        expect(state.isSaved).toBe(true);
+        expect(state.outlookVersionSnapshots).toEqual([]);
+      });
+
+      it('does nothing if cycle ID is not found', () => {
+        const initialState = reducer(undefined, startBlankCycle({}));
+        const state = reducer(initialState, resumeIncompleteCycle({ cycleId: 'nonexistent' }));
+        
+        expect(state).toEqual(initialState);
+      });
+    });
+
+    describe('createOutlookUpdate', () => {
+      it('creates a new outlook version within the current cycle', () => {
+        // Start a workflow cycle
+        let state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        
+        expect(state.workflowMetadata?.outlookVersions).toHaveLength(1);
+        expect(state.workflowMetadata?.outlookVersions[0].version).toBe(1);
+        
+        // Create an update
+        state = reducer(state, createOutlookUpdate());
+        
+        expect(state.workflowMetadata?.outlookVersions).toHaveLength(2);
+        expect(state.workflowMetadata?.outlookVersions[0].status).toBe('completed');
+        expect(state.workflowMetadata?.outlookVersions[1].version).toBe(2);
+        expect(state.workflowMetadata?.outlookVersions[1].status).toBe('in-progress');
+        expect(state.workflowMetadata?.outlookVersions[1].derivedFrom).toBe(1);
+        expect(state.forecastCycle.updateInProgressVersion).toBe(2);
+        expect(state.isSaved).toBe(false);
+      });
+
+      it('clears reviewed package state when creating a same-day update', () => {
+        let state = reducer(undefined, startBlankCycle({
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        state = reducer(state, completeCycle());
+
+        expect(state.forecastCycle.completionAcknowledgedAt).toEqual(expect.any(String));
+
+        state = reducer(state, createOutlookUpdate());
+
+        expect(state.forecastCycle.completionAcknowledgedAt).toBeUndefined();
+        expect(state.forecastCycle.updateInProgressVersion).toBe(2);
+        expect(state.workflowMetadata?.status).toBe('in-progress');
+
+        state = reducer(state, completeCycle());
+
+        expect(state.forecastCycle.updateInProgressVersion).toBeUndefined();
+      });
+
+      it('creates multiple updates incrementing version numbers', () => {
+        let state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        
+        state = reducer(state, createOutlookUpdate());
+        state = reducer(state, createOutlookUpdate());
+        state = reducer(state, createOutlookUpdate());
+        
+        expect(state.workflowMetadata?.outlookVersions).toHaveLength(4);
+        expect(state.workflowMetadata?.outlookVersions[3].version).toBe(4);
+        expect(state.workflowMetadata?.outlookVersions[3].derivedFrom).toBe(3);
+      });
+    });
+
+    describe('startFromPreviousCycle', () => {
+      it('creates a new cycle derived from a previous cycle', () => {
+        // Create and save a cycle with workflow metadata
+        let state = reducer(undefined, startBlankCycle({ 
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        state = reducer(state, addFeature({ feature: createFeature('previous-day-1', 0) }));
+        state = reducer(state, markAsSaved());
+        state = reducer(state, saveCurrentCycle({ label: 'Previous Cycle' }));
+        
+        const previousCycleId = state.savedCycles[0].id;
+        
+        // Start a new cycle from the previous one
+        state = reducer(state, startFromPreviousCycle({
+          sourceCycleId: previousCycleId,
+          newCycleDate: '2026-07-05',
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        
+        expect(state.forecastCycle.cycleDate).toBe('2026-07-05');
+        expect(state.forecastCycle.currentDay).toBe(1);
+        expect(state.forecastCycle.days[1]?.data.tornado?.get('2%')?.[0].id).toBe('previous-day-1');
+        expect(state.forecastCycle.days[2]).toBeUndefined();
+        expect(state.workflowMetadata).toBeDefined();
+        expect(state.workflowMetadata?.workflowId).toBe('severe-day1');
+        expect(state.workflowMetadata?.cycleDate).toBe('2026-07-05');
+        expect(state.workflowMetadata?.status).toBe('in-progress');
+        expect(state.isSaved).toBe(false);
+        expect(state.outlookVersionSnapshots).toEqual([]);
+      });
+
+      it('copies the requested previous day into the requested target day', () => {
+        let state = reducer(undefined, setForecastDay(2));
+        state = reducer(state, addFeature({ feature: createFeature('previous-day-2', 0) }));
+        state = reducer(state, saveCurrentCycle({ label: 'Yesterday Day 2' }));
+
+        state = reducer(state, startFromPreviousCycle({
+          sourceCycleId: state.savedCycles[0].id,
+          sourceDay: 2,
+          targetDay: 1,
+          newCycleDate: '2026-07-05',
+        }));
+
+        expect(state.forecastCycle.cycleDate).toBe('2026-07-05');
+        expect(state.forecastCycle.currentDay).toBe(1);
+        expect(state.forecastCycle.days[1]?.data.tornado?.get('2%')?.[0].id).toBe('previous-day-2');
+        expect(state.forecastCycle.days[2]).toBeUndefined();
+      });
+
+      it('does nothing if source cycle ID is not found', () => {
+        const initialState = reducer(undefined, startBlankCycle({}));
+        const state = reducer(initialState, startFromPreviousCycle({
+          sourceCycleId: 'nonexistent',
+        }));
+        
+        expect(state).toEqual(initialState);
+      });
+    });
   });
 });

--- a/src/store/forecastSlice.test.ts
+++ b/src/store/forecastSlice.test.ts
@@ -817,8 +817,47 @@ describe('forecastSlice undo/redo', () => {
         const state = reducer(initialState, startFromPreviousCycle({
           sourceCycleId: 'nonexistent',
         }));
-        
+
         expect(state).toEqual(initialState);
+      });
+
+      it('leaves workflow inactive when the source is a plain (non-workflow) cycle and no template is passed', () => {
+        let state = reducer(undefined, setForecastDay(1));
+        state = reducer(state, addFeature({ feature: createFeature('plain-day-1', 0) }));
+        state = reducer(state, markAsSaved());
+        state = reducer(state, saveCurrentCycle({ label: 'Plain Previous Cycle' }));
+
+        const plainSourceId = state.savedCycles[0].id;
+
+        state = reducer(state, startFromPreviousCycle({
+          sourceCycleId: plainSourceId,
+          newCycleDate: '2026-07-05',
+        }));
+
+        expect(state.workflowMetadata).toBeUndefined();
+        expect(state.isWorkflowActive).toBe(false);
+        expect(state.workflowTemplate).toBeUndefined();
+        expect(state.forecastCycle.days[1]?.data.tornado?.get('2%')?.[0].id).toBe('plain-day-1');
+      });
+    });
+
+    describe('createOutlookUpdate snapshot scope', () => {
+      it('snapshots every populated day, not only the current one', () => {
+        let state = reducer(undefined, startBlankCycle({
+          workflowTemplate: testWorkflowTemplate,
+        }));
+        state = reducer(state, setForecastDay(1));
+        state = reducer(state, addFeature({ feature: createFeature('day-1-feature', 0) }));
+        state = reducer(state, setForecastDay(2));
+        state = reducer(state, addFeature({ feature: createFeature('day-2-feature', 0) }));
+        state = reducer(state, setForecastDay(2));
+
+        state = reducer(state, createOutlookUpdate());
+
+        const snapshot = state.outlookVersionSnapshots[0];
+        expect(snapshot).toBeDefined();
+        expect(snapshot.days[1]?.data.tornado?.get('2%')?.[0].id).toBe('day-1-feature');
+        expect(snapshot.days[2]?.data.tornado?.get('2%')?.[0].id).toBe('day-2-feature');
       });
     });
   });

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -100,6 +100,7 @@ const ALL_OUTLOOK_TYPES: OutlookType[] = [
 ];
 const DIRECT_DAY12_COPY_TYPES: OutlookType[] = ['tornado', 'wind', 'hail', 'categorical'];
 
+/** Reads the persisted workflow-active flag from localStorage, returning false when storage is blocked or unset. */
 const readStoredWorkflowActive = (): boolean => {
   try {
     return localStorage.getItem(WORKFLOW_ACTIVE_STORAGE_KEY) === 'true';
@@ -108,6 +109,7 @@ const readStoredWorkflowActive = (): boolean => {
   }
 };
 
+/** Persists or clears the workflow-active flag in localStorage, swallowing storage errors to keep the workflow usable. */
 const writeStoredWorkflowActive = (isActive: boolean) => {
   try {
     if (isActive) {
@@ -120,6 +122,7 @@ const writeStoredWorkflowActive = (isActive: boolean) => {
   }
 };
 
+/** Resolves the starting forecast day implied by a workflow template's first grouping, defaulting to day 1. */
 const getWorkflowStartDay = (template?: WorkflowMetadata): DayType => {
   const firstGrouping = template?.groupings[0];
   if (firstGrouping === 'day2') return 2;
@@ -128,6 +131,7 @@ const getWorkflowStartDay = (template?: WorkflowMetadata): DayType => {
   return 1;
 };
 
+/** Filters a template's groupings to the standard set used by completion validation, returning undefined when none qualify. */
 const getWorkflowValidationGroupings = (template?: WorkflowMetadata): StandardGrouping[] | undefined => {
   const standardGroupings = (template?.groupings ?? []).filter(
     (grouping): grouping is StandardGrouping =>

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -236,6 +236,67 @@ const createEmptyOutlook = (day: DayType): OutlookDay => {
   };
 };
 
+interface ApplyRolloverArgs {
+  sourceCycle: ForecastState['savedCycles'][number];
+  sourceDayData: ReturnType<typeof normalizeForecastCycle>['days'][DayType];
+  sourceDayNumber: DayType;
+  targetDay: DayType;
+  targetDate: string;
+  workflowTemplate?: WorkflowMetadata;
+}
+
+/** Builds the fresh rollover cycle and copies the requested day into it. */
+const buildRolloverCycle = ({
+  sourceDayData,
+  sourceDayNumber,
+  targetDay,
+  targetDate,
+}: Omit<ApplyRolloverArgs, 'sourceCycle' | 'workflowTemplate'>): ForecastCycle => {
+  const newCycle: ForecastCycle = {
+    days: { [targetDay]: createEmptyOutlook(targetDay) },
+    currentDay: targetDay,
+    cycleDate: targetDate,
+  };
+  const targetDayData = newCycle.days[targetDay];
+  if (targetDayData) {
+    copyCompatibleOutlooks(sourceDayData.data, targetDayData.data, sourceDayNumber, targetDay);
+  }
+  return newCycle;
+};
+
+/**
+ * Attaches workflow metadata to the rollover only when a template was passed
+ * or the source cycle was already a workflow cycle. Plain rollovers stay plain.
+ */
+const applyRolloverWorkflowState = (
+  state: ForecastState,
+  { sourceCycle, targetDate, workflowTemplate }: Pick<ApplyRolloverArgs, 'sourceCycle' | 'targetDate' | 'workflowTemplate'>,
+  now: string
+) => {
+  const sourceHadWorkflow = Boolean(sourceCycle.workflowMetadata);
+  if (workflowTemplate || sourceHadWorkflow) {
+    const workflowId = resolveWorkflowId(workflowTemplate, sourceCycle.workflowMetadata);
+    state.workflowMetadata = createInitialCycleMetadata(workflowId, targetDate, now);
+    state.isWorkflowActive = true;
+    writeStoredWorkflowActive(true);
+    state.workflowTemplate = workflowTemplate || getWorkflowTemplateById(workflowId) || undefined;
+    return;
+  }
+  state.workflowMetadata = undefined;
+  state.isWorkflowActive = false;
+  writeStoredWorkflowActive(false);
+  state.workflowTemplate = undefined;
+};
+
+/** Resets the in-memory cycle to a fresh rollover derived from the requested source. */
+const applyRolloverFromPreviousCycle = (state: ForecastState, args: ApplyRolloverArgs) => {
+  clearHistory(state);
+  state.forecastCycle = buildRolloverCycle(args);
+  state.isSaved = false;
+  state.outlookVersionSnapshots = [];
+  applyRolloverWorkflowState(state, args, new Date().toISOString());
+};
+
 const initialState: ForecastState = {
   forecastCycle: {
     days: {
@@ -1210,51 +1271,23 @@ export const forecastSlice = createSlice({
       workflowTemplate?: WorkflowMetadata;
     }>) => {
       const { sourceCycleId, newCycleDate, sourceDay, targetDay = 1, workflowTemplate } = action.payload;
-      
-      // Find the source cycle in saved cycles
+
       const sourceCycle = state.savedCycles.find(c => c.id === sourceCycleId);
       if (!sourceCycle) return;
-      
-      const now = new Date().toISOString();
-      const targetDate = newCycleDate || getLocalCalendarDate();
-      
+
       const sourceForecastCycle = normalizeForecastCycle(sourceCycle.forecastCycle);
       const sourceDayNumber = sourceDay ?? sourceForecastCycle.currentDay;
       const sourceDayData = sourceForecastCycle.days[sourceDayNumber];
       if (!sourceDayData) return;
 
-      // Create a fresh cycle and copy only the requested, compatible outlook data
-      // so "start from previous" is a new package, not an import of the old one.
-      clearHistory(state);
-      const newCycle: ForecastCycle = {
-        days: { [targetDay]: createEmptyOutlook(targetDay) },
-        currentDay: targetDay,
-        cycleDate: targetDate,
-      };
-      const targetDayData = newCycle.days[targetDay];
-      if (targetDayData) {
-        copyCompatibleOutlooks(sourceDayData.data, targetDayData.data, sourceDayNumber, targetDay);
-      }
-      state.forecastCycle = newCycle;
-      state.isSaved = false;
-      state.outlookVersionSnapshots = [];
-
-      // Only attach workflow metadata when the caller opted in via a template
-      // or the source cycle was already a workflow cycle. Plain "start from
-      // previous" should not synthesize a workflow for non-workflow forecasts.
-      const sourceHadWorkflow = Boolean(sourceCycle.workflowMetadata);
-      if (workflowTemplate || sourceHadWorkflow) {
-        const workflowId = resolveWorkflowId(workflowTemplate, sourceCycle.workflowMetadata);
-        state.workflowMetadata = createInitialCycleMetadata(workflowId, targetDate, now);
-        state.isWorkflowActive = true;
-        writeStoredWorkflowActive(true);
-        state.workflowTemplate = workflowTemplate || getWorkflowTemplateById(workflowId) || undefined;
-      } else {
-        state.workflowMetadata = undefined;
-        state.isWorkflowActive = false;
-        writeStoredWorkflowActive(false);
-        state.workflowTemplate = undefined;
-      }
+      applyRolloverFromPreviousCycle(state, {
+        sourceCycle,
+        sourceDayData,
+        sourceDayNumber,
+        targetDay,
+        targetDate: newCycleDate || getLocalCalendarDate(),
+        workflowTemplate,
+      });
     },
   }
 });

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1145,27 +1145,33 @@ export const forecastSlice = createSlice({
     /** Create a new outlook version within the current cycle (same-cycle update). */
     createOutlookUpdate: (state) => {
       const now = new Date().toISOString();
-      
+
       // Determine the next version number
       const currentVersions = state.workflowMetadata?.outlookVersions || [];
-      const nextVersion = currentVersions.length > 0 
-        ? Math.max(...currentVersions.map(v => v.version)) + 1 
+      const nextVersion = currentVersions.length > 0
+        ? Math.max(...currentVersions.map(v => v.version)) + 1
         : 1;
-      
-      // Snapshot the current day data before creating the update
-      const currentDay = state.forecastCycle.currentDay;
-      const currentDayData = state.forecastCycle.days[currentDay];
-      
-      if (currentDayData) {
-        // Store a snapshot of the current version, preserving Map-backed outlook data
+
+      // Snapshot every day that has data so full-outlook workflows keep
+      // the whole version side-by-side with the next iteration, not just
+      // the currently selected day.
+      const snapshotDays: typeof state.forecastCycle.days = {};
+      let hasSnapshot = false;
+      (Object.entries(state.forecastCycle.days) as [DayType, typeof state.forecastCycle.days[DayType]][]).forEach(
+        ([day, dayData]) => {
+          if (!dayData) return;
+          snapshotDays[day] = {
+            ...dayData,
+            data: cloneOutlookData(dayData.data),
+          };
+          hasSnapshot = true;
+        },
+      );
+
+      if (hasSnapshot) {
         state.outlookVersionSnapshots.push({
           version: nextVersion - 1, // Snapshot the previous version
-          days: { 
-            [currentDay]: {
-              ...currentDayData,
-              data: cloneOutlookData(currentDayData.data),
-            } 
-          },
+          days: snapshotDays,
           createdAt: now,
         });
       }
@@ -1232,15 +1238,23 @@ export const forecastSlice = createSlice({
       state.forecastCycle = newCycle;
       state.isSaved = false;
       state.outlookVersionSnapshots = [];
-      
-      // Set workflow metadata with derivedFromCycleId
-      const workflowId = resolveWorkflowId(workflowTemplate, sourceCycle.workflowMetadata);
-      state.workflowMetadata = createInitialCycleMetadata(workflowId, targetDate, now);
-      state.isWorkflowActive = true;
-      writeStoredWorkflowActive(true);
-      
-      // Restore or set workflow template
-      state.workflowTemplate = workflowTemplate || getWorkflowTemplateById(workflowId) || undefined;
+
+      // Only attach workflow metadata when the caller opted in via a template
+      // or the source cycle was already a workflow cycle. Plain "start from
+      // previous" should not synthesize a workflow for non-workflow forecasts.
+      const sourceHadWorkflow = Boolean(sourceCycle.workflowMetadata);
+      if (workflowTemplate || sourceHadWorkflow) {
+        const workflowId = resolveWorkflowId(workflowTemplate, sourceCycle.workflowMetadata);
+        state.workflowMetadata = createInitialCycleMetadata(workflowId, targetDate, now);
+        state.isWorkflowActive = true;
+        writeStoredWorkflowActive(true);
+        state.workflowTemplate = workflowTemplate || getWorkflowTemplateById(workflowId) || undefined;
+      } else {
+        state.workflowMetadata = undefined;
+        state.isWorkflowActive = false;
+        writeStoredWorkflowActive(false);
+        state.workflowTemplate = undefined;
+      }
     },
   }
 });

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1,7 +1,7 @@
 import '../immerSetup';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { OutlookData, OutlookType, DrawingState, ForecastCycle, DayType, OutlookDay, DiscussionData, Probability } from '../types/outlooks';
-import type { CycleMetadata, WorkflowMetadata, Package, CycleValidationResult } from '../types/workflow';
+import type { CycleMetadata, WorkflowMetadata, Package, CycleValidationResult, StandardGrouping } from '../types/workflow';
 import { normalizeForecastCycle } from '../utils/outlookMapCoercion';
 import type { Feature } from 'geojson';
 import { RootState } from './index'; // Need RootState for selectors
@@ -10,6 +10,7 @@ import { countForecastMetrics } from '../utils/forecastMetrics';
 import { getLocalCalendarDate } from '../utils/localDate';
 import { areTstmFeaturesEqual } from '../utils/tstmGeneration';
 import { validateCycleCompletion } from '../utils/completionValidation';
+import { getWorkflowTemplateById } from '../components/ForecastWorkflow/workflowTemplates';
 
 export interface SavedCycleStats {
   forecastDays: number;
@@ -43,11 +44,15 @@ export interface ForecastState {
   workflowMetadata?: CycleMetadata;
   /** v2 workflow template metadata (optional, present when the editor is in workflow mode). */
   workflowTemplate?: WorkflowMetadata;
+  /** Whether the forecast workflow shell should be active across routes. */
+  isWorkflowActive: boolean;
   completionValidation: {
     lastResult: CycleValidationResult | null;
     showCompletionModal: boolean;
     omittedDays: Partial<Record<DayType, string>>;
   };
+  /** v2 outlook version snapshots for the active cycle (used for same-cycle updates). */
+  outlookVersionSnapshots: OutlookVersionSnapshot[];
 }
 
 interface ForecastDaySnapshot {
@@ -66,6 +71,16 @@ interface ForecastHistoryStacks {
   redoStack: ForecastHistoryEntry[];
 }
 
+/** Stores a snapshot of outlook data for a specific version within a cycle. */
+interface OutlookVersionSnapshot {
+  /** Version number within the cycle. */
+  version: number;
+  /** Snapshot of day data for this version. */
+  days: Partial<Record<DayType, OutlookDay>>;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+}
+
 type DayBucket = 'day12' | 'day3' | 'day48';
 
 interface CopyFeatureRule {
@@ -74,6 +89,7 @@ interface CopyFeatureRule {
 }
 
 const HISTORY_LIMIT = 50;
+const WORKFLOW_ACTIVE_STORAGE_KEY = 'gfc-active-forecast-workflow';
 const ALL_OUTLOOK_TYPES: OutlookType[] = [
   'tornado',
   'wind',
@@ -83,6 +99,67 @@ const ALL_OUTLOOK_TYPES: OutlookType[] = [
   'day4-8',
 ];
 const DIRECT_DAY12_COPY_TYPES: OutlookType[] = ['tornado', 'wind', 'hail', 'categorical'];
+
+const readStoredWorkflowActive = (): boolean => {
+  try {
+    return localStorage.getItem(WORKFLOW_ACTIVE_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+const writeStoredWorkflowActive = (isActive: boolean) => {
+  try {
+    if (isActive) {
+      localStorage.setItem(WORKFLOW_ACTIVE_STORAGE_KEY, 'true');
+      return;
+    }
+    localStorage.removeItem(WORKFLOW_ACTIVE_STORAGE_KEY);
+  } catch {
+    // Keep workflow state usable when storage is blocked.
+  }
+};
+
+const getWorkflowStartDay = (template?: WorkflowMetadata): DayType => {
+  const firstGrouping = template?.groupings[0];
+  if (firstGrouping === 'day2') return 2;
+  if (firstGrouping === 'day3') return 3;
+  if (firstGrouping === 'day4-8') return 4;
+  return 1;
+};
+
+const getWorkflowValidationGroupings = (template?: WorkflowMetadata): StandardGrouping[] | undefined => {
+  const standardGroupings = (template?.groupings ?? []).filter(
+    (grouping): grouping is StandardGrouping =>
+      grouping === 'day1' || grouping === 'day2' || grouping === 'day3' || grouping === 'day4-8',
+  );
+  return standardGroupings.length > 0 ? standardGroupings : undefined;
+};
+
+/** Resolves the workflow ID from template or cycle metadata, falling back to 'default'. */
+const resolveWorkflowId = (
+  template?: WorkflowMetadata,
+  cycleMetadata?: CycleMetadata,
+): string => template?.id || cycleMetadata?.workflowId || 'default';
+
+/** Creates initial CycleMetadata for a new cycle. */
+const createInitialCycleMetadata = (
+  workflowId: string,
+  cycleDate: string,
+  now: string,
+): CycleMetadata => ({
+  id: `WF-${workflowId}-${cycleDate}`,
+  workflowId,
+  cycleDate,
+  status: 'in-progress',
+  outlookVersions: [{
+    version: 1,
+    status: 'in-progress',
+    createdAt: now,
+  }],
+  createdAt: now,
+  updatedAt: now,
+});
 const COPY_FEATURE_RULES: Record<DayBucket, Record<DayBucket, CopyFeatureRule[]>> = {
   day12: {
     day12: DIRECT_DAY12_COPY_TYPES.map((type) => ({ sourceType: type, targetType: type })),
@@ -181,7 +258,9 @@ const initialState: ForecastState = {
     lastResult: null,
     showCompletionModal: false,
     omittedDays: {},
-  }
+  },
+  isWorkflowActive: readStoredWorkflowActive(),
+  outlookVersionSnapshots: [],
 };
 
 // Helpers to keep reducers small and testable
@@ -367,6 +446,15 @@ const clearHistory = (state: ForecastState) => {
   state.historyByDay = {};
 };
 
+/** Clears stale package completion when forecast package content changes. */
+const invalidateCompletionAcknowledgement = (state: ForecastState) => {
+  if (state.forecastCycle.completionAcknowledgedAt || state.forecastCycle.omittedDayReasons) {
+    delete state.forecastCycle.completionAcknowledgedAt;
+    delete state.forecastCycle.omittedDayReasons;
+  }
+  state.completionValidation.lastResult = null;
+};
+
 /** Ensures low-probability metadata exists before mutating it in reducers. */
 const ensureLowProbabilityOutlooks = (dayData: OutlookDay): OutlookType[] => {
   if (!dayData.metadata.lowProbabilityOutlooks) {
@@ -410,6 +498,7 @@ const applyLowProbabilityState = (
     dayData.metadata.lowProbabilityOutlooks = lowProbabilityOutlooks.filter((type) => type !== outlookType);
   }
 
+  invalidateCompletionAcknowledgement(state);
   state.isSaved = false;
 };
 
@@ -520,6 +609,7 @@ export const forecastSlice = createSlice({
       );
 
       outlookMap.set(probability, [...existingFeatures, featureWithProps]);
+      invalidateCompletionAcknowledgement(state);
       state.isSaved = false;
     },
 
@@ -549,6 +639,7 @@ export const forecastSlice = createSlice({
               ...feature.properties
             }
           };
+          invalidateCompletionAcknowledgement(state);
           state.isSaved = false;
         }
       }
@@ -586,6 +677,7 @@ export const forecastSlice = createSlice({
           outlookMap.delete(probability);
         }
 
+        invalidateCompletionAcknowledgement(state);
         state.isSaved = false;
       }
     },
@@ -606,6 +698,7 @@ export const forecastSlice = createSlice({
       if (tstmFeatures.length > 0) {
         outlooks.categorical.set('TSTM', tstmFeatures);
       }
+      invalidateCompletionAcknowledgement(state);
       state.isSaved = false;
     },
 
@@ -627,6 +720,7 @@ export const forecastSlice = createSlice({
         pushUndoSnapshot(state);
         // @ts-ignore - Dynamic property assignment
         outlookData[outlookType] = map;
+        invalidateCompletionAcknowledgement(state);
         state.isSaved = false;
       }
     },
@@ -638,6 +732,7 @@ export const forecastSlice = createSlice({
       }
 
       outlookData.categorical = action.payload.map;
+      invalidateCompletionAcknowledgement(state);
       state.isSaved = false;
     },
 
@@ -664,6 +759,7 @@ export const forecastSlice = createSlice({
         outlookData.categorical.delete('TSTM');
       }
 
+      invalidateCompletionAcknowledgement(state);
       state.isSaved = false;
     },
 
@@ -694,6 +790,11 @@ export const forecastSlice = createSlice({
 
       state.forecastCycle = newCycle;
       state.isSaved = false;
+      state.outlookVersionSnapshots = [];
+      state.workflowMetadata = undefined;
+      state.workflowTemplate = undefined;
+      state.isWorkflowActive = false;
+      writeStoredWorkflowActive(false);
     },
 
     markAsSaved: (state) => {
@@ -705,6 +806,12 @@ export const forecastSlice = createSlice({
       state.forecastCycle = action.payload;
       clearHistory(state);
       state.isSaved = true;
+      state.outlookVersionSnapshots = [];
+      // Clear workflow state when importing a plain forecast cycle
+      state.workflowMetadata = undefined;
+      state.workflowTemplate = undefined;
+      state.isWorkflowActive = false;
+      writeStoredWorkflowActive(false);
     },
 
     // Legacy import support (Single day) -> Import into CURRENT day
@@ -752,6 +859,7 @@ export const forecastSlice = createSlice({
       if (dayData) {
         dayData.discussion = discussion;
         dayData.metadata.lastModified = new Date().toISOString();
+        invalidateCompletionAcknowledgement(state);
         state.isSaved = false;
       }
     },
@@ -766,6 +874,7 @@ export const forecastSlice = createSlice({
         label: action.payload.label,
         forecastCycle: forecastCycleSnapshot,
         stats: countForecastMetrics(forecastCycleSnapshot),
+        workflowMetadata: state.workflowMetadata ? { ...state.workflowMetadata } : undefined,
       };
       state.savedCycles.push(savedCycle);
       state.isSaved = true;
@@ -778,6 +887,25 @@ export const forecastSlice = createSlice({
         state.forecastCycle = cloneForecastCycle(normalizeForecastCycle(savedCycle.forecastCycle));
         clearHistory(state);
         state.isSaved = true;
+        state.outlookVersionSnapshots = [];
+        
+        // Restore or clear workflow metadata
+        if (savedCycle.workflowMetadata) {
+          state.workflowMetadata = savedCycle.workflowMetadata;
+          // Restore the workflow template from the workflowId
+          state.workflowTemplate = getWorkflowTemplateById(savedCycle.workflowMetadata.workflowId) || {
+            id: savedCycle.workflowMetadata.workflowId,
+            label: savedCycle.workflowMetadata.workflowId,
+            groupings: [],
+          };
+          state.isWorkflowActive = true;
+          writeStoredWorkflowActive(true);
+        } else {
+          state.workflowMetadata = undefined;
+          state.workflowTemplate = undefined;
+          state.isWorkflowActive = false;
+          writeStoredWorkflowActive(false);
+        }
       }
     },
 
@@ -854,6 +982,9 @@ export const forecastSlice = createSlice({
     // v2 workflow metadata reducers
     setWorkflowMetadata: (state, action: PayloadAction<CycleMetadata>) => {
       state.workflowMetadata = action.payload;
+      state.workflowTemplate = getWorkflowTemplateById(action.payload.workflowId) || state.workflowTemplate;
+      state.isWorkflowActive = true;
+      writeStoredWorkflowActive(true);
     },
 
     setWorkflowTemplate: (state, action: PayloadAction<WorkflowMetadata>) => {
@@ -865,9 +996,11 @@ export const forecastSlice = createSlice({
       // Import the first cycle's metadata (packages typically have one cycle)
       if (pkg.cycles.length > 0) {
         state.workflowMetadata = pkg.cycles[0];
+        state.isWorkflowActive = true;
+        writeStoredWorkflowActive(true);
       }
       if (pkg.metadata) {
-        state.workflowTemplate = {
+        state.workflowTemplate = getWorkflowTemplateById(pkg.metadata.workflowId) || {
           id: pkg.metadata.workflowId,
           label: pkg.metadata.workflowId,
           groupings: [],
@@ -875,11 +1008,15 @@ export const forecastSlice = createSlice({
       }
       clearHistory(state);
       state.isSaved = true;
+      state.outlookVersionSnapshots = [];
     },
 
     // Completion validation (WF-03)
     validateCompletion: (state) => {
-      const result = validateCycleCompletion(state.forecastCycle);
+      const result = validateCycleCompletion(
+        state.forecastCycle,
+        getWorkflowValidationGroupings(state.workflowTemplate),
+      );
       state.completionValidation.lastResult = result;
       state.completionValidation.omittedDays = {};
       state.completionValidation.showCompletionModal = true;
@@ -897,6 +1034,7 @@ export const forecastSlice = createSlice({
     completeCycle: (state) => {
       state.forecastCycle.completionAcknowledgedAt = new Date().toISOString();
       delete state.forecastCycle.omittedDayReasons;
+      delete state.forecastCycle.updateInProgressVersion;
       state.completionValidation.showCompletionModal = false;
       state.completionValidation.lastResult = null;
       state.completionValidation.omittedDays = {};
@@ -906,6 +1044,7 @@ export const forecastSlice = createSlice({
     completeWithOmissions: (state) => {
       state.forecastCycle.completionAcknowledgedAt = new Date().toISOString();
       state.forecastCycle.omittedDayReasons = { ...state.completionValidation.omittedDays };
+      delete state.forecastCycle.updateInProgressVersion;
       state.completionValidation.showCompletionModal = false;
       state.completionValidation.lastResult = null;
       state.completionValidation.omittedDays = {};
@@ -914,6 +1053,190 @@ export const forecastSlice = createSlice({
 
     clearOmittedDays: (state) => {
       state.completionValidation.omittedDays = {};
+    },
+
+    // WF-04: Workflow entry, resume, update, and base-cycle actions
+
+    /** Start a new blank cycle with optional workflow metadata. */
+    startBlankCycle: (state, action: PayloadAction<{
+      workflowTemplate?: WorkflowMetadata;
+      cycleDate?: string;
+    }>) => {
+      const { workflowTemplate, cycleDate } = action.payload;
+      clearHistory(state);
+      try {
+        localStorage.removeItem('forecastData');
+      } catch {
+        // Ignore localStorage errors
+      }
+      const today = cycleDate || getLocalCalendarDate();
+      const startDay = getWorkflowStartDay(workflowTemplate);
+      const newCycle: ForecastCycle = {
+        days: { [startDay]: createEmptyOutlook(startDay) },
+        currentDay: startDay,
+        cycleDate: today
+      };
+      state.forecastCycle = newCycle;
+      state.isSaved = false;
+      state.outlookVersionSnapshots = [];
+      
+      if (workflowTemplate) {
+        state.workflowTemplate = workflowTemplate;
+        // Create initial cycle metadata
+        const now = new Date().toISOString();
+        state.workflowMetadata = {
+          id: `WF-${workflowTemplate.id}-${today}`,
+          workflowId: workflowTemplate.id,
+          cycleDate: today,
+          status: 'in-progress',
+          outlookVersions: [{
+            version: 1,
+            status: 'in-progress',
+            createdAt: now,
+          }],
+          createdAt: now,
+          updatedAt: now,
+        };
+        state.isWorkflowActive = true;
+        writeStoredWorkflowActive(true);
+      } else {
+        // Clear stale workflow state when starting without a template
+        state.workflowTemplate = undefined;
+        state.workflowMetadata = undefined;
+        state.isWorkflowActive = false;
+        writeStoredWorkflowActive(false);
+      }
+    },
+
+    /** Resume an incomplete cycle from a saved snapshot, restoring workflow metadata. */
+    resumeIncompleteCycle: (state, action: PayloadAction<{ cycleId: string }>) => {
+      const { cycleId } = action.payload;
+      const savedCycle = state.savedCycles.find((c) => c.id === cycleId);
+      if (!savedCycle) return;
+
+      clearHistory(state);
+      state.forecastCycle = cloneForecastCycle(normalizeForecastCycle(savedCycle.forecastCycle));
+      state.isSaved = true;
+      state.outlookVersionSnapshots = [];
+      
+      // Restore or clear workflow metadata
+      if (savedCycle.workflowMetadata) {
+        state.workflowMetadata = savedCycle.workflowMetadata;
+        // Restore the workflow template from the workflowId
+        state.workflowTemplate = getWorkflowTemplateById(savedCycle.workflowMetadata.workflowId) || {
+          id: savedCycle.workflowMetadata.workflowId,
+          label: savedCycle.workflowMetadata.workflowId,
+          groupings: [],
+        };
+        state.isWorkflowActive = true;
+        writeStoredWorkflowActive(true);
+      } else {
+        state.workflowMetadata = undefined;
+        state.workflowTemplate = undefined;
+        state.isWorkflowActive = false;
+        writeStoredWorkflowActive(false);
+      }
+    },
+
+    /** Create a new outlook version within the current cycle (same-cycle update). */
+    createOutlookUpdate: (state) => {
+      const now = new Date().toISOString();
+      
+      // Determine the next version number
+      const currentVersions = state.workflowMetadata?.outlookVersions || [];
+      const nextVersion = currentVersions.length > 0 
+        ? Math.max(...currentVersions.map(v => v.version)) + 1 
+        : 1;
+      
+      // Snapshot the current day data before creating the update
+      const currentDay = state.forecastCycle.currentDay;
+      const currentDayData = state.forecastCycle.days[currentDay];
+      
+      if (currentDayData) {
+        // Store a snapshot of the current version, preserving Map-backed outlook data
+        state.outlookVersionSnapshots.push({
+          version: nextVersion - 1, // Snapshot the previous version
+          days: { 
+            [currentDay]: {
+              ...currentDayData,
+              data: cloneOutlookData(currentDayData.data),
+            } 
+          },
+          createdAt: now,
+        });
+      }
+      
+      // Mark previous versions as completed
+      if (state.workflowMetadata) {
+        state.workflowMetadata.outlookVersions.forEach(v => {
+          if (v.status === 'in-progress') {
+            v.status = 'completed';
+          }
+        });
+        
+        // Add new version
+        state.workflowMetadata.outlookVersions.push({
+          version: nextVersion,
+          status: 'in-progress',
+          derivedFrom: nextVersion - 1,
+          createdAt: now,
+        });
+        
+        state.workflowMetadata.status = 'in-progress';
+        state.workflowMetadata.updatedAt = now;
+      }
+      
+      state.forecastCycle.updateInProgressVersion = nextVersion;
+      invalidateCompletionAcknowledgement(state);
+      state.isSaved = false;
+    },
+
+    /** Start a new cycle derived from a previous cycle. */
+    startFromPreviousCycle: (state, action: PayloadAction<{
+      sourceCycleId: string;
+      newCycleDate?: string;
+      sourceDay?: DayType;
+      targetDay?: DayType;
+      workflowTemplate?: WorkflowMetadata;
+    }>) => {
+      const { sourceCycleId, newCycleDate, sourceDay, targetDay = 1, workflowTemplate } = action.payload;
+      
+      // Find the source cycle in saved cycles
+      const sourceCycle = state.savedCycles.find(c => c.id === sourceCycleId);
+      if (!sourceCycle) return;
+      
+      const now = new Date().toISOString();
+      const targetDate = newCycleDate || getLocalCalendarDate();
+      
+      const sourceForecastCycle = normalizeForecastCycle(sourceCycle.forecastCycle);
+      const sourceDayNumber = sourceDay ?? sourceForecastCycle.currentDay;
+      const sourceDayData = sourceForecastCycle.days[sourceDayNumber];
+      if (!sourceDayData) return;
+
+      // Create a fresh cycle and copy only the requested, compatible outlook data
+      // so "start from previous" is a new package, not an import of the old one.
+      clearHistory(state);
+      const newCycle: ForecastCycle = {
+        days: { [targetDay]: createEmptyOutlook(targetDay) },
+        currentDay: targetDay,
+        cycleDate: targetDate,
+      };
+      const targetDayData = newCycle.days[targetDay];
+      if (targetDayData) {
+        copyCompatibleOutlooks(sourceDayData.data, targetDayData.data, sourceDayNumber, targetDay);
+      }
+      state.forecastCycle = newCycle;
+      state.isSaved = false;
+      state.outlookVersionSnapshots = [];
+      
+      // Set workflow metadata with derivedFromCycleId
+      const workflowId = resolveWorkflowId(workflowTemplate, sourceCycle.workflowMetadata);
+      state.workflowMetadata = createInitialCycleMetadata(workflowId, targetDate, now);
+      state.isWorkflowActive = true;
+      writeStoredWorkflowActive(true);
+      
+      // Restore or set workflow template
+      state.workflowTemplate = workflowTemplate || getWorkflowTemplateById(workflowId) || undefined;
     },
   }
 });
@@ -956,6 +1279,10 @@ export const {
   completeCycle,
   completeWithOmissions,
   clearOmittedDays,
+  startBlankCycle,
+  resumeIncompleteCycle,
+  createOutlookUpdate,
+  startFromPreviousCycle,
 } = forecastSlice.actions;
 
 /** Selects the full forecast slice. */
@@ -1006,5 +1333,32 @@ export const selectShowCompletionModal = (state: RootState) =>
 /** Selects the omitted days map. */
 export const selectOmittedDays = (state: RootState) =>
   state.forecast.completionValidation.omittedDays;
+
+/** Selects the workflow metadata for the active cycle. */
+export const selectWorkflowMetadata = (state: RootState) =>
+  state.forecast.workflowMetadata;
+
+/** Selects whether a forecast workflow is active across app routes. */
+export const selectIsWorkflowActive = (state: RootState) =>
+  state.forecast.isWorkflowActive;
+
+/** Selects whether the current route should render workflow-specific UI. */
+export const selectHasActiveWorkflow = (state: RootState) =>
+  state.forecast.isWorkflowActive && Boolean(state.forecast.workflowMetadata);
+
+/** Selects the workflow template metadata. */
+export const selectWorkflowTemplate = (state: RootState) =>
+  state.forecast.workflowTemplate;
+
+/** Selects the outlook version snapshots for the active cycle. */
+export const selectOutlookVersionSnapshots = (state: RootState) =>
+  state.forecast.outlookVersionSnapshots;
+
+/** Selects the current version number for the active cycle. */
+export const selectCurrentVersionNumber = (state: RootState) => {
+  const metadata = state.forecast.workflowMetadata;
+  if (!metadata || metadata.outlookVersions.length === 0) return 1;
+  return Math.max(...metadata.outlookVersions.map(v => v.version));
+};
 
 export default forecastSlice.reducer;

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -236,67 +236,6 @@ const createEmptyOutlook = (day: DayType): OutlookDay => {
   };
 };
 
-interface ApplyRolloverArgs {
-  sourceCycle: ForecastState['savedCycles'][number];
-  sourceDayData: ReturnType<typeof normalizeForecastCycle>['days'][DayType];
-  sourceDayNumber: DayType;
-  targetDay: DayType;
-  targetDate: string;
-  workflowTemplate?: WorkflowMetadata;
-}
-
-/** Builds the fresh rollover cycle and copies the requested day into it. */
-const buildRolloverCycle = ({
-  sourceDayData,
-  sourceDayNumber,
-  targetDay,
-  targetDate,
-}: Omit<ApplyRolloverArgs, 'sourceCycle' | 'workflowTemplate'>): ForecastCycle => {
-  const newCycle: ForecastCycle = {
-    days: { [targetDay]: createEmptyOutlook(targetDay) },
-    currentDay: targetDay,
-    cycleDate: targetDate,
-  };
-  const targetDayData = newCycle.days[targetDay];
-  if (targetDayData) {
-    copyCompatibleOutlooks(sourceDayData.data, targetDayData.data, sourceDayNumber, targetDay);
-  }
-  return newCycle;
-};
-
-/**
- * Attaches workflow metadata to the rollover only when a template was passed
- * or the source cycle was already a workflow cycle. Plain rollovers stay plain.
- */
-const applyRolloverWorkflowState = (
-  state: ForecastState,
-  { sourceCycle, targetDate, workflowTemplate }: Pick<ApplyRolloverArgs, 'sourceCycle' | 'targetDate' | 'workflowTemplate'>,
-  now: string
-) => {
-  const sourceHadWorkflow = Boolean(sourceCycle.workflowMetadata);
-  if (workflowTemplate || sourceHadWorkflow) {
-    const workflowId = resolveWorkflowId(workflowTemplate, sourceCycle.workflowMetadata);
-    state.workflowMetadata = createInitialCycleMetadata(workflowId, targetDate, now);
-    state.isWorkflowActive = true;
-    writeStoredWorkflowActive(true);
-    state.workflowTemplate = workflowTemplate || getWorkflowTemplateById(workflowId) || undefined;
-    return;
-  }
-  state.workflowMetadata = undefined;
-  state.isWorkflowActive = false;
-  writeStoredWorkflowActive(false);
-  state.workflowTemplate = undefined;
-};
-
-/** Resets the in-memory cycle to a fresh rollover derived from the requested source. */
-const applyRolloverFromPreviousCycle = (state: ForecastState, args: ApplyRolloverArgs) => {
-  clearHistory(state);
-  state.forecastCycle = buildRolloverCycle(args);
-  state.isSaved = false;
-  state.outlookVersionSnapshots = [];
-  applyRolloverWorkflowState(state, args, new Date().toISOString());
-};
-
 const initialState: ForecastState = {
   forecastCycle: {
     days: {
@@ -518,6 +457,67 @@ const invalidateCompletionAcknowledgement = (state: ForecastState) => {
     delete state.forecastCycle.omittedDayReasons;
   }
   state.completionValidation.lastResult = null;
+};
+
+interface ApplyRolloverArgs {
+  sourceCycle: ForecastState['savedCycles'][number];
+  sourceDayData: ReturnType<typeof normalizeForecastCycle>['days'][DayType];
+  sourceDayNumber: DayType;
+  targetDay: DayType;
+  targetDate: string;
+  workflowTemplate?: WorkflowMetadata;
+}
+
+/** Builds the fresh rollover cycle and copies the requested day into it. */
+const buildRolloverCycle = ({
+  sourceDayData,
+  sourceDayNumber,
+  targetDay,
+  targetDate,
+}: Omit<ApplyRolloverArgs, 'sourceCycle' | 'workflowTemplate'>): ForecastCycle => {
+  const newCycle: ForecastCycle = {
+    days: { [targetDay]: createEmptyOutlook(targetDay) },
+    currentDay: targetDay,
+    cycleDate: targetDate,
+  };
+  const targetDayData = newCycle.days[targetDay];
+  if (targetDayData) {
+    copyCompatibleOutlooks(sourceDayData.data, targetDayData.data, sourceDayNumber, targetDay);
+  }
+  return newCycle;
+};
+
+/**
+ * Attaches workflow metadata to the rollover only when a template was passed
+ * or the source cycle was already a workflow cycle. Plain rollovers stay plain.
+ */
+const applyRolloverWorkflowState = (
+  state: ForecastState,
+  { sourceCycle, targetDate, workflowTemplate }: Pick<ApplyRolloverArgs, 'sourceCycle' | 'targetDate' | 'workflowTemplate'>,
+  now: string
+) => {
+  const sourceHadWorkflow = Boolean(sourceCycle.workflowMetadata);
+  if (workflowTemplate || sourceHadWorkflow) {
+    const workflowId = resolveWorkflowId(workflowTemplate, sourceCycle.workflowMetadata);
+    state.workflowMetadata = createInitialCycleMetadata(workflowId, targetDate, now);
+    state.isWorkflowActive = true;
+    writeStoredWorkflowActive(true);
+    state.workflowTemplate = workflowTemplate || getWorkflowTemplateById(workflowId) || undefined;
+    return;
+  }
+  state.workflowMetadata = undefined;
+  state.isWorkflowActive = false;
+  writeStoredWorkflowActive(false);
+  state.workflowTemplate = undefined;
+};
+
+/** Resets the in-memory cycle to a fresh rollover derived from the requested source. */
+const applyRolloverFromPreviousCycle = (state: ForecastState, args: ApplyRolloverArgs) => {
+  clearHistory(state);
+  state.forecastCycle = buildRolloverCycle(args);
+  state.isSaved = false;
+  state.outlookVersionSnapshots = [];
+  applyRolloverWorkflowState(state, args, new Date().toISOString());
 };
 
 /** Ensures low-probability metadata exists before mutating it in reducers. */

--- a/src/types/outlooks.ts
+++ b/src/types/outlooks.ts
@@ -192,6 +192,8 @@ export interface ForecastCycle {
   completionAcknowledgedAt?: string;
   /** User-provided reasons for omitted forecast days at completion time. */
   omittedDayReasons?: Partial<Record<DayType, string>>;
+  /** Active same-day workflow update version that has not been reviewed yet. */
+  updateInProgressVersion?: number;
 }
 
 // Updated Save Data Interface
@@ -223,6 +225,7 @@ export interface GFCForecastSaveData {
     cycleDate: string;
     completionAcknowledgedAt?: string;
     omittedDayReasons?: Partial<Record<DayType, string>>;
+    updateInProgressVersion?: number;
   };
 
   /** Optional v2 workflow cycle metadata embedded in v1.0.0 saves. */

--- a/src/utils/completionValidation.test.ts
+++ b/src/utils/completionValidation.test.ts
@@ -110,13 +110,14 @@ describe('validateCycleCompletion', () => {
     expect(result.issues.length).toBeGreaterThan(0);
   });
 
-  it('returns complete when all day1 types are low probability', () => {
+  it('returns complete with a warning when all day1 types are low probability but discussion is missing', () => {
     const result = validateCycleCompletion(
       createForecastCycle({ 1: createDayFixture(1, 'lowProb') }),
       ['day1'],
     );
     expect(result.isComplete).toBe(true);
-    expect(result.issues).toHaveLength(0);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].type).toBe('missing-discussion');
   });
 
   it('reports missing polygon for day1 with no data', () => {

--- a/src/utils/completionValidation.ts
+++ b/src/utils/completionValidation.ts
@@ -120,6 +120,14 @@ const addMissingDayIssues = (ctx: DayValidationContext): void => {
       canNavigate: true,
     });
   }
+  ctx.issues.push({
+    day: ctx.grouping,
+    outlookType: 'categorical',
+    type: 'missing-discussion',
+    message: `Day ${ctx.day}: discussion is missing or empty`,
+    severity: 'warning',
+    canNavigate: true,
+  });
   ctx.missingGroupings.add(ctx.grouping);
 };
 
@@ -211,33 +219,10 @@ const validateNoTstmForecast = (ctx: DayValidationContext): void => {
   });
 };
 
-/** Returns true when the day has at least one required non-TSTM polygon. */
-const dayHasDrawnPolygons = (ctx: DayValidationContext): boolean => {
-  const dayData = ctx.dayData;
-  if (!dayData) {
-    return false;
-  }
-
-  const lowProbabilityOutlooks = dayData.metadata.lowProbabilityOutlooks || [];
-
-  return ctx.expectedTypes.some((outlookType) => {
-    if (lowProbabilityOutlooks.includes(outlookType)) {
-      return false;
-    }
-
-    const map = dayData.data[outlookType as keyof typeof dayData.data];
-    return hasNonTstmPolygonData(map as Map<string, unknown[]> | undefined);
-  });
-};
-
-/** Adds a warning when polygons exist but the day discussion is missing. */
+/** Adds a warning when the expected day discussion is missing. */
 const validateDiscussion = (ctx: DayValidationContext): void => {
   const dayData = ctx.dayData;
   if (!dayData) {
-    return;
-  }
-
-  if (!dayHasDrawnPolygons(ctx)) {
     return;
   }
 

--- a/src/utils/fileUtils.extra.test.ts
+++ b/src/utils/fileUtils.extra.test.ts
@@ -69,14 +69,18 @@ describe('fileUtils extra', () => {
     spy.mockRestore();
   });
 
-  test('downloadGfcPackage zips and triggers download with discussions', async () => {
+  test('downloadGfcPackage zips one workflow-ready forecast JSON with discussions', async () => {
     jest.resetModules();
+    let generatedFiles: Record<string, string> = {};
 
     jest.doMock('jszip', () => {
       return class MockJSZip {
         files: Record<string, string> = {};
         file(name: string, content: string) { this.files[name] = content; }
-        generateAsync(_opts: unknown) { return Promise.resolve(new Blob([JSON.stringify(this.files)])); }
+        generateAsync(_opts: unknown) {
+          generatedFiles = this.files;
+          return Promise.resolve(new Blob([JSON.stringify(this.files)]));
+        }
       };
     });
 
@@ -102,6 +106,9 @@ describe('fileUtils extra', () => {
 
     expect(clickMock).toHaveBeenCalled();
     expect(urlHelpers.createObjectURL).toHaveBeenCalled();
+    expect(Object.keys(generatedFiles).sort()).toEqual(['discussion_day1.txt', 'forecast_cycle.json']);
+    expect(generatedFiles.workflow_package_json).toBeUndefined();
+    expect(generatedFiles['workflow_package.json']).toBeUndefined();
     spy.mockRestore();
   });
 });

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -181,12 +181,15 @@ export const validateForecastData = (data: unknown): data is GFCForecastSaveData
 
 /**
  * Triggers a download of the serialized forecast data as a JSON file.
+ * When `cycleMetadata` is provided, the export keeps the active workflow
+ * metadata so a re-import can restore the workflow session.
  */
 export const exportForecastToJson = (
   forecastCycle: ForecastCycle,
-  mapView: { center: [number, number]; zoom: number }
+  mapView: { center: [number, number]; zoom: number },
+  cycleMetadata?: CycleMetadata
 ) => {
-  const data = serializeForecast(forecastCycle, mapView);
+  const data = serializeForecast(forecastCycle, mapView, cycleMetadata);
   const jsonString = JSON.stringify(data, null, 2);
   const blob = new Blob([jsonString], { type: 'application/json' });
   const url = URL.createObjectURL(blob);

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -209,12 +209,13 @@ export const exportForecastToJson = (
  */
 export const downloadGfcPackage = async (
   forecastCycle: ForecastCycle,
-  mapView: { center: [number, number]; zoom: number }
+  mapView: { center: [number, number]; zoom: number },
+  cycleMetadata?: CycleMetadata,
 ): Promise<void> => {
   const zip = new JSZip();
 
   // 1. Forecast JSON
-  const data = serializeForecast(forecastCycle, mapView);
+  const data = serializeForecast(forecastCycle, mapView, cycleMetadata);
   zip.file('forecast_cycle.json', JSON.stringify(data, null, 2));
 
   // 2. Discussion text for each day that has content

--- a/src/utils/forecastCompletionMetadata.ts
+++ b/src/utils/forecastCompletionMetadata.ts
@@ -1,6 +1,6 @@
 import type { ForecastCycle } from '../types/outlooks';
 
-export type CompletionMetadata = Pick<ForecastCycle, 'completionAcknowledgedAt' | 'omittedDayReasons'>;
+export type CompletionMetadata = Pick<ForecastCycle, 'completionAcknowledgedAt' | 'omittedDayReasons' | 'updateInProgressVersion'>;
 
 /** Copies optional completion acknowledgement fields when present. */
 export const completionMetadataFromForecastCycle = (
@@ -11,5 +11,8 @@ export const completionMetadataFromForecastCycle = (
     : {}),
   ...(forecastCycle.omittedDayReasons
     ? { omittedDayReasons: forecastCycle.omittedDayReasons }
+    : {}),
+  ...(typeof forecastCycle.updateInProgressVersion === 'number'
+    ? { updateInProgressVersion: forecastCycle.updateInProgressVersion }
     : {}),
 });


### PR DESCRIPTION
## Summary

Stack 1/4 for WF-04. This PR adds the core workflow state needed before any UI surfaces depend on it:

- Adds reusable workflow templates for Day 1, Day 2, Day 3, Days 4-8, and Full Outlook workflows.
- Persists active workflow state across routes with localStorage-backed activation.
- Starts workflow templates on the correct forecast day and supports same-cycle updates / start-from-previous-cycle behavior.
- Preserves workflow metadata when loading workflow-ready `forecast_cycle.json` files.
- Fixes completion validation to respect the active workflow groupings.
- Invalidates stale package completion when map or discussion content changes.
- Prevents local session restore from overwriting in-progress unsaved forecast/discussion state.

## Issue Links

- Part of #454
- Parent tracker: #429
- Depends on WF-01 schema work: #451
- Relates to package export behavior: #459
- Supersedes the state portion of #680

## Merge Order

1. Merge this PR first.
2. Then merge the package review flow PR.
3. Then merge the persistent route banner PR.
4. Then merge the Home workflow entry PR.

## Verification

- `jest --runTestsByPath src/store/forecastSlice.test.ts src/utils/completionValidation.test.ts src/utils/fileUtils.extra.test.ts src/pages/ForecastPage.test.tsx --runInBand`
- `vite build`
