### PR TITLE
[WF-04] Package review workflow modal

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #683
+
+- Modernize the package review and completion dialogs with shared dialog primitives and review/export actions.
+
 ### PR #681
 
 - Dependency: @radix-ui/react-dialog ^1.1.17 → ^1.1.18

--- a/src/components/CompletionValidation/CompletionValidationModal.css
+++ b/src/components/CompletionValidation/CompletionValidationModal.css
@@ -1,331 +1,146 @@
-.completion-modal-root {
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-}
-
-.completion-modal-overlay {
-  position: absolute;
-  inset: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-}
-
 .completion-modal {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: white;
-  border-radius: 8px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-  z-index: 1;
-  width: 90%;
-  max-width: 560px;
-  max-height: 85vh;
-  display: flex;
-  flex-direction: column;
+  max-width: 40rem;
+  gap: 0.7rem;
+  border-radius: 0.75rem;
+  padding: 1rem;
 }
 
 .completion-modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px;
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.completion-modal-header h2 {
-  margin: 0;
-  font-size: 1.25rem;
-  color: #333;
-}
-
-.completion-modal-close {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
-  color: #666;
-  padding: 0;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
-  transition: background-color 0.2s;
-}
-
-.completion-modal-close:hover {
-  background-color: #f0f0f0;
+  gap: 0.35rem;
+  padding-right: 1.75rem;
 }
 
 .completion-modal-body {
-  padding: 20px;
-  overflow-y: auto;
-  flex: 1;
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.65rem;
 }
 
 .completion-status-badge {
   display: inline-flex;
+  width: 100%;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  border-radius: 6px;
+  gap: 0.5rem;
+  min-height: 2.6rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: 0.5rem;
   font-size: 0.875rem;
-  font-weight: 600;
-  margin-bottom: 16px;
+  font-weight: 700;
 }
 
 .completion-status-badge--complete {
-  background-color: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--muted) / 0.45);
+  color: hsl(var(--foreground));
 }
 
 .completion-status-badge--incomplete {
-  background-color: #fef3c7;
-  color: #92400e;
-  border: 1px solid #fde68a;
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.08);
+  color: rgb(180, 83, 9);
 }
 
 .completion-issues-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 12px;
+  gap: 0.65rem;
 }
 
 .completion-issue-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 14px;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
