### PR TITLE
[codex] Fix Sentry browser noise filters

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -42,6 +42,9 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 ### PR #683
 
 - Modernize the package review and completion dialogs with shared dialog primitives and review/export actions.
+### PR #691
+
+- Filter known no-stack browser telemetry noise tracked by GFC-WEB-K and GFC-WEB-M while preserving actionable errors.
 
 ### PR #681
 

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -139,6 +139,12 @@ describe('instrument', () => {
     },
   });
 
+  const loadBeforeSend = () => {
+    globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+    // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+    return require('./instrument').beforeSend;
+  };
+
   it.each([
     ['GFC-WEB-K NetworkError', 'A network error occurred.'],
     ['GFC-WEB-F wrapped NetworkError', 'NetworkError: A network error occurred.'],

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -199,6 +199,16 @@ describe('instrument', () => {
     });
   });
 
+  it('keeps opaque global errors when breadcrumbs provide context', () => {
+    jest.isolateModules(() => {
+      const beforeSend = loadBeforeSend();
+      const event = createOpaqueGlobalError();
+      event.breadcrumbs = [{ message: 'forecast route loaded' }];
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
+  });
+
   it('keeps the opaque message when it comes from another mechanism', () => {
     jest.isolateModules(() => {
       globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
@@ -211,14 +221,14 @@ describe('instrument', () => {
     });
   });
 
-  it('drops matching request lifecycle noise from message-only events', () => {
+  it('keeps matching request lifecycle messages without exception values', () => {
     jest.isolateModules(() => {
       globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
       // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
       const { beforeSend } = require('./instrument');
       const event = { message: 'A network error occurred.' };
 
-      expect(beforeSend(event, {})).toBeNull();
+      expect(beforeSend(event, {})).toBe(event);
     });
   });
 

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -96,17 +96,12 @@ describe('instrument', () => {
   });
 
   it('keeps matching canvas TypeErrors when they come from application frames', () => {
-    jest.isolateModules(() => {
-      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
-      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
-      const { beforeSend } = require('./instrument');
-      const event = createOpenLayersCanvasEvent(
+    expectBeforeSendToKeep(() =>
+      createOpenLayersCanvasEvent(
         "null is not an object (evaluating 'a.canvas')",
         'auto.browser.global_handlers.onerror'
-      );
-
-      expect(beforeSend(event, {})).toBe(event);
-    });
+      )
+    );
   });
 
   const createRequestLifecycleEvent = (value: string, withStack = false) => ({
@@ -143,6 +138,15 @@ describe('instrument', () => {
     globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
     // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
     return require('./instrument').beforeSend;
+  };
+
+  const expectBeforeSendToKeep = (createEvent: () => any) => {
+    jest.isolateModules(() => {
+      const beforeSend = loadBeforeSend();
+      const event = createEvent();
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
   };
 
   it.each([
@@ -216,14 +220,10 @@ describe('instrument', () => {
   });
 
   it('keeps the opaque message when it comes from another mechanism', () => {
-    jest.isolateModules(() => {
-      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
-      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
-      const { beforeSend } = require('./instrument');
+    expectBeforeSendToKeep(() => {
       const event = createOpaqueGlobalError();
       event.exception.values[0].mechanism.type = 'auto.browser.global_handlers.onunhandledrejection';
-
-      expect(beforeSend(event, {})).toBe(event);
+      return event;
     });
   });
 

--- a/src/instrument.test.ts
+++ b/src/instrument.test.ts
@@ -122,6 +122,23 @@ describe('instrument', () => {
     },
   });
 
+  const createOpaqueGlobalError = (value = 'uncaught exception: undefined', withStack = false) => ({
+    exception: {
+      values: [
+        {
+          value,
+          mechanism: {
+            type: 'auto.browser.global_handlers.onerror',
+            handled: false,
+          },
+          stacktrace: withStack
+            ? { frames: [{ filename: 'src/App.tsx', function: 'renderForecast' }] }
+            : undefined,
+        },
+      ],
+    },
+  });
+
   it.each([
     ['GFC-WEB-K NetworkError', 'A network error occurred.'],
     ['GFC-WEB-F wrapped NetworkError', 'NetworkError: A network error occurred.'],
@@ -143,6 +160,52 @@ describe('instrument', () => {
       // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
       const { beforeSend } = require('./instrument');
       const event = createRequestLifecycleEvent('A network error occurred.', true);
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
+  });
+
+  it.each([
+    ['double-space NetworkError', 'NetworkError:  A network error occurred.'],
+    ['leading/trailing whitespace', '  AbortError:   The user aborted a request.  '],
+  ])('drops whitespace variants of request lifecycle noise: %s', (_label, message) => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+
+      expect(beforeSend(createRequestLifecycleEvent(message), {})).toBeNull();
+    });
+  });
+
+  it('drops no-stack opaque global error noise from Firefox', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+
+      expect(beforeSend(createOpaqueGlobalError(), {})).toBeNull();
+    });
+  });
+
+  it('keeps opaque global errors when they have application stack frames', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createOpaqueGlobalError(undefined, true);
+
+      expect(beforeSend(event, {})).toBe(event);
+    });
+  });
+
+  it('keeps the opaque message when it comes from another mechanism', () => {
+    jest.isolateModules(() => {
+      globalScope.__GFC_SENTRY_DSN__ = 'https://example@o0.ingest.sentry.io/0';
+      // skipcq: JS-C1003, JS-0359 — isolateModules needs require for fresh module load
+      const { beforeSend } = require('./instrument');
+      const event = createOpaqueGlobalError();
+      event.exception.values[0].mechanism.type = 'auto.browser.global_handlers.onunhandledrejection';
 
       expect(beforeSend(event, {})).toBe(event);
     });

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -70,25 +70,42 @@ function isOpaqueGlobalError(value: SentryExceptionValue): boolean {
   );
 }
 
-/** Drops known no-stack browser noise while preserving actionable stacked errors. */
-export function beforeSend(event: Event, _hint: EventHint): Event | null {
+/** True when an exception value matches known request-lifecycle browser noise. */
+function isRequestLifecycleNoise(values: SentryExceptionValue[], message: string): boolean {
+  return (
+    values.length > 0 &&
+    REQUEST_LIFECYCLE_MESSAGES.some((pattern) => pattern.test(message))
+  );
+}
+
+/** True when the event contains any stack or breadcrumb context worth retaining. */
+function hasActionableContext(event: Event, values: SentryExceptionValue[]): boolean {
+  return values.some(hasStackFrames) || Boolean(event.breadcrumbs?.length);
+}
+
+/** True when the event is known browser noise that is safe to drop. */
+function isKnownBrowserNoise(event: Event): boolean {
   const values = event.exception?.values ?? [];
   const message = values[0]?.value ?? event.message ?? '';
   const normalizedMessage = message.replace(/\s+/g, ' ').trim();
-  const hasAnyStackFrames = values.some(hasStackFrames);
-  const isIgnoredRequestNoise =
-    values.length > 0 &&
-    REQUEST_LIFECYCLE_MESSAGES.some((pattern) => pattern.test(normalizedMessage));
-  const isIgnoredOpaqueGlobalError =
-    values.some(isOpaqueGlobalError) && !event.breadcrumbs?.length;
+
+  if (values.some(isOpenLayersCanvasNoise)) {
+    return true;
+  }
+
+  if (hasActionableContext(event, values)) {
+    return false;
+  }
 
   return (
-    (isIgnoredRequestNoise && !hasAnyStackFrames) ||
-    (isIgnoredOpaqueGlobalError && !hasAnyStackFrames) ||
-    values.some(isOpenLayersCanvasNoise)
-  )
-    ? null
-    : event;
+    isRequestLifecycleNoise(values, normalizedMessage) ||
+    values.some(isOpaqueGlobalError)
+  );
+}
+
+/** Drops known no-stack browser noise while preserving actionable stacked errors. */
+export function beforeSend(event: Event, _hint: EventHint): Event | null {
+  return isKnownBrowserNoise(event) ? null : event;
 }
 
 /** Initializes Sentry when a DSN is present. No-op in local dev without a DSN. */

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -76,10 +76,11 @@ export function beforeSend(event: Event, _hint: EventHint): Event | null {
   const message = values[0]?.value ?? event.message ?? '';
   const normalizedMessage = message.replace(/\s+/g, ' ').trim();
   const hasAnyStackFrames = values.some(hasStackFrames);
-  const isIgnoredRequestNoise = REQUEST_LIFECYCLE_MESSAGES.some((pattern) =>
-    pattern.test(normalizedMessage)
-  );
-  const isIgnoredOpaqueGlobalError = values.some(isOpaqueGlobalError);
+  const isIgnoredRequestNoise =
+    values.length > 0 &&
+    REQUEST_LIFECYCLE_MESSAGES.some((pattern) => pattern.test(normalizedMessage));
+  const isIgnoredOpaqueGlobalError =
+    values.some(isOpaqueGlobalError) && !event.breadcrumbs?.length;
 
   return (
     (isIgnoredRequestNoise && !hasAnyStackFrames) ||

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -16,6 +16,8 @@ type SentryExceptionValue = NonNullable<NonNullable<Event['exception']>['values'
 
 const OPENLAYERS_CANVAS_MESSAGE = /^null is not an object \(evaluating '[a-z]{1,2}\.canvas'\)$/i;
 const REQUEST_ANIMATION_FRAME_MECHANISM = 'auto.browser.browserapierrors.requestAnimationFrame';
+const OPAQUE_GLOBAL_ERROR_MESSAGE = /^uncaught exception: undefined$/i;
+const GLOBAL_ERROR_MECHANISM = 'auto.browser.global_handlers.onerror';
 
 const REQUEST_LIFECYCLE_MESSAGES = [
   /^(NetworkError: )?A network error occurred\.?$/i,
@@ -59,14 +61,31 @@ function isOpenLayersCanvasNoise(value: SentryExceptionValue): boolean {
   );
 }
 
-/** Drops no-stack request lifecycle noise while preserving actionable stacked errors. */
+/** True for the opaque Firefox global error with no exception value or stack. */
+function isOpaqueGlobalError(value: SentryExceptionValue): boolean {
+  return (
+    OPAQUE_GLOBAL_ERROR_MESSAGE.test(value.value ?? '') &&
+    value.mechanism?.type === GLOBAL_ERROR_MECHANISM &&
+    value.mechanism.handled === false
+  );
+}
+
+/** Drops known no-stack browser noise while preserving actionable stacked errors. */
 export function beforeSend(event: Event, _hint: EventHint): Event | null {
   const values = event.exception?.values ?? [];
   const message = values[0]?.value ?? event.message ?? '';
+  const normalizedMessage = message.replace(/\s+/g, ' ').trim();
   const hasAnyStackFrames = values.some(hasStackFrames);
-  const isIgnoredRequestNoise = REQUEST_LIFECYCLE_MESSAGES.some((pattern) => pattern.test(message));
+  const isIgnoredRequestNoise = REQUEST_LIFECYCLE_MESSAGES.some((pattern) =>
+    pattern.test(normalizedMessage)
+  );
+  const isIgnoredOpaqueGlobalError = values.some(isOpaqueGlobalError);
 
-  return (isIgnoredRequestNoise && !hasAnyStackFrames) || values.some(isOpenLayersCanvasNoise)
+  return (
+    (isIgnoredRequestNoise && !hasAnyStackFrames) ||
+    (isIgnoredOpaqueGlobalError && !hasAnyStackFrames) ||
+    values.some(isOpenLayersCanvasNoise)
+  )
     ? null
     : event;
 }


### PR DESCRIPTION
## Summary

Fixes the production Sentry telemetry gaps tracked by #689 and #690.

## Root cause

- GFC-WEB-K emits browser `NetworkError` messages with inconsistent whitespace, including `NetworkError:  A network error occurred.`. The existing exact matcher did not recognize those events.
- GFC-WEB-M is a one-off Firefox `onerror` event with the exact message `uncaught exception: undefined`, no stack frames, no breadcrumbs, and no actionable first-party evidence. It is classified as opaque browser noise rather than a confirmed product failure.

## Fix

- Normalize whitespace before matching request-lifecycle exception noise.
- Drop only no-stack `auto.browser.global_handlers.onerror` events matching `uncaught exception: undefined` when they have no breadcrumbs.
- Preserve stacked errors, breadcrumb-rich events, differently-mechanized errors, and message-only telemetry.

## Validation

- `pnpm test -- --runTestsByPath src/instrument.test.ts --runInBand` — 19/19 passed
- `pnpm test -- --runInBand` — 147 suites / 713 tests passed
- `pnpm run build` — completed successfully; local Sentry source-map upload was denied by the available token with HTTP 403
- Live PR checks — CI build/test matrix, CodeQL, DeepSource, CodeScene, Greptile, governance, and feature-exposure policy all passed

## Release follow-up

After this PR is merged and deployed, verify that GFC-WEB-K and GFC-WEB-M receive no new production events, then resolve the corresponding Sentry issues.