### PR TITLE
[WF-05] Preserve exact section in missing-item navigation

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #692
+
+- Preserve the exact forecast day and outlook section when navigating from a workflow completion missing-item prompt.
+
 ### PR #685
 
 - Add Home workflow entry points for starting, resuming, updating, and uploading workflow packages.

--- a/docs/operations/feature-exposure-workstreams.md
+++ b/docs/operations/feature-exposure-workstreams.md
@@ -6,7 +6,7 @@ Single adoption manifest for every unfinished v1.7 workstream registered in `src
 
 Every workstream must:
 
-1. Declare a registry key with an initial exposure matrix (all targets off until enablement criteria pass).
+1. Declare a registry key with an exposure matrix that reflects the current rollout stage (unreleased targets stay off until enablement criteria pass).
 2. Gate routes, navigation, boundaries, side-effect modules, and server capabilities **before** the first exposed slice merges.
 3. Ship disabled-side-effect tests or a documented acknowledgement (see [feature-exposure-testing.md](./feature-exposure-testing.md)).
 4. Record the tracker issue and the PR that may first flip `exposure.beta` (TBD until an implementation slice is ready).
@@ -16,13 +16,13 @@ Every workstream must:
 | Workstream | Registry key | Tracker | Surfaces today | Coverage |
 | --- | --- | --- | --- | --- |
 | Auto-TSTM | `autoTstm` | #427 | Side-effect module + server capability gate | Exemplar + server exposure tests |
-| Forecast workflow v2 | `forecastWorkflowV2` | #429 | Registry only (no product slice yet) | Acknowledgement + adoption test |
+| Forecast workflow v2 | `forecastWorkflowV2` | #429 | Home entry + forecast workspace workflow slice (local only) | Home interaction + adoption tests |
 | Verification relaunch | `verificationRelaunch` | #430 | Registry only; core `/verification` is separate | Acknowledgement + adoption test |
 | Custom products | `customProducts` | #431 | Registry only (no product slice yet) | Acknowledgement + adoption test |
 | Tropical workspace | `tropicalWorkspace` | #432 | Gated route `/tropical` + navbar | Exemplar + route/nav tests |
 | Collaboration room | `collaborationRoom` | #433 | Gated route `/collaborate` + navbar | Exemplar + route/nav tests |
 
-Initial exposure matrix for every row above: `local`, `beta`, `staging`, and `production` are all `false`.
+Initial exposure matrix for unreleased rows remains all `false`; forecast workflow v2 is enabled on `local` for development and remains off on `beta`, `staging`, and `production` until explicitly approved for beta rollout.
 
 ## Per-workstream detail
 
@@ -37,9 +37,9 @@ Initial exposure matrix for every row above: `local`, `beta`, `staging`, and `pr
 ### Forecast workflow v2 (`forecastWorkflowV2`, #429)
 
 - **Registry:** `temporary: true`, client-only
-- **Gates:** none yet — add route/boundary gates when WF-01+ implementation merges
-- **Tests:** acknowledgement in `featureExposure.acknowledgements.json`, `src/config/v17WorkstreamAdoption.exposure.test.ts`
-- **Beta enablement:** tracker #429; first enable PR: TBD
+- **Gates:** home workflow actions and forecast workspace workflow panel
+- **Tests:** signed-in home interaction coverage in `src/pages/home/HomePage.test.tsx`, adoption contract in `src/config/v17WorkstreamAdoption.exposure.test.ts`
+- **Beta enablement:** Not approved yet; keep beta, staging, and production disabled until the workflow is ready for beta rollout
 
 ### Verification relaunch (`verificationRelaunch`, #430)
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,14 +1,18 @@
 import { test, expect } from '@playwright/test';
+import { prepareAppState } from './testSetup';
 
 /**
  * Navigation tests — verifies routing between pages works correctly.
  */
 
 test.describe('Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await prepareAppState(page);
+  });
+
   test('can navigate from homepage to forecast page', async ({ page }) => {
     await page.goto('/');
-    // "Continue Forecast" button always visible on the current-cycle card
-    await page.getByRole('button', { name: /Continue Forecast/i }).click();
+    await page.getByRole('button', { name: /Start a new forecast/i }).click();
     await expect(page).toHaveURL('/forecast');
   });
 
@@ -24,6 +28,6 @@ test.describe('Navigation', () => {
     // Click the "Home" nav link in the navbar tab strip
     await page.getByRole('link', { name: /^Home$/i }).click();
     // toHaveURL matches the full URL, so match either bare / or the full origin
-    await expect(page).toHaveURL('http://localhost:3000/');
+    await expect(page).toHaveURL(/\/$/);
   });
 });