-  background-color: #fafafa;
-  transition: background-color 0.15s;
-}
-
-.completion-issue-item:hover {
-  background-color: #f3f4f6;
+  gap: 1rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  background: hsl(var(--background));
 }
 
 .completion-issue-item--critical {
-  border-left: 3px solid #ef4444;
+  border-left-width: 3px;
+  border-left-color: #ef4444;
 }
 
 .completion-issue-item--warning {
-  border-left: 3px solid #f59e0b;
+  border-left-width: 3px;
+  border-left-color: #f59e0b;
 }
 
 .completion-issue-info {
-  flex: 1;
   min-width: 0;
 }
 
 .completion-issue-day {
+  margin-bottom: 0.2rem;
+  color: hsl(var(--muted-foreground));
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 800;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #6b7280;
-  margin-bottom: 2px;
 }
 
 .completion-issue-message {
-  font-size: 0.875rem;
-  color: #374151;
+  color: hsl(var(--foreground));
+  font-size: 0.9rem;
+  line-height: 1.45;
 }
 
 .completion-issue-nav-btn {
-  margin-left: 12px;
-  padding: 4px 10px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-  background-color: white;
-  color: #374151;
-  cursor: pointer;
-  transition: all 0.15s;
-  white-space: nowrap;
-}
-
-.completion-issue-nav-btn:hover {
-  background-color: #f3f4f6;
-  border-color: #9ca3af;
+  flex: 0 0 auto;
+  min-height: 2rem;
+  padding: 0 0.75rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-size: 0.8rem;
+  font-weight: 700;
 }
 
 .completion-modal-footer {
-  padding: 16px 20px;
-  border-top: 1px solid #e0e0e0;
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.completion-modal-btn {
-  padding: 8px 16px;
-  border: none;
-  border-radius: 4px;
-  font-weight: 600;
-  cursor: pointer;
-  font-size: 0.875rem;
-  transition: background-color 0.2s;
-}
-
-.completion-modal-btn--cancel {
-  background-color: #6b7280;
-  color: white;
-}
-
-.completion-modal-btn--cancel:hover {
-  background-color: #4b5563;
-}
-
-.completion-modal-btn--complete {
-  background-color: #2563eb;
-  color: white;
-}
-
-.completion-modal-btn--complete:hover {
-  background-color: #1d4ed8;
-}
-
-.completion-modal-btn--complete-anyway {
-  background-color: #f59e0b;
-  color: white;
-}
-
-.completion-modal-btn--complete-anyway:hover {
-  background-color: #d97706;
+  gap: 0.5rem;
+  padding-top: 0;
 }
 
 .completion-modal-empty {
+  color: hsl(var(--muted-foreground));
+  padding: 0.75rem 0;
   text-align: center;
-  padding: 24px 16px;
-  color: #6b7280;
-}
-
-.completion-modal-empty p {
-  margin: 4px 0;
 }
 
 .completion-omission-reasons {
-  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
 }
 
 .completion-omission-field {
-  display: block;
-  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
 }
 
 .completion-omission-label {
-  display: block;
-  margin-bottom: 6px;
+  color: hsl(var(--muted-foreground));
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 800;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #6b7280;
 }
 
 .completion-omission-input {
   width: 100%;
-  padding: 8px 10px;
-  border: 1px solid #d1d5db;
-  border-radius: 6px;
-  font-size: 0.875rem;
+  min-height: 4.5rem;
   resize: vertical;
-}
-
-.completion-modal-btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-/* Dark mode support */
-.dark-mode .completion-modal {
-  background-color: #1e1f24;
-  color: #e2e8f0;
-}
-
-.dark-mode .completion-modal-header {
-  border-bottom-color: #374151;
-}
-
-.dark-mode .completion-modal-header h2 {
-  color: #f1f5f9;
-}
-
-.dark-mode .completion-modal-close {
-  color: #9ca3af;
-}
-
-.dark-mode .completion-modal-close:hover {
-  background-color: #374151;
-}
-
-.dark-mode .completion-status-badge--complete {
-  background-color: rgba(34, 197, 94, 0.15);
-  color: #4ade80;
-  border-color: rgba(34, 197, 94, 0.3);
-}
-
-.dark-mode .completion-status-badge--incomplete {
-  background-color: rgba(245, 158, 11, 0.15);
-  color: #fbbf24;
-  border-color: rgba(245, 158, 11, 0.3);
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  padding: 0.7rem 0.8rem;
 }
 
 .dark-mode .completion-issue-item {
-  background-color: #2a2b30;
-  border-color: #374151;
-}
-
-.dark-mode .completion-issue-item:hover {
-  background-color: #323338;
-}
-
-.dark-mode .completion-issue-day {
-  color: #9ca3af;
-}
-
-.dark-mode .completion-issue-message {
-  color: #e2e8f0;
-}
-
-.dark-mode .completion-issue-nav-btn {
-  background-color: #374151;
-  border-color: #4b5563;
-  color: #e2e8f0;
-}
-
-.dark-mode .completion-issue-nav-btn:hover {
-  background-color: #4b5563;
-}
-
-.dark-mode .completion-modal-footer {
-  border-top-color: #374151;
-}
-
-.dark-mode .completion-modal-btn--cancel {
-  background-color: #4b5563;
-}
-
-.dark-mode .completion-modal-btn--cancel:hover {
-  background-color: #6b7280;
-}
-
-.dark-mode .completion-modal-empty {
-  color: #9ca3af;
-}
-
-.dark-mode .completion-omission-label {
-  color: #9ca3af;
-}
-
-.dark-mode .completion-omission-input {
-  background-color: #2a2b30;
-  border-color: #4b5563;
-  color: #e2e8f0;
+  background: rgba(255, 255, 255, 0.04);
 }

--- a/src/components/CompletionValidation/CompletionValidationModal.test.tsx
+++ b/src/components/CompletionValidation/CompletionValidationModal.test.tsx
@@ -5,6 +5,7 @@ import type { CycleValidationResult } from '../../types/workflow';
 jest.mock('lucide-react', () => ({
   CheckCircle2: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
   AlertTriangle: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  X: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
 }));
 
 const completeResult: CycleValidationResult = {
@@ -75,7 +76,7 @@ describe('CompletionValidationModal', () => {
 
   it('renders complete status badge', () => {
     renderModal(completeResult);
-    expect(screen.getByText('Forecast cycle is complete')).toBeInTheDocument();
+    expect(screen.getByText('Ready for export')).toBeInTheDocument();
   });
 
   it('renders incomplete status badge with issue count', () => {
@@ -93,8 +94,17 @@ describe('CompletionValidationModal', () => {
   it('calls onComplete when Complete is clicked', () => {
     const onComplete = jest.fn();
     renderModal(completeResult, { onComplete });
-    fireEvent.click(screen.getByText('Complete'));
+    fireEvent.click(screen.getByText('Mark Reviewed'));
     expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onComplete and onExport when Mark Reviewed & Export is clicked', () => {
+    const onComplete = jest.fn();
+    const onExport = jest.fn();
+    renderModal(completeResult, { onComplete, onExport });
+    fireEvent.click(screen.getByText('Mark Reviewed & Export'));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onExport).toHaveBeenCalledTimes(1);
   });
 
   it('shows "Complete Anyway" for incomplete cycle', () => {

--- a/src/components/CompletionValidation/CompletionValidationModal.tsx
+++ b/src/components/CompletionValidation/CompletionValidationModal.tsx
@@ -3,6 +3,13 @@ import React, { useCallback } from 'react';
 import type { CycleValidationResult } from '../../types/workflow';
 import type { DayType } from '../../types/outlooks';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import {
   CompletionValidationModalBody,
   CompletionValidationModalFooter,
   hasAllOmissionReasons,
@@ -18,6 +25,7 @@ interface CompletionValidationModalProps {
   onCompleteWithOmissions: () => void;
   onOmitDay: (day: DayType, reason: string) => void;
   onNavigateToIssue?: (day: DayType) => void;
+  onExport?: () => void;
 }
 
 /** Maps a validation grouping key to its primary forecast day number. */
@@ -41,6 +49,7 @@ export const CompletionValidationModal: React.FC<CompletionValidationModalProps>
   onCompleteWithOmissions,
   onOmitDay,
   onNavigateToIssue,
+  onExport,
 }) => {
   const handleNavigate = useCallback(
     (grouping: string) => {
@@ -60,22 +69,20 @@ export const CompletionValidationModal: React.FC<CompletionValidationModalProps>
   const warningIssues = issues.filter((issue) => issue.severity === 'warning');
   const canCompleteWithOmissions = hasAllOmissionReasons(missingGroupings, omittedDays);
 
-  return (
-    <div className="completion-modal-root">
-      <div className="completion-modal-overlay" onClick={onClose} />
-      <div className="completion-modal" role="dialog" aria-modal="true" aria-labelledby="completion-title">
-        <div className="completion-modal-header">
-          <h2 id="completion-title">Complete Forecast Cycle</h2>
-          <button
-            type="button"
-            className="completion-modal-close"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            &times;
-          </button>
-        </div>
+  const handleCompleteAndExport = () => {
+    onComplete();
+    onExport?.();
+  };
 
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="completion-modal" aria-describedby="completion-summary">
+        <DialogHeader className="completion-modal-header">
+          <DialogTitle id="completion-title">Review Package</DialogTitle>
+          <DialogDescription>
+            Confirm the outlook map and discussion before exporting the workflow bundle.
+          </DialogDescription>
+        </DialogHeader>
         <CompletionValidationModalBody
           isComplete={isComplete}
           issues={issues}
@@ -93,9 +100,10 @@ export const CompletionValidationModal: React.FC<CompletionValidationModalProps>
           onClose={onClose}
           onComplete={onComplete}
           onCompleteWithOmissions={onCompleteWithOmissions}
+          onCompleteAndExport={onExport ? handleCompleteAndExport : undefined}
         />
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/components/CompletionValidation/CompletionValidationModal.tsx
+++ b/src/components/CompletionValidation/CompletionValidationModal.tsx
@@ -69,7 +69,8 @@ export const CompletionValidationModal: React.FC<CompletionValidationModalProps>
   const warningIssues = issues.filter((issue) => issue.severity === 'warning');
   const canCompleteWithOmissions = hasAllOmissionReasons(missingGroupings, omittedDays);
 
-  const handleCompleteAndExport = () => {
+/** Completes the forecast review and starts the optional export flow. */
+const handleCompleteAndExport = () => {
     onComplete();
     onExport?.();
   };

--- a/src/components/CompletionValidation/CompletionValidationModal.tsx
+++ b/src/components/CompletionValidation/CompletionValidationModal.tsx
@@ -70,10 +70,10 @@ export const CompletionValidationModal: React.FC<CompletionValidationModalProps>
   const canCompleteWithOmissions = hasAllOmissionReasons(missingGroupings, omittedDays);
 
 /** Completes the forecast review and starts the optional export flow. */
-const handleCompleteAndExport = () => {
-    onComplete();
-    onExport?.();
-  };
+function handleCompleteAndExport(): void {
+  onComplete();
+  onExport?.();
+}
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>

--- a/src/components/CompletionValidation/CompletionValidationModalSections.tsx
+++ b/src/components/CompletionValidation/CompletionValidationModalSections.tsx
@@ -4,6 +4,8 @@ import { CheckCircle2, AlertTriangle } from 'lucide-react';
 import type { ValidationIssue } from '../../types/workflow';
 import type { DayType } from '../../types/outlooks';
 import { MissingItemsList } from './MissingItemsList';
+import { Button } from '../ui/button';
+import { DialogFooter } from '../ui/dialog';
 
 /** Formats a workflow grouping key for display in the modal. */
 const formatGrouping = (grouping: string): string => {
@@ -111,12 +113,12 @@ export const CompletionValidationModalBody: React.FC<CompletionValidationModalBo
 }) => (
   <div className="completion-modal-body">
     {isComplete ? (
-      <div className="completion-status-badge completion-status-badge--complete">
+      <div className="completion-status-badge completion-status-badge--complete" id="completion-summary">
         <CheckCircle2 className="h-4 w-4" />
-        <span>Forecast cycle is complete</span>
+        <span>Ready for export</span>
       </div>
     ) : (
-      <div className="completion-status-badge completion-status-badge--incomplete">
+      <div className="completion-status-badge completion-status-badge--incomplete" id="completion-summary">
         <AlertTriangle className="h-4 w-4" />
         <span>{criticalIssues.length} item{criticalIssues.length !== 1 ? 's' : ''} missing for completion</span>
       </div>
@@ -165,6 +167,7 @@ interface CompletionValidationModalFooterProps {
   onClose: () => void;
   onComplete: () => void;
   onCompleteWithOmissions: () => void;
+  onCompleteAndExport?: () => void;
 }
 
 /** Renders completion modal action buttons for cancel and finalize flows. */
@@ -174,31 +177,29 @@ export const CompletionValidationModalFooter: React.FC<CompletionValidationModal
   onClose,
   onComplete,
   onCompleteWithOmissions,
+  onCompleteAndExport,
 }) => (
-  <div className="completion-modal-footer">
-    <button
-      type="button"
-      className="completion-modal-btn completion-modal-btn--cancel"
-      onClick={onClose}
-    >
+  <DialogFooter className="completion-modal-footer">
+    <Button type="button" variant="outline" onClick={onClose}>
       Cancel
-    </button>
+    </Button>
     {!isComplete && (
-      <button
+      <Button
         type="button"
-        className="completion-modal-btn completion-modal-btn--complete-anyway"
+        variant="warning"
         onClick={onCompleteWithOmissions}
         disabled={!canCompleteWithOmissions}
       >
         Complete with Omissions
-      </button>
+      </Button>
     )}
-    <button
-      type="button"
-      className="completion-modal-btn completion-modal-btn--complete"
-      onClick={onComplete}
-    >
-      {isComplete ? 'Complete' : 'Complete Anyway'}
-    </button>
-  </div>
+    {isComplete && onCompleteAndExport ? (
+      <Button type="button" onClick={onCompleteAndExport}>
+        Mark Reviewed & Export
+      </Button>
+    ) : null}
+    <Button type="button" variant={isComplete ? 'default' : 'warning'} onClick={onComplete}>
+      {isComplete ? 'Mark Reviewed' : 'Complete Anyway'}
+    </Button>
+  </DialogFooter>
 );

--- a/src/components/DrawingTools/ConfirmationModal.css
+++ b/src/components/DrawingTools/ConfirmationModal.css
@@ -1,0 +1,4 @@
+/* Keep confirmations above the cycle history dialog even when ExportModal.css is not loaded. */
+.export-modal-overlay--stacked {
+  z-index: 10000;
+}

--- a/src/components/DrawingTools/ConfirmationModal.tsx
+++ b/src/components/DrawingTools/ConfirmationModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './ConfirmationModal.css';
 import { Button } from '../ui/button';
 import {
   Dialog,

--- a/src/components/DrawingTools/ConfirmationModal.tsx
+++ b/src/components/DrawingTools/ConfirmationModal.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import './ExportModal.css'; // Reuse modal styles
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
 
 interface ConfirmationModalProps {
   isOpen: boolean;
@@ -23,35 +31,28 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   cancelLabel = "Cancel",
   overlayClassName,
 }) => {
-  if (!isOpen) return null;
-
-  const overlayClass = overlayClassName
-    ? `export-modal-overlay ${overlayClassName}`
-    : 'export-modal-overlay';
-
   return (
-    <div className={overlayClass}>
-      <div className="export-modal" role="dialog" aria-modal="true" aria-labelledby="confirm-title" aria-describedby="confirm-desc">
-        <h3 id="confirm-title">{title}</h3>
-        <p id="confirm-desc">{message}</p>
-        <div className="export-modal-actions">
-          <button
-            type="button"
-            className="export-modal-btn export-modal-cancel"
-            onClick={onCancel}
-          >
+    <Dialog open={isOpen} onOpenChange={(open) => {
+      if (!open) onCancel();
+    }}>
+      <DialogContent
+        className={overlayClassName ? `confirmation-dialog ${overlayClassName}` : 'confirmation-dialog'}
+        aria-describedby="confirm-desc"
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription id="confirm-desc">{message}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onCancel}>
             {cancelLabel}
-          </button>
-          <button
-            type="button"
-            className="export-modal-btn export-modal-confirm"
-            onClick={onConfirm}
-          >
+          </Button>
+          <Button type="button" onClick={onConfirm}>
             {confirmLabel}
-          </button>
-        </div>
-      </div>
-    </div>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/components/DrawingTools/ConfirmationModal.tsx
+++ b/src/components/DrawingTools/ConfirmationModal.tsx
@@ -21,6 +21,7 @@ interface ConfirmationModalProps {
   overlayClassName?: string;
 }
 
+/** Renders a confirmation dialog, optionally stacked above another modal. */
 const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   isOpen,
   title,

--- a/src/components/DrawingTools/ConfirmationModal.tsx
+++ b/src/components/DrawingTools/ConfirmationModal.tsx
@@ -36,7 +36,8 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
       if (!open) onCancel();
     }}>
       <DialogContent
-        className={overlayClassName ? `confirmation-dialog ${overlayClassName}` : 'confirmation-dialog'}
+        className="confirmation-dialog"
+        overlayClassName={overlayClassName}
         aria-describedby="confirm-desc"
       >
         <DialogHeader>

--- a/src/components/ForecastWorkspace/ForecastWorkspaceModals.tsx
+++ b/src/components/ForecastWorkspace/ForecastWorkspaceModals.tsx
@@ -72,6 +72,7 @@ export const ForecastWorkspaceModals: React.FC<{ controller: ForecastWorkspaceCo
         onCompleteWithOmissions={controller.onCompleteWithOmissions}
         onOmitDay={controller.onOmitDay}
         onNavigateToIssue={controller.onNavigateToIssue}
+        onExport={controller.onInitiateExport}
       />
     </>
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -50,15 +50,19 @@ const partitionDialogChildren = (children: React.ReactNode) => {
   return { body, footers };
 };
 
+type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+  overlayClassName?: string;
+};
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => {
+  DialogContentProps
+>(({ className, children, overlayClassName, ...props }, ref) => {
   const { body, footers } = partitionDialogChildren(children);
 
   return (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -87,6 +87,7 @@ const DialogContent = React.forwardRef<
 });
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
+/** Renders the title and supporting content area for a dialog. */
 const DialogHeader = ({
   className,
   ...props
@@ -101,6 +102,7 @@ const DialogHeader = ({
 );
 DialogHeader.displayName = 'DialogHeader';
 
+/** Renders the action area for a dialog. */
 const DialogFooter = ({
   className,
   ...props

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -68,6 +68,7 @@ const DialogContent = React.forwardRef<
       className={cn(
         'fixed left-[50%] top-[50%] z-modal flex w-[calc(100%-1.5rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-hidden rounded-lg border border-border bg-background p-4 shadow-lg duration-200 data-[state=open]:animate-scale-in sm:p-6',
         'max-h-[min(90dvh,calc(100%-1.5rem))]',
+        overlayClassName && 'z-[10001]',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Stack 2/4 for WF-04. This PR sits on top of #682 and focuses only on the package review / completion dialog surface:

- Moves package review into the shared dialog primitives.
- Tightens the review modal copy and spacing.
- Adds `Mark Reviewed` / `Mark Reviewed & Export` actions for the workflow review flow.
- Keeps discussion warnings visible as part of the package review path.
- Modernizes the unsaved-change confirmation dialog used by cycle actions.

## Issue Links

- Part of #454
- Parent tracker: #429
- Builds on #682
- Supersedes the review-modal portion of #680

## Merge Order

1. #682 must merge first.
2. Merge this PR second.
3. Then merge the persistent route banner PR.
4. Then merge the Home workflow entry PR.

## Verification

- `jest --runTestsByPath src/components/CompletionValidation/CompletionValidationModal.test.tsx src/store/forecastSlice.test.ts src/utils/completionValidation.test.ts --runInBand`
- `vite build`
