### PR TITLE
[WF-04] Home workflow entry points

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,11 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #685
+
+- Add Home workflow entry points for starting, resuming, updating, and uploading workflow packages.
+- Protect workflow starts from disabled exposure targets and unsaved-cycle loss.
+
 ### PR #684
 
 - Add a persistent workflow banner across the Forecast and Discussion routes with map, discussion, review, update, and export actions.

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -943,6 +943,128 @@
     margin-top: 2.5rem;
 }
 
+.home-concept-workflow-start-grid {
+    display: grid;
+    gap: 0.55rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-top: 1.25rem;
+    max-width: 34rem;
+}
+
+.home-concept-workflow-start {
+    display: inline-flex;
+    min-height: 2.55rem;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+    color: var(--text-primary);
+    font-weight: 800;
+    text-align: center;
+    transition:
+        transform 160ms ease,
+        border-color 160ms ease,
+        background-color 160ms ease;
+}
+
+.home-concept-workflow-inline-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.home-concept-workflow-inline-actions button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    color: var(--button-bg);
+    font-weight: 800;
+}
+
+.home-concept-workflow-active-actions,
+.home-concept-workflow-new-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin-top: 1rem;
+}
+
+.home-concept-workflow-active-actions button,
+.home-concept-workflow-new-row button {
+    display: inline-flex;
+    min-height: 2.4rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+    padding: 0 0.8rem;
+    color: var(--text-primary);
+    font-weight: 800;
+}
+
+.home-concept-workflow-active-actions button.is-primary {
+    border-color: var(--button-bg);
+    background: linear-gradient(135deg, #7b61ff, var(--button-bg));
+    color: #fff;
+}
+
+.home-concept-workflow-new-row {
+    margin-top: 0.7rem;
+}
+
+.home-concept-workflow-new-row button {
+    min-height: 2rem;
+    padding: 0 0.65rem;
+    color: var(--button-bg);
+    font-size: 0.85rem;
+}
+
+.home-concept-workflow-start:hover {
+    transform: translateY(-1px);
+    border-color: color-mix(in srgb, var(--button-bg) 35%, var(--border-color));
+    background: color-mix(in srgb, var(--button-bg) 6%, var(--bg-primary));
+}
+
+.home-concept-workflow-status {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin-top: 1.35rem;
+}
+
+.home-concept-workflow-status span {
+    display: inline-flex;
+    min-height: 2.1rem;
+    align-items: center;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 700;
+}
+
+.home-concept-workflow-status span.is-active {
+    border-color: color-mix(in srgb, var(--button-bg) 35%, var(--border-color));
+    background: color-mix(in srgb, var(--button-bg) 8%, var(--bg-primary));
+    color: var(--button-bg);
+}
+
+.home-concept-workflow-status span.is-complete {
+    border-color: rgba(39, 174, 96, 0.32);
+    background: rgba(39, 174, 96, 0.1);
+    color: rgb(39, 174, 96);
+}
+
 .home-concept-action {
     justify-content: flex-start;
     gap: 1rem;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -19,6 +19,8 @@ type HomeSectionProps = Pick<
   | 'formattedDate'
   | 'savedCycles'
   | 'forecastCycle'
+  | 'workflowMetadata'
+  | 'hasActiveWorkflow'
   | 'isSaved'
   | 'handleNavigateForecast'
   | 'handleNavigateDiscussion'
@@ -26,6 +28,8 @@ type HomeSectionProps = Pick<
   | 'handleOpenHistoryModal'
   | 'handleQuickStartClick'
   | 'handleNewCycle'
+  | 'handleStartWorkflow'
+  | 'handleCreateWorkflowUpdate'
   | 'handleSave'
   | 'openFilePicker'
   | 'handleLoadRecentCycleClick'
@@ -38,6 +42,8 @@ const HomeSignedInSection: React.FC<HomeSectionProps> = ({
   formattedDate,
   savedCycles,
   forecastCycle,
+  workflowMetadata,
+  hasActiveWorkflow,
   isSaved,
   handleNavigateForecast,
   handleNavigateDiscussion,
@@ -45,6 +51,8 @@ const HomeSignedInSection: React.FC<HomeSectionProps> = ({
   handleOpenHistoryModal,
   handleQuickStartClick,
   handleNewCycle,
+  handleStartWorkflow,
+  handleCreateWorkflowUpdate,
   handleSave,
   openFilePicker,
   handleLoadRecentCycleClick,
@@ -69,9 +77,13 @@ const HomeSignedInSection: React.FC<HomeSectionProps> = ({
           formattedDate={formattedDate}
           isSaved={isSaved}
           forecastCycle={forecastCycle}
+          workflowMetadata={workflowMetadata}
+          hasActiveWorkflow={hasActiveWorkflow}
           stats={stats}
           onQuickStartClick={handleQuickStartClick}
           onNewCycle={handleNewCycle}
+          onStartWorkflow={handleStartWorkflow}
+          onCreateWorkflowUpdate={handleCreateWorkflowUpdate}
           onSave={handleSave}
           onOpenFile={openFilePicker}
           onOpenHistory={handleOpenHistoryModal}
@@ -104,6 +116,8 @@ const HomeSignedOutSection: React.FC<HomeSectionProps> = ({
   formattedDate,
   savedCycles,
   forecastCycle,
+  workflowMetadata,
+  hasActiveWorkflow,
   isSaved,
   handleNavigateForecast,
   handleNavigateDiscussion,
@@ -111,6 +125,8 @@ const HomeSignedOutSection: React.FC<HomeSectionProps> = ({
   handleOpenHistoryModal,
   handleQuickStartClick,
   handleNewCycle,
+  handleStartWorkflow,
+  handleCreateWorkflowUpdate,
   handleSave,
   openFilePicker,
   handleLoadRecentCycleClick,
@@ -134,9 +150,13 @@ const HomeSignedOutSection: React.FC<HomeSectionProps> = ({
           formattedDate={formattedDate}
           isSaved={isSaved}
           forecastCycle={forecastCycle}
+          workflowMetadata={workflowMetadata}
+          hasActiveWorkflow={hasActiveWorkflow}
           stats={stats}
           onQuickStartClick={handleQuickStartClick}
           onNewCycle={handleNewCycle}
+          onStartWorkflow={handleStartWorkflow}
+          onCreateWorkflowUpdate={handleCreateWorkflowUpdate}
           onSave={handleSave}
           onOpenFile={openFilePicker}
           onOpenHistory={handleOpenHistoryModal}
@@ -179,6 +199,8 @@ const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
     handleNewCycle,
     savedCycles,
     forecastCycle,
+    workflowMetadata,
+    hasActiveWorkflow,
     isSaved,
   } = logic;
 
@@ -192,6 +214,8 @@ const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
             formattedDate={formattedDate}
             savedCycles={savedCycles}
             forecastCycle={forecastCycle}
+            workflowMetadata={workflowMetadata}
+            hasActiveWorkflow={hasActiveWorkflow}
             isSaved={isSaved}
             handleNavigateForecast={handleNavigateForecast}
             handleNavigateDiscussion={handleNavigateDiscussion}
@@ -199,6 +223,8 @@ const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
             handleOpenHistoryModal={handleOpenHistoryModal}
             handleQuickStartClick={handleQuickStartClick}
             handleNewCycle={handleNewCycle}
+            handleStartWorkflow={logic.handleStartWorkflow}
+            handleCreateWorkflowUpdate={logic.handleCreateWorkflowUpdate}
             handleSave={handleSave}
             openFilePicker={openFilePicker}
             handleLoadRecentCycleClick={handleLoadRecentCycleClick}
@@ -210,6 +236,8 @@ const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
             formattedDate={formattedDate}
             savedCycles={savedCycles}
             forecastCycle={forecastCycle}
+            workflowMetadata={workflowMetadata}
+            hasActiveWorkflow={hasActiveWorkflow}
             isSaved={isSaved}
             handleNavigateForecast={handleNavigateForecast}
             handleNavigateDiscussion={handleNavigateDiscussion}
@@ -217,6 +245,8 @@ const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
             handleOpenHistoryModal={handleOpenHistoryModal}
             handleQuickStartClick={handleQuickStartClick}
             handleNewCycle={handleNewCycle}
+            handleStartWorkflow={logic.handleStartWorkflow}
+            handleCreateWorkflowUpdate={logic.handleCreateWorkflowUpdate}
             handleSave={handleSave}
             openFilePicker={openFilePicker}
             handleLoadRecentCycleClick={handleLoadRecentCycleClick}
@@ -231,11 +261,11 @@ const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
       <CycleHistoryModal isOpen={showHistoryModal} onClose={handleCloseHistoryModal} />
       <ConfirmationModal
         isOpen={confirmNewCycle}
-        title="Start New Cycle"
-        message="You have unsaved changes. Start a new cycle anyway?"
+        title="Start Blank Cycle"
+        message="You have unsaved changes. Start a blank forecast cycle without workflow steps?"
         onConfirm={handleConfirmNewCycle}
         onCancel={handleCancelNewCycle}
-        confirmLabel="Start New Cycle"
+        confirmLabel="Start Blank Cycle"
       />
     </div>
   );
@@ -261,6 +291,8 @@ const HomePage: React.FC = () => {
     handleNewCycle,
     savedCycles,
     forecastCycle,
+    workflowMetadata,
+    hasActiveWorkflow,
     isSaved,
   } = logic;
 
@@ -278,11 +310,16 @@ const HomePage: React.FC = () => {
         formattedDate={formattedDate}
         savedCycles={savedCycles}
         forecastCycle={forecastCycle}
+        workflowMetadata={workflowMetadata}
+        hasActiveWorkflow={hasActiveWorkflow}
         isSaved={isSaved}
         onResumeForecast={handleNavigateForecast}
+        onWriteDiscussion={logic.handleNavigateDiscussion}
         onOpenHistory={logic.handleOpenHistoryModal}
         onOpenFile={openFilePicker}
         onNewCycle={handleNewCycle}
+        onStartWorkflow={logic.handleStartWorkflow}
+        onCreateWorkflowUpdate={logic.handleCreateWorkflowUpdate}
         onLoadRecentCycle={handleLoadRecentCycleClick}
         onNavigateAccount={handleNavigateAccount}
       />
@@ -290,11 +327,11 @@ const HomePage: React.FC = () => {
       <CycleHistoryModal isOpen={showHistoryModal} onClose={handleCloseHistoryModal} />
       <ConfirmationModal
         isOpen={confirmNewCycle}
-        title="Start New Cycle"
-        message="You have unsaved changes. Start a new cycle anyway?"
+        title="Start Blank Cycle"
+        message="You have unsaved changes. Start a blank forecast cycle without workflow steps?"
         onConfirm={handleConfirmNewCycle}
         onCancel={handleCancelNewCycle}
-        confirmLabel="Start New Cycle"
+        confirmLabel="Start Blank Cycle"
       />
     </div>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -311,6 +311,7 @@ const HomePage: React.FC = () => {
         savedCycles={savedCycles}
         forecastCycle={forecastCycle}
         workflowMetadata={workflowMetadata}
+        workflowEnabled={logic.workflowEnabled}
         hasActiveWorkflow={hasActiveWorkflow}
         isSaved={isSaved}
         onResumeForecast={handleNavigateForecast}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -311,7 +311,7 @@ const HomePage: React.FC = () => {
         savedCycles={savedCycles}
         forecastCycle={forecastCycle}
         workflowMetadata={workflowMetadata}
-        workflowEnabled={logic.workflowEnabled}
+        workflowEnabled={logic.workflowEnabled ?? true}
         hasActiveWorkflow={hasActiveWorkflow}
         isSaved={isSaved}
         onResumeForecast={handleNavigateForecast}

--- a/src/pages/home/HomeConceptPage.tsx
+++ b/src/pages/home/HomeConceptPage.tsx
@@ -295,6 +295,25 @@ interface SignedInWorkflowPanelProps {
   onCreateWorkflowUpdate: () => void;
 }
 
+interface WorkflowNextAction {
+  icon: React.ElementType;
+  label: string;
+  onClick: () => void;
+}
+
+/** Chooses the next editor action for the active workflow state. */
+function getWorkflowNextAction(
+  mapStarted: boolean,
+  discussionStarted: boolean,
+  onWriteDiscussion: () => void,
+  onResumeForecast: () => void,
+): WorkflowNextAction {
+  if (mapStarted && !discussionStarted) {
+    return { icon: MessageSquare, label: 'Write Discussion', onClick: onWriteDiscussion };
+  }
+  return { icon: PlayCircle, label: 'Continue Map', onClick: onResumeForecast };
+}
+
 /** Renders workflow scope buttons when no workflow is active. */
 const SignedInWorkflowStartPanel: React.FC<Pick<SignedInWorkflowPanelProps, 'workflowEnabled' | 'onOpenFile' | 'onStartWorkflow'>> = ({
   workflowEnabled,
@@ -337,9 +356,7 @@ const SignedInWorkflowActivePanel: React.FC<SignedInWorkflowPanelProps> = ({
   const activeDay = forecastCycle.days[forecastCycle.currentDay];
   const mapStarted = dayHasMapWork(activeDay);
   const discussionStarted = dayHasDiscussion(activeDay);
-  const nextAction = mapStarted && !discussionStarted
-    ? { icon: MessageSquare, label: 'Write Discussion', onClick: onWriteDiscussion }
-    : { icon: PlayCircle, label: 'Continue Map', onClick: onResumeForecast };
+  const nextAction = getWorkflowNextAction(mapStarted, discussionStarted, onWriteDiscussion, onResumeForecast);
   const NextActionIcon = nextAction.icon;
 
   return (

--- a/src/pages/home/HomeConceptPage.tsx
+++ b/src/pages/home/HomeConceptPage.tsx
@@ -14,14 +14,16 @@ import {
   MessageSquare,
   MoreVertical,
   PlayCircle,
-  PlusCircle,
+  RefreshCw,
   ShieldCheck,
   Sparkles,
   Upload,
   Zap,
 } from 'lucide-react';
 import type { SavedCycle } from '../../store/forecastSlice';
-import type { ForecastCycle } from '../../types/outlooks';
+import type { ForecastCycle, OutlookDay } from '../../types/outlooks';
+import { DEFAULT_WORKFLOW_TEMPLATES } from '../../components/ForecastWorkflow/workflowTemplates';
+import type { CycleMetadata, WorkflowMetadata } from '../../types/workflow';
 
 type HomeConceptVariant = 'signed_in' | 'signed_out';
 
@@ -30,11 +32,15 @@ interface HomeConceptPageProps {
   formattedDate: string;
   savedCycles: SavedCycle[];
   forecastCycle: ForecastCycle;
+  workflowMetadata?: CycleMetadata;
+  hasActiveWorkflow: boolean;
   isSaved: boolean;
   onResumeForecast: () => void;
   onOpenHistory: () => void;
   onOpenFile: () => void;
   onNewCycle: () => void;
+  onStartWorkflow: (workflowTemplate: WorkflowMetadata) => void;
+  onCreateWorkflowUpdate: () => void;
   onLoadRecentCycle: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onNavigateAccount: () => void;
 }
@@ -56,6 +62,32 @@ const featureItems = [
     body: 'Use built-in verification tools to improve accuracy and consistency.',
   },
 ];
+
+const dayHasMapWork = (day?: OutlookDay): boolean => {
+  if (!day) return false;
+  const hasOutlookFeatures = Object.values(day.data).some((outlookMap) => (outlookMap?.size ?? 0) > 0);
+  return hasOutlookFeatures || (day.metadata.lowProbabilityOutlooks?.length ?? 0) > 0;
+};
+
+const dayHasDiscussion = (day?: OutlookDay): boolean => {
+  const discussion = day?.discussion;
+  if (!discussion) return false;
+  if (discussion.mode === 'diy') return Boolean(discussion.diyContent?.trim());
+  return Boolean(discussion.guidedContent && Object.values(discussion.guidedContent).some((value) => value.trim()));
+};
+
+const getWorkflowLabel = (workflowMetadata?: CycleMetadata, currentDay?: number): string =>
+  DEFAULT_WORKFLOW_TEMPLATES.find((template) => template.id === workflowMetadata?.workflowId)?.label
+  ?? workflowMetadata?.workflowId
+  ?? `Day ${currentDay ?? 1} workflow`;
+
+const workflowStartLabels: Record<string, string> = {
+  'severe-day1': 'Day 1',
+  'severe-day2': 'Day 2',
+  'severe-day3': 'Day 3',
+  'severe-day4-8': 'Days 4-8',
+  'convective-outlook': 'Full Outlook',
+};
 
 const accountBenefits = [
   {
@@ -248,32 +280,120 @@ const SignedInCycleBar: React.FC<{
 
 /** Main signed-in hero panel with resume, history, and new-cycle actions. */
 const SignedInContinuePanel: React.FC<{
+  forecastCycle: ForecastCycle;
+  workflowMetadata?: CycleMetadata;
+  hasActiveWorkflow: boolean;
   onResumeForecast: () => void;
-  onOpenHistory: () => void;
-  onNewCycle: () => void;
-}> = ({ onResumeForecast, onOpenHistory, onNewCycle }) => (
-  <section className="home-concept-continue">
-    <h2>
-      <span>Continue your</span>
-      <span className="home-concept-heading-line">forecast <Zap className="h-10 w-10" /></span>
-    </h2>
-    <p>Pick up right where you left off. Continue editing, verify your work, and publish with confidence.</p>
-    <div className="home-concept-continue-actions">
-      <HeroActionButton icon={PlayCircle} label="Resume Forecast" onClick={onResumeForecast} primary />
-      <HeroActionButton icon={Folder} label="Open another saved cycle" onClick={onOpenHistory} />
-      <HeroActionButton icon={PlusCircle} label="Start a new forecast cycle" onClick={onNewCycle} />
-    </div>
-  </section>
-);
+  onWriteDiscussion: () => void;
+  onOpenFile: () => void;
+  onStartWorkflow: (workflowTemplate: WorkflowMetadata) => void;
+  onCreateWorkflowUpdate: () => void;
+}> = ({
+  forecastCycle,
+  workflowMetadata,
+  hasActiveWorkflow,
+  onResumeForecast,
+  onWriteDiscussion,
+  onOpenFile,
+  onStartWorkflow,
+  onCreateWorkflowUpdate,
+}) => {
+  const activeDay = forecastCycle.days[forecastCycle.currentDay];
+  const mapStarted = dayHasMapWork(activeDay);
+  const discussionStarted = dayHasDiscussion(activeDay);
+  const nextAction = mapStarted && !discussionStarted
+    ? { icon: MessageSquare, label: 'Write Discussion', onClick: onWriteDiscussion }
+    : { icon: PlayCircle, label: 'Continue Map', onClick: onResumeForecast };
+  const NextActionIcon = nextAction.icon;
+
+  if (!hasActiveWorkflow) {
+    return (
+      <section className="home-concept-continue">
+        <h2>
+          <span>Continue your</span>
+          <span className="home-concept-heading-line">forecast <Zap className="h-10 w-10" /></span>
+        </h2>
+        <p>Start a forecast workflow by scope, or upload a workflow package from your device.</p>
+        <div className="home-concept-workflow-start-grid" aria-label="Start workflow">
+          {DEFAULT_WORKFLOW_TEMPLATES.map((template) => (
+            <button
+              type="button"
+              key={template.id}
+              className="home-concept-workflow-start"
+              onClick={() => onStartWorkflow(template)}
+            >
+              {workflowStartLabels[template.id] ?? template.label}
+            </button>
+          ))}
+        </div>
+        <div className="home-concept-workflow-inline-actions">
+          <button type="button" onClick={onOpenFile}>
+            <Upload className="h-4 w-4" />
+            Upload workflow
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="home-concept-continue">
+      <h2>
+        <span>Continue your</span>
+        <span className="home-concept-heading-line">forecast <Zap className="h-10 w-10" /></span>
+      </h2>
+      <p>
+        {getWorkflowLabel(workflowMetadata, forecastCycle.currentDay)} is {workflowMetadata?.status ?? 'draft'}.
+        {' '}Day {forecastCycle.currentDay}: map {mapStarted ? 'started' : 'not started'}, discussion {discussionStarted ? 'started' : 'not started'}.
+      </p>
+      <div className="home-concept-workflow-status" aria-label="Workflow status">
+        <span className={mapStarted ? 'is-complete' : 'is-active'}>Map</span>
+        <span className={discussionStarted ? 'is-complete' : mapStarted ? 'is-active' : ''}>Discussion</span>
+        <span className={mapStarted && discussionStarted ? 'is-complete' : ''}>Complete</span>
+      </div>
+      <div className="home-concept-workflow-active-actions">
+        <button type="button" className="is-primary" onClick={nextAction.onClick}>
+          <NextActionIcon className="h-4 w-4" />
+          {nextAction.label}
+        </button>
+        <button type="button" onClick={onCreateWorkflowUpdate}>
+          <RefreshCw className="h-4 w-4" />
+          Create update
+        </button>
+        <button type="button" onClick={onOpenFile}>
+          <Upload className="h-4 w-4" />
+          Upload workflow
+        </button>
+      </div>
+      <div className="home-concept-workflow-new-row" aria-label="Start new workflow">
+        {DEFAULT_WORKFLOW_TEMPLATES.map((template) => (
+          <button
+            type="button"
+            key={template.id}
+            onClick={() => onStartWorkflow(template)}
+          >
+            {workflowStartLabels[template.id] ?? template.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
 
 /** Signed-in concept home screen. */
 const SignedInConcept: React.FC<HomeConceptPageProps> = ({
   formattedDate,
   savedCycles,
+  forecastCycle,
+  workflowMetadata,
+  hasActiveWorkflow,
   isSaved,
   onResumeForecast,
+  onWriteDiscussion,
   onOpenHistory,
-  onNewCycle,
+  onOpenFile,
+  onStartWorkflow,
+  onCreateWorkflowUpdate,
   onLoadRecentCycle,
 }) => (
   <main className="home-concept-shell home-concept-shell-signed-in">
@@ -287,9 +407,14 @@ const SignedInConcept: React.FC<HomeConceptPageProps> = ({
 
     <div className="home-concept-signed-in-grid">
       <SignedInContinuePanel
+        forecastCycle={forecastCycle}
+        workflowMetadata={workflowMetadata}
+        hasActiveWorkflow={hasActiveWorkflow}
         onResumeForecast={onResumeForecast}
-        onOpenHistory={onOpenHistory}
-        onNewCycle={onNewCycle}
+        onWriteDiscussion={onWriteDiscussion}
+        onOpenFile={onOpenFile}
+        onStartWorkflow={onStartWorkflow}
+        onCreateWorkflowUpdate={onCreateWorkflowUpdate}
       />
       <aside className="home-concept-side-rail">
         <AtAGlance

--- a/src/pages/home/HomeConceptPage.tsx
+++ b/src/pages/home/HomeConceptPage.tsx
@@ -33,6 +33,7 @@ interface HomeConceptPageProps {
   savedCycles: SavedCycle[];
   forecastCycle: ForecastCycle;
   workflowMetadata?: CycleMetadata;
+  workflowEnabled: boolean;
   hasActiveWorkflow: boolean;
   isSaved: boolean;
   onResumeForecast: () => void;
@@ -281,7 +282,8 @@ const SignedInCycleBar: React.FC<{
 /** Main signed-in hero panel with resume, history, and new-cycle actions. */
 const SignedInContinuePanel: React.FC<{
   forecastCycle: ForecastCycle;
-  workflowMetadata?: CycleMetadata;
+    workflowMetadata?: CycleMetadata;
+    workflowEnabled: boolean;
   hasActiveWorkflow: boolean;
   onResumeForecast: () => void;
   onWriteDiscussion: () => void;
@@ -290,7 +292,8 @@ const SignedInContinuePanel: React.FC<{
   onCreateWorkflowUpdate: () => void;
 }> = ({
   forecastCycle,
-  workflowMetadata,
+    workflowMetadata,
+    workflowEnabled,
   hasActiveWorkflow,
   onResumeForecast,
   onWriteDiscussion,
@@ -320,7 +323,8 @@ const SignedInContinuePanel: React.FC<{
               type="button"
               key={template.id}
               className="home-concept-workflow-start"
-              onClick={() => onStartWorkflow(template)}
+                onClick={() => onStartWorkflow(template)}
+                disabled={!workflowEnabled}
             >
               {workflowStartLabels[template.id] ?? template.label}
             </button>
@@ -356,7 +360,7 @@ const SignedInContinuePanel: React.FC<{
           <NextActionIcon className="h-4 w-4" />
           {nextAction.label}
         </button>
-        <button type="button" onClick={onCreateWorkflowUpdate}>
+          <button type="button" onClick={onCreateWorkflowUpdate} disabled={!workflowEnabled}>
           <RefreshCw className="h-4 w-4" />
           Create update
         </button>
@@ -370,7 +374,8 @@ const SignedInContinuePanel: React.FC<{
           <button
             type="button"
             key={template.id}
-            onClick={() => onStartWorkflow(template)}
+              onClick={() => onStartWorkflow(template)}
+              disabled={!workflowEnabled}
           >
             {workflowStartLabels[template.id] ?? template.label}
           </button>
@@ -386,6 +391,7 @@ const SignedInConcept: React.FC<HomeConceptPageProps> = ({
   savedCycles,
   forecastCycle,
   workflowMetadata,
+  workflowEnabled,
   hasActiveWorkflow,
   isSaved,
   onResumeForecast,
@@ -409,6 +415,7 @@ const SignedInConcept: React.FC<HomeConceptPageProps> = ({
       <SignedInContinuePanel
         forecastCycle={forecastCycle}
         workflowMetadata={workflowMetadata}
+        workflowEnabled={workflowEnabled}
         hasActiveWorkflow={hasActiveWorkflow}
         onResumeForecast={onResumeForecast}
         onWriteDiscussion={onWriteDiscussion}

--- a/src/pages/home/HomeConceptPage.tsx
+++ b/src/pages/home/HomeConceptPage.tsx
@@ -64,23 +64,27 @@ const featureItems = [
   },
 ];
 
-const dayHasMapWork = (day?: OutlookDay): boolean => {
+/** Returns whether a forecast day contains any map work. */
+function dayHasMapWork(day?: OutlookDay): boolean {
   if (!day) return false;
   const hasOutlookFeatures = Object.values(day.data).some((outlookMap) => (outlookMap?.size ?? 0) > 0);
   return hasOutlookFeatures || (day.metadata.lowProbabilityOutlooks?.length ?? 0) > 0;
-};
+}
 
-const dayHasDiscussion = (day?: OutlookDay): boolean => {
+/** Returns whether a forecast day contains any discussion content. */
+function dayHasDiscussion(day?: OutlookDay): boolean {
   const discussion = day?.discussion;
   if (!discussion) return false;
   if (discussion.mode === 'diy') return Boolean(discussion.diyContent?.trim());
   return Boolean(discussion.guidedContent && Object.values(discussion.guidedContent).some((value) => value.trim()));
-};
+}
 
-const getWorkflowLabel = (workflowMetadata?: CycleMetadata, currentDay?: number): string =>
-  DEFAULT_WORKFLOW_TEMPLATES.find((template) => template.id === workflowMetadata?.workflowId)?.label
-  ?? workflowMetadata?.workflowId
-  ?? `Day ${currentDay ?? 1} workflow`;
+/** Returns the readable label for the active workflow template. */
+function getWorkflowLabel(workflowMetadata?: CycleMetadata, currentDay?: number): string {
+  return DEFAULT_WORKFLOW_TEMPLATES.find((template) => template.id === workflowMetadata?.workflowId)?.label
+    ?? workflowMetadata?.workflowId
+    ?? `Day ${currentDay ?? 1} workflow`;
+}
 
 const workflowStartLabels: Record<string, string> = {
   'severe-day1': 'Day 1',
@@ -279,22 +283,51 @@ const SignedInCycleBar: React.FC<{
   </section>
 );
 
-/** Main signed-in hero panel with resume, history, and new-cycle actions. */
-const SignedInContinuePanel: React.FC<{
+interface SignedInWorkflowPanelProps {
   forecastCycle: ForecastCycle;
-    workflowMetadata?: CycleMetadata;
-    workflowEnabled: boolean;
+  workflowMetadata?: CycleMetadata;
+  workflowEnabled: boolean;
   hasActiveWorkflow: boolean;
   onResumeForecast: () => void;
   onWriteDiscussion: () => void;
   onOpenFile: () => void;
   onStartWorkflow: (workflowTemplate: WorkflowMetadata) => void;
   onCreateWorkflowUpdate: () => void;
-}> = ({
+}
+
+/** Renders workflow scope buttons when no workflow is active. */
+const SignedInWorkflowStartPanel: React.FC<Pick<SignedInWorkflowPanelProps, 'workflowEnabled' | 'onOpenFile' | 'onStartWorkflow'>> = ({
+  workflowEnabled,
+  onOpenFile,
+  onStartWorkflow,
+}) => (
+  <section className="home-concept-continue">
+    <h2>
+      <span>Continue your</span>
+      <span className="home-concept-heading-line">forecast <Zap className="h-10 w-10" /></span>
+    </h2>
+    <p>Start a forecast workflow by scope, or upload a workflow package from your device.</p>
+    <div className="home-concept-workflow-start-grid" aria-label="Start workflow">
+      {DEFAULT_WORKFLOW_TEMPLATES.map((template) => (
+        <button type="button" key={template.id} className="home-concept-workflow-start" onClick={() => onStartWorkflow(template)} disabled={!workflowEnabled}>
+          {workflowStartLabels[template.id] ?? template.label}
+        </button>
+      ))}
+    </div>
+    <div className="home-concept-workflow-inline-actions">
+      <button type="button" onClick={onOpenFile}>
+        <Upload className="h-4 w-4" />
+        Upload workflow
+      </button>
+    </div>
+  </section>
+);
+
+/** Renders status and actions when a workflow is active. */
+const SignedInWorkflowActivePanel: React.FC<SignedInWorkflowPanelProps> = ({
   forecastCycle,
-    workflowMetadata,
-    workflowEnabled,
-  hasActiveWorkflow,
+  workflowMetadata,
+  workflowEnabled,
   onResumeForecast,
   onWriteDiscussion,
   onOpenFile,
@@ -308,37 +341,6 @@ const SignedInContinuePanel: React.FC<{
     ? { icon: MessageSquare, label: 'Write Discussion', onClick: onWriteDiscussion }
     : { icon: PlayCircle, label: 'Continue Map', onClick: onResumeForecast };
   const NextActionIcon = nextAction.icon;
-
-  if (!hasActiveWorkflow) {
-    return (
-      <section className="home-concept-continue">
-        <h2>
-          <span>Continue your</span>
-          <span className="home-concept-heading-line">forecast <Zap className="h-10 w-10" /></span>
-        </h2>
-        <p>Start a forecast workflow by scope, or upload a workflow package from your device.</p>
-        <div className="home-concept-workflow-start-grid" aria-label="Start workflow">
-          {DEFAULT_WORKFLOW_TEMPLATES.map((template) => (
-            <button
-              type="button"
-              key={template.id}
-              className="home-concept-workflow-start"
-                onClick={() => onStartWorkflow(template)}
-                disabled={!workflowEnabled}
-            >
-              {workflowStartLabels[template.id] ?? template.label}
-            </button>
-          ))}
-        </div>
-        <div className="home-concept-workflow-inline-actions">
-          <button type="button" onClick={onOpenFile}>
-            <Upload className="h-4 w-4" />
-            Upload workflow
-          </button>
-        </div>
-      </section>
-    );
-  }
 
   return (
     <section className="home-concept-continue">
@@ -360,7 +362,7 @@ const SignedInContinuePanel: React.FC<{
           <NextActionIcon className="h-4 w-4" />
           {nextAction.label}
         </button>
-          <button type="button" onClick={onCreateWorkflowUpdate} disabled={!workflowEnabled}>
+        <button type="button" onClick={onCreateWorkflowUpdate} disabled={!workflowEnabled}>
           <RefreshCw className="h-4 w-4" />
           Create update
         </button>
@@ -371,18 +373,21 @@ const SignedInContinuePanel: React.FC<{
       </div>
       <div className="home-concept-workflow-new-row" aria-label="Start new workflow">
         {DEFAULT_WORKFLOW_TEMPLATES.map((template) => (
-          <button
-            type="button"
-            key={template.id}
-              onClick={() => onStartWorkflow(template)}
-              disabled={!workflowEnabled}
-          >
+          <button type="button" key={template.id} onClick={() => onStartWorkflow(template)} disabled={!workflowEnabled}>
             {workflowStartLabels[template.id] ?? template.label}
           </button>
         ))}
       </div>
     </section>
   );
+};
+
+/** Main signed-in hero panel with resume, history, and new-cycle actions. */
+const SignedInContinuePanel: React.FC<SignedInWorkflowPanelProps> = (props) => {
+  if (!props.hasActiveWorkflow) {
+    return <SignedInWorkflowStartPanel {...props} />;
+  }
+  return <SignedInWorkflowActivePanel {...props} />;
 };
 
 /** Signed-in concept home screen. */

--- a/src/pages/home/HomePage.test.tsx
+++ b/src/pages/home/HomePage.test.tsx
@@ -65,7 +65,11 @@ describe('HomePage', () => {
       confirmNewCycle: false,
       savedCycles: [],
       forecastCycle: baseForecastCycle,
+      workflowMetadata: undefined,
+      hasActiveWorkflow: false,
       isSaved: false,
+      handleStartWorkflow: jest.fn(),
+      handleCreateWorkflowUpdate: jest.fn(),
       ...handlers,
     });
 
@@ -98,6 +102,7 @@ describe('HomePage', () => {
     const save = jest.fn();
     const loadFile = jest.fn();
     const navigateForecast = jest.fn();
+    const startWorkflow = jest.fn();
 
     mockUseHomePageLogic.mockReturnValue({
       variant: 'signed_in',
@@ -149,6 +154,8 @@ describe('HomePage', () => {
         },
       ],
       forecastCycle: baseForecastCycle,
+      workflowMetadata: undefined,
+      hasActiveWorkflow: false,
       isSaved: true,
       handleNavigateForecast: navigateForecast,
       handleNavigateDiscussion: jest.fn(),
@@ -156,6 +163,8 @@ describe('HomePage', () => {
       handleOpenHistoryModal: openHistory,
       handleQuickStartClick: quickStart,
       handleNewCycle: jest.fn(),
+      handleStartWorkflow: startWorkflow,
+      handleCreateWorkflowUpdate: jest.fn(),
       handleSave: save,
       openFilePicker,
       handleLoadRecentCycleClick: loadRecent,
@@ -177,8 +186,8 @@ describe('HomePage', () => {
     expect(screen.getByText(/Confirm start new cycle modal open/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /View full history/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getAllByRole('button', { name: /Resume Forecast/i })[0]);
-    expect(navigateForecast).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /Day 1/i }));
+    expect(startWorkflow).toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: /2026-03-25/i }));
     expect(loadRecent).toHaveBeenCalled();
@@ -199,6 +208,74 @@ describe('HomePage', () => {
     expect(quickStart).not.toHaveBeenCalled();
     expect(save).not.toHaveBeenCalled();
     expect(openFilePicker).not.toHaveBeenCalled();
+  });
+
+  test('renders active workflow status and create update on the signed-in home', () => {
+    const createUpdate = jest.fn();
+    const navigateForecast = jest.fn();
+    const startWorkflow = jest.fn();
+
+    mockUseHomePageLogic.mockReturnValue({
+      variant: 'signed_in',
+      stats: baseStats,
+      formattedDate: 'Friday, March 27, 2026',
+      fileInputRef: { current: null },
+      showHistoryModal: false,
+      confirmNewCycle: false,
+      savedCycles: [],
+      forecastCycle: {
+        ...baseForecastCycle,
+        days: {
+          4: {
+            day: 4,
+            data: {},
+            metadata: {},
+          },
+        },
+      },
+      workflowMetadata: {
+        workflowId: 'severe-day4-8',
+        status: 'draft',
+        createdAt: '2026-03-27T12:00:00Z',
+        updatedAt: '2026-03-27T12:00:00Z',
+        outlookVersions: [{ version: 1, label: 'Initial outlook', createdAt: '2026-03-27T12:00:00Z' }],
+      },
+      hasActiveWorkflow: true,
+      isSaved: true,
+      handleNavigateForecast: navigateForecast,
+      handleNavigateDiscussion: jest.fn(),
+      handleNavigateAccount: jest.fn(),
+      handleOpenHistoryModal: jest.fn(),
+      handleQuickStartClick: jest.fn(),
+      handleNewCycle: jest.fn(),
+      handleStartWorkflow: startWorkflow,
+      handleCreateWorkflowUpdate: createUpdate,
+      handleSave: jest.fn(),
+      openFilePicker: jest.fn(),
+      handleLoadRecentCycleClick: jest.fn(),
+      handleConfirmNewCycle: jest.fn(),
+      handleCancelNewCycle: jest.fn(),
+      handleFileSelect: jest.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /Continue your forecast/i })).toBeInTheDocument();
+    expect(screen.getByText(/Severe Convective Days 4-8 is draft/i)).toBeInTheDocument();
+    expect(screen.getByText(/draft/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Continue Map/i })[0]);
+    expect(navigateForecast).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Create update/i }));
+    expect(createUpdate).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Day 1/i }));
+    expect(startWorkflow).toHaveBeenCalled();
   });
 
   test('keeps the classic home page available with a query switch', () => {
@@ -227,7 +304,11 @@ describe('HomePage', () => {
       confirmNewCycle: false,
       savedCycles: [],
       forecastCycle: baseForecastCycle,
+      workflowMetadata: undefined,
+      hasActiveWorkflow: false,
       isSaved: false,
+      handleStartWorkflow: jest.fn(),
+      handleCreateWorkflowUpdate: jest.fn(),
       ...handlers,
     });
 
@@ -277,7 +358,11 @@ describe('HomePage', () => {
         },
       ],
       forecastCycle: baseForecastCycle,
+      workflowMetadata: undefined,
+      hasActiveWorkflow: false,
       isSaved: false,
+      handleStartWorkflow: jest.fn(),
+      handleCreateWorkflowUpdate: jest.fn(),
       ...handlers,
     });
 

--- a/src/pages/home/MainGrid.tsx
+++ b/src/pages/home/MainGrid.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AlertTriangle, Calendar, CheckCircle2, Clock3, History, Layers3, Map, Save, Upload } from 'lucide-react';
 import type { DayType, ForecastCycle } from '../../types/outlooks';
+import type { CycleMetadata, WorkflowMetadata } from '../../types/workflow';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
 import { cn } from '../../lib/utils';
@@ -21,9 +22,13 @@ interface Props {
   formattedDate: string;
   isSaved: boolean;
   forecastCycle: ForecastCycle;
+  workflowMetadata?: CycleMetadata;
+  hasActiveWorkflow: boolean;
   stats: HomeStats;
   onQuickStartClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onNewCycle: () => void;
+  onStartWorkflow: (workflowTemplate: WorkflowMetadata) => void;
+  onCreateWorkflowUpdate: () => void;
   onSave: () => void;
   onOpenFile: () => void;
   onOpenHistory: () => void;

--- a/src/pages/home/useHomePageLogic.ts
+++ b/src/pages/home/useHomePageLogic.ts
@@ -20,6 +20,13 @@ import { createFileHandlers } from '../../hooks/useFileLoader';
 import { useAuth } from '../../auth/AuthProvider';
 import { isFeatureExposed } from '../../config/featureExposure';
 
+const getLocalCalendarDate = () => {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+};
+
 /**
  * Encapsulates the state and handlers used by the HomePage component so the page
  * component remains a focused presentational layer. This reduces HomePage's
@@ -77,7 +84,7 @@ const useHomePageLogic = () => {
     }
     dispatch(startBlankCycle({
       workflowTemplate,
-      cycleDate: new Date().toISOString().slice(0, 10),
+      cycleDate: getLocalCalendarDate(),
     }));
     addToast(`Started ${workflowTemplate.label} workflow`, 'success');
     navigate('/forecast');
@@ -138,7 +145,7 @@ const useHomePageLogic = () => {
     if (pendingWorkflow) {
       dispatch(startBlankCycle({
         workflowTemplate: pendingWorkflow,
-        cycleDate: new Date().toISOString().slice(0, 10),
+        cycleDate: getLocalCalendarDate(),
       }));
       setPendingWorkflow(null);
       setConfirmNewCycle(false);

--- a/src/pages/home/useHomePageLogic.ts
+++ b/src/pages/home/useHomePageLogic.ts
@@ -3,8 +3,18 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import type { AddToastFn } from '../../components/Layout';
 import { RootState } from '../../store';
-import { selectForecastCycle, setForecastDay, resetForecasts, importForecastCycle } from '../../store/forecastSlice';
+import {
+  selectForecastCycle,
+  setForecastDay,
+  resetForecasts,
+  importForecastCycle,
+  selectWorkflowMetadata,
+  selectHasActiveWorkflow,
+  startBlankCycle,
+  createOutlookUpdate,
+} from '../../store/forecastSlice';
 import { DayType } from '../../types/outlooks';
+import type { WorkflowMetadata } from '../../types/workflow';
 import { computeHomeStats, formatCycleDate } from '../homeUtils';
 import { createFileHandlers } from '../../hooks/useFileLoader';
 import { useAuth } from '../../auth/AuthProvider';
@@ -20,6 +30,8 @@ const useHomePageLogic = () => {
   const { addToast } = useOutletContext<{ addToast: AddToastFn }>();
   const { hostedAuthEnabled, status } = useAuth();
   const forecastCycle = useSelector(selectForecastCycle);
+  const workflowMetadata = useSelector(selectWorkflowMetadata);
+  const hasActiveWorkflow = useSelector(selectHasActiveWorkflow);
   const savedCycles = useSelector((state: RootState) => state.forecast.savedCycles);
   const isSaved = useSelector((state: RootState) => state.forecast.isSaved);
 
@@ -49,6 +61,23 @@ const useHomePageLogic = () => {
   /** Quickly navigate to the forecast editor for the given day. */
   const handleQuickStart = (day: DayType) => {
     dispatch(setForecastDay(day));
+    navigate('/forecast');
+  };
+
+  /** Start a workflow package from the selected scope. */
+  const handleStartWorkflow = (workflowTemplate: WorkflowMetadata) => {
+    dispatch(startBlankCycle({
+      workflowTemplate,
+      cycleDate: forecastCycle.cycleDate,
+    }));
+    addToast(`Started ${workflowTemplate.label} workflow`, 'success');
+    navigate('/forecast');
+  };
+
+  /** Start a same-day update for the active workflow. */
+  const handleCreateWorkflowUpdate = () => {
+    dispatch(createOutlookUpdate());
+    addToast('Started same-day workflow update', 'success');
     navigate('/forecast');
   };
 
@@ -127,7 +156,11 @@ const useHomePageLogic = () => {
     handleNewCycle,
     savedCycles,
     forecastCycle,
+    workflowMetadata,
+    hasActiveWorkflow,
     isSaved,
+    handleStartWorkflow,
+    handleCreateWorkflowUpdate,
   } as const;
 };
 

--- a/src/pages/home/useHomePageLogic.ts
+++ b/src/pages/home/useHomePageLogic.ts
@@ -20,12 +20,13 @@ import { createFileHandlers } from '../../hooks/useFileLoader';
 import { useAuth } from '../../auth/AuthProvider';
 import { isFeatureExposed } from '../../config/featureExposure';
 
-const getLocalCalendarDate = () => {
+/** Returns today's local calendar date as YYYY-MM-DD without UTC conversion. */
+function getLocalCalendarDate(): string {
   const now = new Date();
   const month = String(now.getMonth() + 1).padStart(2, '0');
   const day = String(now.getDate()).padStart(2, '0');
   return `${now.getFullYear()}-${month}-${day}`;
-};
+}
 
 /**
  * Encapsulates the state and handlers used by the HomePage component so the page

--- a/src/pages/home/useHomePageLogic.ts
+++ b/src/pages/home/useHomePageLogic.ts
@@ -18,6 +18,7 @@ import type { WorkflowMetadata } from '../../types/workflow';
 import { computeHomeStats, formatCycleDate } from '../homeUtils';
 import { createFileHandlers } from '../../hooks/useFileLoader';
 import { useAuth } from '../../auth/AuthProvider';
+import { isFeatureExposed } from '../../config/featureExposure';
 
 /**
  * Encapsulates the state and handlers used by the HomePage component so the page
@@ -34,9 +35,11 @@ const useHomePageLogic = () => {
   const hasActiveWorkflow = useSelector(selectHasActiveWorkflow);
   const savedCycles = useSelector((state: RootState) => state.forecast.savedCycles);
   const isSaved = useSelector((state: RootState) => state.forecast.isSaved);
+  const workflowEnabled = isFeatureExposed('forecastWorkflowV2');
 
   const [showHistoryModal, setShowHistoryModal] = useState(false);
   const [confirmNewCycle, setConfirmNewCycle] = useState(false);
+  const [pendingWorkflow, setPendingWorkflow] = useState<WorkflowMetadata | null>(null);
 
   const { fileInputRef, handleFileSelect, handleOpenFilePicker, handleSave: doSave } = createFileHandlers({
     addToast,
@@ -66,9 +69,15 @@ const useHomePageLogic = () => {
 
   /** Start a workflow package from the selected scope. */
   const handleStartWorkflow = (workflowTemplate: WorkflowMetadata) => {
+    if (!workflowEnabled) return;
+    if (!isSaved) {
+      setPendingWorkflow(workflowTemplate);
+      setConfirmNewCycle(true);
+      return;
+    }
     dispatch(startBlankCycle({
       workflowTemplate,
-      cycleDate: forecastCycle.cycleDate,
+      cycleDate: new Date().toISOString().slice(0, 10),
     }));
     addToast(`Started ${workflowTemplate.label} workflow`, 'success');
     navigate('/forecast');
@@ -76,6 +85,7 @@ const useHomePageLogic = () => {
 
   /** Start a same-day update for the active workflow. */
   const handleCreateWorkflowUpdate = () => {
+    if (!workflowEnabled) return;
     dispatch(createOutlookUpdate());
     addToast('Started same-day workflow update', 'success');
     navigate('/forecast');
@@ -125,13 +135,27 @@ const useHomePageLogic = () => {
 
   /** Confirm starting a new cycle (discard changes). */
   const handleConfirmNewCycle = () => {
+    if (pendingWorkflow) {
+      dispatch(startBlankCycle({
+        workflowTemplate: pendingWorkflow,
+        cycleDate: new Date().toISOString().slice(0, 10),
+      }));
+      setPendingWorkflow(null);
+      setConfirmNewCycle(false);
+      addToast(`Started ${pendingWorkflow.label} workflow`, 'success');
+      navigate('/forecast');
+      return;
+    }
     dispatch(resetForecasts());
     addToast('Started new forecast cycle', 'success');
     setConfirmNewCycle(false);
   };
 
   /** Cancel the 'start new cycle' confirmation. */
-  const handleCancelNewCycle = () => setConfirmNewCycle(false);
+  const handleCancelNewCycle = () => {
+    setPendingWorkflow(null);
+    setConfirmNewCycle(false);
+  };
 
   return {
     variant,
@@ -159,6 +183,7 @@ const useHomePageLogic = () => {
     workflowMetadata,
     hasActiveWorkflow,
     isSaved,
+    workflowEnabled,
     handleStartWorkflow,
     handleCreateWorkflowUpdate,
   } as const;


### PR DESCRIPTION
## Summary

Adds Home-page entry points for the WF-04 workflow experience now that the Forecast, package review, and route-banner work has landed.

The Home page now:

- starts Day 1, Day 2, Day 3, Days 4-8, and Full Outlook workflows
- resumes the active workflow and routes users to the appropriate editor
- starts same-day workflow updates
- imports workflow packages through the existing upload path
- confirms before a workflow start discards unsaved cycle edits
- keeps workflow controls disabled when `forecastWorkflowV2` is not exposed

The implementation is rebased onto the merged PR #684 and preserves the existing signed-in Home layout rather than adding a duplicate workflow surface.

## Issue Links

- Part of #454
- Parent tracker: #429
- Supersedes the Home workflow-entry portion of #680

## Verification

- `pnpm run build`
- `pnpm test -- --runInBand`
- `git diff --check`

## Changelog

- Adds Home workflow entry points and unsaved-change protection.
- Keeps workflow actions gated by the existing exposure policy.
