### PR TITLE
[WF-04] Persistent forecast workflow banner

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -46,7 +46,7 @@ enabled = true
   skip_doc_coverage = [
     "function-declaration",
     "function-expression",
-    "arrow-function",
+    "arrow-function-expression",
     "class-declaration",
     "class-expression",
     "method-definition",

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -46,7 +46,7 @@ enabled = true
   skip_doc_coverage = [
     "function-declaration",
     "function-expression",
-    "arrow-function-expression",
+    "arrow-function",
     "class-declaration",
     "class-expression",
     "method-definition",

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,11 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #684
+
+- Add a persistent workflow banner across the Forecast and Discussion routes with map, discussion, review, update, and export actions.
+- Keep the workflow feature gated by the existing exposure policy until rollout adoption is updated.
+
 ### PR #682
 
 - Add reusable workflow templates for Day 1, Day 2, Day 3, Days 4-8, and Full Outlook workflows with persistent activation in localStorage.

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.css
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.css
@@ -1,0 +1,191 @@
+.forecast-workflow-panel {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 18px;
+  border-bottom: 1px solid hsl(var(--border));
+  background: hsl(var(--background) / 0.96);
+  padding: 10px 14px 10px 22px;
+  box-shadow: 0 10px 28px -26px rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(8px);
+}
+
+.forecast-workflow-panel--updating {
+  border-bottom-color: rgba(37, 99, 235, 0.26);
+  background:
+    linear-gradient(90deg, rgba(37, 99, 235, 0.08), transparent 42%),
+    hsl(var(--background) / 0.96);
+}
+
+.forecast-workflow-panel__content {
+  display: grid;
+  min-width: 0;
+  flex: 1 1 auto;
+  width: 100%;
+  grid-template-columns: minmax(max-content, auto) minmax(0, 1fr) max-content;
+  align-items: center;
+  column-gap: 24px;
+}
+
+.forecast-workflow-panel__meta-row {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 9px;
+  color: hsl(var(--muted-foreground));
+  font-size: 11px;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.forecast-workflow-panel__meta-row > span:not(.forecast-workflow-panel__update-badge)::after {
+  content: "•";
+  margin-left: 9px;
+  color: hsl(var(--muted-foreground) / 0.55);
+}
+
+.forecast-workflow-panel__meta-row strong {
+  color: hsl(var(--foreground));
+  font-weight: 850;
+}
+
+.forecast-workflow-panel__update-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid rgba(37, 99, 235, 0.3);
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: rgb(29, 78, 216);
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 800;
+  white-space: nowrap;
+  text-transform: none;
+}
+
+.forecast-workflow-panel__steps {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.forecast-workflow-step {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 7px;
+  background: hsl(var(--background));
+  padding: 6px 9px;
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+}
+
+.forecast-workflow-step--complete {
+  border-color: rgba(34, 197, 94, 0.32);
+  background: rgba(34, 197, 94, 0.11);
+  color: rgb(21, 128, 61);
+}
+
+.forecast-workflow-step--active {
+  border-color: rgba(37, 99, 235, 0.38);
+  background: rgba(37, 99, 235, 0.08);
+  color: rgb(29, 78, 216);
+}
+
+.forecast-workflow-panel__actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  align-content: center;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.forecast-workflow-panel__actions button {
+  border-radius: 8px;
+}
+
+.forecast-workflow-panel__notice {
+  display: inline-flex;
+  flex: 0 0 100%;
+  align-items: center;
+  gap: 7px;
+  color: hsl(var(--warning-foreground, var(--foreground)));
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.dark-mode .forecast-workflow-panel {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+  background: rgba(17, 18, 21, 0.96);
+}
+
+.dark-mode .forecast-workflow-panel--updating {
+  border-bottom-color: rgba(96, 165, 250, 0.26);
+  background:
+    linear-gradient(90deg, rgba(59, 130, 246, 0.14), transparent 42%),
+    rgba(17, 18, 21, 0.96);
+}
+
+.dark-mode .forecast-workflow-step {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.dark-mode .forecast-workflow-step--complete {
+  border-color: rgba(74, 222, 128, 0.26);
+  background: rgba(34, 197, 94, 0.14);
+  color: #86efac;
+}
+
+.dark-mode .forecast-workflow-step--active {
+  border-color: rgba(96, 165, 250, 0.26);
+  background: rgba(59, 130, 246, 0.14);
+  color: #93c5fd;
+}
+
+@media (max-width: 900px) {
+  .forecast-workflow-panel {
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px 10px 8px 16px;
+  }
+
+  .forecast-workflow-panel__content {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .forecast-workflow-panel__actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    max-width: none;
+  }
+}
+
+@media (max-width: 640px), (max-height: 500px) and (orientation: landscape) {
+  .forecast-workflow-panel {
+    max-height: 124px;
+    overflow-y: auto;
+  }
+
+  .forecast-workflow-step {
+    min-height: 30px;
+    padding: 5px 7px;
+  }
+
+  .forecast-workflow-panel__actions button {
+    min-height: 34px;
+    font-size: 12px;
+  }
+}

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -79,7 +79,7 @@ const getPreviousSourceDay = (targetDay: DayType): DayType | null => {
 };
 
 /** Formats a cycle date for the compact workflow banner label. */
-const formatCycleDate = (cycleDate: string): string => {
+function formatCycleDate(cycleDate: string): string {
   const parsed = new Date(`${cycleDate}T00:00:00`);
   if (Number.isNaN(parsed.getTime())) return cycleDate;
   return parsed.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
@@ -125,17 +125,21 @@ const usePreviousOutlookSuggestion = (): PreviousOutlookSuggestion | null => {
   }, [forecastCycle.currentDay, savedCycles]);
 };
 
-/** Displays one map, discussion, or review step in the workflow banner. */
-const WorkflowStep: React.FC<{
+interface WorkflowStepProps {
   icon: React.ReactNode;
   label: string;
   status: 'complete' | 'active' | 'pending';
-}> = ({ icon, label, status }) => (
-  <div className={`forecast-workflow-step forecast-workflow-step--${status}`}>
-    <span>{icon}</span>
-    <strong>{label}</strong>
-  </div>
-);
+}
+
+/** Displays one map, discussion, or review step in the workflow banner. */
+function WorkflowStep({ icon, label, status }: WorkflowStepProps): React.ReactElement {
+  return (
+    <div className={`forecast-workflow-step forecast-workflow-step--${status}`}>
+      <span>{icon}</span>
+      <strong>{label}</strong>
+    </div>
+  );
+}
 
 interface WorkflowPanelActionsProps {
   context: 'forecast' | 'discussion';
@@ -165,7 +169,7 @@ const WorkflowPanelExportAction: React.FC<WorkflowPanelActionsProps> = ({ canExp
       Export
     </Button>
   );
-};
+}
 
 /** Adds the optional review action for controller-backed forecast workspaces. */
 const WorkflowPanelReviewAction: React.FC<WorkflowPanelActionsProps> = ({ canReviewPackage, hasController, isReviewed, isUpdating, onOpenReview }) => {
@@ -203,14 +207,16 @@ const WorkflowPanelPreviousAction: React.FC<WorkflowPanelActionsProps> = ({ prev
 };
 
 /** Renders the optional secondary workflow actions. */
-const WorkflowPanelExtras: React.FC<WorkflowPanelActionsProps> = (props) => (
-  <>
-    <WorkflowPanelExportAction {...props} />
-    <WorkflowPanelReviewAction {...props} />
-    <WorkflowPanelUpdateAction {...props} />
-    <WorkflowPanelPreviousAction {...props} />
-  </>
-);
+function WorkflowPanelExtras(props: WorkflowPanelActionsProps): React.ReactElement {
+  return (
+    <>
+      <WorkflowPanelExportAction {...props} />
+      <WorkflowPanelReviewAction {...props} />
+      <WorkflowPanelUpdateAction {...props} />
+      <WorkflowPanelPreviousAction {...props} />
+    </>
+  );
+}
 
 /** Renders the primary action for the current workflow state. */
 const WorkflowPanelPrimaryAction: React.FC<WorkflowPanelActionsProps> = ({
@@ -286,20 +292,30 @@ const WorkflowPanelActions: React.FC<WorkflowPanelActionsProps> = (props) => (
 );
 
 /** Returns the concise status shown in the workflow banner. */
-const getWorkflowStatusLabel = (
-  hasMapStarted: boolean,
-  isUpdating: boolean,
-  activeUpdateVersion: number | undefined,
-  mapIsComplete: boolean,
-  discussionIsComplete: boolean,
-  isReviewed: boolean,
-): string => {
+interface WorkflowStatusState {
+  hasMapStarted: boolean;
+  isUpdating: boolean;
+  activeUpdateVersion: number | undefined;
+  mapIsComplete: boolean;
+  discussionIsComplete: boolean;
+  isReviewed: boolean;
+}
+
+/** Returns the concise status shown in the workflow banner. */
+function getWorkflowStatusLabel({
+  hasMapStarted,
+  isUpdating,
+  activeUpdateVersion,
+  mapIsComplete,
+  discussionIsComplete,
+  isReviewed,
+}: WorkflowStatusState): string {
   if (!hasMapStarted) return 'Map not started';
   if (isUpdating) return `Update v${activeUpdateVersion} in progress`;
   if (!mapIsComplete) return 'Map in progress';
   if (!discussionIsComplete) return 'Discussion needed';
   return isReviewed ? 'Ready to export' : 'Ready for review';
-};
+}
 
 /** Displays the workflow progress steps without mixing them into the panel orchestration. */
 const WorkflowPanelSteps: React.FC<{
@@ -439,37 +455,37 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const hasSameDayWork = hasSameDayWorkflowWork(forecastCycle.cycleDate, currentDay);
   const currentVersion = getCurrentWorkflowVersion(workflowMetadata.outlookVersions);
 
-  const statusLabel = getWorkflowStatusLabel(
+  const statusLabel = getWorkflowStatusLabel({
     hasMapStarted,
     isUpdating,
     activeUpdateVersion,
     mapIsComplete,
     discussionIsComplete,
     isReviewed,
-  );
+  });
 
   /** Starts a same-day workflow update from the current package. */
-  const handleCreateUpdate = () => {
+  function handleCreateUpdate(): void {
     dispatch(createOutlookUpdate());
-  };
+  }
   /** Opens the completion review in the active workspace or validates it locally. */
-  const handleOpenReview = () => {
+  function handleOpenReview(): void {
     if (controller) {
       controller.onOpenCompletionModal();
       return;
     }
     dispatch(validateCompletion());
-  };
+  }
   /** Closes the local completion review modal. */
-  const handleCloseReview = () => dispatch(dismissCompletionModal());
+  function handleCloseReview(): void { dispatch(dismissCompletionModal()); }
   /** Marks the current workflow package complete. */
-  const handleCompleteReview = () => dispatch(completeCycle());
+  function handleCompleteReview(): void { dispatch(completeCycle()); }
   /** Completes the workflow package while retaining explicitly omitted days. */
-  const handleCompleteWithOmissions = () => dispatch(completeWithOmissions());
+  function handleCompleteWithOmissions(): void { dispatch(completeWithOmissions()); }
   /** Records why a workflow day was intentionally omitted. */
-  const handleOmitDay = (day: DayType, reason: string) => dispatch(omitDay({ day, reason }));
+  function handleOmitDay(day: DayType, reason: string): void { dispatch(omitDay({ day, reason })); }
   /** Exports the current workflow package and restores the button state afterward. */
-  const handleWorkflowExport = async () => {
+  async function handleWorkflowExport(): Promise<void> {
     setIsPackageDownloading(true);
     try {
       await downloadGfcPackage(
@@ -480,9 +496,9 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
     } finally {
       setIsPackageDownloading(false);
     }
-  };
+  }
   /** Starts today's workflow from the suggested previous-cycle outlook. */
-  const handleStartFromPrevious = () => {
+  function handleStartFromPrevious(): void {
     if (!previousSuggestion) return;
     dispatch(startFromPreviousCycle({
       sourceCycleId: previousSuggestion.cycleId,
@@ -490,7 +506,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
       targetDay: previousSuggestion.targetDay,
       newCycleDate: getLocalCalendarDate(),
     }));
-  };
+  }
 
   return (
     <section

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -1,0 +1,340 @@
+import React, { useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { Archive, CheckCircle2, Clock3, FileText, GitBranch, Map, RefreshCw } from 'lucide-react';
+import { isFeatureExposed } from '../../config/featureExposure';
+import { Button } from '../ui/button';
+import {
+  selectForecastCycle,
+  selectSavedCycles,
+  selectHasActiveWorkflow,
+  selectWorkflowMetadata,
+  selectWorkflowTemplate,
+  selectCompletionValidationResult,
+  selectOmittedDays,
+  createOutlookUpdate,
+  startFromPreviousCycle,
+  validateCompletion,
+  completeCycle,
+  completeWithOmissions,
+  dismissCompletionModal,
+  omitDay,
+} from '../../store/forecastSlice';
+import { getLocalCalendarDate } from '../../utils/localDate';
+import { validateCycleCompletion } from '../../utils/completionValidation';
+import { downloadGfcPackage } from '../../utils/fileUtils';
+import type { DayType } from '../../types/outlooks';
+import type { StandardGrouping } from '../../types/workflow';
+import type { ForecastWorkspaceController } from '../ForecastWorkspace/useForecastWorkspaceController';
+import CompletionValidationModal from '../CompletionValidation/CompletionValidationModal';
+import './ForecastWorkflowPanel.css';
+
+interface ForecastWorkflowPanelProps {
+  controller?: ForecastWorkspaceController;
+  context?: 'forecast' | 'discussion';
+}
+
+interface PreviousOutlookSuggestion {
+  cycleId: string;
+  label: string;
+  sourceDay: DayType;
+  targetDay: DayType;
+}
+
+const dayValues = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+
+/** True when one forecast day has any drawn outlook or low-probability marker. */
+const dayHasMapWork = (day: NonNullable<ReturnType<typeof selectForecastCycle>['days'][DayType]>): boolean => {
+  const hasMapData = Object.values(day.data).some((outlookMap) => (outlookMap?.size ?? 0) > 0);
+  const hasLowProbability = (day.metadata.lowProbabilityOutlooks?.length ?? 0) > 0;
+  return hasMapData || hasLowProbability;
+};
+
+/** True when one forecast day has any map or discussion work started. */
+const dayHasPackageWork = (day: NonNullable<ReturnType<typeof selectForecastCycle>['days'][DayType]>): boolean => {
+  return dayHasMapWork(day) || Boolean(day.discussion);
+};
+
+/** Returns true when a discussion contains user-authored content. */
+const hasDiscussionContent = (discussion: NonNullable<ReturnType<typeof selectForecastCycle>['days'][DayType]>['discussion']): boolean => {
+  if (!discussion) return false;
+  if (discussion.mode === 'diy') {
+    return Boolean(discussion.diyContent?.trim());
+  }
+  const guidedContent = discussion.guidedContent;
+  return Boolean(guidedContent && Object.values(guidedContent).some((value) => value.trim().length > 0));
+};
+
+/** Returns yesterday's local calendar date as YYYY-MM-DD. */
+const getYesterdayLocalDate = (): string => {
+  const today = new Date(`${getLocalCalendarDate()}T00:00:00`);
+  today.setDate(today.getDate() - 1);
+  return today.toISOString().slice(0, 10);
+};
+
+/** Maps yesterday's forecast day to the current day's useful starting point. */
+const getPreviousSourceDay = (targetDay: DayType): DayType | null => {
+  if (targetDay >= 1 && targetDay <= 7) {
+    return (targetDay + 1) as DayType;
+  }
+  return null;
+};
+
+const formatCycleDate = (cycleDate: string): string => {
+  const parsed = new Date(`${cycleDate}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return cycleDate;
+  return parsed.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+};
+
+/** Returns the standard groupings that should be validated for a workflow template. */
+const getWorkflowValidationGroupings = (
+  template: ReturnType<typeof selectWorkflowTemplate>,
+): StandardGrouping[] | undefined => {
+  const groupings = (template?.groupings ?? []).filter(
+    (grouping): grouping is StandardGrouping =>
+      grouping === 'day1' || grouping === 'day2' || grouping === 'day3' || grouping === 'day4-8',
+  );
+  return groupings.length > 0 ? groupings : undefined;
+};
+
+/** Finds the most relevant previous outlook for the active forecast day. */
+const usePreviousOutlookSuggestion = (): PreviousOutlookSuggestion | null => {
+  const forecastCycle = useSelector(selectForecastCycle);
+  const savedCycles = useSelector(selectSavedCycles);
+
+  return useMemo(() => {
+    const sourceDay = getPreviousSourceDay(forecastCycle.currentDay);
+    if (!sourceDay) return null;
+
+    const yesterday = getYesterdayLocalDate();
+    const candidate = savedCycles
+      .slice()
+      .reverse()
+      .find((cycle) => {
+        const source = cycle.forecastCycle.days[sourceDay];
+        return cycle.cycleDate === yesterday && source && dayHasPackageWork(source);
+      });
+
+    if (!candidate) return null;
+
+    return {
+      cycleId: candidate.id,
+      label: `${formatCycleDate(candidate.cycleDate)} Day ${sourceDay}`,
+      sourceDay,
+      targetDay: forecastCycle.currentDay,
+    };
+  }, [forecastCycle.currentDay, savedCycles]);
+};
+
+const WorkflowStep: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  status: 'complete' | 'active' | 'pending';
+}> = ({ icon, label, status }) => (
+  <div className={`forecast-workflow-step forecast-workflow-step--${status}`}>
+    <span>{icon}</span>
+    <strong>{label}</strong>
+  </div>
+);
+
+/** Persistent package workflow prompt for the forecast editor. */
+export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ controller, context = 'forecast' }) => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const [isPackageDownloading, setIsPackageDownloading] = useState(false);
+  const forecastCycle = useSelector(selectForecastCycle);
+  const hasActiveWorkflow = useSelector(selectHasActiveWorkflow);
+  const workflowMetadata = useSelector(selectWorkflowMetadata);
+  const workflowTemplate = useSelector(selectWorkflowTemplate);
+  const validationResult = useSelector(selectCompletionValidationResult);
+  const omittedDays = useSelector(selectOmittedDays);
+  const previousSuggestion = usePreviousOutlookSuggestion();
+
+  if (!isFeatureExposed('forecastWorkflowV2') || !hasActiveWorkflow || !workflowMetadata) {
+    return null;
+  }
+
+  const currentDay = forecastCycle.days[forecastCycle.currentDay];
+  const hasMapStarted = currentDay ? dayHasMapWork(currentDay) : false;
+  const hasDiscussion = hasDiscussionContent(currentDay?.discussion);
+  const currentValidation = validateCycleCompletion(forecastCycle, getWorkflowValidationGroupings(workflowTemplate));
+  const mapIsComplete = !currentValidation.issues.some((issue) => issue.type === 'missing-polygon');
+  const discussionIsComplete = !currentValidation.issues.some((issue) => issue.type === 'missing-discussion');
+  const activeUpdateVersion = forecastCycle.updateInProgressVersion;
+  const isUpdating = typeof activeUpdateVersion === 'number';
+  const canReviewPackage = mapIsComplete && discussionIsComplete && !isUpdating && (Boolean(controller) || context === 'discussion');
+  const canExportPackage = hasMapStarted || hasDiscussion || workflowMetadata.outlookVersions.length > 0;
+  const isReviewed = Boolean(forecastCycle.completionAcknowledgedAt);
+  const hasSameDayWork = forecastCycle.cycleDate === getLocalCalendarDate() && Boolean(currentDay && dayHasPackageWork(currentDay));
+  const currentVersion = workflowMetadata.outlookVersions.length > 0
+    ? Math.max(...workflowMetadata.outlookVersions.map((version) => version.version))
+    : 1;
+
+  const statusLabel = !hasMapStarted
+    ? 'Map not started'
+    : isUpdating
+      ? `Update v${activeUpdateVersion} in progress`
+      : !mapIsComplete
+        ? 'Map in progress'
+        : !discussionIsComplete
+          ? 'Discussion needed'
+          : !forecastCycle.completionAcknowledgedAt
+            ? 'Ready for review'
+            : 'Ready to export';
+
+  const handleCreateUpdate = () => {
+    dispatch(createOutlookUpdate());
+  };
+  const handleOpenReview = () => {
+    if (controller) {
+      controller.onOpenCompletionModal();
+      return;
+    }
+    dispatch(validateCompletion());
+  };
+  const handleCloseReview = () => dispatch(dismissCompletionModal());
+  const handleCompleteReview = () => dispatch(completeCycle());
+  const handleCompleteWithOmissions = () => dispatch(completeWithOmissions());
+  const handleOmitDay = (day: DayType, reason: string) => dispatch(omitDay({ day, reason }));
+  const handleWorkflowExport = async () => {
+    setIsPackageDownloading(true);
+    try {
+      await downloadGfcPackage(
+        forecastCycle,
+        { center: [39.8283, -98.5795], zoom: 4 },
+        workflowMetadata,
+      );
+    } finally {
+      setIsPackageDownloading(false);
+    }
+  };
+  const handleStartFromPrevious = () => {
+    if (!previousSuggestion) return;
+    dispatch(startFromPreviousCycle({
+      sourceCycleId: previousSuggestion.cycleId,
+      sourceDay: previousSuggestion.sourceDay,
+      targetDay: previousSuggestion.targetDay,
+      newCycleDate: getLocalCalendarDate(),
+    }));
+  };
+
+  return (
+    <section
+      className={`forecast-workflow-panel${isUpdating ? ' forecast-workflow-panel--updating' : ''}`}
+      aria-label="Forecast package workflow"
+    >
+      <div className="forecast-workflow-panel__content">
+        <div className="forecast-workflow-panel__meta-row">
+          <span>Day {forecastCycle.currentDay} package</span>
+          <span>{formatCycleDate(forecastCycle.cycleDate)}</span>
+          <span>v{currentVersion}</span>
+          <strong>{statusLabel}</strong>
+          {isUpdating ? (
+            <span className="forecast-workflow-panel__update-badge">
+              <RefreshCw className="h-3.5 w-3.5" />
+              Editing update
+            </span>
+          ) : null}
+        </div>
+
+        <div className="forecast-workflow-panel__steps">
+          <WorkflowStep icon={<Map className="h-4 w-4" />} label="Outlook map" status={mapIsComplete ? 'complete' : hasMapStarted ? 'active' : 'pending'} />
+          <WorkflowStep icon={<FileText className="h-4 w-4" />} label="Discussion" status={discussionIsComplete ? 'complete' : mapIsComplete ? 'active' : 'pending'} />
+          <WorkflowStep icon={<CheckCircle2 className="h-4 w-4" />} label={isUpdating ? `Update v${activeUpdateVersion}` : 'Review'} status={isReviewed ? 'complete' : (canReviewPackage || isUpdating) ? 'active' : 'pending'} />
+        </div>
+        <div className="forecast-workflow-panel__actions">
+          {isReviewed ? (
+            <Button size="sm" onClick={() => { handleWorkflowExport().catch(() => undefined); }} disabled={isPackageDownloading}>
+              <Archive className="h-4 w-4 mr-2" />
+              {isPackageDownloading ? 'Exporting...' : 'Export Workflow'}
+            </Button>
+          ) : canReviewPackage ? (
+            <Button size="sm" onClick={handleOpenReview}>
+              <CheckCircle2 className="h-4 w-4 mr-2" />
+              Review Package
+            </Button>
+          ) : isUpdating ? (
+            <>
+              {context === 'forecast' ? (
+                <Button size="sm" onClick={() => navigate('/discussion')} disabled={!mapIsComplete}>
+                  <FileText className="h-4 w-4 mr-2" />
+                  Update Discussion
+                </Button>
+              ) : (
+                <Button size="sm" onClick={() => navigate('/forecast')}>
+                  <Map className="h-4 w-4 mr-2" />
+                  Update Map
+                </Button>
+              )}
+              <Button size="sm" variant="outline" onClick={handleOpenReview}>
+                <CheckCircle2 className="h-4 w-4 mr-2" />
+                Mark Ready
+              </Button>
+            </>
+          ) : context === 'discussion' && !mapIsComplete ? (
+            <Button size="sm" onClick={() => navigate('/forecast')}>
+              <Map className="h-4 w-4 mr-2" />
+              Continue Map
+            </Button>
+          ) : context === 'discussion' ? (
+            <Button size="sm" onClick={() => navigate('/forecast')}>
+              <Map className="h-4 w-4 mr-2" />
+              Finish Map
+            </Button>
+          ) : (
+            <Button size="sm" onClick={() => navigate('/discussion')} disabled={!mapIsComplete}>
+              <FileText className="h-4 w-4 mr-2" />
+              Write Discussion
+            </Button>
+          )}
+          {canExportPackage && !isReviewed ? (
+            <Button size="sm" variant="outline" onClick={() => { handleWorkflowExport().catch(() => undefined); }} disabled={isPackageDownloading}>
+              <Archive className="h-4 w-4 mr-2" />
+              Export
+            </Button>
+          ) : null}
+          {controller && !isUpdating && (!canReviewPackage || forecastCycle.completionAcknowledgedAt) ? (
+            <Button size="sm" variant="outline" onClick={handleOpenReview}>
+              <CheckCircle2 className="h-4 w-4 mr-2" />
+              Review
+            </Button>
+          ) : null}
+          {!isUpdating && hasSameDayWork ? (
+            <Button size="sm" variant="outline" onClick={handleCreateUpdate}>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Update
+            </Button>
+          ) : null}
+          {previousSuggestion ? (
+            <Button size="sm" variant="outline" onClick={handleStartFromPrevious}>
+              <GitBranch className="h-4 w-4 mr-2" />
+              Use {previousSuggestion.label}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {forecastCycle.cycleDate !== getLocalCalendarDate() ? (
+        <div className="forecast-workflow-panel__notice">
+          <Clock3 className="h-4 w-4" />
+          This forecast was created before today and may now be out of date.
+        </div>
+      ) : null}
+      {!controller ? (
+        <CompletionValidationModal
+          isOpen={Boolean(validationResult)}
+          validationResult={validationResult}
+          omittedDays={omittedDays}
+          onClose={handleCloseReview}
+          onComplete={handleCompleteReview}
+          onCompleteWithOmissions={handleCompleteWithOmissions}
+          onOmitDay={handleOmitDay}
+          onNavigateToIssue={() => navigate('/forecast')}
+          onExport={() => { handleWorkflowExport().catch(() => undefined); }}
+        />
+      ) : null}
+    </section>
+  );
+};
+
+export default ForecastWorkflowPanel;

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -169,7 +169,9 @@ const WorkflowPanelExportAction: React.FC<WorkflowPanelActionsProps> = ({ canExp
 
 /** Adds the optional review action for controller-backed forecast workspaces. */
 const WorkflowPanelReviewAction: React.FC<WorkflowPanelActionsProps> = ({ canReviewPackage, hasController, isReviewed, isUpdating, onOpenReview }) => {
-  if (!hasController || isUpdating || (canReviewPackage && !isReviewed)) return null;
+  if (!hasController) return null;
+  if (isUpdating) return null;
+  if (canReviewPackage && !isReviewed) return null;
   return (
     <Button size="sm" variant="outline" onClick={onOpenReview}>
       <CheckCircle2 className="h-4 w-4 mr-2" />
@@ -200,6 +202,7 @@ const WorkflowPanelPreviousAction: React.FC<WorkflowPanelActionsProps> = ({ prev
   );
 };
 
+/** Renders the optional secondary workflow actions. */
 const WorkflowPanelExtras: React.FC<WorkflowPanelActionsProps> = (props) => (
   <>
     <WorkflowPanelExportAction {...props} />
@@ -217,7 +220,6 @@ const WorkflowPanelPrimaryAction: React.FC<WorkflowPanelActionsProps> = ({
   isUpdating,
   mapIsComplete,
   isPackageDownloading,
-  activeUpdateVersion,
   onExport,
   onOpenReview,
   onNavigate,
@@ -377,6 +379,35 @@ const getCurrentWorkflowVersion = (versions: { version: number }[]): number => {
   return Math.max(...versions.map((version) => version.version));
 };
 
+/** Determines whether the banner has enough state to render. */
+const shouldHideWorkflowPanel = (
+  isExposed: boolean,
+  hasActiveWorkflow: boolean,
+  workflowMetadata: ReturnType<typeof selectWorkflowMetadata>,
+): boolean => !isExposed || !hasActiveWorkflow || !workflowMetadata;
+
+/** Determines whether the current package can enter review. */
+const canReviewWorkflowPackage = (
+  mapIsComplete: boolean,
+  discussionIsComplete: boolean,
+  isUpdating: boolean,
+  hasController: boolean,
+  context: 'forecast' | 'discussion',
+): boolean => mapIsComplete && discussionIsComplete && !isUpdating && (hasController || context === 'discussion');
+
+/** Determines whether the current package has anything available to export. */
+const canExportWorkflowPackage = (
+  hasMapStarted: boolean,
+  hasDiscussion: boolean,
+  outlookVersionCount: number,
+): boolean => hasMapStarted || hasDiscussion || outlookVersionCount > 0;
+
+/** Determines whether the current package can start a same-day update. */
+const hasSameDayWorkflowWork = (
+  cycleDate: string,
+  currentDay: NonNullable<ReturnType<typeof selectForecastCycle>['days'][DayType]> | undefined,
+): boolean => cycleDate === getLocalCalendarDate() && Boolean(currentDay && dayHasPackageWork(currentDay));
+
 /** Persistent package workflow prompt for the forecast editor. */
 export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ controller, context = 'forecast' }) => {
   const dispatch = useDispatch();
@@ -390,7 +421,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const omittedDays = useSelector(selectOmittedDays);
   const previousSuggestion = usePreviousOutlookSuggestion();
 
-  if (!isFeatureExposed('forecastWorkflowV2') || !hasActiveWorkflow || !workflowMetadata) {
+  if (shouldHideWorkflowPanel(isFeatureExposed('forecastWorkflowV2'), hasActiveWorkflow, workflowMetadata)) {
     return null;
   }
 
@@ -402,10 +433,10 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const discussionIsComplete = !currentValidation.issues.some((issue) => issue.type === 'missing-discussion');
   const activeUpdateVersion = forecastCycle.updateInProgressVersion;
   const isUpdating = typeof activeUpdateVersion === 'number';
-  const canReviewPackage = mapIsComplete && discussionIsComplete && !isUpdating && (Boolean(controller) || context === 'discussion');
-  const canExportPackage = hasMapStarted || hasDiscussion || workflowMetadata.outlookVersions.length > 0;
+  const canReviewPackage = canReviewWorkflowPackage(mapIsComplete, discussionIsComplete, isUpdating, Boolean(controller), context);
+  const canExportPackage = canExportWorkflowPackage(hasMapStarted, hasDiscussion, workflowMetadata.outlookVersions.length);
   const isReviewed = Boolean(forecastCycle.completionAcknowledgedAt);
-  const hasSameDayWork = forecastCycle.cycleDate === getLocalCalendarDate() && Boolean(currentDay && dayHasPackageWork(currentDay));
+  const hasSameDayWork = hasSameDayWorkflowWork(forecastCycle.cycleDate, currentDay);
   const currentVersion = getCurrentWorkflowVersion(workflowMetadata.outlookVersions);
 
   const statusLabel = getWorkflowStatusLabel(

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -41,8 +41,6 @@ interface PreviousOutlookSuggestion {
   targetDay: DayType;
 }
 
-const dayValues = [1, 2, 3, 4, 5, 6, 7, 8] as const;
-
 /** True when one forecast day has any drawn outlook or low-probability marker. */
 const dayHasMapWork = (day: NonNullable<ReturnType<typeof selectForecastCycle>['days'][DayType]>): boolean => {
   const hasMapData = Object.values(day.data).some((outlookMap) => (outlookMap?.size ?? 0) > 0);
@@ -137,6 +135,157 @@ const WorkflowStep: React.FC<{
   </div>
 );
 
+interface WorkflowPanelActionsProps {
+  context: 'forecast' | 'discussion';
+  isReviewed: boolean;
+  canReviewPackage: boolean;
+  isUpdating: boolean;
+  mapIsComplete: boolean;
+  canExportPackage: boolean;
+  hasController: boolean;
+  hasSameDayWork: boolean;
+  isPackageDownloading: boolean;
+  previousSuggestion: PreviousOutlookSuggestion | null;
+  activeUpdateVersion: number | undefined;
+  onExport: () => void;
+  onOpenReview: () => void;
+  onCreateUpdate: () => void;
+  onStartFromPrevious: () => void;
+  onNavigate: (path: string) => void;
+}
+
+const WorkflowPanelExtras: React.FC<WorkflowPanelActionsProps> = ({
+  canExportPackage,
+  hasController,
+  hasSameDayWork,
+  isPackageDownloading,
+  isReviewed,
+  isUpdating,
+  previousSuggestion,
+  onCreateUpdate,
+  onExport,
+  onNavigate,
+  onOpenReview,
+  onStartFromPrevious,
+}) => (
+  <>
+    {canExportPackage && !isReviewed ? (
+      <Button size="sm" variant="outline" onClick={onExport} disabled={isPackageDownloading}>
+        <Archive className="h-4 w-4 mr-2" />
+        Export
+      </Button>
+    ) : null}
+    {hasController && !isUpdating && (!canReviewPackage || isReviewed) ? (
+      <Button size="sm" variant="outline" onClick={onOpenReview}>
+        <CheckCircle2 className="h-4 w-4 mr-2" />
+        Review
+      </Button>
+    ) : null}
+    {!isUpdating && hasSameDayWork ? (
+      <Button size="sm" variant="outline" onClick={onCreateUpdate}>
+        <RefreshCw className="h-4 w-4 mr-2" />
+        Update
+      </Button>
+    ) : null}
+    {previousSuggestion ? (
+      <Button size="sm" variant="outline" onClick={onStartFromPrevious}>
+        <GitBranch className="h-4 w-4 mr-2" />
+        Use {previousSuggestion.label}
+      </Button>
+    ) : null}
+  </>
+);
+
+/** Renders the primary action for the current workflow state. */
+const WorkflowPanelPrimaryAction: React.FC<WorkflowPanelActionsProps> = ({
+  context,
+  isReviewed,
+  canReviewPackage,
+  isUpdating,
+  mapIsComplete,
+  isPackageDownloading,
+  activeUpdateVersion,
+  onExport,
+  onOpenReview,
+  onNavigate,
+}) => {
+  if (isReviewed) {
+    return (
+      <Button size="sm" onClick={onExport} disabled={isPackageDownloading}>
+        <Archive className="h-4 w-4 mr-2" />
+        {isPackageDownloading ? 'Exporting...' : 'Export Workflow'}
+      </Button>
+    );
+  }
+  if (canReviewPackage) {
+    return (
+      <Button size="sm" onClick={onOpenReview}>
+        <CheckCircle2 className="h-4 w-4 mr-2" />
+        Review Package
+      </Button>
+    );
+  }
+  if (isUpdating) {
+    return (
+      <>
+        {context === 'forecast' ? (
+          <Button size="sm" onClick={() => onNavigate('/discussion')} disabled={!mapIsComplete}>
+            <FileText className="h-4 w-4 mr-2" />
+            Update Discussion
+          </Button>
+        ) : (
+          <Button size="sm" onClick={() => onNavigate('/forecast')}>
+            <Map className="h-4 w-4 mr-2" />
+            Update Map
+          </Button>
+        )}
+        <Button size="sm" variant="outline" onClick={onOpenReview}>
+          <CheckCircle2 className="h-4 w-4 mr-2" />
+          Mark Ready
+        </Button>
+      </>
+    );
+  }
+  if (context === 'discussion') {
+    return (
+      <Button size="sm" onClick={() => onNavigate('/forecast')}>
+        <Map className="h-4 w-4 mr-2" />
+        {mapIsComplete ? 'Finish Map' : 'Continue Map'}
+      </Button>
+    );
+  }
+  return (
+    <Button size="sm" onClick={() => onNavigate('/discussion')} disabled={!mapIsComplete}>
+      <FileText className="h-4 w-4 mr-2" />
+      Write Discussion
+    </Button>
+  );
+};
+
+/** Renders navigation and export controls beside the primary workflow action. */
+const WorkflowPanelActions: React.FC<WorkflowPanelActionsProps> = (props) => (
+  <div className="forecast-workflow-panel__actions">
+    <WorkflowPanelPrimaryAction {...props} />
+    <WorkflowPanelExtras {...props} />
+  </div>
+);
+
+/** Returns the concise status shown in the workflow banner. */
+const getWorkflowStatusLabel = (
+  hasMapStarted: boolean,
+  isUpdating: boolean,
+  activeUpdateVersion: number | undefined,
+  mapIsComplete: boolean,
+  discussionIsComplete: boolean,
+  isReviewed: boolean,
+): string => {
+  if (!hasMapStarted) return 'Map not started';
+  if (isUpdating) return `Update v${activeUpdateVersion} in progress`;
+  if (!mapIsComplete) return 'Map in progress';
+  if (!discussionIsComplete) return 'Discussion needed';
+  return isReviewed ? 'Ready to export' : 'Ready for review';
+};
+
 /** Persistent package workflow prompt for the forecast editor. */
 export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ controller, context = 'forecast' }) => {
   const dispatch = useDispatch();
@@ -170,17 +319,14 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
     ? Math.max(...workflowMetadata.outlookVersions.map((version) => version.version))
     : 1;
 
-  const statusLabel = !hasMapStarted
-    ? 'Map not started'
-    : isUpdating
-      ? `Update v${activeUpdateVersion} in progress`
-      : !mapIsComplete
-        ? 'Map in progress'
-        : !discussionIsComplete
-          ? 'Discussion needed'
-          : !forecastCycle.completionAcknowledgedAt
-            ? 'Ready for review'
-            : 'Ready to export';
+  const statusLabel = getWorkflowStatusLabel(
+    hasMapStarted,
+    isUpdating,
+    activeUpdateVersion,
+    mapIsComplete,
+    discussionIsComplete,
+    isReviewed,
+  );
 
   const handleCreateUpdate = () => {
     dispatch(createOutlookUpdate());
@@ -208,6 +354,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
       setIsPackageDownloading(false);
     }
   };
+  /** Starts today's workflow from the suggested previous-cycle outlook. */
   const handleStartFromPrevious = () => {
     if (!previousSuggestion) return;
     dispatch(startFromPreviousCycle({
@@ -242,76 +389,24 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
           <WorkflowStep icon={<FileText className="h-4 w-4" />} label="Discussion" status={discussionIsComplete ? 'complete' : mapIsComplete ? 'active' : 'pending'} />
           <WorkflowStep icon={<CheckCircle2 className="h-4 w-4" />} label={isUpdating ? `Update v${activeUpdateVersion}` : 'Review'} status={isReviewed ? 'complete' : (canReviewPackage || isUpdating) ? 'active' : 'pending'} />
         </div>
-        <div className="forecast-workflow-panel__actions">
-          {isReviewed ? (
-            <Button size="sm" onClick={() => { handleWorkflowExport().catch(() => undefined); }} disabled={isPackageDownloading}>
-              <Archive className="h-4 w-4 mr-2" />
-              {isPackageDownloading ? 'Exporting...' : 'Export Workflow'}
-            </Button>
-          ) : canReviewPackage ? (
-            <Button size="sm" onClick={handleOpenReview}>
-              <CheckCircle2 className="h-4 w-4 mr-2" />
-              Review Package
-            </Button>
-          ) : isUpdating ? (
-            <>
-              {context === 'forecast' ? (
-                <Button size="sm" onClick={() => navigate('/discussion')} disabled={!mapIsComplete}>
-                  <FileText className="h-4 w-4 mr-2" />
-                  Update Discussion
-                </Button>
-              ) : (
-                <Button size="sm" onClick={() => navigate('/forecast')}>
-                  <Map className="h-4 w-4 mr-2" />
-                  Update Map
-                </Button>
-              )}
-              <Button size="sm" variant="outline" onClick={handleOpenReview}>
-                <CheckCircle2 className="h-4 w-4 mr-2" />
-                Mark Ready
-              </Button>
-            </>
-          ) : context === 'discussion' && !mapIsComplete ? (
-            <Button size="sm" onClick={() => navigate('/forecast')}>
-              <Map className="h-4 w-4 mr-2" />
-              Continue Map
-            </Button>
-          ) : context === 'discussion' ? (
-            <Button size="sm" onClick={() => navigate('/forecast')}>
-              <Map className="h-4 w-4 mr-2" />
-              Finish Map
-            </Button>
-          ) : (
-            <Button size="sm" onClick={() => navigate('/discussion')} disabled={!mapIsComplete}>
-              <FileText className="h-4 w-4 mr-2" />
-              Write Discussion
-            </Button>
-          )}
-          {canExportPackage && !isReviewed ? (
-            <Button size="sm" variant="outline" onClick={() => { handleWorkflowExport().catch(() => undefined); }} disabled={isPackageDownloading}>
-              <Archive className="h-4 w-4 mr-2" />
-              Export
-            </Button>
-          ) : null}
-          {controller && !isUpdating && (!canReviewPackage || forecastCycle.completionAcknowledgedAt) ? (
-            <Button size="sm" variant="outline" onClick={handleOpenReview}>
-              <CheckCircle2 className="h-4 w-4 mr-2" />
-              Review
-            </Button>
-          ) : null}
-          {!isUpdating && hasSameDayWork ? (
-            <Button size="sm" variant="outline" onClick={handleCreateUpdate}>
-              <RefreshCw className="h-4 w-4 mr-2" />
-              Update
-            </Button>
-          ) : null}
-          {previousSuggestion ? (
-            <Button size="sm" variant="outline" onClick={handleStartFromPrevious}>
-              <GitBranch className="h-4 w-4 mr-2" />
-              Use {previousSuggestion.label}
-            </Button>
-          ) : null}
-        </div>
+        <WorkflowPanelActions
+          context={context}
+          isReviewed={isReviewed}
+          canReviewPackage={canReviewPackage}
+          isUpdating={isUpdating}
+          mapIsComplete={mapIsComplete}
+          canExportPackage={canExportPackage}
+          hasController={Boolean(controller)}
+          hasSameDayWork={hasSameDayWork}
+          isPackageDownloading={isPackageDownloading}
+          previousSuggestion={previousSuggestion}
+          activeUpdateVersion={activeUpdateVersion}
+          onExport={() => { handleWorkflowExport().catch(() => undefined); }}
+          onOpenReview={handleOpenReview}
+          onCreateUpdate={handleCreateUpdate}
+          onStartFromPrevious={handleStartFromPrevious}
+          onNavigate={navigate}
+        />
       </div>
 
       {forecastCycle.cycleDate !== getLocalCalendarDate() ? (

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -78,6 +78,7 @@ const getPreviousSourceDay = (targetDay: DayType): DayType | null => {
   return null;
 };
 
+/** Formats a cycle date for the compact workflow banner label. */
 const formatCycleDate = (cycleDate: string): string => {
   const parsed = new Date(`${cycleDate}T00:00:00`);
   if (Number.isNaN(parsed.getTime())) return cycleDate;
@@ -124,6 +125,7 @@ const usePreviousOutlookSuggestion = (): PreviousOutlookSuggestion | null => {
   }, [forecastCycle.currentDay, savedCycles]);
 };
 
+/** Displays one map, discussion, or review step in the workflow banner. */
 const WorkflowStep: React.FC<{
   icon: React.ReactNode;
   label: string;
@@ -154,45 +156,56 @@ interface WorkflowPanelActionsProps {
   onNavigate: (path: string) => void;
 }
 
-const WorkflowPanelExtras: React.FC<WorkflowPanelActionsProps> = ({
-  canExportPackage,
-  hasController,
-  hasSameDayWork,
-  isPackageDownloading,
-  isReviewed,
-  isUpdating,
-  previousSuggestion,
-  onCreateUpdate,
-  onExport,
-  onNavigate,
-  onOpenReview,
-  onStartFromPrevious,
-}) => (
+/** Adds the optional workflow export action. */
+const WorkflowPanelExportAction: React.FC<WorkflowPanelActionsProps> = ({ canExportPackage, isPackageDownloading, isReviewed, onExport }) => {
+  if (!canExportPackage || isReviewed) return null;
+  return (
+    <Button size="sm" variant="outline" onClick={onExport} disabled={isPackageDownloading}>
+      <Archive className="h-4 w-4 mr-2" />
+      Export
+    </Button>
+  );
+};
+
+/** Adds the optional review action for controller-backed forecast workspaces. */
+const WorkflowPanelReviewAction: React.FC<WorkflowPanelActionsProps> = ({ canReviewPackage, hasController, isReviewed, isUpdating, onOpenReview }) => {
+  if (!hasController || isUpdating || (canReviewPackage && !isReviewed)) return null;
+  return (
+    <Button size="sm" variant="outline" onClick={onOpenReview}>
+      <CheckCircle2 className="h-4 w-4 mr-2" />
+      Review
+    </Button>
+  );
+};
+
+/** Adds the optional same-day update action. */
+const WorkflowPanelUpdateAction: React.FC<WorkflowPanelActionsProps> = ({ hasSameDayWork, isUpdating, onCreateUpdate }) => {
+  if (isUpdating || !hasSameDayWork) return null;
+  return (
+    <Button size="sm" variant="outline" onClick={onCreateUpdate}>
+      <RefreshCw className="h-4 w-4 mr-2" />
+      Update
+    </Button>
+  );
+};
+
+/** Adds the optional previous-cycle workflow action. */
+const WorkflowPanelPreviousAction: React.FC<WorkflowPanelActionsProps> = ({ previousSuggestion, onStartFromPrevious }) => {
+  if (!previousSuggestion) return null;
+  return (
+    <Button size="sm" variant="outline" onClick={onStartFromPrevious}>
+      <GitBranch className="h-4 w-4 mr-2" />
+      Use {previousSuggestion.label}
+    </Button>
+  );
+};
+
+const WorkflowPanelExtras: React.FC<WorkflowPanelActionsProps> = (props) => (
   <>
-    {canExportPackage && !isReviewed ? (
-      <Button size="sm" variant="outline" onClick={onExport} disabled={isPackageDownloading}>
-        <Archive className="h-4 w-4 mr-2" />
-        Export
-      </Button>
-    ) : null}
-    {hasController && !isUpdating && (!canReviewPackage || isReviewed) ? (
-      <Button size="sm" variant="outline" onClick={onOpenReview}>
-        <CheckCircle2 className="h-4 w-4 mr-2" />
-        Review
-      </Button>
-    ) : null}
-    {!isUpdating && hasSameDayWork ? (
-      <Button size="sm" variant="outline" onClick={onCreateUpdate}>
-        <RefreshCw className="h-4 w-4 mr-2" />
-        Update
-      </Button>
-    ) : null}
-    {previousSuggestion ? (
-      <Button size="sm" variant="outline" onClick={onStartFromPrevious}>
-        <GitBranch className="h-4 w-4 mr-2" />
-        Use {previousSuggestion.label}
-      </Button>
-    ) : null}
+    <WorkflowPanelExportAction {...props} />
+    <WorkflowPanelReviewAction {...props} />
+    <WorkflowPanelUpdateAction {...props} />
+    <WorkflowPanelPreviousAction {...props} />
   </>
 );
 
@@ -286,6 +299,84 @@ const getWorkflowStatusLabel = (
   return isReviewed ? 'Ready to export' : 'Ready for review';
 };
 
+/** Displays the workflow progress steps without mixing them into the panel orchestration. */
+const WorkflowPanelSteps: React.FC<{
+  mapIsComplete: boolean;
+  hasMapStarted: boolean;
+  discussionIsComplete: boolean;
+  isReviewed: boolean;
+  canReviewPackage: boolean;
+  isUpdating: boolean;
+  activeUpdateVersion: number | undefined;
+}> = ({
+  mapIsComplete,
+  hasMapStarted,
+  discussionIsComplete,
+  isReviewed,
+  canReviewPackage,
+  isUpdating,
+  activeUpdateVersion,
+}) => (
+  <div className="forecast-workflow-panel__steps">
+    <WorkflowStep icon={<Map className="h-4 w-4" />} label="Outlook map" status={mapIsComplete ? 'complete' : hasMapStarted ? 'active' : 'pending'} />
+    <WorkflowStep icon={<FileText className="h-4 w-4" />} label="Discussion" status={discussionIsComplete ? 'complete' : mapIsComplete ? 'active' : 'pending'} />
+    <WorkflowStep icon={<CheckCircle2 className="h-4 w-4" />} label={isUpdating ? `Update v${activeUpdateVersion}` : 'Review'} status={isReviewed ? 'complete' : (canReviewPackage || isUpdating) ? 'active' : 'pending'} />
+  </div>
+);
+
+/** Displays the stale-date notice and route-local completion modal. */
+const WorkflowPanelFooter: React.FC<{
+  cycleDate: string;
+  validationResult: ReturnType<typeof selectCompletionValidationResult>;
+  omittedDays: ReturnType<typeof selectOmittedDays>;
+  hasController: boolean;
+  onClose: () => void;
+  onComplete: () => void;
+  onCompleteWithOmissions: () => void;
+  onOmitDay: (day: DayType, reason: string) => void;
+  onNavigateToIssue: () => void;
+  onExport: () => void;
+}> = ({
+  cycleDate,
+  validationResult,
+  omittedDays,
+  hasController,
+  onClose,
+  onComplete,
+  onCompleteWithOmissions,
+  onOmitDay,
+  onNavigateToIssue,
+  onExport,
+}) => (
+  <>
+    {cycleDate !== getLocalCalendarDate() ? (
+      <div className="forecast-workflow-panel__notice">
+        <Clock3 className="h-4 w-4" />
+        This forecast was created before today and may now be out of date.
+      </div>
+    ) : null}
+    {!hasController ? (
+      <CompletionValidationModal
+        isOpen={Boolean(validationResult)}
+        validationResult={validationResult}
+        omittedDays={omittedDays}
+        onClose={onClose}
+        onComplete={onComplete}
+        onCompleteWithOmissions={onCompleteWithOmissions}
+        onOmitDay={onOmitDay}
+        onNavigateToIssue={onNavigateToIssue}
+        onExport={onExport}
+      />
+    ) : null}
+  </>
+);
+
+/** Returns the highest workflow package version, defaulting to the initial package. */
+const getCurrentWorkflowVersion = (versions: { version: number }[]): number => {
+  if (versions.length === 0) return 1;
+  return Math.max(...versions.map((version) => version.version));
+};
+
 /** Persistent package workflow prompt for the forecast editor. */
 export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ controller, context = 'forecast' }) => {
   const dispatch = useDispatch();
@@ -304,7 +395,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   }
 
   const currentDay = forecastCycle.days[forecastCycle.currentDay];
-  const hasMapStarted = currentDay ? dayHasMapWork(currentDay) : false;
+  const hasMapStarted = Boolean(currentDay && dayHasMapWork(currentDay));
   const hasDiscussion = hasDiscussionContent(currentDay?.discussion);
   const currentValidation = validateCycleCompletion(forecastCycle, getWorkflowValidationGroupings(workflowTemplate));
   const mapIsComplete = !currentValidation.issues.some((issue) => issue.type === 'missing-polygon');
@@ -315,9 +406,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const canExportPackage = hasMapStarted || hasDiscussion || workflowMetadata.outlookVersions.length > 0;
   const isReviewed = Boolean(forecastCycle.completionAcknowledgedAt);
   const hasSameDayWork = forecastCycle.cycleDate === getLocalCalendarDate() && Boolean(currentDay && dayHasPackageWork(currentDay));
-  const currentVersion = workflowMetadata.outlookVersions.length > 0
-    ? Math.max(...workflowMetadata.outlookVersions.map((version) => version.version))
-    : 1;
+  const currentVersion = getCurrentWorkflowVersion(workflowMetadata.outlookVersions);
 
   const statusLabel = getWorkflowStatusLabel(
     hasMapStarted,
@@ -328,9 +417,11 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
     isReviewed,
   );
 
+  /** Starts a same-day workflow update from the current package. */
   const handleCreateUpdate = () => {
     dispatch(createOutlookUpdate());
   };
+  /** Opens the completion review in the active workspace or validates it locally. */
   const handleOpenReview = () => {
     if (controller) {
       controller.onOpenCompletionModal();
@@ -338,10 +429,15 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
     }
     dispatch(validateCompletion());
   };
+  /** Closes the local completion review modal. */
   const handleCloseReview = () => dispatch(dismissCompletionModal());
+  /** Marks the current workflow package complete. */
   const handleCompleteReview = () => dispatch(completeCycle());
+  /** Completes the workflow package while retaining explicitly omitted days. */
   const handleCompleteWithOmissions = () => dispatch(completeWithOmissions());
+  /** Records why a workflow day was intentionally omitted. */
   const handleOmitDay = (day: DayType, reason: string) => dispatch(omitDay({ day, reason }));
+  /** Exports the current workflow package and restores the button state afterward. */
   const handleWorkflowExport = async () => {
     setIsPackageDownloading(true);
     try {
@@ -384,11 +480,15 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
           ) : null}
         </div>
 
-        <div className="forecast-workflow-panel__steps">
-          <WorkflowStep icon={<Map className="h-4 w-4" />} label="Outlook map" status={mapIsComplete ? 'complete' : hasMapStarted ? 'active' : 'pending'} />
-          <WorkflowStep icon={<FileText className="h-4 w-4" />} label="Discussion" status={discussionIsComplete ? 'complete' : mapIsComplete ? 'active' : 'pending'} />
-          <WorkflowStep icon={<CheckCircle2 className="h-4 w-4" />} label={isUpdating ? `Update v${activeUpdateVersion}` : 'Review'} status={isReviewed ? 'complete' : (canReviewPackage || isUpdating) ? 'active' : 'pending'} />
-        </div>
+        <WorkflowPanelSteps
+          mapIsComplete={mapIsComplete}
+          hasMapStarted={hasMapStarted}
+          discussionIsComplete={discussionIsComplete}
+          isReviewed={isReviewed}
+          canReviewPackage={canReviewPackage}
+          isUpdating={isUpdating}
+          activeUpdateVersion={activeUpdateVersion}
+        />
         <WorkflowPanelActions
           context={context}
           isReviewed={isReviewed}
@@ -409,25 +509,18 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
         />
       </div>
 
-      {forecastCycle.cycleDate !== getLocalCalendarDate() ? (
-        <div className="forecast-workflow-panel__notice">
-          <Clock3 className="h-4 w-4" />
-          This forecast was created before today and may now be out of date.
-        </div>
-      ) : null}
-      {!controller ? (
-        <CompletionValidationModal
-          isOpen={Boolean(validationResult)}
-          validationResult={validationResult}
-          omittedDays={omittedDays}
-          onClose={handleCloseReview}
-          onComplete={handleCompleteReview}
-          onCompleteWithOmissions={handleCompleteWithOmissions}
-          onOmitDay={handleOmitDay}
-          onNavigateToIssue={() => navigate('/forecast')}
-          onExport={() => { handleWorkflowExport().catch(() => undefined); }}
-        />
-      ) : null}
+      <WorkflowPanelFooter
+        cycleDate={forecastCycle.cycleDate}
+        validationResult={validationResult}
+        omittedDays={omittedDays}
+        hasController={Boolean(controller)}
+        onClose={handleCloseReview}
+        onComplete={handleCompleteReview}
+        onCompleteWithOmissions={handleCompleteWithOmissions}
+        onOmitDay={handleOmitDay}
+        onNavigateToIssue={() => navigate('/forecast')}
+        onExport={() => { handleWorkflowExport().catch(() => undefined); }}
+      />
     </section>
   );
 };

--- a/src/components/ForecastWorkspace/ForecastWorkspaceLayouts.test.tsx
+++ b/src/components/ForecastWorkspace/ForecastWorkspaceLayouts.test.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 import { configureStore } from '@reduxjs/toolkit';
 import forecastReducer from '../../store/forecastSlice';
 import overlaysReducer from '../../store/overlaysSlice';
@@ -63,9 +64,11 @@ describe('Tabbed toolbar layout', () => {
     const store = createStore();
 
     render(
-      <Provider store={store}>
-        <LayoutHarness />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={store}>
+          <LayoutHarness />
+        </Provider>
+      </MemoryRouter>
     );
 
     await user.click(screen.getByRole('tab', { name: /days/i }));

--- a/src/components/ForecastWorkspace/ForecastWorkspaceLayouts.tsx
+++ b/src/components/ForecastWorkspace/ForecastWorkspaceLayouts.tsx
@@ -4,6 +4,7 @@ import ForecastMap, { ForecastMapHandle } from '../Map/ForecastMap';
 import { TabbedIntegratedToolbar } from '../IntegratedToolbar/IntegratedToolbar';
 import { TooltipProvider } from '../ui/tooltip';
 import type { ForecastWorkspaceController } from './useForecastWorkspaceController';
+import ForecastWorkflowPanel from '../ForecastWorkflow/ForecastWorkflowPanel';
 
 export interface ForecastWorkspaceLayoutProps {
   controller: ForecastWorkspaceController;
@@ -21,6 +22,7 @@ export const ForecastTabbedToolbarLayout: React.FC<ForecastWorkspaceLayoutProps>
 }) => (
   <TooltipProvider>
     <div className="forecast-workspace-layout flex h-full min-h-0 flex-col bg-gradient-to-b from-background via-background to-muted/10">
+      <ForecastWorkflowPanel controller={controller} />
       <div className="forecast-workspace-layout__map relative min-h-0 flex-1">
         <ForecastMap ref={mapRef} tstmPreviewFeatures={tstmPreviewFeatures} />
       </div>

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -115,7 +115,7 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 427,
   },
   forecastWorkflowV2: {
-    exposure: { ...ALL_TARGETS_OFF },
+    exposure: { ...ALL_TARGETS_OFF, local: true },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -115,7 +115,7 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 427,
   },
   forecastWorkflowV2: {
-    exposure: { ...ALL_TARGETS_OFF, local: true },
+      exposure: { ...ALL_TARGETS_OFF },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,

--- a/src/pages/DiscussionPage.test.tsx
+++ b/src/pages/DiscussionPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
 import { DiscussionPage } from './DiscussionPage';
 import forecastReducer from '../store/forecastSlice';
 import overlaysReducer from '../store/overlaysSlice';
@@ -51,9 +52,11 @@ describe('DiscussionPage', () => {
     });
 
     render(
-      <Provider store={createStore()}>
-        <DiscussionPage />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={createStore()}>
+          <DiscussionPage />
+        </Provider>
+      </MemoryRouter>
     );
 
     expect(screen.getByDisplayValue('WeatherboySuper')).toBeInTheDocument();

--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -20,6 +20,7 @@ import { useAuth } from '../auth/AuthProvider';
 import { queueProductMetric } from '../utils/productMetrics';
 import DIYDiscussionEditor from '../components/DiscussionEditor/DIYDiscussionEditor';
 import GuidedDiscussionEditor from '../components/DiscussionEditor/GuidedDiscussionEditor';
+import ForecastWorkflowPanel from '../components/ForecastWorkflow/ForecastWorkflowPanel';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
@@ -543,6 +544,7 @@ export const DiscussionPage: React.FC = () => {
 
   return (
     <div className="h-full flex flex-col bg-background">
+      <ForecastWorkflowPanel context="discussion" />
       <DiscussionHeaderBar
         currentDay={currentDay}
         hasUnsavedChanges={editorState.hasUnsavedChanges}


### PR DESCRIPTION
## Summary

Adds the persistent WF-04 workflow banner to the Forecast and Discussion routes.

The banner keeps the active workflow visible across routes and guides the user through:

- map completion
- discussion completion
- same-day workflow updates
- package review
- workflow export

It also supports navigating between the Forecast and Discussion editors, starting from a relevant previous-cycle outlook, and exporting the reusable `forecast_cycle.json` workflow package.

The implementation is now based on the merged PR #683 changes and keeps `forecastWorkflowV2` disabled in the exposure registry until the rollout policy is updated.

## Issue Links

- Part of #454
- Parent tracker: #429
- Related package export behavior: #459
- Supersedes the route-banner/action portion of #680

## Verification

- `pnpm run build`
- `pnpm test -- --runInBand`
- `git diff --check`

## Changelog

- Adds the persistent forecast workflow banner and cross-route workflow actions.
- Keeps the new workflow feature gated off by the existing exposure policy.