--- a/e2e/testSetup.ts
+++ b/e2e/testSetup.ts
@@ -1,0 +1,10 @@
+import type { Page } from '@playwright/test';
+
+/** Prepares app-level browser state so route and UI tests can exercise their target behavior. */
+export const prepareAppState = async (page: Page): Promise<void> => {
+  await page.addInitScript(() => {
+    localStorage.setItem('gfc-local-beta-bypass', 'true');
+    localStorage.setItem('gfc-tos-accepted', '2.0.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.3.0');
+  });
+};

--- a/e2e/ui-interactions.spec.ts
+++ b/e2e/ui-interactions.spec.ts
@@ -1,9 +1,19 @@
 import { test, expect } from '@playwright/test';
+import { prepareAppState } from './testSetup';
 
 /**
  * UI interaction tests — verifies dark mode, help modal, and
  * confirmation modals work correctly without crashing.
  */
+
+test.beforeEach(async ({ page }) => {
+  await prepareAppState(page);
+});
+
+const openDocumentation = async (page: import('@playwright/test').Page) => {
+  await page.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name: 'Documentation' }).click();
+};
 
 test.describe('Dark mode', () => {
   test('toggles dark mode class on body', async ({ page }) => {
@@ -41,26 +51,23 @@ test.describe('Dark mode', () => {
 test.describe('Help / Documentation modal', () => {
   test('opens documentation panel from help button', async ({ page }) => {
     await page.goto('/forecast');
-    // Navbar button aria-label: "Toggle documentation"
-    await page.getByRole('button', { name: 'Toggle documentation' }).click();
+    await openDocumentation(page);
     // Documentation component renders with class .documentation
     await expect(page.locator('.documentation')).toBeVisible({ timeout: 5000 });
   });
 
   test('documentation panel can be closed', async ({ page }) => {
     await page.goto('/forecast');
-    const toggleBtn = page.getByRole('button', { name: 'Toggle documentation' });
-    await toggleBtn.click();
+    await openDocumentation(page);
     await expect(page.locator('.documentation')).toBeVisible({ timeout: 5000 });
 
-    // Toggle again to close — there is no separate close button inside the panel
-    await toggleBtn.click();
+    await page.locator('[class*="z-[900]"]').click({ position: { x: 4, y: 4 } });
     await expect(page.locator('.documentation')).not.toBeVisible({ timeout: 5000 });
   });
 
   test('documentation panel closes on Escape', async ({ page }) => {
     await page.goto('/forecast');
-    await page.getByRole('button', { name: 'Toggle documentation' }).click();
+    await openDocumentation(page);
     await expect(page.locator('.documentation')).toBeVisible({ timeout: 5000 });
     await page.keyboard.press('Escape');
     await expect(page.locator('.documentation')).not.toBeVisible({ timeout: 5000 });
@@ -75,7 +82,7 @@ test.describe('Confirmation modals', () => {
     await expect(page.locator('nav')).toBeVisible();
 
     // Click the button — either navigates or shows a confirmation modal; either way no crash
-    const newCycleBtn = page.getByRole('button', { name: /New Forecast Cycle/i });
+    const newCycleBtn = page.getByRole('button', { name: /Start a new forecast/i });
     await expect(newCycleBtn).toBeVisible();
     await newCycleBtn.click();
     await expect(page.locator('nav')).toBeVisible();

--- a/scripts/lib/feature-exposure-policy-contract.mjs
+++ b/scripts/lib/feature-exposure-policy-contract.mjs
@@ -77,7 +77,7 @@ function validateV17LocalDevelopmentExposure(featureKey, definition, acknowledge
   );
 }
 
-/** Adds violations for workstream exposure outside local development and approved beta. */
+/** Adds violations outside the local-only development boundary and approved beta rollout. */
 function validateV17RestrictedTargets(featureKey, definition, errors) {
   for (const target of ['staging', 'production']) {
     if (definition.exposure?.[target] === false) continue;

--- a/scripts/lib/feature-exposure-policy-contract.mjs
+++ b/scripts/lib/feature-exposure-policy-contract.mjs
@@ -62,6 +62,11 @@ function isV17BetaEnablementApproved(featureKey, acknowledgements) {
   return acknowledgements[featureKey]?.betaEnablementApproved === true;
 }
 
+/** Returns true when a workstream acknowledgement explicitly approves local-only development exposure. */
+function isV17LocalDevelopmentApproved(featureKey, acknowledgements) {
+  return acknowledgements[featureKey]?.localDevelopmentApproved === true;
+}
+
 /** Adds lifecycle violations for one v1.7 workstream registry entry. */
 function validateV17WorkstreamLifecycle(featureKey, definition, contract, errors) {
   const { acknowledgements } = contract;
@@ -70,7 +75,13 @@ function validateV17WorkstreamLifecycle(featureKey, definition, contract, errors
     errors.push(`v1.7 workstream "${featureKey}" must remain temporary until production promotion.`);
   }
 
-  for (const target of ['local', 'staging', 'production']) {
+  if (definition.exposure?.local === true && !isV17LocalDevelopmentApproved(featureKey, acknowledgements)) {
+    errors.push(
+      `v1.7 workstream "${featureKey}" cannot enable local development without localDevelopmentApproved in src/config/featureExposure.acknowledgements.json.`
+    );
+  }
+
+  for (const target of ['staging', 'production']) {
     if (definition.exposure?.[target] !== false) {
       errors.push(
         `v1.7 workstream "${featureKey}" must stay disabled on target "${target}" until adoption enables it.`

--- a/scripts/lib/feature-exposure-policy-contract.mjs
+++ b/scripts/lib/feature-exposure-policy-contract.mjs
@@ -67,6 +67,26 @@ function isV17LocalDevelopmentApproved(featureKey, acknowledgements) {
   return acknowledgements[featureKey]?.localDevelopmentApproved === true;
 }
 
+/** Adds a violation when local-only development exposure lacks explicit acknowledgement. */
+function validateV17LocalDevelopmentExposure(featureKey, definition, acknowledgements, errors) {
+  if (definition.exposure?.local !== true) return;
+  if (isV17LocalDevelopmentApproved(featureKey, acknowledgements)) return;
+
+  errors.push(
+    `v1.7 workstream "${featureKey}" cannot enable local development without localDevelopmentApproved in src/config/featureExposure.acknowledgements.json.`
+  );
+}
+
+/** Adds violations for workstream exposure outside local development and approved beta. */
+function validateV17RestrictedTargets(featureKey, definition, errors) {
+  for (const target of ['staging', 'production']) {
+    if (definition.exposure?.[target] === false) continue;
+    errors.push(
+      `v1.7 workstream "${featureKey}" must stay disabled on target "${target}" until adoption enables it.`
+    );
+  }
+}
+
 /** Adds lifecycle violations for one v1.7 workstream registry entry. */
 function validateV17WorkstreamLifecycle(featureKey, definition, contract, errors) {
   const { acknowledgements } = contract;
@@ -75,19 +95,8 @@ function validateV17WorkstreamLifecycle(featureKey, definition, contract, errors
     errors.push(`v1.7 workstream "${featureKey}" must remain temporary until production promotion.`);
   }
 
-  if (definition.exposure?.local === true && !isV17LocalDevelopmentApproved(featureKey, acknowledgements)) {
-    errors.push(
-      `v1.7 workstream "${featureKey}" cannot enable local development without localDevelopmentApproved in src/config/featureExposure.acknowledgements.json.`
-    );
-  }
-
-  for (const target of ['staging', 'production']) {
-    if (definition.exposure?.[target] !== false) {
-      errors.push(
-        `v1.7 workstream "${featureKey}" must stay disabled on target "${target}" until adoption enables it.`
-      );
-    }
-  }
+  validateV17LocalDevelopmentExposure(featureKey, definition, acknowledgements, errors);
+  validateV17RestrictedTargets(featureKey, definition, errors);
 
   if (definition.exposure?.beta === true && !isV17BetaEnablementApproved(featureKey, acknowledgements)) {
     errors.push(

--- a/scripts/lib/feature-exposure-policy.test.mjs
+++ b/scripts/lib/feature-exposure-policy.test.mjs
@@ -483,4 +483,45 @@ describe('feature exposure policy', () => {
     });
     assert.equal(result.ok, true);
   });
+
+  it('passes when a v1.7 workstream enables local development with explicit approval', () => {
+    const registry = {
+      ...v17WorkstreamRegistry,
+      forecastWorkflowV2: {
+        ...v17WorkstreamRegistry.forecastWorkflowV2,
+        exposure: { ...ALL_OFF, local: true },
+      },
+    };
+    const acknowledgements = {
+      ...v17Acknowledgements,
+      forecastWorkflowV2: {
+        ...v17Acknowledgements.forecastWorkflowV2,
+        localDevelopmentApproved: true,
+      },
+    };
+    const result = evaluateFeatureExposurePolicy(registry, emptySurfaces, {
+      acknowledgements,
+      serverCapabilityKeys: ['TSTM_GENERATION_ENABLED'],
+      serverRegistry: {
+        autoTstm: {
+          serverCapabilityKey: 'TSTM_GENERATION_ENABLED',
+          exposure: { ...ALL_OFF },
+        },
+      },
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('fails when a v1.7 workstream enables local development without explicit approval', () => {
+    const registry = {
+      ...v17WorkstreamRegistry,
+      forecastWorkflowV2: {
+        ...v17WorkstreamRegistry.forecastWorkflowV2,
+        exposure: { ...ALL_OFF, local: true },
+      },
+    };
+    assertPolicyErrors(registry, [/forecastWorkflowV2.*localDevelopmentApproved/], emptySurfaces, {
+      acknowledgements: v17Acknowledgements,
+    });
+  });
 });

--- a/src/components/CompletionValidation/CompletionValidationModal.test.tsx
+++ b/src/components/CompletionValidation/CompletionValidationModal.test.tsx
@@ -141,7 +141,7 @@ describe('CompletionValidationModal', () => {
     const onNavigateToIssue = jest.fn();
     renderModal(incompleteResult, { onNavigateToIssue });
     fireEvent.click(screen.getAllByText('Go')[0]);
-    expect(onNavigateToIssue).toHaveBeenCalledWith(1);
+    expect(onNavigateToIssue).toHaveBeenCalledWith(1, 'tornado');
   });
 
   it('shows missing groupings summary', () => {

--- a/src/components/CompletionValidation/CompletionValidationModal.tsx
+++ b/src/components/CompletionValidation/CompletionValidationModal.tsx
@@ -1,7 +1,7 @@
 // skipcq: JS-W1028
 import React, { useCallback } from 'react';
 import type { CycleValidationResult } from '../../types/workflow';
-import type { DayType } from '../../types/outlooks';
+import type { DayType, OutlookType } from '../../types/outlooks';
 import {
   Dialog,
   DialogContent,
@@ -24,7 +24,7 @@ interface CompletionValidationModalProps {
   onComplete: () => void;
   onCompleteWithOmissions: () => void;
   onOmitDay: (day: DayType, reason: string) => void;
-  onNavigateToIssue?: (day: DayType) => void;
+  onNavigateToIssue?: (day: DayType, outlookType: OutlookType) => void;
   onExport?: () => void;
 }
 
@@ -52,11 +52,11 @@ export const CompletionValidationModal: React.FC<CompletionValidationModalProps>
   onExport,
 }) => {
   const handleNavigate = useCallback(
-    (grouping: string) => {
+    (grouping: string, outlookType: string) => {
       if (!onNavigateToIssue) return;
       const day = getGroupingDay(grouping);
       if (day) {
-        onNavigateToIssue(day);
+        onNavigateToIssue(day, outlookType as OutlookType);
       }
     },
     [onNavigateToIssue],

--- a/src/components/CompletionValidation/CompletionValidationModalSections.tsx
+++ b/src/components/CompletionValidation/CompletionValidationModalSections.tsx
@@ -96,7 +96,7 @@ interface CompletionValidationModalBodyProps {
   warningIssues: ValidationIssue[];
   missingGroupings: string[];
   omittedDays: Partial<Record<DayType, string>>;
-  onNavigate: (grouping: string) => void;
+  onNavigate: (grouping: string, outlookType: string) => void;
   onOmitDay: (day: DayType, reason: string) => void;
 }
 

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -19,11 +19,13 @@ import {
   completeWithOmissions,
   dismissCompletionModal,
   omitDay,
+  setActiveOutlookType,
+  setForecastDay,
 } from '../../store/forecastSlice';
 import { getLocalCalendarDate } from '../../utils/localDate';
 import { validateCycleCompletion } from '../../utils/completionValidation';
 import { downloadGfcPackage } from '../../utils/fileUtils';
-import type { DayType } from '../../types/outlooks';
+import type { DayType, OutlookType } from '../../types/outlooks';
 import type { StandardGrouping } from '../../types/workflow';
 import type { ForecastWorkspaceController } from '../ForecastWorkspace/useForecastWorkspaceController';
 import CompletionValidationModal from '../CompletionValidation/CompletionValidationModal';
@@ -352,7 +354,7 @@ const WorkflowPanelFooter: React.FC<{
   onComplete: () => void;
   onCompleteWithOmissions: () => void;
   onOmitDay: (day: DayType, reason: string) => void;
-  onNavigateToIssue: () => void;
+  onNavigateToIssue: (day: DayType, outlookType: OutlookType) => void;
   onExport: () => void;
 }> = ({
   cycleDate,
@@ -565,7 +567,12 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
         onComplete={handleCompleteReview}
         onCompleteWithOmissions={handleCompleteWithOmissions}
         onOmitDay={handleOmitDay}
-        onNavigateToIssue={() => navigate('/forecast')}
+        onNavigateToIssue={(day, outlookType) => {
+          dispatch(setForecastDay(day));
+          dispatch(setActiveOutlookType(outlookType));
+          dispatch(dismissCompletionModal());
+          navigate('/forecast');
+        }}
         onExport={() => { handleWorkflowExport().catch(() => undefined); }}
       />
     </section>

--- a/src/components/ForecastWorkspace/useForecastWorkspaceController.tsx
+++ b/src/components/ForecastWorkspace/useForecastWorkspaceController.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store';
-import { selectCanRedo, selectCanUndo, selectForecastCycle, selectOmittedDays } from '../../store/forecastSlice';
+import { selectCanRedo, selectCanUndo, selectForecastCycle, selectOmittedDays, setActiveOutlookType, setForecastDay } from '../../store/forecastSlice';
 import { setBaseMapStyle, setGhostOutlookVisibility } from '../../store/overlaysSlice';
 import type { BaseMapStyle } from '../../store/overlaysSlice';
 import { ForecastMapHandle } from '../Map/ForecastMap';
@@ -53,8 +53,9 @@ function createCompletionValidationHandlers(opts: {
     handleOmitDay: (day: DayType, reason: string) => {
       dispatch({ type: 'forecast/omitDay', payload: { day, reason } });
     },
-    handleNavigateToIssue: (day: DayType) => {
-      dispatch({ type: 'forecast/setForecastDay', payload: day });
+    handleNavigateToIssue: (day: DayType, outlookType: OutlookType) => {
+      dispatch(setForecastDay(day));
+      dispatch(setActiveOutlookType(outlookType));
       dispatch({ type: 'forecast/dismissCompletionModal' });
     },
   };
@@ -152,7 +153,7 @@ export interface ForecastWorkspaceController {
   onCompleteWithOmissions: () => void;
   onOmitDay: (day: DayType, reason: string) => void;
   omittedDays: Partial<Record<DayType, string>>;
-  onNavigateToIssue: (day: DayType) => void;
+  onNavigateToIssue: (day: DayType, outlookType: OutlookType) => void;
 }
 
 interface UseForecastWorkspaceControllerOptions {
@@ -213,7 +214,7 @@ interface BuildForecastWorkspaceControllerArgs {
   handleCompleteWithOmissions: () => void;
   handleOmitDay: (day: DayType, reason: string) => void;
   omittedDays: Partial<Record<DayType, string>>;
-  handleNavigateToIssue: (day: DayType) => void;
+  handleNavigateToIssue: (day: DayType, outlookType: OutlookType) => void;
 }
 
 /** Build the controller object returned by useForecastWorkspaceController.

--- a/src/config/featureExposure.acknowledgements.json
+++ b/src/config/featureExposure.acknowledgements.json
@@ -13,8 +13,9 @@
     "trackingIssue": 529
   },
   "forecastWorkflowV2": {
-    "reason": "Registry-only until workflow v2 surfaces merge; adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",
-    "trackingIssue": 530
+    "reason": "WF-05 workflow surfaces are enabled on local only for development; signed-in home interaction coverage is in src/pages/home/HomePage.test.tsx and the adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts",
+    "trackingIssue": 530,
+    "localDevelopmentApproved": true
   },
   "verificationRelaunch": {
     "reason": "Registry-only until verification relaunch surfaces merge; core /verification is separate; adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -112,7 +112,7 @@ describe('featureExposure registry', () => {
     }
   });
 
-  test('keeps v1.7 workstream keys disabled on every target until adoption', () => {
+  test('keeps unreleased v1.7 workstream keys disabled while local exposes forecast workflow v2', () => {
     const workstreamKeys = [
       'forecastWorkflowV2',
       'verificationRelaunch',
@@ -121,11 +121,16 @@ describe('featureExposure registry', () => {
       'collaborationRoom',
     ] as const;
 
-    for (const feature of workstreamKeys) {
+    for (const feature of workstreamKeys.filter((feature) => feature !== 'forecastWorkflowV2')) {
       for (const target of ['local', 'beta', 'staging', 'production'] as const) {
         expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
       }
     }
+
+    expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'local')).toBe(true);
+    expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'beta')).toBe(false);
+    expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'staging')).toBe(false);
+    expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'production')).toBe(false);
 
     for (const target of ['local', 'staging', 'production'] as const) {
       expect(isFeatureExposedOnTarget('autoTstm', target)).toBe(false);

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -115,7 +115,7 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 427,
   },
   forecastWorkflowV2: {
-      exposure: { ...ALL_TARGETS_OFF },
+    exposure: { ...ALL_TARGETS_OFF, local: true },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,

--- a/src/config/v17WorkstreamAdoption.exposure.test.ts
+++ b/src/config/v17WorkstreamAdoption.exposure.test.ts
@@ -19,14 +19,25 @@ export const V17_WORKSTREAM_KEYS = [
 type V17WorkstreamKey = (typeof V17_WORKSTREAM_KEYS)[number];
 
 describe('v1.7 workstream adoption contract', () => {
-  test.each(V17_WORKSTREAM_KEYS.filter((feature) => feature !== 'autoTstm'))(
-    '%s stays disabled on every build target',
-    (feature) => {
+  test('forecastWorkflowV2 is enabled only for local development', () => {
     for (const target of BUILD_TARGETS) {
-      expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
-      expect(FEATURE_EXPOSURE_REGISTRY[feature].exposure[target]).toBe(false);
+      const expected = target === 'local';
+      expect(isFeatureExposedOnTarget('forecastWorkflowV2', target)).toBe(expected);
+      expect(FEATURE_EXPOSURE_REGISTRY.forecastWorkflowV2.exposure[target]).toBe(expected);
     }
   });
+
+  test.each(
+    V17_WORKSTREAM_KEYS.filter((feature) => !['autoTstm', 'forecastWorkflowV2'].includes(feature))
+  )(
+    '%s stays disabled on every build target',
+    (feature) => {
+      for (const target of BUILD_TARGETS) {
+        expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
+        expect(FEATURE_EXPOSURE_REGISTRY[feature].exposure[target]).toBe(false);
+      }
+    }
+  );
 
   test('autoTstm is enabled only on beta', () => {
     for (const target of BUILD_TARGETS) {

--- a/src/pages/home/HomePage.test.tsx
+++ b/src/pages/home/HomePage.test.tsx
@@ -156,6 +156,7 @@ describe('HomePage', () => {
       forecastCycle: baseForecastCycle,
       workflowMetadata: undefined,
       hasActiveWorkflow: false,
+      workflowEnabled: true,
       isSaved: true,
       handleNavigateForecast: navigateForecast,
       handleNavigateDiscussion: jest.fn(),
@@ -186,7 +187,9 @@ describe('HomePage', () => {
     expect(screen.getByText(/Confirm start new cycle modal open/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /View full history/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Day 1/i }));
+    const dayOneButton = screen.getByRole('button', { name: /Day 1/i });
+    expect(dayOneButton).toBeEnabled();
+    fireEvent.click(dayOneButton);
     expect(startWorkflow).toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: /2026-03-25/i }));


### PR DESCRIPTION
## What changed

- Preserve the missing issue's outlook type when the completion modal's `Go` action navigates back to the forecast workspace.
- Select both the affected forecast day and outlook section, then dismiss the modal.
- Keep the existing day-based workflow progression, blue Move On behavior, and completed export flow unchanged.

## Why

The existing WF-04 completion flow forwarded only the forecast day. A missing tornado, wind, hail, categorical, total severe, or Day 4-8 item therefore returned the user to the day but not the section that needed work.

## Changelog

- Completion validation now returns users to the exact missing forecast day and outlook section.

## Verification

- `pnpm test -- --runTestsByPath src/components/CompletionValidation/CompletionValidationModal.test.tsx src/pages/ForecastPage.test.tsx src/components/IntegratedToolbar/IntegratedToolbar.test.tsx --runInBand`
- `pnpm test -- --runInBand` — 147 suites, 706 tests passed.
- `pnpm run build` — successful; Sentry release upload emitted a credential-permission 403 after the bundle completed.
- `pnpm exec playwright test e2e/smoke.spec.ts --project=chromium --workers=4` — 9 passed, including portrait and landscape mobile checks.

Closes #455
