### PR TITLE
Refine forecast toolbar control density

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,11 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #687
+
+- Replace the repeated header selection/status pill with compact context text and tighten the Days tab width.
+- Add structure for grouped Tools actions and breathing room between ghost-layer icons and labels.
+
 ### PR #686
 
 - Add horizontal breathing room to the forecast toolbar selection swatch (wider min width, larger padding and gap) and switch the probability digits to tabular-nums so the chip stays balanced with longer outlook names.

--- a/src/components/IntegratedToolbar/IntegratedToolbar.test.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.test.tsx
@@ -140,9 +140,9 @@ describe('TabbedIntegratedToolbar completion validation exposure', () => {
       await user.click(screen.getByRole('tab', { name: /Tools/i }));
 
       if (visible) {
-        expect(screen.getByText('Complete')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Complete' })).toBeInTheDocument();
       } else {
-        expect(screen.queryByText('Complete')).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Complete' })).not.toBeInTheDocument();
       }
     }
   );

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -395,46 +395,6 @@ const ToolbarCurrentSelectionSection: React.FC<{ controller: ForecastWorkspaceCo
   </div>
 );
 
-/** Simple pill used in the toolbar status area. */
-const ToolbarHeaderPill: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className }) => (
-  <div
-    className={cn(
-      'tabbed-integrated-toolbar__status-pill inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/35 px-3 py-1.5 text-xs font-semibold text-foreground shadow-sm',
-      className
-    )}
-  >
-    {children}
-  </div>
-);
-
-/** Displays the compact selection pill showing current outlook and probability. */
-const TabbedToolbarSelectionPill: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => {
-  const isDarkText =
-    controller.activeOutlookType === 'categorical' &&
-    ['TSTM', 'MRGL', 'SLGT'].includes(controller.activeProbability);
-  const sigSuffix = controller.isSignificant && controller.significantThreatsEnabled ? ' Sig' : '';
-
-  return (
-    <ToolbarHeaderPill className="h-[24px] pr-2.5 pl-1 py-1 gap-1.5 bg-background shadow-sm border border-border">
-      <span
-        className={cn(
-          'flex h-[18px] min-w-[32px] items-center justify-center rounded-full px-1.5 text-[10px] font-black leading-none pb-[1px]',
-          controller.isLowProb && 'opacity-45 grayscale'
-        )}
-        style={{ backgroundColor: controller.currentColor }}
-      >
-        <span className={cn(isDarkText ? 'text-black' : 'text-white')}>
-          {controller.activeProbability}
-        </span>
-      </span>
-      <span className="max-w-[180px] truncate text-[11px] font-bold leading-none translate-y-[0px]">
-        {outlookLabels[controller.activeOutlookType]}
-        {sigSuffix}
-      </span>
-    </ToolbarHeaderPill>
-  );
-};
-
 const tabbedToolbarTypeLabels: Partial<Record<OutlookType, string>> = {
   tornado: 'Tor',
   wind: 'Wind',
@@ -443,6 +403,8 @@ const tabbedToolbarTypeLabels: Partial<Record<OutlookType, string>> = {
   totalSevere: 'Severe',
   'day4-8': 'D4-8',
 };
+
+type TabbedToolbarTabKey = 'draw' | 'days' | 'layers' | 'tools';
 
 /** Section wrapper used inside tab rows to group related controls. */
 const TabbedToolbarStripSection: React.FC<{
@@ -521,12 +483,12 @@ const TabbedToolbarProbabilityButton: React.FC<{
       onClick={controller.probabilityHandlers[probability]}
       title={tooltipLabel}
       className={cn(
-        'tabbed-integrated-toolbar__probability-button flex h-9 min-w-[44px] items-center justify-center rounded-xl border-2 px-2 text-sm font-black transition-all',
-        isActive ? 'is-active scale-[1.01] shadow-md ring-2 ring-ring ring-offset-2' : 'hover:opacity-90'
+        'tabbed-integrated-toolbar__probability-button flex h-9 min-w-[58px] items-center justify-center rounded-xl border px-3 text-sm font-black transition-all',
+        isActive ? 'is-active shadow-sm' : 'hover:opacity-90'
       )}
       style={{
         backgroundColor: color,
-        borderColor: isActive ? 'var(--ring)' : 'transparent',
+        borderColor: isActive ? 'rgba(15, 23, 42, 0.24)' : 'transparent',
         color: isLightCategorical ? '#111827' : '#ffffff',
       }}
     >
@@ -538,11 +500,30 @@ const TabbedToolbarProbabilityButton: React.FC<{
 /* TabbedToolbarSelectionStrip moved to its own file (TabbedToolbarSelectionStrip.tsx) */
 
 /** Row wrapper for tabbed toolbar sections. */
-const TabbedToolbarTabRow: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className="tabbed-integrated-toolbar__row h-full overflow-x-auto overflow-y-hidden">
-    <div className="flex h-full min-w-max items-stretch gap-2">{children}</div>
-  </div>
-);
+const TabbedToolbarTabRow: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    const row = event.currentTarget;
+    const canScroll = row.scrollWidth > row.clientWidth;
+
+    if (!canScroll || Math.abs(event.deltaX) >= Math.abs(event.deltaY)) {
+      return;
+    }
+
+    row.scrollLeft += event.deltaY;
+    event.preventDefault();
+  };
+
+  return (
+    <div
+      className="tabbed-integrated-toolbar__row h-full overflow-x-auto overflow-y-hidden"
+      onWheel={handleWheel}
+      role="group"
+      aria-label="Toolbar controls"
+    >
+      <div className="flex h-full min-w-max items-stretch gap-2">{children}</div>
+    </div>
+  );
+};
 
 /** Small stat pill used to display compact numeric metadata. */
 const TabbedToolbarStatPill: React.FC<{ label: string; value: string }> = ({ label, value }) => (
@@ -630,13 +611,13 @@ const CycleDateStrip: React.FC<{ controller: ForecastWorkspaceController }> = ({
 
 /** Forecast days strip with prev/next and day buttons. */
 const ForecastDaysStrip: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
-  <TabbedToolbarStripSection label="Forecast Days" hint="1-8" className="tabbed-integrated-toolbar__section--days min-w-[680px] flex-1">
+  <TabbedToolbarStripSection label="Forecast Days" hint="1-8" className="tabbed-integrated-toolbar__section--days w-[510px]">
     <div className="flex items-center gap-2">
       <Button size="icon" variant="outline" className="tabbed-integrated-toolbar__ghost-action h-10 w-10 shrink-0 rounded-xl" onClick={controller.onPrevDay} disabled={controller.currentDay === 1}>
         <ChevronLeft className="h-4 w-4" />
       </Button>
       <div className="min-w-0 flex-1">
-        <div className="flex min-w-max items-center gap-2">
+        <div className="tabbed-integrated-toolbar__day-strip flex min-w-max items-center gap-1 rounded-2xl p-1">
           {FORECAST_DAYS.map((day) => {
             const isActive = controller.currentDay === day;
             const hasData = hasDayOutlookData(controller.days, day);
@@ -648,10 +629,10 @@ const ForecastDaysStrip: React.FC<{ controller: ForecastWorkspaceController }> =
                 data-day={day}
                 onClick={controller.onDayButtonClick}
                 className={cn(
-                  'tabbed-integrated-toolbar__day-button relative h-10 min-w-[48px] rounded-xl border px-3 text-sm font-semibold transition-colors',
+                  'tabbed-integrated-toolbar__day-button relative h-10 min-w-[48px] rounded-xl border px-3 text-sm font-semibold transition-all',
                   isActive
                     ? 'is-active border-primary bg-primary text-primary-foreground shadow-md shadow-primary/20'
-                    : 'border-border/80 bg-background hover:bg-accent'
+                    : 'border-transparent bg-transparent hover:bg-background'
                 )}
               >
                 {day}
@@ -712,7 +693,7 @@ const TabbedToolbarLayersTab: React.FC<{ controller: ForecastWorkspaceController
                 type="button"
                 onClick={controller.ghostOutlookHandlers[type]}
                 className={cn(
-                  'tabbed-integrated-toolbar__ghost-layer-button relative flex h-10 min-w-[132px] items-center justify-start gap-2.5 rounded-xl border px-3 text-left transition-all',
+                  'tabbed-integrated-toolbar__ghost-layer-button relative flex h-10 min-w-[148px] items-center justify-start gap-3 rounded-xl border px-3.5 text-left transition-all',
                   isVisible
                     ? 'is-active shadow-md'
                     : 'border-border/80 bg-background text-foreground hover:border-primary/30 hover:bg-accent/60'
@@ -926,6 +907,32 @@ const TabbedToolbarActionTile: React.FC<{ item: TabbedToolbarActionItem }> = ({ 
   </Tooltip>
 );
 
+const TabbedToolbarActionGroup: React.FC<{
+  label: string;
+  items: TabbedToolbarActionItem[];
+  tone?: 'default' | 'danger';
+}> = ({ label, items, tone = 'default' }) => {
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        'tabbed-integrated-toolbar__action-group flex items-center gap-2',
+        tone === 'danger' && 'tabbed-integrated-toolbar__action-group--danger'
+      )}
+    >
+      <span className="tabbed-integrated-toolbar__action-group-label">
+        {label}
+      </span>
+      <div className="flex flex-wrap items-center gap-2">
+        {items.map((item) => (
+          <TabbedToolbarActionTile key={item.key} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
 /** Tools tab exposing workspace actions, file actions, and cloud context. */
 const TabbedToolbarToolsTab: React.FC<{
   controller: ForecastWorkspaceController;
@@ -940,29 +947,11 @@ const TabbedToolbarToolsTab: React.FC<{
   return (
     <TabbedToolbarTabRow>
       <TabbedToolbarStripSection label="Workspace Actions" className="tabbed-integrated-toolbar__section--workspace-actions min-w-[760px] flex-1">
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="tabbed-integrated-toolbar__action-group flex flex-wrap items-center gap-2 border-r border-border/70 pr-3">
-            {historyItems.map((item) => (
-              <TabbedToolbarActionTile key={item.key} item={item} />
-            ))}
-          </div>
-          <div className="tabbed-integrated-toolbar__action-group flex flex-wrap items-center gap-2 border-r border-border/70 pr-3">
-            {fileItems.map((item) => (
-              <TabbedToolbarActionTile key={item.key} item={item} />
-            ))}
-          </div>
-          {completionItems.length > 0 ? (
-            <div className="tabbed-integrated-toolbar__action-group flex flex-wrap items-center gap-2 border-r border-border/70 pr-3">
-              {completionItems.map((item) => (
-                <TabbedToolbarActionTile key={item.key} item={item} />
-              ))}
-            </div>
-          ) : null}
-          <div className="tabbed-integrated-toolbar__action-group flex flex-wrap items-center gap-2">
-            {destructiveItems.map((item) => (
-              <TabbedToolbarActionTile key={item.key} item={item} />
-            ))}
-          </div>
+        <div className="tabbed-integrated-toolbar__action-groups flex flex-wrap items-center gap-2">
+          <TabbedToolbarActionGroup label="History" items={historyItems} />
+          <TabbedToolbarActionGroup label="File" items={fileItems} />
+          <TabbedToolbarActionGroup label="Complete" items={completionItems} />
+          <TabbedToolbarActionGroup label="Danger" items={destructiveItems} tone="danger" />
         </div>
       </TabbedToolbarStripSection>
 
@@ -980,56 +969,117 @@ const TabbedToolbarToolsTab: React.FC<{
 };
 
 /** Toolbar tabs list (extracted to reduce nesting depth in the header). */
-const TabbedIntegratedToolbarTabsList: React.FC = () => (
-  <TabsList className="tabbed-integrated-toolbar__tabs-list relative z-10 mb-[-1px] h-auto gap-1 bg-transparent p-0">
-    <TabsTrigger
-      value="draw"
-      className="tabbed-integrated-toolbar__trigger gap-2 rounded-t-xl rounded-b-none border border-border/70 bg-muted/35 px-3 py-1.5 text-xs font-semibold shadow-none data-[state=active]:border-b-0 data-[state=active]:bg-background sm:text-sm"
+const TabbedIntegratedToolbarTabsList: React.FC<{
+  activeTab: TabbedToolbarTabKey;
+  onTabChange: (value: TabbedToolbarTabKey) => void;
+}> = ({ activeTab, onTabChange }) => {
+  const tabsListRef = React.useRef<HTMLDivElement | null>(null);
+  const triggerRefs = React.useRef<Record<TabbedToolbarTabKey, HTMLButtonElement | null>>({
+    draw: null,
+    days: null,
+    layers: null,
+    tools: null,
+  });
+  const [indicatorStyle, setIndicatorStyle] = React.useState<React.CSSProperties>({});
+
+  React.useLayoutEffect(() => {
+    const tabsList = tabsListRef.current;
+    const trigger = triggerRefs.current[activeTab];
+
+    if (!tabsList || !trigger) {
+      return;
+    }
+
+    const tabsRect = tabsList.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+
+    setIndicatorStyle({
+      width: triggerRect.width,
+      transform: `translateX(${triggerRect.left - tabsRect.left}px)`,
+    });
+  }, [activeTab]);
+
+  return (
+    <TabsList
+      ref={tabsListRef}
+      className="tabbed-integrated-toolbar__tabs-list relative z-10 mb-[-1px] h-auto gap-1 bg-transparent p-0"
+      aria-label="Forecast toolbar sections"
     >
-      <PenTool className="h-4 w-4" />
-      Draw
-    </TabsTrigger>
-    <TabsTrigger
-      value="days"
-      className="tabbed-integrated-toolbar__trigger gap-2 rounded-t-xl rounded-b-none border border-border/70 bg-muted/35 px-3 py-1.5 text-xs font-semibold shadow-none data-[state=active]:border-b-0 data-[state=active]:bg-background sm:text-sm"
-    >
-      <CalendarDays className="h-4 w-4" />
-      Days
-    </TabsTrigger>
-    <TabsTrigger
-      value="layers"
-      className="tabbed-integrated-toolbar__trigger gap-2 rounded-t-xl rounded-b-none border border-border/70 bg-muted/35 px-3 py-1.5 text-xs font-semibold shadow-none data-[state=active]:border-b-0 data-[state=active]:bg-background sm:text-sm"
-    >
-      <Layers className="h-4 w-4" />
-      Layers
-    </TabsTrigger>
-    <TabsTrigger
-      value="tools"
-      className="tabbed-integrated-toolbar__trigger gap-2 rounded-t-xl rounded-b-none border border-border/70 bg-muted/35 px-3 py-1.5 text-xs font-semibold shadow-none data-[state=active]:border-b-0 data-[state=active]:bg-background sm:text-sm"
-    >
-      <Wrench className="h-4 w-4" />
-      Tools
-    </TabsTrigger>
-  </TabsList>
-);
+      <span className="tabbed-integrated-toolbar__tab-indicator" style={indicatorStyle} aria-hidden="true" />
+      <TabsTrigger
+        value="draw"
+        ref={(node) => {
+          triggerRefs.current.draw = node;
+        }}
+        onClick={() => onTabChange('draw')}
+        className="tabbed-integrated-toolbar__trigger gap-2 rounded-t-xl rounded-b-none border border-transparent bg-transparent px-3 py-1.5 text-xs font-semibold shadow-none sm:text-sm"
+      >
+        <PenTool className="h-4 w-4" />
+        Draw
+      </TabsTrigger>
+      <TabsTrigger
+        value="days"
+        ref={(node) => {
+          triggerRefs.current.days = node;
+        }}
+        onClick={() => onTabChange('days')}
+        className="tabbed-integrated-toolbar__trigger gap-2 rounded-t-xl rounded-b-none border border-transparent bg-transparent px-3 py-1.5 text-xs font-semibold shadow-none sm:text-sm"
+      >
+        <CalendarDays className="h-4 w-4" />
+        Days
+      </TabsTrigger>
+      <TabsTrigger
+        value="layers"
+        ref={(node) => {
+          triggerRefs.current.layers = node;
+        }}
+        onClick={() => onTabChange('layers')}
+        className="tabbed-integrated-toolbar__trigger gap-2 rounded-t-xl rounded-b-none border border-transparent bg-transparent px-3 py-1.5 text-xs font-semibold shadow-none sm:text-sm"
+      >
+        <Layers className="h-4 w-4" />
+        Layers
+      </TabsTrigger>
+      <TabsTrigger
+        value="tools"
+        ref={(node) => {
+          triggerRefs.current.tools = node;
+        }}
+        onClick={() => onTabChange('tools')}
+        className="tabbed-integrated-toolbar__trigger gap-2 rounded-t-xl rounded-b-none border border-transparent bg-transparent px-3 py-1.5 text-xs font-semibold shadow-none sm:text-sm"
+      >
+        <Wrench className="h-4 w-4" />
+        Tools
+      </TabsTrigger>
+    </TabsList>
+  );
+};
 
 /** Status bar for the tabbed integrated toolbar header. */
 const TabbedIntegratedToolbarStatusBar: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
-  <div className="tabbed-integrated-toolbar__status-bar mb-1.5 flex min-w-0 flex-wrap items-center gap-2 rounded-full border border-border/70 bg-muted/45 px-2.5 py-1 shadow-sm h-[32px]">
-    <ToolbarHeaderPill className="tabbed-integrated-toolbar__status-pill--beta bg-background py-1 px-2.5 h-[24px]">
-      <span className="text-[10px] font-bold uppercase tracking-[0.05em] text-primary/80 leading-none">Toolbar Beta</span>
-    </ToolbarHeaderPill>
-    <ToolbarHeaderPill className="py-1 px-2.5 h-[24px] text-[11px] leading-none">Day {controller.currentDay}</ToolbarHeaderPill>
-    <ToolbarHeaderPill className="py-1 px-2.5 h-[24px] text-[11px] leading-none">Cycle {new Date(`${controller.cycleDate}T00:00:00`).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</ToolbarHeaderPill>
-    <TabbedToolbarSelectionPill controller={controller} />
+  <div className="tabbed-integrated-toolbar__status-bar flex min-w-0 items-center gap-2 text-xs font-semibold text-muted-foreground">
+    <span className="tabbed-integrated-toolbar__context-label text-[10px] font-bold uppercase tracking-[0.18em]">
+      Context
+      <span className="sr-only">: </span>
+    </span>
+    <span className="tabbed-integrated-toolbar__context-value text-foreground">
+      Day {controller.currentDay}
+    </span>
+    <span className="tabbed-integrated-toolbar__context-separator" aria-hidden="true"> · </span>
+    <span className="tabbed-integrated-toolbar__context-value text-foreground">
+      {new Date(`${controller.cycleDate}T00:00:00`).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} Cycle
+    </span>
   </div>
 );
 
 /** Header area for the tabbed integrated toolbar. */
-const TabbedIntegratedToolbarHeader: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
-  <div className="tabbed-integrated-toolbar__header px-3 pt-2 lg:px-4">
+const TabbedIntegratedToolbarHeader: React.FC<{
+  controller: ForecastWorkspaceController;
+  activeTab: TabbedToolbarTabKey;
+  onTabChange: (value: TabbedToolbarTabKey) => void;
+}> = ({ controller, activeTab, onTabChange }) => (
+  <div className="tabbed-integrated-toolbar__header px-3 pt-3 lg:px-4">
     <div className="mb-[0px] flex flex-wrap items-end justify-between gap-3">
-      <TabbedIntegratedToolbarTabsList />
+      <TabbedIntegratedToolbarTabsList activeTab={activeTab} onTabChange={onTabChange} />
 
       <TabbedIntegratedToolbarStatusBar controller={controller} />
     </div>
@@ -1038,7 +1088,7 @@ const TabbedIntegratedToolbarHeader: React.FC<{ controller: ForecastWorkspaceCon
 
 /** Tray area containing the tab panels. */
 const TabbedIntegratedToolbarTray: React.FC<IntegratedToolbarProps> = ({ controller, autoTstmTools }) => (
-  <div className="tabbed-integrated-toolbar__tray min-h-0 flex-1 overflow-hidden border-t border-border/70 bg-background px-3 py-2 lg:px-4">
+  <div className="tabbed-integrated-toolbar__tray min-h-0 flex-1 overflow-hidden bg-background px-3 py-2 lg:px-4">
     <TabsContent value="draw" className="tabbed-integrated-toolbar__panel mt-0 h-full">
       <TabbedToolbarDrawTab controller={controller} />
     </TabsContent>
@@ -1058,14 +1108,18 @@ const TabbedIntegratedToolbarTray: React.FC<IntegratedToolbarProps> = ({ control
 );
 
 /** Toolbar variant that keeps the original integrated-bar footprint but moves secondary controls behind tabs. */
-const TabbedIntegratedToolbarBody: React.FC<IntegratedToolbarProps> = ({ controller, autoTstmTools }) => (
-  <div className="tabbed-integrated-toolbar shrink-0 border-t border-border/80 bg-background/95 shadow-lg h-[168px] overflow-hidden backdrop-blur">
-    <Tabs defaultValue="draw" className="flex h-full flex-col">
-      <TabbedIntegratedToolbarHeader controller={controller} />
-      <TabbedIntegratedToolbarTray controller={controller} autoTstmTools={autoTstmTools} />
-    </Tabs>
-  </div>
-);
+const TabbedIntegratedToolbarBody: React.FC<IntegratedToolbarProps> = ({ controller, autoTstmTools }) => {
+  const [activeTab, setActiveTab] = React.useState<TabbedToolbarTabKey>('draw');
+
+  return (
+    <div className="tabbed-integrated-toolbar shrink-0 border-t border-border/80 bg-background/95 shadow-lg h-[168px] overflow-hidden backdrop-blur">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabbedToolbarTabKey)} className="flex h-full flex-col">
+        <TabbedIntegratedToolbarHeader controller={controller} activeTab={activeTab} onTabChange={setActiveTab} />
+        <TabbedIntegratedToolbarTray controller={controller} autoTstmTools={autoTstmTools} />
+      </Tabs>
+    </div>
+  );
+};
 
 /**
  * Tabbed variant of the integrated toolbar — keeps primary footprint and moves secondary controls behind tabs.

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -1031,6 +1031,7 @@ const TabbedIntegratedToolbarTabsList: React.FC<{
       if (trigger) observer.observe(trigger);
     });
 
+    // skipcq: JS-0045 React effects intentionally return cleanup callbacks.
     return function cleanup() {
       observer.disconnect();
     };

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -501,6 +501,7 @@ const TabbedToolbarProbabilityButton: React.FC<{
 
 /** Row wrapper for tabbed toolbar sections. */
 const TabbedToolbarTabRow: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  /** Translate vertical trackpad wheel deltas into horizontal scroll on the toolbar row. */
   const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
     const row = event.currentTarget;
     const canScroll = row.scrollWidth > row.clientWidth;
@@ -907,6 +908,7 @@ const TabbedToolbarActionTile: React.FC<{ item: TabbedToolbarActionItem }> = ({ 
   </Tooltip>
 );
 
+/** Group of action tiles sharing a label, used to cluster related Tools actions. */
 const TabbedToolbarActionGroup: React.FC<{
   label: string;
   items: TabbedToolbarActionItem[];
@@ -983,20 +985,37 @@ const TabbedIntegratedToolbarTabsList: React.FC<{
   const [indicatorStyle, setIndicatorStyle] = React.useState<React.CSSProperties>({});
 
   React.useLayoutEffect(() => {
-    const tabsList = tabsListRef.current;
-    const trigger = triggerRefs.current[activeTab];
+    const measure = () => {
+      const tabsList = tabsListRef.current;
+      const trigger = triggerRefs.current[activeTab];
 
-    if (!tabsList || !trigger) {
+      if (!tabsList || !trigger) {
+        return;
+      }
+
+      const tabsRect = tabsList.getBoundingClientRect();
+      const triggerRect = trigger.getBoundingClientRect();
+
+      setIndicatorStyle({
+        width: triggerRect.width,
+        transform: `translateX(${triggerRect.left - tabsRect.left}px)`,
+      });
+    };
+
+    measure();
+
+    const tabsList = tabsListRef.current;
+    if (!tabsList || typeof ResizeObserver === 'undefined') {
       return;
     }
 
-    const tabsRect = tabsList.getBoundingClientRect();
-    const triggerRect = trigger.getBoundingClientRect();
-
-    setIndicatorStyle({
-      width: triggerRect.width,
-      transform: `translateX(${triggerRect.left - tabsRect.left}px)`,
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(tabsList);
+    Object.values(triggerRefs.current).forEach((trigger) => {
+      if (trigger) observer.observe(trigger);
     });
+
+    return () => observer.disconnect();
   }, [activeTab]);
 
   return (
@@ -1005,7 +1024,11 @@ const TabbedIntegratedToolbarTabsList: React.FC<{
       className="tabbed-integrated-toolbar__tabs-list relative z-10 mb-[-1px] h-auto gap-1 bg-transparent p-0"
       aria-label="Forecast toolbar sections"
     >
-      <span className="tabbed-integrated-toolbar__tab-indicator" style={indicatorStyle} aria-hidden="true" />
+      <span
+        className="tabbed-integrated-toolbar__tab-indicator pointer-events-none absolute inset-y-0 left-0"
+        style={indicatorStyle}
+        aria-hidden="true"
+      />
       <TabsTrigger
         value="draw"
         ref={(node) => {

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -985,6 +985,7 @@ const TabbedIntegratedToolbarTabsList: React.FC<{
   const [indicatorStyle, setIndicatorStyle] = React.useState<React.CSSProperties>({});
 
   React.useLayoutEffect(() => {
+    /** Re-measure the active trigger and update the sliding indicator position. */
     const measure = () => {
       const tabsList = tabsListRef.current;
       const trigger = triggerRefs.current[activeTab];
@@ -1015,7 +1016,9 @@ const TabbedIntegratedToolbarTabsList: React.FC<{
       if (trigger) observer.observe(trigger);
     });
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+    };
   }, [activeTab]);
 
   return (

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -1004,13 +1004,28 @@ const TabbedIntegratedToolbarTabsList: React.FC<{
     };
 
     measure();
+  }, [activeTab]);
 
+  React.useEffect(function setupTabIndicatorObserver() {
     const tabsList = tabsListRef.current;
     if (!tabsList || typeof ResizeObserver === 'undefined') {
       return;
     }
 
-    const observer = new ResizeObserver(() => measure());
+    const observer = new ResizeObserver(() => {
+      const trigger = triggerRefs.current[activeTab];
+      if (!tabsList.isConnected || !trigger) {
+        return;
+      }
+
+      const tabsRect = tabsList.getBoundingClientRect();
+      const triggerRect = trigger.getBoundingClientRect();
+
+      setIndicatorStyle({
+        width: triggerRect.width,
+        transform: `translateX(${triggerRect.left - tabsRect.left}px)`,
+      });
+    });
     observer.observe(tabsList);
     Object.values(triggerRefs.current).forEach((trigger) => {
       if (trigger) observer.observe(trigger);

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -1016,7 +1016,7 @@ const TabbedIntegratedToolbarTabsList: React.FC<{
       if (trigger) observer.observe(trigger);
     });
 
-    return () => {
+    return function cleanup() {
       observer.disconnect();
     };
   }, [activeTab]);


### PR DESCRIPTION
## Summary
- Removes repeated header selection/status pill UI in favor of compact context text.
- Tightens Days tab width so the day controls no longer leave a huge empty span.
- Adds structure for grouped Tools actions without the previous heavy boxed layout.
- Adds room between ghost-layer icons and labels.

## Parallel PR dependencies
This PR is part of the toolbar design uplift and targets `beta` directly.

- **Depends on:** #686 (must merge first — JSX touches adjacent toolbar regions).
- **Merge order:** merge after #686, before #688.

| PR | Title | Targets | Depends on |
|----|-------|---------|------------|
| #686 | Polish toolbar selection chip spacing | `beta` | — |
| #687 | Refine forecast toolbar control density | `beta` | #686 |
| #688 | Polish forecast toolbar motion and tabs | `beta` | #686, #687 |

## Validation
- Full stack validated on `design/forecast-toolbar-motion-polish` with:
  - `pnpm exec playwright test e2e/smoke.spec.ts --grep "forecast editor"`
  - `pnpm run build` (bundle completed; Sentry sourcemap upload still reports HTTP 403)

Note: this branch was rebased onto `beta` to drop the parent commit from #686, so the diff now shows only this PR's own changes; #686 must land first.