### PR TITLE
Polish toolbar selection chip spacing

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #686
+
+- Add horizontal breathing room to the forecast toolbar selection swatch (wider min width, larger padding and gap) and switch the probability digits to tabular-nums so the chip stays balanced with longer outlook names.
+
 ### PR #681
 
 - Dependency: @radix-ui/react-dialog ^1.1.17 → ^1.1.18

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -579,7 +579,7 @@ const TabbedToolbarDrawTab: React.FC<{ controller: ForecastWorkspaceController }
       </div>
     </TabbedToolbarStripSection>
 
-    <TabbedToolbarStripSection label="Current Selection" className="tabbed-integrated-toolbar__section--selection w-[334px]">
+    <TabbedToolbarStripSection label="Current Selection" className="tabbed-integrated-toolbar__section--selection w-[342px]">
       <TabbedToolbarSelectionStrip controller={controller} showShortcuts={false} />
     </TabbedToolbarStripSection>
   </TabbedToolbarTabRow>

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -579,7 +579,7 @@ const TabbedToolbarDrawTab: React.FC<{ controller: ForecastWorkspaceController }
       </div>
     </TabbedToolbarStripSection>
 
-    <TabbedToolbarStripSection label="Current Selection" className="tabbed-integrated-toolbar__section--selection w-[342px]">
+    <TabbedToolbarStripSection label="Current Selection" className="tabbed-integrated-toolbar__section--selection w-[360px]">
       <TabbedToolbarSelectionStrip controller={controller} showShortcuts={false} />
     </TabbedToolbarStripSection>
   </TabbedToolbarTabRow>

--- a/src/components/IntegratedToolbar/TabbedToolbarSelectionStrip.tsx
+++ b/src/components/IntegratedToolbar/TabbedToolbarSelectionStrip.tsx
@@ -15,16 +15,16 @@ const SelectionSwatch: React.FC<{ controller: ForecastWorkspaceController }> = (
   return (
     <div
       className={cn(
-        'tabbed-integrated-toolbar__selection-swatch flex min-w-[124px] items-center justify-between gap-3 rounded-xl px-3 py-2 shadow-sm transition-opacity',
+        'tabbed-integrated-toolbar__selection-swatch flex min-w-[162px] items-center justify-between gap-4 rounded-xl px-4 py-2 shadow-sm transition-opacity',
         controller.isLowProb && 'opacity-45 grayscale'
       )}
       style={{ backgroundColor: controller.currentColor }}
     >
       <div className="flex min-w-0 flex-row items-center gap-2">
-        <div className={cn('truncate text-base font-semibold leading-tight', isDarkText ? 'text-black' : 'text-white')}>
+        <div className={cn('truncate text-base font-bold leading-tight', isDarkText ? 'text-black' : 'text-white')}>
           {outlookLabels[controller.activeOutlookType]}
         </div>
-        <div className={cn('truncate text-lg font-black leading-tight', isDarkText ? 'text-black' : 'text-white')}>
+        <div className={cn('truncate text-lg font-black leading-tight tabular-nums', isDarkText ? 'text-black' : 'text-white')}>
           {controller.activeProbability}
           {sigSuffix}
         </div>


### PR DESCRIPTION
## Summary
- Adds more horizontal breathing room inside the current selection swatch.
- Keeps the current selection text from crowding the rounded edge of its color chip.

## Parallel PR dependencies
This PR is part of the toolbar design uplift and targets `beta` directly.

- **Depends on:** none (foundation of the set).
- **Merge order:** merge first. PRs #687 and #688 depend on this one.

| PR | Title | Targets | Depends on |
|----|-------|---------|------------|
| #686 | Polish toolbar selection chip spacing | `beta` | — |
| #687 | Refine forecast toolbar control density | `beta` | #686 |
| #688 | Polish forecast toolbar motion and tabs | `beta` | #686, #687 |

## Validation
- Full stack validated on `design/forecast-toolbar-motion-polish` with:
  - `pnpm exec playwright test e2e/smoke.spec.ts --grep "forecast editor"`
  - `pnpm run build` (bundle completed; Sentry sourcemap upload still reports HTTP 403)