### PR TITLE
fix: make day rollover persistence safe (WF-08)

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #696
+
+- Preserve forecast sessions and cloud handoffs across day rollover choices.
+
 ### PR #693
 
 - Dependency: @radix-ui/react-dialog ^1.1.18 → ^1.1.19

--- a/e2e/day-rollover.spec.ts
+++ b/e2e/day-rollover.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+
+const localDay = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const staleSession = () => {
+  const today = new Date();
+  const previousDay = new Date(today);
+  previousDay.setDate(today.getDate() - 1);
+
+  return {
+    today: localDay(today),
+    previousDay: localDay(previousDay),
+    forecastData: {
+      version: '0.5.0',
+      type: 'forecast-cycle',
+      timestamp: today.toISOString(),
+      forecastCycle: {
+        days: {
+          1: {
+            day: 1,
+            metadata: {
+              issueDate: today.toISOString(),
+              validDate: today.toISOString(),
+              issuanceTime: '0600',
+              createdAt: today.toISOString(),
+              lastModified: today.toISOString(),
+              lowProbabilityOutlooks: [],
+            },
+            data: {
+              tornado: [['2%', [{
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [0, 0] },
+                properties: {},
+              }]]],
+            },
+          },
+        },
+        currentDay: 1,
+        cycleDate: localDay(previousDay),
+      },
+      mapView: { center: [39.8283, -98.5795], zoom: 4 },
+    },
+  };
+};
+
+const openStaleSession = async (page: import('@playwright/test').Page) => {
+  const session = staleSession();
+  await page.addInitScript(({ sessionData }) => {
+    localStorage.clear();
+    localStorage.setItem('gfc-local-beta-bypass', 'true');
+    localStorage.setItem('gfc-tos-accepted', '2.0.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.2.0');
+    localStorage.setItem('forecastData', JSON.stringify(sessionData.forecastData));
+    localStorage.setItem('gfc-last-active-local-day', sessionData.previousDay);
+  }, { sessionData: session });
+
+  await page.goto('/forecast?localBetaBypass=true');
+
+  for (let i = 0; i < 2; i += 1) {
+    const agreementCheckbox = page.getByRole('checkbox', { name: /I have read and agree/i });
+    if (!(await agreementCheckbox.isVisible().catch(() => false))) break;
+
+    await agreementCheckbox.check();
+    await page.getByRole('button', { name: /Accept & Continue/i }).click();
+  }
+
+  await expect(page.getByRole('dialog').filter({ hasText: 'New day detected' })).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole('heading', { name: 'New day detected' })).toBeVisible();
+  return session;
+};
+
+test.describe('New day rollover prompt', () => {
+  test('offers all four choices and keeps the session when deferred', async ({ page }) => {
+    await openStaleSession(page);
+
+    await expect(page.getByRole('button', { name: 'Download a copy & start new day' })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Premium cloud save unavailable/i })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Keep for now' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Replace without saving' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Keep for now' }).click();
+    await expect(page.getByRole('dialog').filter({ hasText: 'New day detected' })).not.toBeVisible();
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('forecastData'))).not.toBeNull();
+  });
+
+  test('downloads the restored session before starting a new day', async ({ page }) => {
+    await openStaleSession(page);
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download a copy & start new day' }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/forecast/i);
+    await expect(page.getByRole('dialog').filter({ hasText: 'New day detected' })).not.toBeVisible();
+  });
+
+  test('replaces the restored session without saving when explicitly selected', async ({ page }) => {
+    await openStaleSession(page);
+
+    await page.getByRole('button', { name: 'Replace without saving' }).click();
+    await expect(page.getByRole('dialog').filter({ hasText: 'New day detected' })).not.toBeVisible();
+    await expect(page.getByText(/Previous session replaced/i)).toBeVisible();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,8 +15,8 @@ import {
 
 import { useAutoSave } from './hooks/useAutoSave';
 import { useFirestoreSleepRecovery } from './hooks/useFirestoreSleepRecovery';
-import { useCycleHistoryPersistence } from './utils/cycleHistoryPersistence';
-import { AuthProvider } from './auth/AuthProvider';
+import { setupCycleHistoryListener, useCycleHistoryPersistence } from './utils/cycleHistoryPersistence';
+import { AuthProvider, useAuth } from './auth/AuthProvider';
 import { EntitlementProvider } from './billing/EntitlementProvider';
 
 // New UI components
@@ -67,18 +67,21 @@ function useLaunchGate(): boolean {
 // App-level hooks component (runs shared hooks)
 const AppHooks = () => {
   const dispatch = useDispatch();
+  const { user } = useAuth();
+  const userId = user?.uid;
 
   // Use the auto categorical hook to generate categorical outlooks
   useAutoCategorical();
-  
-  // Enable Auto-Save
-  useAutoSave();
+
+  // Enable account-scoped Auto-Save
+  useAutoSave(userId);
 
   // Pause Firestore while the tab sleeps (Safari IndexedDB recovery)
   useFirestoreSleepRecovery();
 
-  // Load cycle history from localStorage
-  useCycleHistoryPersistence();
+  // Load and persist Cycle History for the active account only
+  useCycleHistoryPersistence(userId);
+  useEffect(() => setupCycleHistoryListener(store, userId), [userId]);
 
   // Derive emergency mode and the first exposed outlook from build-target exposure.
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,6 +183,7 @@ const AppRoutes: React.FC<AppRoutesProps> = ({ showComingSoon }) => {
 };
 
 // Main App with Router
+/** Renders the authenticated application shell and route tree. */
 function App() {
   const isLaunched = useLaunchGate();
   const showComingSoon = COMING_SOON_MODE && !isLaunched;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,11 +79,13 @@ const AppHooks = () => {
   // Pause Firestore while the tab sleeps (Safari IndexedDB recovery)
   useFirestoreSleepRecovery();
 
-  // Load and persist Cycle History for the active account only
-  useCycleHistoryPersistence(userId);
+  // Tear down the previous account's persistence listener before hydration clears
+  // Redux. This ordering prevents the old scope from persisting the empty rollover state.
   useEffect(() => {
     return setupCycleHistoryListener(store, userId);
   }, [userId]);
+  // Load and persist Cycle History for the active account only
+  useCycleHistoryPersistence(userId);
 
   // Derive emergency mode and the first exposed outlook from build-target exposure.
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,13 +79,13 @@ const AppHooks = () => {
   // Pause Firestore while the tab sleeps (Safari IndexedDB recovery)
   useFirestoreSleepRecovery();
 
-  // Tear down the previous account's persistence listener before hydration clears
-  // Redux. This ordering prevents the old scope from persisting the empty rollover state.
+  // Hydrate the active account before starting its persistence listener. React runs
+  // effect cleanups before new effects, so the previous listener is removed before
+  // this clears Redux and the new listener only observes the hydrated scope.
+  useCycleHistoryPersistence(userId);
   useEffect(() => {
     return setupCycleHistoryListener(store, userId);
   }, [userId]);
-  // Load and persist Cycle History for the active account only
-  useCycleHistoryPersistence(userId);
 
   // Derive emergency mode and the first exposed outlook from build-target exposure.
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,9 @@ const AppHooks = () => {
 
   // Load and persist Cycle History for the active account only
   useCycleHistoryPersistence(userId);
-  useEffect(() => setupCycleHistoryListener(store, userId), [userId]);
+  useEffect(() => {
+    return setupCycleHistoryListener(store, userId);
+  }, [userId]);
 
   // Derive emergency mode and the first exposed outlook from build-target exposure.
   useEffect(() => {

--- a/src/hooks/useAutoSave.test.tsx
+++ b/src/hooks/useAutoSave.test.tsx
@@ -51,14 +51,14 @@ describe('useAutoSave', () => {
     expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ live: true, unsaved: 'edit', timestamp: '2026-07-14T00:00:00.000Z' }));
   });
 
-  test('does not promote unscoped legacy over an existing account autosave on sign-in', () => {
+  test('does not promote anonymous live state over an existing account autosave on sign-in', () => {
     localStorage.setItem('forecastData', JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' }));
     localStorage.setItem('forecastData:user-user-1', JSON.stringify({ account: true, timestamp: '2026-07-13T12:00:00.000Z' }));
 
     migrateLegacyAutoSave('user-1', { live: true, timestamp: '2026-07-14T11:00:00.000Z' });
 
     expect(localStorage.getItem('forecastData')).toBe(JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' }));
-    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ live: true, timestamp: '2026-07-14T11:00:00.000Z' }));
+    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ account: true, timestamp: '2026-07-13T12:00:00.000Z' }));
   });
 
   test('selectPreferredAutoSaveValue keeps account autosave over legacy copies', () => {

--- a/src/hooks/useAutoSave.test.tsx
+++ b/src/hooks/useAutoSave.test.tsx
@@ -42,6 +42,15 @@ describe('useAutoSave', () => {
     expect(localStorage.getItem('forecastData:user-user%2F1')).toBe(JSON.stringify({ legacy: true }));
   });
 
+  test('persists live in-memory edits instead of migrating a stale legacy snapshot', () => {
+    localStorage.setItem('forecastData', JSON.stringify({ legacy: true }));
+
+    migrateLegacyAutoSave('user-1', { live: true, unsaved: 'edit' });
+
+    expect(localStorage.getItem('forecastData')).toBeNull();
+    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ live: true, unsaved: 'edit' }));
+  });
+
   test('does not overwrite an existing signed-in autosave during migration', () => {
     localStorage.setItem('forecastData', JSON.stringify({ legacy: true }));
     localStorage.setItem('forecastData:user-user-1', JSON.stringify({ account: true }));

--- a/src/hooks/useAutoSave.test.tsx
+++ b/src/hooks/useAutoSave.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { act, render, waitFor } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import forecastReducer, { setMapView, setCycleDate } from '../store/forecastSlice';
-import { migrateLegacyAutoSave, useAutoSave } from './useAutoSave';
+import { migrateLegacyAutoSave, pickNewestAutoSaveValue, selectPreferredAutoSaveValue, useAutoSave } from './useAutoSave';
 import { serializeForecast } from '../utils/fileUtils';
 
 jest.mock('../utils/fileUtils', () => ({
@@ -43,12 +43,30 @@ describe('useAutoSave', () => {
   });
 
   test('persists live in-memory edits instead of migrating a stale legacy snapshot', () => {
-    localStorage.setItem('forecastData', JSON.stringify({ legacy: true }));
+    localStorage.setItem('forecastData', JSON.stringify({ legacy: true, timestamp: '2026-07-13T00:00:00.000Z' }));
 
-    migrateLegacyAutoSave('user-1', { live: true, unsaved: 'edit' });
+    migrateLegacyAutoSave('user-1', { live: true, unsaved: 'edit', timestamp: '2026-07-14T00:00:00.000Z' });
 
     expect(localStorage.getItem('forecastData')).toBeNull();
-    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ live: true, unsaved: 'edit' }));
+    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ live: true, unsaved: 'edit', timestamp: '2026-07-14T00:00:00.000Z' }));
+  });
+
+  test('prefers the newest snapshot when signing in with both scoped and legacy autosaves', () => {
+    localStorage.setItem('forecastData', JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' }));
+    localStorage.setItem('forecastData:user-user-1', JSON.stringify({ account: true, timestamp: '2026-07-13T12:00:00.000Z' }));
+
+    migrateLegacyAutoSave('user-1', { live: true, timestamp: '2026-07-14T11:00:00.000Z' });
+
+    expect(localStorage.getItem('forecastData')).toBeNull();
+    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' }));
+  });
+
+  test('selectPreferredAutoSaveValue keeps the newest snapshot', () => {
+    const scoped = JSON.stringify({ account: true, timestamp: '2026-07-13T12:00:00.000Z' });
+    const legacy = JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' });
+
+    expect(selectPreferredAutoSaveValue(scoped, legacy)).toBe(legacy);
+    expect(pickNewestAutoSaveValue(scoped, legacy, JSON.stringify({ live: true, timestamp: '2026-07-14T11:00:00.000Z' }))).toBe(legacy);
   });
 
   test('does not overwrite an existing signed-in autosave during migration', () => {

--- a/src/hooks/useAutoSave.test.tsx
+++ b/src/hooks/useAutoSave.test.tsx
@@ -51,21 +51,22 @@ describe('useAutoSave', () => {
     expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ live: true, unsaved: 'edit', timestamp: '2026-07-14T00:00:00.000Z' }));
   });
 
-  test('prefers the newest snapshot when signing in with both scoped and legacy autosaves', () => {
+  test('does not promote unscoped legacy over an existing account autosave on sign-in', () => {
     localStorage.setItem('forecastData', JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' }));
     localStorage.setItem('forecastData:user-user-1', JSON.stringify({ account: true, timestamp: '2026-07-13T12:00:00.000Z' }));
 
     migrateLegacyAutoSave('user-1', { live: true, timestamp: '2026-07-14T11:00:00.000Z' });
 
-    expect(localStorage.getItem('forecastData')).toBeNull();
-    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' }));
+    expect(localStorage.getItem('forecastData')).toBe(JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' }));
+    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ live: true, timestamp: '2026-07-14T11:00:00.000Z' }));
   });
 
-  test('selectPreferredAutoSaveValue keeps the newest snapshot', () => {
+  test('selectPreferredAutoSaveValue keeps account autosave over legacy copies', () => {
     const scoped = JSON.stringify({ account: true, timestamp: '2026-07-13T12:00:00.000Z' });
     const legacy = JSON.stringify({ legacy: true, timestamp: '2026-07-14T12:00:00.000Z' });
 
-    expect(selectPreferredAutoSaveValue(scoped, legacy)).toBe(legacy);
+    expect(selectPreferredAutoSaveValue(scoped, legacy)).toBe(scoped);
+    expect(selectPreferredAutoSaveValue(null, legacy)).toBe(legacy);
     expect(pickNewestAutoSaveValue(scoped, legacy, JSON.stringify({ live: true, timestamp: '2026-07-14T11:00:00.000Z' }))).toBe(legacy);
   });
 

--- a/src/hooks/useAutoSave.test.tsx
+++ b/src/hooks/useAutoSave.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { act, render, waitFor } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import forecastReducer, { setMapView, setCycleDate } from '../store/forecastSlice';
-import { useAutoSave } from './useAutoSave';
+import { migrateLegacyAutoSave, useAutoSave } from './useAutoSave';
 import { serializeForecast } from '../utils/fileUtils';
 
 jest.mock('../utils/fileUtils', () => ({
@@ -31,6 +31,25 @@ describe('useAutoSave', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  test('migrates the legacy anonymous autosave into a signed-in scope', () => {
+    localStorage.setItem('forecastData', JSON.stringify({ legacy: true }));
+
+    migrateLegacyAutoSave('user/1');
+
+    expect(localStorage.getItem('forecastData')).toBeNull();
+    expect(localStorage.getItem('forecastData:user-user%2F1')).toBe(JSON.stringify({ legacy: true }));
+  });
+
+  test('does not overwrite an existing signed-in autosave during migration', () => {
+    localStorage.setItem('forecastData', JSON.stringify({ legacy: true }));
+    localStorage.setItem('forecastData:user-user-1', JSON.stringify({ account: true }));
+
+    migrateLegacyAutoSave('user-1');
+
+    expect(localStorage.getItem('forecastData')).toBe(JSON.stringify({ legacy: true }));
+    expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify({ account: true }));
   });
 
   test('skips initial render, then debounces forecast saves to localStorage', async () => {

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -11,6 +11,24 @@ const LOCAL_STORAGE_KEY = 'forecastData';
 export const getAutoSaveStorageKey = (userId?: string | null): string =>
   userId ? getScopedStorageKey(LOCAL_STORAGE_KEY, getStorageScope(userId)) : LOCAL_STORAGE_KEY;
 
+/** Moves an anonymous autosave into the signed-in account scope once, without overwriting account data. */
+export const migrateLegacyAutoSave = (userId?: string | null): void => {
+  if (!userId) return;
+
+  try {
+    const scopedKey = getAutoSaveStorageKey(userId);
+    if (localStorage.getItem(scopedKey) === null) {
+      const legacyValue = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (legacyValue !== null) {
+        localStorage.setItem(scopedKey, legacyValue);
+        localStorage.removeItem(LOCAL_STORAGE_KEY);
+      }
+    }
+  } catch {
+    // Ignore storage failures so sign-in never disrupts editing.
+  }
+};
+
 export const useAutoSave = (userId?: string | null) => {
   const forecastCycle = useSelector(selectForecastCycle);
   const mapView = useSelector((state: RootState) => state.forecast.currentMapView);

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -53,8 +53,8 @@ export const migrateLegacyAutoSave = (userId?: string | null, liveSession?: unkn
     const legacyValue = localStorage.getItem(LOCAL_STORAGE_KEY);
 
     if (liveSession !== undefined) {
-      const liveValue = JSON.stringify(liveSession);
       if (scopedValue === null) {
+        const liveValue = JSON.stringify(liveSession);
         const preferred = pickNewestAutoSaveValue(legacyValue, liveValue);
         if (preferred) {
           localStorage.setItem(scopedKey, preferred);
@@ -62,12 +62,6 @@ export const migrateLegacyAutoSave = (userId?: string | null, liveSession?: unkn
         if (legacyValue !== null) {
           localStorage.removeItem(LOCAL_STORAGE_KEY);
         }
-        return;
-      }
-
-      const preferred = pickNewestAutoSaveValue(scopedValue, liveValue);
-      if (preferred) {
-        localStorage.setItem(scopedKey, preferred);
       }
       return;
     }

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -12,20 +12,59 @@ const LOCAL_STORAGE_KEY = 'forecastData';
 export const getAutoSaveStorageKey = (userId?: string | null): string =>
   userId ? getScopedStorageKey(LOCAL_STORAGE_KEY, getStorageScope(userId)) : LOCAL_STORAGE_KEY;
 
+/** Returns the persisted autosave timestamp, or 0 when missing or malformed. */
+export const getAutoSaveTimestamp = (storedValue: string | null): number => {
+  if (!storedValue) return 0;
+
+  try {
+    const parsed = JSON.parse(storedValue) as { timestamp?: string };
+    return parsed.timestamp ? Date.parse(parsed.timestamp) : 0;
+  } catch {
+    return 0;
+  }
+};
+
+/** Picks the newest autosave snapshot when multiple scoped copies exist. */
+export const pickNewestAutoSaveValue = (...values: (string | null)[]): string | null => {
+  const candidates = values.filter((value): value is string => value !== null);
+  if (candidates.length === 0) return null;
+
+  return candidates.reduce((best, current) => (
+    getAutoSaveTimestamp(current) > getAutoSaveTimestamp(best) ? current : best
+  ));
+};
+
+/** Picks the newest autosave snapshot when both scoped and legacy copies exist. */
+export const selectPreferredAutoSaveValue = (
+  scopedValue: string | null,
+  legacyValue: string | null,
+): string | null => pickNewestAutoSaveValue(scopedValue, legacyValue);
+
 /** Moves an anonymous autosave into the signed-in account scope once, without overwriting account data.
- * When the live editor is available, persist it instead of copying a potentially stale legacy snapshot.
+ * On sign-in, reconcile scoped, legacy, and live editor snapshots by timestamp so anonymous work is not dropped.
  */
 export const migrateLegacyAutoSave = (userId?: string | null, liveSession?: unknown): void => {
   if (!userId) return;
 
   try {
     const scopedKey = getAutoSaveStorageKey(userId);
-    if (localStorage.getItem(scopedKey) === null) {
-      const legacyValue = localStorage.getItem(LOCAL_STORAGE_KEY);
+    const scopedValue = localStorage.getItem(scopedKey);
+    const legacyValue = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+    if (liveSession !== undefined) {
+      const preferred = pickNewestAutoSaveValue(scopedValue, legacyValue, JSON.stringify(liveSession));
+      if (preferred) {
+        localStorage.setItem(scopedKey, preferred);
+      }
       if (legacyValue !== null) {
-        localStorage.setItem(scopedKey, liveSession === undefined ? legacyValue : JSON.stringify(liveSession));
         localStorage.removeItem(LOCAL_STORAGE_KEY);
       }
+      return;
+    }
+
+    if (scopedValue === null && legacyValue !== null) {
+      localStorage.setItem(scopedKey, legacyValue);
+      localStorage.removeItem(LOCAL_STORAGE_KEY);
     }
   } catch {
     // Ignore storage failures so sign-in never disrupts editing.

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -40,7 +40,7 @@ export const useAutoSave = (userId?: string | null) => {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const isFirstRender = useRef(true);
 
-  useEffect(function autoSaveEffect() {
+  useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false;
       return;
@@ -59,7 +59,7 @@ export const useAutoSave = (userId?: string | null) => {
       }
     }, AUTOSAVE_DELAY);
 
-    return function cleanupAutoSaveEffect() {
+    return () => {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -12,8 +12,10 @@ const LOCAL_STORAGE_KEY = 'forecastData';
 export const getAutoSaveStorageKey = (userId?: string | null): string =>
   userId ? getScopedStorageKey(LOCAL_STORAGE_KEY, getStorageScope(userId)) : LOCAL_STORAGE_KEY;
 
-/** Moves an anonymous autosave into the signed-in account scope once, without overwriting account data. */
-export const migrateLegacyAutoSave = (userId?: string | null): void => {
+/** Moves an anonymous autosave into the signed-in account scope once, without overwriting account data.
+ * When the live editor is available, persist it instead of copying a potentially stale legacy snapshot.
+ */
+export const migrateLegacyAutoSave = (userId?: string | null, liveSession?: unknown): void => {
   if (!userId) return;
 
   try {
@@ -21,7 +23,7 @@ export const migrateLegacyAutoSave = (userId?: string | null): void => {
     if (localStorage.getItem(scopedKey) === null) {
       const legacyValue = localStorage.getItem(LOCAL_STORAGE_KEY);
       if (legacyValue !== null) {
-        localStorage.setItem(scopedKey, legacyValue);
+        localStorage.setItem(scopedKey, liveSession === undefined ? legacyValue : JSON.stringify(liveSession));
         localStorage.removeItem(LOCAL_STORAGE_KEY);
       }
     }

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -3,11 +3,15 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../store';
 import { selectForecastCycle } from '../store/forecastSlice';
 import { serializeForecast } from '../utils/fileUtils';
+import { getScopedStorageKey, getStorageScope } from '../utils/storageScope';
 
 const AUTOSAVE_DELAY = 5000; // 5 seconds debounce
 const LOCAL_STORAGE_KEY = 'forecastData';
 
-export const useAutoSave = () => {
+export const getAutoSaveStorageKey = (userId?: string | null): string =>
+  userId ? getScopedStorageKey(LOCAL_STORAGE_KEY, getStorageScope(userId)) : LOCAL_STORAGE_KEY;
+
+export const useAutoSave = (userId?: string | null) => {
   const forecastCycle = useSelector(selectForecastCycle);
   const mapView = useSelector((state: RootState) => state.forecast.currentMapView);
   const workflowMetadata = useSelector((state: RootState) => state.forecast.workflowMetadata);
@@ -27,7 +31,7 @@ export const useAutoSave = () => {
     timerRef.current = setTimeout(() => {
       try {
         const data = serializeForecast(forecastCycle, mapView, workflowMetadata);
-        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(data));
+        localStorage.setItem(getAutoSaveStorageKey(userId), JSON.stringify(data));
       } catch {
         // Auto-save silently fails to avoid disrupting the user
       }
@@ -38,5 +42,5 @@ export const useAutoSave = () => {
         clearTimeout(timerRef.current);
       }
     };
-  }, [forecastCycle, mapView, workflowMetadata]);
+  }, [forecastCycle, mapView, userId, workflowMetadata]);
 };

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -40,7 +40,7 @@ export const useAutoSave = (userId?: string | null) => {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const isFirstRender = useRef(true);
 
-  useEffect(() => {
+  useEffect(function autoSaveEffect() {
     if (isFirstRender.current) {
       isFirstRender.current = false;
       return;
@@ -59,7 +59,7 @@ export const useAutoSave = (userId?: string | null) => {
       }
     }, AUTOSAVE_DELAY);
 
-    return () => {
+    return function cleanupAutoSaveEffect() {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -34,14 +34,15 @@ export const pickNewestAutoSaveValue = (...values: (string | null)[]): string | 
   ));
 };
 
-/** Picks the newest autosave snapshot when both scoped and legacy copies exist. */
+/** Picks the autosave snapshot for restore without crossing account boundaries. */
 export const selectPreferredAutoSaveValue = (
   scopedValue: string | null,
   legacyValue: string | null,
-): string | null => pickNewestAutoSaveValue(scopedValue, legacyValue);
+): string | null => scopedValue ?? legacyValue;
 
 /** Moves an anonymous autosave into the signed-in account scope once, without overwriting account data.
- * On sign-in, reconcile scoped, legacy, and live editor snapshots by timestamp so anonymous work is not dropped.
+ * On sign-in, reconcile live editor state with scoped storage, but never promote unscoped legacy over an
+ * existing account autosave on shared browsers.
  */
 export const migrateLegacyAutoSave = (userId?: string | null, liveSession?: unknown): void => {
   if (!userId) return;
@@ -52,12 +53,21 @@ export const migrateLegacyAutoSave = (userId?: string | null, liveSession?: unkn
     const legacyValue = localStorage.getItem(LOCAL_STORAGE_KEY);
 
     if (liveSession !== undefined) {
-      const preferred = pickNewestAutoSaveValue(scopedValue, legacyValue, JSON.stringify(liveSession));
+      const liveValue = JSON.stringify(liveSession);
+      if (scopedValue === null) {
+        const preferred = pickNewestAutoSaveValue(legacyValue, liveValue);
+        if (preferred) {
+          localStorage.setItem(scopedKey, preferred);
+        }
+        if (legacyValue !== null) {
+          localStorage.removeItem(LOCAL_STORAGE_KEY);
+        }
+        return;
+      }
+
+      const preferred = pickNewestAutoSaveValue(scopedValue, liveValue);
       if (preferred) {
         localStorage.setItem(scopedKey, preferred);
-      }
-      if (legacyValue !== null) {
-        localStorage.removeItem(LOCAL_STORAGE_KEY);
       }
       return;
     }

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -8,6 +8,7 @@ import { getScopedStorageKey, getStorageScope } from '../utils/storageScope';
 const AUTOSAVE_DELAY = 5000; // 5 seconds debounce
 const LOCAL_STORAGE_KEY = 'forecastData';
 
+/** Returns the autosave key for an account scope, or the legacy key anonymously. */
 export const getAutoSaveStorageKey = (userId?: string | null): string =>
   userId ? getScopedStorageKey(LOCAL_STORAGE_KEY, getStorageScope(userId)) : LOCAL_STORAGE_KEY;
 
@@ -29,6 +30,7 @@ export const migrateLegacyAutoSave = (userId?: string | null): void => {
   }
 };
 
+/** Debounces forecast edits into the current anonymous or account-scoped autosave. */
 export const useAutoSave = (userId?: string | null) => {
   const forecastCycle = useSelector(selectForecastCycle);
   const mapView = useSelector((state: RootState) => state.forecast.currentMapView);

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -37,8 +37,8 @@ export const useAutoSave = (userId?: string | null) => {
   const forecastCycle = useSelector(selectForecastCycle);
   const mapView = useSelector((state: RootState) => state.forecast.currentMapView);
   const workflowMetadata = useSelector((state: RootState) => state.forecast.workflowMetadata);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
   const isFirstRender = useRef(true);
+  const saveGenerationRef = useRef(0);
 
   useEffect(() => {
     if (isFirstRender.current) {
@@ -46,11 +46,9 @@ export const useAutoSave = (userId?: string | null) => {
       return;
     }
 
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-    }
-
-    timerRef.current = setTimeout(() => {
+    const generation = ++saveGenerationRef.current;
+    setTimeout(() => {
+      if (generation !== saveGenerationRef.current) return;
       try {
         const data = serializeForecast(forecastCycle, mapView, workflowMetadata);
         localStorage.setItem(getAutoSaveStorageKey(userId), JSON.stringify(data));
@@ -58,11 +56,5 @@ export const useAutoSave = (userId?: string | null) => {
         // Auto-save silently fails to avoid disrupting the user
       }
     }, AUTOSAVE_DELAY);
-
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
   }, [forecastCycle, mapView, userId, workflowMetadata]);
 };

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -19,7 +19,13 @@ export interface UseCloudCyclesResult {
   currentCloud: CloudCycleContext | null;
   loading: boolean;
   error: string | null;
-  saveCycle: (label: string, cycleDate: string, stats: SavedCycleStats, payload: GFCForecastSaveData) => Promise<boolean>;
+  saveCycle: (
+    label: string,
+    cycleDate: string,
+    stats: SavedCycleStats,
+    payload: GFCForecastSaveData,
+    options?: { saveAsNew?: boolean }
+  ) => Promise<boolean>;
   loadCycle: (cycleId: string) => Promise<GFCForecastSaveData | null>;
   deleteCycle: (cycleId: string) => Promise<boolean>;
   renameCycle: (cycleId: string, newLabel: string) => Promise<boolean>;
@@ -270,7 +276,8 @@ function useCloudSaveCycle({
       label: string,
       cycleDate: string,
       stats: SavedCycleStats,
-      payload: GFCForecastSaveData
+      payload: GFCForecastSaveData,
+      options?: { saveAsNew?: boolean }
     ): Promise<boolean> => {
       if (!userId || !canWrite) {
         setError(getCloudWriteBlockedMessage({ userId, canWrite }));
@@ -288,7 +295,7 @@ function useCloudSaveCycle({
         cycleDate,
         stats,
         payload,
-        existingId: currentCloudRef.current?.id,
+        existingId: options?.saveAsNew ? undefined : currentCloudRef.current?.id,
       });
 
       if (!result.success) {

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -258,6 +258,26 @@ function useCloudCycleMutation<TArgs extends unknown[]>({
   );
 }
 
+/** Returns true when a cloud save can proceed for the current access context. */
+function canSaveCloudCycle({ userId, canWrite }: CloudAccessContext): boolean {
+  return Boolean(userId && canWrite);
+}
+
+/** Handles a failed cloud save and updates the active sync state. */
+function handleCloudSaveFailure({
+  result,
+  setError,
+  updateSyncState,
+}: {
+  result: CloudOperationResult;
+  setError: Dispatch<SetStateAction<string | null>>;
+  updateSyncState: (state: CloudSyncState, error?: string) => void;
+}): false {
+  setError(result.error || 'Failed to save cloud cycle');
+  updateSyncState('error', result.error);
+  return false;
+}
+
 /** Returns the save callback for hosted cloud cycles. */
 function useCloudSaveCycle({
   userId,
@@ -279,7 +299,7 @@ function useCloudSaveCycle({
       payload: GFCForecastSaveData,
       options?: { saveAsNew?: boolean }
     ): Promise<boolean> => {
-      if (!userId || !canWrite) {
+      if (!canSaveCloudCycle({ userId, canWrite })) {
         setError(getCloudWriteBlockedMessage({ userId, canWrite }));
         return false;
       }
@@ -299,9 +319,7 @@ function useCloudSaveCycle({
       });
 
       if (!result.success) {
-        setError(result.error || 'Failed to save cloud cycle');
-        updateSyncState('error', result.error);
-        return false;
+        return handleCloudSaveFailure({ result, setError, updateSyncState });
       }
 
       if (result.data) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,6 @@ import './index.css';
 import './darkMode.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import { store } from './store';
 import { trackPageView } from './utils/analyticsUtils';
 
 const rootElement = document.getElementById('root') as HTMLElement;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,11 +10,7 @@ import './darkMode.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { store } from './store';
-import { setupCycleHistoryListener } from './utils/cycleHistoryPersistence';
 import { trackPageView } from './utils/analyticsUtils';
-
-// Setup cycle history persistence
-setupCycleHistoryListener(store);
 
 const rootElement = document.getElementById('root') as HTMLElement;
 const root = ReactDOM.createRoot(

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -289,6 +289,7 @@ const DiscussionDefaultsSection: React.FC<{
 );
 
 /** Bottom action row for saving defaults and ending the current session. */
+/** Renders one account action row for an authenticated user. */
 const SignedInActionRow: React.FC<{
   savingDefaults: boolean;
   saveMessage: string | null;

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '../auth/AuthProvider';
 import { useEntitlement } from '../billing/EntitlementProvider';
 import { useCloudCycles } from '../hooks/useCloudCycles';
 import { CloudCycleMetadata } from '../types/cloudCycles';
+import { getScopedStorageKey, getStorageScope } from '../utils/storageScope';
 import './CloudLibraryPage.css';
 
 /** Formats cloud-cycle timestamps for the library surface. */
@@ -620,6 +621,7 @@ const useCloudLibraryActions = ({
   renameCycle,
   refreshCycles,
   navigate,
+  userId,
 }: {
   cycles: CloudCycleMetadata[];
   loadCycle: ReturnType<typeof useCloudCycles>['loadCycle'];
@@ -627,15 +629,18 @@ const useCloudLibraryActions = ({
   renameCycle: ReturnType<typeof useCloudCycles>['renameCycle'];
   refreshCycles: ReturnType<typeof useCloudCycles>['refreshCycles'];
   navigate: ReturnType<typeof useNavigate>;
+  userId?: string;
 }): CloudLibraryActions => {
+  const payloadKey = getScopedStorageKey('cloudCyclePayload', getStorageScope(userId));
+  const metaKey = getScopedStorageKey('cloudCycleMeta', getStorageScope(userId));
   const [message, setMessage] = useState<string | null>(null);
 
   const persistCloudCycleToSession = useCallback(
     (cycleId: string, label: string, payload: unknown): boolean => {
       try {
-        sessionStorage.setItem('cloudCyclePayload', JSON.stringify(payload));
+        sessionStorage.setItem(payloadKey, JSON.stringify(payload));
         sessionStorage.setItem(
-          'cloudCycleMeta',
+          metaKey,
           JSON.stringify({
             id: cycleId,
             label,
@@ -647,7 +652,7 @@ const useCloudLibraryActions = ({
         return false;
       }
     },
-    []
+    [metaKey, payloadKey]
   );
 
   /** Loads one hosted cycle into the forecast editor and preserves its cloud metadata in session storage. */
@@ -712,6 +717,7 @@ const CloudLibraryPage: React.FC = () => {
     renameCycle,
     refreshCycles,
     navigate,
+    userId: user?.uid,
   });
 
   const canWrite = premiumActive;

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
@@ -10,6 +10,7 @@ import ForecastPage, {
   cycleHasDiscussionContent,
   dayHasAnyFeatures,
   formatRolloverDayLabel,
+  getDayRolloverPromptState,
   getProbabilityList,
   getUndoRedoAction,
   hasAnyModifierKey,
@@ -22,6 +23,8 @@ import ForecastPage, {
   parseStoredCloudMeta,
   parseStoredForecastPayload,
   processShortcutKeyDown,
+  runDayRolloverCloudSaveAction,
+  runDayRolloverDownloadAction,
   readStoredDayValue,
   writeStoredDayValue,
 } from './ForecastPage';
@@ -33,7 +36,9 @@ import appModeReducer from '../store/appModeSlice';
 import themeReducer from '../store/themeSlice';
 import verificationReducer from '../store/verificationSlice';
 import monitorReducer from '../store/monitorSlice';
+import * as fileUtils from '../utils/fileUtils';
 import { serializeForecast } from '../utils/fileUtils';
+import { getLocalCalendarDate } from '../utils/localDate';
 import type { Feature } from 'geojson';
 
 const mockAddToast = jest.fn();
@@ -55,6 +60,7 @@ jest.mock('../components/ForecastWorkspace/ForecastWorkspaceModals', () => () =>
 
 jest.mock('../hooks/useAutoSave', () => ({
   useAutoSave: jest.fn(),
+  getAutoSaveStorageKey: (userId?: string | null) => userId ? `forecastData:user-${userId}` : 'forecastData',
 }));
 
 jest.mock('../hooks/useAutoCategorical', () => jest.fn());
@@ -72,6 +78,7 @@ jest.mock('../hooks/useCloudCycles', () => ({
     currentCloud: null,
     saveCycle: jest.fn(),
     markAsCurrent: jest.fn(),
+    clearCurrent: jest.fn(),
   }),
 }));
 jest.mock('../hooks/useCloudSync', () => ({
@@ -207,6 +214,31 @@ describe('ForecastPage layout selection', () => {
 
     expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('10%')?.[0].id).toBe('autosave-outlook');
   });
+
+  test('waits for restored session state before committing the local-day baseline', async () => {
+    const sourceStore = createStore();
+    sourceStore.dispatch(addFeature({
+      feature: {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      },
+    }));
+    localStorage.setItem('forecastData', JSON.stringify(serializeForecast(
+      sourceStore.getState().forecast.forecastCycle,
+      sourceStore.getState().forecast.currentMapView,
+    )));
+    const today = getLocalCalendarDate();
+    const previousDay = getLocalCalendarDate(new Date(Date.now() - 24 * 60 * 60 * 1000));
+    localStorage.setItem('gfc-last-active-local-day', previousDay);
+
+    renderForecastPage(createStore());
+
+    await waitFor(() => expect(screen.getByText('New day detected')).toBeInTheDocument());
+    expect(localStorage.getItem('gfc-last-active-local-day:anonymous')).toBe(today);
+    expect(screen.getByRole('button', { name: 'Download a copy & start new day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Replace without saving' })).toBeInTheDocument();
+  });
 });
 
 describe('ForecastPage helpers', () => {
@@ -247,6 +279,51 @@ describe('ForecastPage helpers', () => {
     clearStoredCloudSession();
     expect(sessionStorage.getItem('cloudCyclePayload')).toBeNull();
     expect(sessionStorage.getItem('cloudCycleMeta')).toBeNull();
+  });
+
+  test('recovers a pending rollover prompt after session restore marks the cycle saved', () => {
+    const emptyCycle = createStore().getState().forecast.forecastCycle;
+    const pending = { previousDay: '2026-04-23', currentDay: '2026-04-24' };
+    expect(getDayRolloverPromptState({
+      restoreComplete: true,
+      lastActiveDay: '2026-04-24',
+      today: '2026-04-24',
+      alreadyPromptedToday: true,
+      pendingPrompt: pending,
+      promptOpen: false,
+      forecastCycle: emptyCycle,
+      isSaved: true,
+    })).toEqual(pending);
+  });
+
+  test('covers rollover download and cloud-save success and failure paths', async () => {
+    const forecastCycle = createStore().getState().forecast.forecastCycle;
+    const mapView = { center: [0, 0] as [number, number], zoom: 4 };
+    const dispatch = jest.fn();
+    const clearCurrent = jest.fn();
+    const exportSpy = jest.spyOn(fileUtils, 'exportForecastToJson').mockImplementation(() => undefined);
+
+    expect(runDayRolloverDownloadAction({ forecastCycle, mapView, dispatch })).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    exportSpy.mockImplementationOnce(() => { throw new Error('download failed'); });
+    dispatch.mockClear();
+    expect(runDayRolloverDownloadAction({ forecastCycle, mapView, dispatch })).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+
+    const saveCycle = jest.fn().mockResolvedValue(true);
+    dispatch.mockClear();
+    expect(await runDayRolloverCloudSaveAction({ forecastCycle, currentMapView: mapView, saveCycle, clearCurrent, dispatch })).toBe(true);
+    expect(saveCycle).toHaveBeenCalledWith(expect.stringContaining('Rollover save'), forecastCycle.cycleDate, expect.any(Object), expect.any(Object), { saveAsNew: true });
+    expect(clearCurrent).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    saveCycle.mockResolvedValueOnce(false);
+    clearCurrent.mockClear();
+    dispatch.mockClear();
+    expect(await runDayRolloverCloudSaveAction({ forecastCycle, currentMapView: mapView, saveCycle, clearCurrent, dispatch })).toBe(false);
+    expect(clearCurrent).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+    exportSpy.mockRestore();
   });
 
   test('detects rollover candidates, map view fallbacks, keyboard targets, and undo/redo keys', () => {

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -288,7 +288,7 @@ describe('ForecastPage layout selection', () => {
 
     await waitFor(() => {
       expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('10%')?.[0].id).toBe('anonymous-outlook');
-      expect(localStorage.getItem('forecastData')).toBeNull();
+      expect(localStorage.getItem('forecastData')).toBe(JSON.stringify(anonymousPayload));
       const scopedPayload = parseStoredForecastPayload(localStorage.getItem('forecastData:user-user-1'));
       expect(scopedPayload?.forecastCycle?.days?.[1]?.data?.tornado?.[0]?.[1]?.[0]?.id).toBe('anonymous-outlook');
     });

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -60,9 +60,8 @@ jest.mock('../components/ForecastWorkspace/ForecastWorkspaceLayouts', () => ({
 jest.mock('../components/ForecastWorkspace/ForecastWorkspaceModals', () => () => null);
 
 jest.mock('../hooks/useAutoSave', () => ({
+  ...jest.requireActual('../hooks/useAutoSave'),
   useAutoSave: jest.fn(),
-  migrateLegacyAutoSave: jest.fn(),
-  getAutoSaveStorageKey: (userId?: string | null) => userId ? `forecastData:user-${userId}` : 'forecastData',
 }));
 
 jest.mock('../hooks/useAutoCategorical', () => jest.fn());
@@ -238,6 +237,61 @@ describe('ForecastPage layout selection', () => {
     renderForecastPage(store);
 
     expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('10%')?.[0].id).toBe('autosave-outlook');
+  });
+
+  test('prefers newer anonymous autosave over stale signed-in snapshot on sign-in', async () => {
+    const store = createStore();
+    const stalePayload = serializeForecast(store.getState().forecast.forecastCycle, { center: [0, 0], zoom: 0 });
+    stalePayload.timestamp = '2026-07-13T12:00:00.000Z';
+
+    const anonymousCycle = { ...store.getState().forecast.forecastCycle };
+    const features = new Map<string, Feature[]>();
+    features.set('10%', [{
+      type: 'Feature',
+      id: 'anonymous-outlook',
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      properties: { outlookType: 'tornado', probability: '10%', isSignificant: false },
+    } as Feature]);
+    anonymousCycle.days = {
+      1: {
+        data: { tornado: features, wind: new Map(), hail: new Map(), categorical: new Map(), totalSevere: new Map() } as never,
+        metadata: { lowProbabilityOutlooks: [] },
+      },
+    } as typeof anonymousCycle.days;
+    const anonymousPayload = serializeForecast(anonymousCycle, { center: [0, 0], zoom: 0 });
+    anonymousPayload.timestamp = '2026-07-14T12:00:00.000Z';
+
+    localStorage.setItem('forecastData', JSON.stringify(anonymousPayload));
+    localStorage.setItem('forecastData:user-user-1', JSON.stringify(stalePayload));
+
+    mockUseAuth.mockReturnValue({ user: null, syncedSettings: null });
+    const view = render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <ForecastPage />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('10%')?.[0].id).toBe('anonymous-outlook');
+    });
+
+    mockUseAuth.mockReturnValue({ user: { uid: 'user-1' }, syncedSettings: null });
+    view.rerender(
+      <MemoryRouter>
+        <Provider store={store}>
+          <ForecastPage />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('10%')?.[0].id).toBe('anonymous-outlook');
+      expect(localStorage.getItem('forecastData')).toBeNull();
+      const scopedPayload = parseStoredForecastPayload(localStorage.getItem('forecastData:user-user-1'));
+      expect(scopedPayload?.forecastCycle?.days?.[1]?.data?.tornado?.[0]?.[1]?.[0]?.id).toBe('anonymous-outlook');
+    });
   });
 
   test('waits for restored session state before committing the local-day baseline', async () => {

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -60,6 +60,7 @@ jest.mock('../components/ForecastWorkspace/ForecastWorkspaceModals', () => () =>
 
 jest.mock('../hooks/useAutoSave', () => ({
   useAutoSave: jest.fn(),
+  migrateLegacyAutoSave: jest.fn(),
   getAutoSaveStorageKey: (userId?: string | null) => userId ? `forecastData:user-${userId}` : 'forecastData',
 }));
 

--- a/src/pages/ForecastPage.test.tsx
+++ b/src/pages/ForecastPage.test.tsx
@@ -239,7 +239,7 @@ describe('ForecastPage layout selection', () => {
     expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('10%')?.[0].id).toBe('autosave-outlook');
   });
 
-  test('prefers newer anonymous autosave over stale signed-in snapshot on sign-in', async () => {
+  test('keeps in-memory anonymous edits on sign-in without overwriting account autosave', async () => {
     const store = createStore();
     const stalePayload = serializeForecast(store.getState().forecast.forecastCycle, { center: [0, 0], zoom: 0 });
     stalePayload.timestamp = '2026-07-13T12:00:00.000Z';
@@ -289,8 +289,7 @@ describe('ForecastPage layout selection', () => {
     await waitFor(() => {
       expect(store.getState().forecast.forecastCycle.days[1]?.data.tornado?.get('10%')?.[0].id).toBe('anonymous-outlook');
       expect(localStorage.getItem('forecastData')).toBe(JSON.stringify(anonymousPayload));
-      const scopedPayload = parseStoredForecastPayload(localStorage.getItem('forecastData:user-user-1'));
-      expect(scopedPayload?.forecastCycle?.days?.[1]?.data?.tornado?.[0]?.[1]?.[0]?.id).toBe('anonymous-outlook');
+      expect(localStorage.getItem('forecastData:user-user-1')).toBe(JSON.stringify(stalePayload));
     });
   });
 

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -136,10 +136,13 @@ const DAY_ROLLOVER_CHECK_INTERVAL_MS = 60_000;
 
 interface StoredRolloverPrompt extends DayRolloverPromptState {}
 
-const getRolloverStorageKey = (key: string, userId?: string | null): string =>
-  getScopedStorageKey(key, getStorageScope(userId));
+/** Returns the localStorage key for rollover state in the current workspace scope. */
+function getRolloverStorageKey(key: string, userId?: string | null): string {
+  return getScopedStorageKey(key, getStorageScope(userId));
+}
 
-const readStoredRolloverPrompt = (userId?: string | null): StoredRolloverPrompt | null => {
+/** Reads a pending rollover prompt, ignoring malformed or unavailable storage. */
+function readStoredRolloverPrompt(userId?: string | null): StoredRolloverPrompt | null {
   const stored = readStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId));
   if (!stored) return null;
 
@@ -166,22 +169,23 @@ const clearStoredRolloverPrompt = (userId?: string | null): void => {
 };
 
 /** Reads one stored day string from localStorage, returning null when storage is unavailable. */
-export const readStoredDayValue = (key: string): string | null => {
+/** Reads one stored day string from localStorage, returning null when storage is unavailable. */
+export function readStoredDayValue(key: string): string | null {
   try {
     return localStorage.getItem(key);
   } catch {
     return null;
   }
-};
+}
 
 /** Persists one day string into localStorage, ignoring storage errors. */
-export const writeStoredDayValue = (key: string, value: string) => {
+export function writeStoredDayValue(key: string, value: string): void {
   try {
     localStorage.setItem(key, value);
   } catch {
     // Ignore storage write failures so the editor keeps functioning.
   }
-};
+}
 
 /** Returns true when the forecast cycle contains any drawable outlook data or saved low-probability state. */
 export const hasRolloverForecastData = (
@@ -782,11 +786,18 @@ const restoreLocalSession = (
     return false;
   }
 
-  const data = parseStoredForecastPayload(localStorage.getItem(getAutoSaveStorageKey(userId)));
+  const scopedKey = getAutoSaveStorageKey(userId);
+  const scopedValue = localStorage.getItem(scopedKey);
+  const legacyValue = userId && scopedValue === null ? localStorage.getItem('forecastData') : null;
+  const data = parseStoredForecastPayload(scopedValue ?? legacyValue);
   if (!data) {
     return false;
   }
 
+  if (userId && scopedValue === null && legacyValue !== null) {
+    localStorage.setItem(scopedKey, legacyValue);
+    localStorage.removeItem('forecastData');
+  }
   restoreStoredForecastPayload(data, dispatch);
   addToast('Session restored from auto-save.', 'success');
   return true;
@@ -821,19 +832,21 @@ const useSessionRestore = (
   userId?: string | null
 ) => {
   const onCloudCycleLoadedRef = useRef(currentSession.onCloudCycleLoaded);
+  const forecastCycleRef = useRef(currentSession.forecastCycle);
   const [restoreComplete, setRestoreComplete] = useState(false);
   const [restoredSession, setRestoredSession] = useState(false);
   const [restoreAttempted, setRestoreAttempted] = useState(false);
 
   useEffect(() => {
     onCloudCycleLoadedRef.current = currentSession.onCloudCycleLoaded;
-  }, [currentSession.onCloudCycleLoaded]);
+    forecastCycleRef.current = currentSession.forecastCycle;
+  }, [currentSession.forecastCycle, currentSession.onCloudCycleLoaded]);
 
   useEffect(() => {
     try {
       migrateLegacyAutoSave(userId);
       setRestoredSession(restoreAvailableSession(dispatch, addToast, {
-        forecastCycle: currentSession.forecastCycle,
+        forecastCycle: forecastCycleRef.current,
         onCloudCycleLoaded: onCloudCycleLoadedRef.current,
       }, userId));
     } catch {

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -783,11 +783,29 @@ const readLegacyAutoSave = (userId: string | null | undefined, scopedValue: stri
   return localStorage.getItem('forecastData');
 };
 
-/** Migrates a legacy auto-save into the signed-in scope after it is selected. */
-const migrateLegacyAutoSaveIfNeeded = (userId: string | null | undefined, scopedKey: string, scopedValue: string | null, legacyValue: string | null): void => {
-  if (!userId || scopedValue !== null || legacyValue === null) return;
+/** Returns true when a legacy auto-save should be copied into the signed-in scope. */
+const shouldMigrateLegacyAutoSave = (
+  userId: string | null | undefined,
+  scopedValue: string | null,
+  legacyValue: string | null,
+): boolean => Boolean(userId) && scopedValue === null && legacyValue !== null;
+
+/** Copies a legacy auto-save into the signed-in scope and removes the unscoped copy. */
+const copyLegacyAutoSaveToScopedStorage = (scopedKey: string, legacyValue: string | null): void => {
+  if (legacyValue === null) return;
   localStorage.setItem(scopedKey, legacyValue);
   localStorage.removeItem('forecastData');
+};
+
+/** Migrates a legacy auto-save into the signed-in scope after it is selected. */
+const migrateLegacyAutoSaveIfNeeded = (
+  userId: string | null | undefined,
+  scopedKey: string,
+  scopedValue: string | null,
+  legacyValue: string | null,
+): void => {
+  if (!shouldMigrateLegacyAutoSave(userId, scopedValue, legacyValue)) return;
+  copyLegacyAutoSaveToScopedStorage(scopedKey, legacyValue);
 };
 
 /** Restores the last local auto-saved forecast when no cloud-loaded payload is pending. */
@@ -1086,6 +1104,36 @@ const persistDetectedRolloverPrompt = (prompt: DayRolloverPromptState, today: st
   writeStoredRolloverPrompt(prompt, userId);
 };
 
+/** Applies one rollover detection result to storage and prompt state. */
+const applyDayRolloverDetection = ({
+  promptState,
+  today,
+  restoreComplete,
+  userId,
+  persistPrompt,
+  setPromptState,
+  setActionError,
+}: {
+  promptState: DayRolloverPromptState | null;
+  today: string;
+  restoreComplete: boolean;
+  userId?: string;
+  persistPrompt: (prompt: DayRolloverPromptState, today: string, userId?: string) => void;
+  setPromptState: React.Dispatch<React.SetStateAction<DayRolloverPromptState | null>>;
+  setActionError: React.Dispatch<React.SetStateAction<string | null>>;
+}): void => {
+  if (!promptState) {
+    if (restoreComplete) {
+      writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId), today);
+    }
+    return;
+  }
+
+  persistPrompt(promptState, today, userId);
+  setActionError(null);
+  setPromptState(promptState);
+};
+
 /** Watches for a local calendar-day rollover and offers to save the previous session before starting a new one. */
 const useDayRolloverPrompt = ({ restoreComplete, restoredSession, dispatch, addToast, forecastCycle, currentMapView, isSaved, userId, canSaveToCloud, saveCycle, clearCurrent }: {
   restoreComplete: boolean;
@@ -1117,21 +1165,28 @@ const useDayRolloverPrompt = ({ restoreComplete, restoredSession, dispatch, addT
   const detectDayRollover = useCallback(() => {
     const { today, lastActiveDay, alreadyPromptedToday, pendingPrompt } = getDayRolloverSnapshot(userId);
     const nextPromptState = getDayRolloverPromptState({ restoreComplete, lastActiveDay, today, alreadyPromptedToday, pendingPrompt, promptOpen: Boolean(promptStateRef.current), forecastCycle: forecastCycleRef.current, isSaved: isSavedRef.current && !restoredSessionRef.current });
-    if (!nextPromptState) {
-      if (restoreComplete) writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId), today);
-      return;
-    }
-    persistDetectedRolloverPrompt(nextPromptState, today, userId);
-    setActionError(null);
-    setPromptState(nextPromptState);
+    applyDayRolloverDetection({
+      promptState: nextPromptState,
+      today,
+      restoreComplete,
+      userId,
+      persistPrompt: persistDetectedRolloverPrompt,
+      setPromptState,
+      setActionError,
+    });
   }, [restoreComplete, restoredSession, userId]);
 
   useEffect(() => {
     detectDayRollover();
-    const handleVisibilityChange = () => { if (!document.hidden) detectDayRollover(); };
+    const handleVisibilityChange = () => {
+      if (!document.hidden) detectDayRollover();
+    };
     const intervalId = window.setInterval(detectDayRollover, DAY_ROLLOVER_CHECK_INTERVAL_MS);
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => { window.clearInterval(intervalId); document.removeEventListener('visibilitychange', handleVisibilityChange); };
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [detectDayRollover]);
 
   const completeRollover = useCallback(() => { clearStoredRolloverPrompt(userId); setPromptState(null); setActionError(null); }, [userId]);

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -8,7 +8,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog';
@@ -41,7 +40,6 @@ import { getAutoSaveStorageKey, migrateLegacyAutoSave } from '../hooks/useAutoSa
 import {
   DAY_ROLLOVER_CHECK_INTERVAL_MS,
   DAY_ROLLOVER_LAST_ACTIVE_KEY,
-  DAY_ROLLOVER_PENDING_KEY,
   DAY_ROLLOVER_PROMPTED_KEY,
   type DayRolloverPromptState,
   clearStoredRolloverPrompt,
@@ -871,12 +869,16 @@ const useUnsavedChangesWarning = (isSaved: boolean) => {
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
   }, [isSaved]);
 };
 
 /** Returns true when legacy rollover keys describe a prompt for today. */
 const isLegacyPromptForToday = (today: string, legacyPromptedDay: string | null): boolean => legacyPromptedDay === today;
+
+/** Returns true when a legacy active day exists and differs from today. */
 const hasPriorLegacyDay = (today: string, legacyLastActiveDay: string | null): legacyLastActiveDay is string => Boolean(legacyLastActiveDay) && legacyLastActiveDay !== today;
 
 /** Returns a pending prompt reconstructed from legacy rollover keys when needed. */
@@ -1135,6 +1137,7 @@ const useDayRolloverPrompt = ({ restoreComplete, restoredSession, dispatch, addT
 
   useEffect(() => {
     detectDayRollover();
+    /** Rechecks rollover state when the document becomes visible again. */
     const handleVisibilityChange = () => {
       if (!document.hidden) detectDayRollover();
     };
@@ -1148,12 +1151,6 @@ const useDayRolloverPrompt = ({ restoreComplete, restoredSession, dispatch, addT
 
   const completeRollover = useCallback(() => { clearStoredRolloverPrompt(userId); setPromptState(null); setActionError(null); }, [userId]);
   const handleKeepCurrentSession = useCallback(() => completeRollover(), [completeRollover]);
-  const handleSaveAndStartNewDay = useCallback(() => {
-    clearCurrent();
-    const didSaveSession = runDayRolloverSaveAction({ forecastCycle, isSaved: isSaved && !restoredSession, dispatch });
-    addToast(didSaveSession ? 'Saved the previous session to Cycle History and started a new forecast for today.' : 'Started a new forecast for today.', 'success');
-    completeRollover();
-  }, [addToast, clearCurrent, completeRollover, dispatch, forecastCycle, isSaved, restoredSession]);
   const handleDownloadAndStartNewDay = useCallback(() => {
     if (!runDayRolloverDownloadAction({ forecastCycle, mapView: currentMapView, dispatch, clearCurrent })) { setActionError('Unable to download this session. Your current forecast is still open.'); return; }
     addToast('Forecast downloaded and a new day started.', 'success');

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -827,12 +827,17 @@ const useSessionRestore = (
   addToast: AddToastFn,
   currentSession: {
     forecastCycle: ReturnType<typeof selectForecastCycle>;
+    currentMapView: RootState['forecast']['currentMapView'];
+    workflowMetadata: RootState['forecast']['workflowMetadata'];
     onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void;
   },
   userId?: string | null
 ) => {
   const onCloudCycleLoadedRef = useRef(currentSession.onCloudCycleLoaded);
   const forecastCycleRef = useRef(currentSession.forecastCycle);
+  const currentMapViewRef = useRef(currentSession.currentMapView);
+  const workflowMetadataRef = useRef(currentSession.workflowMetadata);
+  const previousUserIdRef = useRef(userId);
   const [restoreComplete, setRestoreComplete] = useState(false);
   const [restoredSession, setRestoredSession] = useState(false);
   const [restoreAttempted, setRestoreAttempted] = useState(false);
@@ -840,11 +845,17 @@ const useSessionRestore = (
   useEffect(() => {
     onCloudCycleLoadedRef.current = currentSession.onCloudCycleLoaded;
     forecastCycleRef.current = currentSession.forecastCycle;
-  }, [currentSession.forecastCycle, currentSession.onCloudCycleLoaded]);
+    currentMapViewRef.current = currentSession.currentMapView;
+    workflowMetadataRef.current = currentSession.workflowMetadata;
+  }, [currentSession.currentMapView, currentSession.forecastCycle, currentSession.onCloudCycleLoaded, currentSession.workflowMetadata]);
 
   useEffect(() => {
     try {
-      migrateLegacyAutoSave(userId);
+      const liveSession = previousUserIdRef.current == null && userId
+        ? serializeForecast(forecastCycleRef.current, currentMapViewRef.current, workflowMetadataRef.current)
+        : undefined;
+      migrateLegacyAutoSave(userId, liveSession);
+      previousUserIdRef.current = userId;
       setRestoredSession(restoreAvailableSession(dispatch, addToast, {
         forecastCycle: forecastCycleRef.current,
         onCloudCycleLoaded: onCloudCycleLoadedRef.current,
@@ -854,7 +865,7 @@ const useSessionRestore = (
     } finally {
       setRestoreAttempted(true);
     }
-  }, [dispatch, addToast, userId]);
+  }, [addToast, dispatch, userId]);
 
   useEffect(() => {
     if (restoreAttempted) setRestoreComplete(true);
@@ -1305,6 +1316,8 @@ const useForecastPageWorkspace = ({
 
   const { restoreComplete, restoredSession } = useSessionRestore(dispatch, addToast, {
     forecastCycle,
+    currentMapView,
+    workflowMetadata,
     onCloudCycleLoaded: handleCloudCycleLoaded,
   }, user?.uid);
   useUnsavedChangesWarning(isSaved);

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -777,6 +777,19 @@ const shouldSkipLocalRestore = (
 ): boolean =>
   hasRolloverForecastData(forecastCycle) || cycleHasDiscussionContent(forecastCycle);
 
+/** Returns the legacy auto-save only when a signed-in scope has no snapshot. */
+const readLegacyAutoSave = (userId: string | null | undefined, scopedValue: string | null): string | null => {
+  if (!userId || scopedValue !== null) return null;
+  return localStorage.getItem('forecastData');
+};
+
+/** Migrates a legacy auto-save into the signed-in scope after it is selected. */
+const migrateLegacyAutoSaveIfNeeded = (userId: string | null | undefined, scopedKey: string, scopedValue: string | null, legacyValue: string | null): void => {
+  if (!userId || scopedValue !== null || legacyValue === null) return;
+  localStorage.setItem(scopedKey, legacyValue);
+  localStorage.removeItem('forecastData');
+};
+
 /** Restores the last local auto-saved forecast when no cloud-loaded payload is pending. */
 const restoreLocalSession = (
   dispatch: ShortcutDispatch,
@@ -784,22 +797,15 @@ const restoreLocalSession = (
   currentSession: { forecastCycle: ReturnType<typeof selectForecastCycle> },
   userId?: string | null
 ): boolean => {
-  if (shouldSkipLocalRestore(currentSession.forecastCycle)) {
-    return false;
-  }
+  if (shouldSkipLocalRestore(currentSession.forecastCycle)) return false;
 
   const scopedKey = getAutoSaveStorageKey(userId);
   const scopedValue = localStorage.getItem(scopedKey);
-  const legacyValue = userId && scopedValue === null ? localStorage.getItem('forecastData') : null;
+  const legacyValue = readLegacyAutoSave(userId, scopedValue);
   const data = parseStoredForecastPayload(scopedValue ?? legacyValue);
-  if (!data) {
-    return false;
-  }
+  if (!data) return false;
 
-  if (userId && scopedValue === null && legacyValue !== null) {
-    localStorage.setItem(scopedKey, legacyValue);
-    localStorage.removeItem('forecastData');
-  }
+  migrateLegacyAutoSaveIfNeeded(userId, scopedKey, scopedValue, legacyValue);
   restoreStoredForecastPayload(data, dispatch);
   addToast('Session restored from auto-save.', 'success');
   return true;
@@ -894,17 +900,27 @@ const useUnsavedChangesWarning = (isSaved: boolean) => {
   }, [isSaved]);
 };
 
+/** Returns true when legacy rollover keys describe a prompt for today. */
+const isLegacyPromptForToday = (today: string, legacyPromptedDay: string | null): boolean => legacyPromptedDay === today;
+const hasPriorLegacyDay = (today: string, legacyLastActiveDay: string | null): legacyLastActiveDay is string => Boolean(legacyLastActiveDay) && legacyLastActiveDay !== today;
+
 /** Returns a pending prompt reconstructed from legacy rollover keys when needed. */
 const getLegacyPendingRolloverPrompt = (
   today: string,
   legacyLastActiveDay: string | null,
   legacyPromptedDay: string | null,
 ): DayRolloverPromptState | null => {
-  if (legacyPromptedDay !== today || !legacyLastActiveDay || legacyLastActiveDay === today) {
-    return null;
-  }
+  if (!isLegacyPromptForToday(today, legacyPromptedDay)) return null;
+  if (!hasPriorLegacyDay(today, legacyLastActiveDay)) return null;
   return { previousDay: legacyLastActiveDay, currentDay: today };
 };
+
+/** Returns true when the anonymous baseline can be copied into its scoped key. */
+const canMigrateLegacyRolloverBaseline = (
+  userId: string | null | undefined,
+  legacyLastActiveDay: string | null,
+  scopedLastActiveDay: string | null,
+): legacyLastActiveDay is string => !userId && Boolean(legacyLastActiveDay) && !scopedLastActiveDay;
 
 /** Copies the anonymous rollover baseline into its scoped key during migration. */
 const migrateLegacyRolloverBaseline = (
@@ -913,9 +929,8 @@ const migrateLegacyRolloverBaseline = (
   legacyLastActiveDay: string | null,
   scopedLastActiveDay: string | null,
 ): void => {
-  if (!userId && legacyLastActiveDay && !scopedLastActiveDay) {
-    writeStoredDayValue(scopedLastActiveKey, legacyLastActiveDay);
-  }
+  if (!canMigrateLegacyRolloverBaseline(userId, legacyLastActiveDay, scopedLastActiveDay)) return;
+  writeStoredDayValue(scopedLastActiveKey, legacyLastActiveDay);
 };
 
 /** Reads the stored day-rollover snapshot without mutating the baseline used by the decision. */
@@ -970,6 +985,14 @@ export const shouldSkipDayRolloverPrompt = ({
   return !hasUnsavedWork;
 };
 
+/** Returns true when a stored pending prompt can be reused for the current day. */
+const isCurrentPendingRolloverPrompt = (
+  restoreComplete: boolean,
+  pendingPrompt: DayRolloverPromptState | null | undefined,
+  today: string,
+  promptOpen: boolean,
+): pendingPrompt is DayRolloverPromptState => restoreComplete && !promptOpen && pendingPrompt?.currentDay === today;
+
 /** Saves the previous cycle when needed, resets the editor, and returns whether a history save occurred. */
 export const getDayRolloverPromptState = ({
   restoreComplete,
@@ -991,11 +1014,7 @@ export const getDayRolloverPromptState = ({
   pendingPrompt?: DayRolloverPromptState | null;
 }): DayRolloverPromptState | null => {
   const hasUnsavedWork = hasUnsavedRolloverCandidateSession(forecastCycle, isSaved);
-
-  if (restoreComplete && pendingPrompt?.currentDay === today && !promptOpen) {
-    return pendingPrompt;
-  }
-
+  if (isCurrentPendingRolloverPrompt(restoreComplete, pendingPrompt, today, promptOpen)) return pendingPrompt;
   if (shouldSkipDayRolloverPrompt({
     restoreComplete,
     lastActiveDay,
@@ -1003,14 +1022,9 @@ export const getDayRolloverPromptState = ({
     alreadyPromptedToday,
     promptOpen,
     hasUnsavedWork,
-  })) {
-    return null;
-  }
+  })) return null;
 
-  return {
-    previousDay: lastActiveDay as string,
-    currentDay: today,
-  };
+  return { previousDay: lastActiveDay as string, currentDay: today };
 };
 
 /** Saves the current session to Cycle History when needed, then resets the editor for the new local day. */
@@ -1065,6 +1079,13 @@ export const runDayRolloverCloudSaveAction = async ({ forecastCycle, currentMapV
   } catch { return false; }
 };
 
+/** Stores the detected prompt and marks today's rollover check as handled. */
+const persistDetectedRolloverPrompt = (prompt: DayRolloverPromptState, today: string, userId?: string): void => {
+  writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PROMPTED_KEY, userId), today);
+  writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId), today);
+  writeStoredRolloverPrompt(prompt, userId);
+};
+
 /** Watches for a local calendar-day rollover and offers to save the previous session before starting a new one. */
 const useDayRolloverPrompt = ({ restoreComplete, restoredSession, dispatch, addToast, forecastCycle, currentMapView, isSaved, userId, canSaveToCloud, saveCycle, clearCurrent }: {
   restoreComplete: boolean;
@@ -1100,9 +1121,7 @@ const useDayRolloverPrompt = ({ restoreComplete, restoredSession, dispatch, addT
       if (restoreComplete) writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId), today);
       return;
     }
-    writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PROMPTED_KEY, userId), today);
-    writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId), today);
-    writeStoredRolloverPrompt(nextPromptState, userId);
+    persistDetectedRolloverPrompt(nextPromptState, today, userId);
     setActionError(null);
     setPromptState(nextPromptState);
   }, [restoreComplete, restoredSession, userId]);

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -134,7 +134,7 @@ const DAY_ROLLOVER_PROMPTED_KEY = 'gfc-day-rollover-prompt-day';
 const DAY_ROLLOVER_PENDING_KEY = 'gfc-day-rollover-pending';
 const DAY_ROLLOVER_CHECK_INTERVAL_MS = 60_000;
 
-interface StoredRolloverPrompt extends DayRolloverPromptState {}
+type StoredRolloverPrompt = DayRolloverPromptState;
 
 /** Returns the localStorage key for rollover state in the current workspace scope. */
 function getRolloverStorageKey(key: string, userId?: string | null): string {
@@ -156,10 +156,12 @@ function readStoredRolloverPrompt(userId?: string | null): StoredRolloverPrompt 
   }
 };
 
+/** Persists a pending rollover prompt for the active workspace scope. */
 const writeStoredRolloverPrompt = (prompt: StoredRolloverPrompt, userId?: string | null): void => {
   writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId), JSON.stringify(prompt));
 };
 
+/** Removes a pending rollover prompt for the active workspace scope. */
 const clearStoredRolloverPrompt = (userId?: string | null): void => {
   try {
     localStorage.removeItem(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId));
@@ -892,25 +894,44 @@ const useUnsavedChangesWarning = (isSaved: boolean) => {
   }, [isSaved]);
 };
 
+/** Returns a pending prompt reconstructed from legacy rollover keys when needed. */
+const getLegacyPendingRolloverPrompt = (
+  today: string,
+  legacyLastActiveDay: string | null,
+  legacyPromptedDay: string | null,
+): DayRolloverPromptState | null => {
+  if (legacyPromptedDay !== today || !legacyLastActiveDay || legacyLastActiveDay === today) {
+    return null;
+  }
+  return { previousDay: legacyLastActiveDay, currentDay: today };
+};
+
+/** Copies the anonymous rollover baseline into its scoped key during migration. */
+const migrateLegacyRolloverBaseline = (
+  userId: string | null | undefined,
+  scopedLastActiveKey: string,
+  legacyLastActiveDay: string | null,
+  scopedLastActiveDay: string | null,
+): void => {
+  if (!userId && legacyLastActiveDay && !scopedLastActiveDay) {
+    writeStoredDayValue(scopedLastActiveKey, legacyLastActiveDay);
+  }
+};
+
 /** Reads the stored day-rollover snapshot without mutating the baseline used by the decision. */
 const getDayRolloverSnapshot = (userId?: string | null) => {
   const today = getLocalCalendarDate();
   const scopedLastActiveKey = getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId);
   const scopedPromptedKey = getRolloverStorageKey(DAY_ROLLOVER_PROMPTED_KEY, userId);
-  const legacyLastActiveDay = !userId ? readStoredDayValue(DAY_ROLLOVER_LAST_ACTIVE_KEY) : null;
-  const legacyPromptedDay = !userId ? readStoredDayValue(DAY_ROLLOVER_PROMPTED_KEY) : null;
+  const legacyLastActiveDay = userId ? null : readStoredDayValue(DAY_ROLLOVER_LAST_ACTIVE_KEY);
+  const legacyPromptedDay = userId ? null : readStoredDayValue(DAY_ROLLOVER_PROMPTED_KEY);
   const scopedLastActiveDay = readStoredDayValue(scopedLastActiveKey);
   const lastActiveDay = scopedLastActiveDay ?? legacyLastActiveDay;
   const alreadyPromptedToday = (readStoredDayValue(scopedPromptedKey) ?? legacyPromptedDay) === today;
   const existingPendingPrompt = readStoredRolloverPrompt(userId);
-  const pendingPrompt = existingPendingPrompt
-    ?? (legacyPromptedDay === today && legacyLastActiveDay && legacyLastActiveDay !== today
-      ? { previousDay: legacyLastActiveDay, currentDay: today }
-      : null);
+  const pendingPrompt = existingPendingPrompt ?? getLegacyPendingRolloverPrompt(today, legacyLastActiveDay, legacyPromptedDay);
 
-  if (!userId && legacyLastActiveDay && !scopedLastActiveDay) {
-    writeStoredDayValue(scopedLastActiveKey, legacyLastActiveDay);
-  }
+  migrateLegacyRolloverBaseline(userId, scopedLastActiveKey, legacyLastActiveDay, scopedLastActiveDay);
   if (pendingPrompt && !existingPendingPrompt) {
     writeStoredRolloverPrompt(pendingPrompt, userId);
   }

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -37,7 +37,7 @@ import {
   getFirstExposedOutlookType,
   shouldActivateEmergencyMode,
 } from '../config/productExposureSelectors';
-import { getAutoSaveStorageKey } from '../hooks/useAutoSave';
+import { getAutoSaveStorageKey, migrateLegacyAutoSave } from '../hooks/useAutoSave';
 import { getStorageScope, getScopedStorageKey } from '../utils/storageScope';
 import useAutoCategorical from '../hooks/useAutoCategorical';
 import { useAutoTstm } from '../hooks/useAutoTstm';
@@ -821,7 +821,6 @@ const useSessionRestore = (
   userId?: string | null
 ) => {
   const onCloudCycleLoadedRef = useRef(currentSession.onCloudCycleLoaded);
-  const initialCycleRef = useRef(currentSession.forecastCycle);
   const [restoreComplete, setRestoreComplete] = useState(false);
   const [restoredSession, setRestoredSession] = useState(false);
   const [restoreAttempted, setRestoreAttempted] = useState(false);
@@ -832,8 +831,9 @@ const useSessionRestore = (
 
   useEffect(() => {
     try {
+      migrateLegacyAutoSave(userId);
       setRestoredSession(restoreAvailableSession(dispatch, addToast, {
-        forecastCycle: initialCycleRef.current,
+        forecastCycle: currentSession.forecastCycle,
         onCloudCycleLoaded: onCloudCycleLoadedRef.current,
       }, userId));
     } catch {

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -741,12 +741,10 @@ const restoreCloudSession = (
 const shouldSkipLocalRestore = (
   forecastCycle: ReturnType<typeof selectForecastCycle>,
   discussionDraftsByScope: RootState['forecast']['discussionDraftsByScope'],
-): boolean => {
-  if (hasRolloverForecastData(forecastCycle)) return true;
-  if (cycleHasDiscussionContent(forecastCycle)) return true;
-  if (hasUnpublishedDiscussionDrafts(discussionDraftsByScope)) return true;
-  return false;
-};
+): boolean =>
+  hasRolloverForecastData(forecastCycle)
+  || cycleHasDiscussionContent(forecastCycle)
+  || hasUnpublishedDiscussionDrafts(discussionDraftsByScope);
 
 /** Copies a legacy auto-save into the signed-in scope and removes the unscoped copy. */
 const copyLegacyAutoSaveToScopedStorage = (scopedKey: string, legacyValue: string | null): void => {
@@ -892,6 +890,7 @@ const useUnsavedChangesWarning = (isSaved: boolean) => {
 const isLegacyPromptForToday = (today: string, legacyPromptedDay: string | null): boolean => legacyPromptedDay === today;
 
 /** Returns true when a legacy active day exists and differs from today. */
+/** Returns true when a legacy last-active day exists and differs from today. */
 const hasPriorLegacyDay = (today: string, legacyLastActiveDay: string | null): legacyLastActiveDay is string => Boolean(legacyLastActiveDay) && legacyLastActiveDay !== today;
 
 /** Returns a pending prompt reconstructed from legacy rollover keys when needed. */

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -38,6 +38,19 @@ import {
   shouldActivateEmergencyMode,
 } from '../config/productExposureSelectors';
 import { getAutoSaveStorageKey, migrateLegacyAutoSave } from '../hooks/useAutoSave';
+import {
+  DAY_ROLLOVER_CHECK_INTERVAL_MS,
+  DAY_ROLLOVER_LAST_ACTIVE_KEY,
+  DAY_ROLLOVER_PENDING_KEY,
+  DAY_ROLLOVER_PROMPTED_KEY,
+  type DayRolloverPromptState,
+  clearStoredRolloverPrompt,
+  getRolloverStorageKey,
+  readStoredDayValue,
+  readStoredRolloverPrompt,
+  writeStoredDayValue,
+  writeStoredRolloverPrompt,
+} from '../utils/dayRolloverStorage';
 import { getStorageScope, getScopedStorageKey } from '../utils/storageScope';
 import useAutoCategorical from '../hooks/useAutoCategorical';
 import { useAutoTstm } from '../hooks/useAutoTstm';
@@ -63,6 +76,15 @@ import {
   type ForecastUiVariant,
 } from '../utils/forecastUiVariant';
 import './ForecastPage.css';
+
+export {
+  clearStoredRolloverPrompt,
+  getRolloverStorageKey,
+  readStoredDayValue,
+  readStoredRolloverPrompt,
+  writeStoredDayValue,
+  writeStoredRolloverPrompt,
+};
 
 interface PageContext {
   addToast: AddToastFn;
@@ -123,71 +145,6 @@ const EmergencyModeMessage: React.FC = () => (
     </div>
   </div>
 );
-
-interface DayRolloverPromptState {
-  previousDay: string;
-  currentDay: string;
-}
-
-const DAY_ROLLOVER_LAST_ACTIVE_KEY = 'gfc-last-active-local-day';
-const DAY_ROLLOVER_PROMPTED_KEY = 'gfc-day-rollover-prompt-day';
-const DAY_ROLLOVER_PENDING_KEY = 'gfc-day-rollover-pending';
-const DAY_ROLLOVER_CHECK_INTERVAL_MS = 60_000;
-
-type StoredRolloverPrompt = DayRolloverPromptState;
-
-/** Returns the localStorage key for rollover state in the current workspace scope. */
-function getRolloverStorageKey(key: string, userId?: string | null): string {
-  return getScopedStorageKey(key, getStorageScope(userId));
-}
-
-/** Reads a pending rollover prompt, ignoring malformed or unavailable storage. */
-function readStoredRolloverPrompt(userId?: string | null): StoredRolloverPrompt | null {
-  const stored = readStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId));
-  if (!stored) return null;
-
-  try {
-    const parsed = JSON.parse(stored) as Partial<StoredRolloverPrompt>;
-    return typeof parsed.previousDay === 'string' && typeof parsed.currentDay === 'string'
-      ? { previousDay: parsed.previousDay, currentDay: parsed.currentDay }
-      : null;
-  } catch {
-    return null;
-  }
-};
-
-/** Persists a pending rollover prompt for the active workspace scope. */
-const writeStoredRolloverPrompt = (prompt: StoredRolloverPrompt, userId?: string | null): void => {
-  writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId), JSON.stringify(prompt));
-};
-
-/** Removes a pending rollover prompt for the active workspace scope. */
-const clearStoredRolloverPrompt = (userId?: string | null): void => {
-  try {
-    localStorage.removeItem(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId));
-  } catch {
-    // Ignore storage failures.
-  }
-};
-
-/** Reads one stored day string from localStorage, returning null when storage is unavailable. */
-/** Reads one stored day string from localStorage, returning null when storage is unavailable. */
-export function readStoredDayValue(key: string): string | null {
-  try {
-    return localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-/** Persists one day string into localStorage, ignoring storage errors. */
-export function writeStoredDayValue(key: string, value: string): void {
-  try {
-    localStorage.setItem(key, value);
-  } catch {
-    // Ignore storage write failures so the editor keeps functioning.
-  }
-}
 
 /** Returns true when the forecast cycle contains any drawable outlook data or saved low-probability state. */
 export const hasRolloverForecastData = (

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -37,8 +37,8 @@ import {
   getFirstExposedOutlookType,
   shouldActivateEmergencyMode,
 } from '../config/productExposureSelectors';
-import { useAutoSave } from '../hooks/useAutoSave';
-import { useCycleHistoryPersistence } from '../utils/cycleHistoryPersistence';
+import { getAutoSaveStorageKey } from '../hooks/useAutoSave';
+import { getStorageScope, getScopedStorageKey } from '../utils/storageScope';
 import useAutoCategorical from '../hooks/useAutoCategorical';
 import { useAutoTstm } from '../hooks/useAutoTstm';
 import AutoTstmWorkspaceTools from '../components/AutoTstm/AutoTstmWorkspaceTools';
@@ -131,7 +131,39 @@ interface DayRolloverPromptState {
 
 const DAY_ROLLOVER_LAST_ACTIVE_KEY = 'gfc-last-active-local-day';
 const DAY_ROLLOVER_PROMPTED_KEY = 'gfc-day-rollover-prompt-day';
+const DAY_ROLLOVER_PENDING_KEY = 'gfc-day-rollover-pending';
 const DAY_ROLLOVER_CHECK_INTERVAL_MS = 60_000;
+
+interface StoredRolloverPrompt extends DayRolloverPromptState {}
+
+const getRolloverStorageKey = (key: string, userId?: string | null): string =>
+  getScopedStorageKey(key, getStorageScope(userId));
+
+const readStoredRolloverPrompt = (userId?: string | null): StoredRolloverPrompt | null => {
+  const stored = readStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId));
+  if (!stored) return null;
+
+  try {
+    const parsed = JSON.parse(stored) as Partial<StoredRolloverPrompt>;
+    return typeof parsed.previousDay === 'string' && typeof parsed.currentDay === 'string'
+      ? { previousDay: parsed.previousDay, currentDay: parsed.currentDay }
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredRolloverPrompt = (prompt: StoredRolloverPrompt, userId?: string | null): void => {
+  writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId), JSON.stringify(prompt));
+};
+
+const clearStoredRolloverPrompt = (userId?: string | null): void => {
+  try {
+    localStorage.removeItem(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId));
+  } catch {
+    // Ignore storage failures.
+  }
+};
 
 /** Reads one stored day string from localStorage, returning null when storage is unavailable. */
 export const readStoredDayValue = (key: string): string | null => {
@@ -195,14 +227,24 @@ export const formatRolloverDayLabel = (value: string): string => {
 /** Modal prompt shown when the editor detects the local day rolled over while an older session still has work. */
 const DayRolloverDialog: React.FC<{
   promptState: DayRolloverPromptState | null;
+  canSaveToCloud: boolean;
+  isBusy: boolean;
+  error: string | null;
   onKeepCurrentSession: () => void;
-  onSaveAndStartNewDay: () => void;
+  onDownloadAndStartNewDay: () => void;
+  onSaveToCloudAndStartNewDay: () => void;
+  onReplaceWithoutSaving: () => void;
 }> = ({
   promptState,
+  canSaveToCloud,
+  isBusy,
+  error,
   onKeepCurrentSession,
-  onSaveAndStartNewDay,
+  onDownloadAndStartNewDay,
+  onSaveToCloudAndStartNewDay,
+  onReplaceWithoutSaving,
 }) => (
-  <Dialog open={Boolean(promptState)} onOpenChange={(isOpen) => { if (!isOpen) onKeepCurrentSession(); }}>
+  <Dialog open={Boolean(promptState)} onOpenChange={(isOpen) => { if (!isOpen && !isBusy) onKeepCurrentSession(); }}>
     <DialogContent>
       <DialogHeader>
         <DialogTitle>New day detected</DialogTitle>
@@ -210,21 +252,28 @@ const DayRolloverDialog: React.FC<{
           {promptState ? (
             <>
               It looks like your current Forecast session is from {formatRolloverDayLabel(promptState.previousDay)} and today is{' '}
-              {formatRolloverDayLabel(promptState.currentDay)}. Do you want to save that session to Cycle History and start a
-              fresh forecast for today?
+              {formatRolloverDayLabel(promptState.currentDay)}. Choose how to handle this session before starting today&apos;s forecast.
             </>
           ) : null}
         </DialogDescription>
       </DialogHeader>
 
-      <DialogFooter>
-        <Button variant="outline" onClick={onKeepCurrentSession}>
-          Keep Current Session
+      {error ? <p role="alert" className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="grid gap-2">
+        <Button variant="outline" onClick={onDownloadAndStartNewDay} disabled={isBusy}>
+          Download a copy &amp; start new day
         </Button>
-        <Button onClick={onSaveAndStartNewDay}>
-          Save Session &amp; Start New Day
+        <Button onClick={onSaveToCloudAndStartNewDay} disabled={isBusy || !canSaveToCloud}>
+          {canSaveToCloud ? 'Save to premium cloud & start new day' : 'Premium cloud save unavailable'}
         </Button>
-      </DialogFooter>
+        <Button variant="secondary" onClick={onKeepCurrentSession} disabled={isBusy}>
+          Keep for now
+        </Button>
+        <Button variant="ghost" onClick={onReplaceWithoutSaving} disabled={isBusy}>
+          Replace without saving
+        </Button>
+      </div>
     </DialogContent>
   </Dialog>
 );
@@ -664,9 +713,13 @@ export const parseStoredCloudMeta = (storedValue: string | null): StoredCloudMet
 };
 
 /** Clears the temporary session-storage keys used for handing a cloud cycle into the editor. */
-export const clearStoredCloudSession = () => {
-  sessionStorage.removeItem(CLOUD_CYCLE_PAYLOAD_KEY);
-  sessionStorage.removeItem(CLOUD_CYCLE_META_KEY);
+export const clearStoredCloudSession = (userId?: string | null) => {
+  sessionStorage.removeItem(getScopedStorageKey(CLOUD_CYCLE_PAYLOAD_KEY, getStorageScope(userId)));
+  sessionStorage.removeItem(getScopedStorageKey(CLOUD_CYCLE_META_KEY, getStorageScope(userId)));
+  if (!userId) {
+    sessionStorage.removeItem(CLOUD_CYCLE_PAYLOAD_KEY);
+    sessionStorage.removeItem(CLOUD_CYCLE_META_KEY);
+  }
 };
 
 /** Returns true when stored cloud metadata includes the id and label needed to restore selection context. */
@@ -690,19 +743,24 @@ const restoreCloudSelectionContext = (
 const restoreCloudSession = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
-  onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void
+  onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void,
+  userId?: string | null
 ): boolean => {
-  const cloudPayloadStr = sessionStorage.getItem(CLOUD_CYCLE_PAYLOAD_KEY);
+  const scopedPayloadKey = getScopedStorageKey(CLOUD_CYCLE_PAYLOAD_KEY, getStorageScope(userId));
+  const cloudPayloadStr = sessionStorage.getItem(scopedPayloadKey)
+    ?? (!userId ? sessionStorage.getItem(CLOUD_CYCLE_PAYLOAD_KEY) : null);
   const data = parseStoredForecastPayload(cloudPayloadStr);
   if (!data) {
     return false;
   }
 
-  const cloudMeta = parseStoredCloudMeta(sessionStorage.getItem(CLOUD_CYCLE_META_KEY));
+  const scopedMetaKey = getScopedStorageKey(CLOUD_CYCLE_META_KEY, getStorageScope(userId));
+  const cloudMeta = parseStoredCloudMeta(sessionStorage.getItem(scopedMetaKey)
+    ?? (!userId ? sessionStorage.getItem(CLOUD_CYCLE_META_KEY) : null));
 
   restoreStoredForecastPayload(data, dispatch);
   restoreCloudSelectionContext(cloudMeta, onCloudCycleLoaded);
-  clearStoredCloudSession();
+  clearStoredCloudSession(userId);
   addToast('Cloud forecast loaded successfully.', 'success');
   return true;
 };
@@ -717,19 +775,21 @@ const shouldSkipLocalRestore = (
 const restoreLocalSession = (
   dispatch: ShortcutDispatch,
   addToast: AddToastFn,
-  currentSession: { forecastCycle: ReturnType<typeof selectForecastCycle> }
-): void => {
+  currentSession: { forecastCycle: ReturnType<typeof selectForecastCycle> },
+  userId?: string | null
+): boolean => {
   if (shouldSkipLocalRestore(currentSession.forecastCycle)) {
-    return;
+    return false;
   }
 
-  const data = parseStoredForecastPayload(localStorage.getItem('forecastData'));
+  const data = parseStoredForecastPayload(localStorage.getItem(getAutoSaveStorageKey(userId)));
   if (!data) {
-    return;
+    return false;
   }
 
   restoreStoredForecastPayload(data, dispatch);
   addToast('Session restored from auto-save.', 'success');
+  return true;
 };
 
 /** Restores a pending cloud session first, then falls back to the local auto-save snapshot. */
@@ -739,14 +799,15 @@ const restoreAvailableSession = (
   currentSession: {
     forecastCycle: ReturnType<typeof selectForecastCycle>;
     onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void;
-  }
-) => {
-  const restoredCloudSession = restoreCloudSession(dispatch, addToast, currentSession.onCloudCycleLoaded);
+  },
+  userId?: string | null
+): boolean => {
+  const restoredCloudSession = restoreCloudSession(dispatch, addToast, currentSession.onCloudCycleLoaded, userId);
   if (restoredCloudSession) {
-    return;
+    return true;
   }
 
-  restoreLocalSession(dispatch, addToast, currentSession);
+  return restoreLocalSession(dispatch, addToast, currentSession, userId);
 };
 
 /** Attempts to restore the last auto-saved forecast session from localStorage on mount. */
@@ -756,11 +817,14 @@ const useSessionRestore = (
   currentSession: {
     forecastCycle: ReturnType<typeof selectForecastCycle>;
     onCloudCycleLoaded?: (cloudCycle: { id: string; label: string }) => void;
-  }
+  },
+  userId?: string | null
 ) => {
   const onCloudCycleLoadedRef = useRef(currentSession.onCloudCycleLoaded);
   const initialCycleRef = useRef(currentSession.forecastCycle);
   const [restoreComplete, setRestoreComplete] = useState(false);
+  const [restoredSession, setRestoredSession] = useState(false);
+  const [restoreAttempted, setRestoreAttempted] = useState(false);
 
   useEffect(() => {
     onCloudCycleLoadedRef.current = currentSession.onCloudCycleLoaded;
@@ -768,18 +832,22 @@ const useSessionRestore = (
 
   useEffect(() => {
     try {
-      restoreAvailableSession(dispatch, addToast, {
+      setRestoredSession(restoreAvailableSession(dispatch, addToast, {
         forecastCycle: initialCycleRef.current,
         onCloudCycleLoaded: onCloudCycleLoadedRef.current,
-      });
+      }, userId));
     } catch {
-      // Silently skip auto-load errors to avoid disrupting initial render
+      setRestoredSession(false);
     } finally {
-      setRestoreComplete(true);
+      setRestoreAttempted(true);
     }
-  }, [dispatch, addToast]);
+  }, [dispatch, addToast, userId]);
 
-  return restoreComplete;
+  useEffect(() => {
+    if (restoreAttempted) setRestoreComplete(true);
+  }, [restoreAttempted]);
+
+  return { restoreComplete, restoredSession };
 };
 
 /** Registers a beforeunload listener to warn the user when the forecast has unsaved changes. */
@@ -800,19 +868,30 @@ const useUnsavedChangesWarning = (isSaved: boolean) => {
   }, [isSaved]);
 };
 
-/** Returns the stored/derived day-rollover snapshot needed to decide whether a prompt should be shown. */
-const getDayRolloverSnapshot = () => {
+/** Reads the stored day-rollover snapshot without mutating the baseline used by the decision. */
+const getDayRolloverSnapshot = (userId?: string | null) => {
   const today = getLocalCalendarDate();
-  const lastActiveDay = readStoredDayValue(DAY_ROLLOVER_LAST_ACTIVE_KEY);
-  const alreadyPromptedToday = readStoredDayValue(DAY_ROLLOVER_PROMPTED_KEY) === today;
+  const scopedLastActiveKey = getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId);
+  const scopedPromptedKey = getRolloverStorageKey(DAY_ROLLOVER_PROMPTED_KEY, userId);
+  const legacyLastActiveDay = !userId ? readStoredDayValue(DAY_ROLLOVER_LAST_ACTIVE_KEY) : null;
+  const legacyPromptedDay = !userId ? readStoredDayValue(DAY_ROLLOVER_PROMPTED_KEY) : null;
+  const scopedLastActiveDay = readStoredDayValue(scopedLastActiveKey);
+  const lastActiveDay = scopedLastActiveDay ?? legacyLastActiveDay;
+  const alreadyPromptedToday = (readStoredDayValue(scopedPromptedKey) ?? legacyPromptedDay) === today;
+  const existingPendingPrompt = readStoredRolloverPrompt(userId);
+  const pendingPrompt = existingPendingPrompt
+    ?? (legacyPromptedDay === today && legacyLastActiveDay && legacyLastActiveDay !== today
+      ? { previousDay: legacyLastActiveDay, currentDay: today }
+      : null);
 
-  writeStoredDayValue(DAY_ROLLOVER_LAST_ACTIVE_KEY, today);
+  if (!userId && legacyLastActiveDay && !scopedLastActiveDay) {
+    writeStoredDayValue(scopedLastActiveKey, legacyLastActiveDay);
+  }
+  if (pendingPrompt && !existingPendingPrompt) {
+    writeStoredRolloverPrompt(pendingPrompt, userId);
+  }
 
-  return {
-    today,
-    lastActiveDay,
-    alreadyPromptedToday,
-  };
+  return { today, lastActiveDay, alreadyPromptedToday, pendingPrompt };
 };
 
 /** Returns true when the day-rollover modal should not be shown for the current snapshot. */
@@ -855,6 +934,7 @@ export const getDayRolloverPromptState = ({
   promptOpen,
   forecastCycle,
   isSaved,
+  pendingPrompt,
 }: {
   restoreComplete: boolean;
   lastActiveDay: string | null;
@@ -863,8 +943,13 @@ export const getDayRolloverPromptState = ({
   promptOpen: boolean;
   forecastCycle: ReturnType<typeof selectForecastCycle>;
   isSaved: boolean;
+  pendingPrompt?: DayRolloverPromptState | null;
 }): DayRolloverPromptState | null => {
   const hasUnsavedWork = hasUnsavedRolloverCandidateSession(forecastCycle, isSaved);
+
+  if (restoreComplete && pendingPrompt?.currentDay === today && !promptOpen) {
+    return pendingPrompt;
+  }
 
   if (shouldSkipDayRolloverPrompt({
     restoreComplete,
@@ -903,109 +988,113 @@ export const runDayRolloverSaveAction = ({
   return didSaveSession;
 };
 
+/** Downloads the rollover session and only resets the editor after the browser download succeeds. */
+export const runDayRolloverDownloadAction = ({ forecastCycle, mapView, dispatch, clearCurrent }: {
+  forecastCycle: ReturnType<typeof selectForecastCycle>;
+  mapView: RootState['forecast']['currentMapView'];
+  dispatch: ShortcutDispatch;
+  clearCurrent?: UseCloudCyclesResult['clearCurrent'];
+}): boolean => {
+  try {
+    exportForecastToJson(forecastCycle, mapView);
+    clearCurrent?.();
+    dispatch(resetForecasts());
+    return true;
+  } catch { return false; }
+};
+
+/** Saves the rollover session as a new cloud cycle and resets only after a confirmed success. */
+export const runDayRolloverCloudSaveAction = async ({ forecastCycle, currentMapView, saveCycle, clearCurrent, dispatch }: {
+  forecastCycle: ReturnType<typeof selectForecastCycle>;
+  currentMapView: RootState['forecast']['currentMapView'];
+  saveCycle: UseCloudCyclesResult['saveCycle'];
+  clearCurrent: UseCloudCyclesResult['clearCurrent'];
+  dispatch: ShortcutDispatch;
+}): Promise<boolean> => {
+  try {
+    const success = await saveCycle(buildRolloverSaveLabel(forecastCycle.cycleDate), forecastCycle.cycleDate, countForecastMetrics(forecastCycle), serializeForecast(forecastCycle, currentMapView), { saveAsNew: true });
+    if (!success) return false;
+    clearCurrent();
+    dispatch(resetForecasts());
+    return true;
+  } catch { return false; }
+};
+
 /** Watches for a local calendar-day rollover and offers to save the previous session before starting a new one. */
-const useDayRolloverPrompt = ({
-  restoreComplete,
-  dispatch,
-  addToast,
-  forecastCycle,
-  isSaved,
-}: {
+const useDayRolloverPrompt = ({ restoreComplete, restoredSession, dispatch, addToast, forecastCycle, currentMapView, isSaved, userId, canSaveToCloud, saveCycle, clearCurrent }: {
   restoreComplete: boolean;
+  restoredSession: boolean;
   dispatch: ShortcutDispatch;
   addToast: AddToastFn;
   forecastCycle: ReturnType<typeof selectForecastCycle>;
+  currentMapView: RootState['forecast']['currentMapView'];
   isSaved: boolean;
+  userId?: string;
+  canSaveToCloud: boolean;
+  saveCycle: UseCloudCyclesResult['saveCycle'];
+  clearCurrent: UseCloudCyclesResult['clearCurrent'];
 }) => {
   const [promptState, setPromptState] = useState<DayRolloverPromptState | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
   const forecastCycleRef = useRef(forecastCycle);
   const isSavedRef = useRef(isSaved);
+  const restoredSessionRef = useRef(restoredSession);
   const promptStateRef = useRef(promptState);
-
-  useEffect(() => {
-    forecastCycleRef.current = forecastCycle;
-  }, [forecastCycle]);
-
-  useEffect(() => {
-    isSavedRef.current = isSaved;
-  }, [isSaved]);
-
-  useEffect(() => {
-    promptStateRef.current = promptState;
-  }, [promptState]);
+  const previousUserIdRef = useRef(userId);
+  useEffect(() => { if (previousUserIdRef.current !== userId) { previousUserIdRef.current = userId; setPromptState(null); setActionError(null); } }, [userId]);
+  useEffect(() => { forecastCycleRef.current = forecastCycle; }, [forecastCycle]);
+  useEffect(() => { isSavedRef.current = isSaved; }, [isSaved]);
+  useEffect(() => { restoredSessionRef.current = restoredSession; }, [restoredSession]);
+  useEffect(() => { promptStateRef.current = promptState; }, [promptState]);
 
   const detectDayRollover = useCallback(() => {
-    const { today, lastActiveDay, alreadyPromptedToday } = getDayRolloverSnapshot();
-    const nextPromptState = getDayRolloverPromptState({
-      restoreComplete,
-      lastActiveDay,
-      today,
-      alreadyPromptedToday,
-      promptOpen: Boolean(promptStateRef.current),
-      forecastCycle: forecastCycleRef.current,
-      isSaved: isSavedRef.current,
-    });
-
+    const { today, lastActiveDay, alreadyPromptedToday, pendingPrompt } = getDayRolloverSnapshot(userId);
+    const nextPromptState = getDayRolloverPromptState({ restoreComplete, lastActiveDay, today, alreadyPromptedToday, pendingPrompt, promptOpen: Boolean(promptStateRef.current), forecastCycle: forecastCycleRef.current, isSaved: isSavedRef.current && !restoredSessionRef.current });
     if (!nextPromptState) {
+      if (restoreComplete) writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId), today);
       return;
     }
-
-    writeStoredDayValue(DAY_ROLLOVER_PROMPTED_KEY, today);
+    writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PROMPTED_KEY, userId), today);
+    writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_LAST_ACTIVE_KEY, userId), today);
+    writeStoredRolloverPrompt(nextPromptState, userId);
+    setActionError(null);
     setPromptState(nextPromptState);
-  }, [restoreComplete]);
+  }, [restoreComplete, restoredSession, userId]);
 
   useEffect(() => {
     detectDayRollover();
-
-    /** Re-checks the local day when the tab regains focus so midnight rollovers are caught quickly. */
-    const handleVisibilityChange = () => {
-      if (!document.hidden) {
-        detectDayRollover();
-      }
-    };
-
+    const handleVisibilityChange = () => { if (!document.hidden) detectDayRollover(); };
     const intervalId = window.setInterval(detectDayRollover, DAY_ROLLOVER_CHECK_INTERVAL_MS);
     document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      window.clearInterval(intervalId);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
+    return () => { window.clearInterval(intervalId); document.removeEventListener('visibilitychange', handleVisibilityChange); };
   }, [detectDayRollover]);
 
-  useEffect(() => {
-    if (!restoreComplete) {
-      return;
-    }
-
-    writeStoredDayValue(DAY_ROLLOVER_LAST_ACTIVE_KEY, getLocalCalendarDate());
-  }, [restoreComplete]);
-
-  const handleKeepCurrentSession = useCallback(() => {
-    setPromptState(null);
-  }, []);
-
+  const completeRollover = useCallback(() => { clearStoredRolloverPrompt(userId); setPromptState(null); setActionError(null); }, [userId]);
+  const handleKeepCurrentSession = useCallback(() => completeRollover(), [completeRollover]);
   const handleSaveAndStartNewDay = useCallback(() => {
-    const didSaveSession = runDayRolloverSaveAction({
-      forecastCycle,
-      isSaved,
-      dispatch,
-    });
+    clearCurrent();
+    const didSaveSession = runDayRolloverSaveAction({ forecastCycle, isSaved: isSaved && !restoredSession, dispatch });
+    addToast(didSaveSession ? 'Saved the previous session to Cycle History and started a new forecast for today.' : 'Started a new forecast for today.', 'success');
+    completeRollover();
+  }, [addToast, clearCurrent, completeRollover, dispatch, forecastCycle, isSaved, restoredSession]);
+  const handleDownloadAndStartNewDay = useCallback(() => {
+    if (!runDayRolloverDownloadAction({ forecastCycle, mapView: currentMapView, dispatch, clearCurrent })) { setActionError('Unable to download this session. Your current forecast is still open.'); return; }
+    addToast('Forecast downloaded and a new day started.', 'success');
+    completeRollover();
+  }, [addToast, clearCurrent, completeRollover, currentMapView, dispatch, forecastCycle]);
+  const handleSaveToCloudAndStartNewDay = useCallback(async () => {
+    setIsBusy(true); setActionError(null);
+    try {
+      const success = await runDayRolloverCloudSaveAction({ forecastCycle, currentMapView, saveCycle, clearCurrent, dispatch });
+      if (!success) { setActionError('Unable to save this session to the cloud. Your current forecast is still open.'); return; }
+      addToast('Session saved to the cloud and a new day started.', 'success');
+      completeRollover();
+    } finally { setIsBusy(false); }
+  }, [addToast, clearCurrent, completeRollover, currentMapView, dispatch, forecastCycle, saveCycle]);
+  const handleReplaceWithoutSaving = useCallback(() => { clearCurrent(); dispatch(resetForecasts()); addToast('Previous session replaced and a new forecast started.', 'success'); completeRollover(); }, [addToast, clearCurrent, completeRollover, dispatch]);
 
-    addToast(
-      didSaveSession
-        ? 'Saved the previous session to Cycle History and started a new forecast for today.'
-        : 'Started a new forecast for today.',
-      'success'
-    );
-    setPromptState(null);
-  }, [addToast, dispatch, forecastCycle, isSaved]);
-
-  return {
-    promptState,
-    handleKeepCurrentSession,
-    handleSaveAndStartNewDay,
-  };
+  return { promptState, canSaveToCloud, isBusy, error: actionError, handleKeepCurrentSession, handleDownloadAndStartNewDay, handleSaveToCloudAndStartNewDay, handleReplaceWithoutSaving };
 };
 
 /** Composes save, load, and file-input-change callbacks into a single hook return. */
@@ -1181,15 +1270,13 @@ const useForecastPageWorkspace = ({
   const { user } = useAuth();
   const { premiumActive, effectiveSource } = useEntitlement();
   const cloudCycles = useCloudCycles();
-  const { currentCloud, saveCycle, markAsCurrent } = cloudCycles;
+  const { currentCloud, saveCycle, markAsCurrent, clearCurrent } = cloudCycles;
   const cloudSync = useCloudSync(cloudCycles);
   const { markCurrentStateSynced } = cloudSync;
   const isExpiredPremium = !premiumActive && effectiveSource === 'stripe';
 
   useAutoCategorical();
   const autoTstm = useAutoTstm();
-  useAutoSave();
-  useCycleHistoryPersistence();
   useOutlookExposureSync(dispatch);
 
   const { handleCloudCycleLoaded, handleSaveToCloud } = useCloudForecastActions({
@@ -1203,10 +1290,10 @@ const useForecastPageWorkspace = ({
     workflowMetadata,
   });
 
-  const restoreComplete = useSessionRestore(dispatch, addToast, {
+  const { restoreComplete, restoredSession } = useSessionRestore(dispatch, addToast, {
     forecastCycle,
     onCloudCycleLoaded: handleCloudCycleLoaded,
-  });
+  }, user?.uid);
   useUnsavedChangesWarning(isSaved);
 
   const { handleSave, handleLoad } = useForecastFileActions(
@@ -1233,10 +1320,16 @@ const useForecastPageWorkspace = ({
 
   const dayRolloverPrompt = useDayRolloverPrompt({
     restoreComplete,
+    restoredSession,
     dispatch,
     addToast,
     forecastCycle,
+    currentMapView,
     isSaved,
+    userId: user?.uid,
+    canSaveToCloud: premiumActive,
+    saveCycle,
+    clearCurrent,
   });
 
   const workspaceController = useForecastWorkspaceController({
@@ -1308,8 +1401,13 @@ export const ForecastPage: React.FC = () => {
       <ForecastWorkspaceModals controller={workspaceController} />
       <DayRolloverDialog
         promptState={dayRolloverPrompt.promptState}
+        canSaveToCloud={dayRolloverPrompt.canSaveToCloud}
+        isBusy={dayRolloverPrompt.isBusy}
+        error={dayRolloverPrompt.error}
         onKeepCurrentSession={dayRolloverPrompt.handleKeepCurrentSession}
-        onSaveAndStartNewDay={dayRolloverPrompt.handleSaveAndStartNewDay}
+        onDownloadAndStartNewDay={dayRolloverPrompt.handleDownloadAndStartNewDay}
+        onSaveToCloudAndStartNewDay={dayRolloverPrompt.handleSaveToCloudAndStartNewDay}
+        onReplaceWithoutSaving={dayRolloverPrompt.handleReplaceWithoutSaving}
       />
     </div>
   );

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -37,7 +37,7 @@ import {
   getFirstExposedOutlookType,
   shouldActivateEmergencyMode,
 } from '../config/productExposureSelectors';
-import { getAutoSaveStorageKey, migrateLegacyAutoSave } from '../hooks/useAutoSave';
+import { getAutoSaveStorageKey, migrateLegacyAutoSave, selectPreferredAutoSaveValue } from '../hooks/useAutoSave';
 import {
   DAY_ROLLOVER_CHECK_INTERVAL_MS,
   DAY_ROLLOVER_LAST_ACTIVE_KEY,
@@ -742,35 +742,11 @@ const shouldSkipLocalRestore = (
   || cycleHasDiscussionContent(forecastCycle)
   || hasUnpublishedDiscussionDrafts(discussionDraftsByScope);
 
-/** Returns the legacy auto-save only when a signed-in scope has no snapshot. */
-const readLegacyAutoSave = (userId: string | null | undefined, scopedValue: string | null): string | null => {
-  if (!userId || scopedValue !== null) return null;
-  return localStorage.getItem('forecastData');
-};
-
-/** Returns true when a legacy auto-save should be copied into the signed-in scope. */
-const shouldMigrateLegacyAutoSave = (
-  userId: string | null | undefined,
-  scopedValue: string | null,
-  legacyValue: string | null,
-): boolean => Boolean(userId) && scopedValue === null && legacyValue !== null;
-
 /** Copies a legacy auto-save into the signed-in scope and removes the unscoped copy. */
 const copyLegacyAutoSaveToScopedStorage = (scopedKey: string, legacyValue: string | null): void => {
   if (legacyValue === null) return;
   localStorage.setItem(scopedKey, legacyValue);
   localStorage.removeItem('forecastData');
-};
-
-/** Migrates a legacy auto-save into the signed-in scope after it is selected. */
-const migrateLegacyAutoSaveIfNeeded = (
-  userId: string | null | undefined,
-  scopedKey: string,
-  scopedValue: string | null,
-  legacyValue: string | null,
-): void => {
-  if (!shouldMigrateLegacyAutoSave(userId, scopedValue, legacyValue)) return;
-  copyLegacyAutoSaveToScopedStorage(scopedKey, legacyValue);
 };
 
 /** Restores the last local auto-saved forecast when no cloud-loaded payload is pending. */
@@ -787,11 +763,14 @@ const restoreLocalSession = (
 
   const scopedKey = getAutoSaveStorageKey(userId);
   const scopedValue = localStorage.getItem(scopedKey);
-  const legacyValue = readLegacyAutoSave(userId, scopedValue);
-  const data = parseStoredForecastPayload(scopedValue ?? legacyValue);
+  const legacyValue = userId ? localStorage.getItem('forecastData') : null;
+  const storedValue = userId ? selectPreferredAutoSaveValue(scopedValue, legacyValue) : scopedValue;
+  const data = parseStoredForecastPayload(storedValue);
   if (!data) return false;
 
-  migrateLegacyAutoSaveIfNeeded(userId, scopedKey, scopedValue, legacyValue);
+  if (userId && legacyValue !== null && storedValue === legacyValue) {
+    copyLegacyAutoSaveToScopedStorage(scopedKey, legacyValue);
+  }
   restoreStoredForecastPayload(data, dispatch, true);
   addToast('Session restored from auto-save.', 'success');
   return true;

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -203,6 +203,11 @@ describe('cycleHistoryPersistence', () => {
       getState: () => state,
     };
 
+    const unsubscribe = mod.setupCycleHistoryListener(store as never);
+    expect(listeners).toHaveLength(1);
+    unsubscribe();
+    expect(listeners).toHaveLength(0);
+
     mod.setupCycleHistoryListener(store as never);
 
     state = { forecast: { savedCycles: [{ id: 'a', timestamp: 't', cycleDate: 'd', forecastCycle: {}, stats: {} }] } };

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -221,6 +221,33 @@ describe('cycleHistoryPersistence', () => {
     spy.mockRestore();
   });
 
+  test('account rollover cleanup prevents the old listener from persisting the hydration clear', async () => {
+    const mod = await import('./cycleHistoryPersistence');
+    const oldCycle: SavedCycle = { id: 'old', timestamp: 't', cycleDate: 'd', forecastCycle: {}, stats: {} };
+    const listeners: Array<() => void> = [];
+    let state = { forecast: { savedCycles: [oldCycle] } };
+    const store: StoreLike = {
+      subscribe: (cb: () => void) => {
+        listeners.push(cb);
+        return () => {
+          const index = listeners.indexOf(cb);
+          if (index >= 0) listeners.splice(index, 1);
+        };
+      },
+      getState: () => state,
+    };
+
+    const oldScopeKey = mod.getCycleHistoryStorageKey('old-user');
+    const existingHistory = JSON.stringify([{ id: 'persisted-old-history' }]);
+    localStorage.setItem(oldScopeKey, existingHistory);
+    const oldScopeCleanup = mod.setupCycleHistoryListener(store as never, 'old-user');
+    state = { forecast: { savedCycles: [] } };
+    oldScopeCleanup();
+    listeners.forEach((listener) => listener());
+
+    expect(localStorage.getItem(oldScopeKey)).toBe(existingHistory);
+  });
+
   test('loadCycleHistoryFromStorage returns empty on JSON parse error', async () => {
     localStorage.setItem('gfc-cycle-history', 'not-json');
     const mod = await import('./cycleHistoryPersistence');

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -134,8 +134,24 @@ describe('cycleHistoryPersistence', () => {
 
     localStorage.setItem('gfc-cycle-history', JSON.stringify([{ id: 'new-legacy' }]));
     mod.migrateLegacyCycleHistory('user-1');
-    expect(localStorage.getItem('gfc-cycle-history')).toBe(JSON.stringify([{ id: 'new-legacy' }]));
-    expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify([{ id: 'legacy' }]));
+    expect(localStorage.getItem('gfc-cycle-history')).toBeNull();
+    expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify([{ id: 'new-legacy' }]));
+  });
+
+  test('falls back to usable legacy history when signed-in scope is empty or unusable', async () => {
+    jest.doMock('./outlookMapCoercion', () => ({ normalizeForecastCycle: (cycle: unknown) => cycle }));
+    const mod = await import('./cycleHistoryPersistence');
+    const legacy = [{ id: 'legacy', timestamp: 't1', cycleDate: 'd1', forecastCycle: {} }];
+    localStorage.setItem('gfc-cycle-history:user-user-1', JSON.stringify({ invalid: true }));
+    localStorage.setItem('gfc-cycle-history', JSON.stringify(legacy));
+
+    mod.migrateLegacyCycleHistory('user-1');
+    const loaded = mod.loadCycleHistoryFromStorage('user-1');
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe('legacy');
+    expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify(legacy));
+    expect(localStorage.getItem('gfc-cycle-history')).toBeNull();
   });
 
   test('loadCycleHistoryFromStorage returns empty on invalid stored data', async () => {

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -123,6 +123,21 @@ describe('cycleHistoryPersistence', () => {
     expect(loaded[0].stats).toEqual({});
   });
 
+  test('migrates legacy cycle history into a signed-in scope without overwriting account history', async () => {
+    const mod = await import('./cycleHistoryPersistence');
+    localStorage.setItem('gfc-cycle-history', JSON.stringify([{ id: 'legacy' }]));
+
+    mod.migrateLegacyCycleHistory('user-1');
+
+    expect(localStorage.getItem('gfc-cycle-history')).toBeNull();
+    expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify([{ id: 'legacy' }]));
+
+    localStorage.setItem('gfc-cycle-history', JSON.stringify([{ id: 'new-legacy' }]));
+    mod.migrateLegacyCycleHistory('user-1');
+    expect(localStorage.getItem('gfc-cycle-history')).toBe(JSON.stringify([{ id: 'new-legacy' }]));
+    expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify([{ id: 'legacy' }]));
+  });
+
   test('loadCycleHistoryFromStorage returns empty on invalid stored data', async () => {
     localStorage.setItem('gfc-cycle-history', JSON.stringify({ not: 'an array' }));
     const mod = await import('./cycleHistoryPersistence');

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -138,6 +138,21 @@ describe('cycleHistoryPersistence', () => {
     expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify([{ id: 'new-legacy' }]));
   });
 
+  test('does not import legacy cycle history into a different signed-in account', async () => {
+    const mod = await import('./cycleHistoryPersistence');
+    localStorage.setItem('gfc-cycle-history', JSON.stringify([{ id: 'legacy' }]));
+
+    mod.migrateLegacyCycleHistory('user-1');
+    expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify([{ id: 'legacy' }]));
+    expect(localStorage.getItem('gfc-cycle-history-claim')).toBe('user-1');
+
+    localStorage.removeItem('gfc-cycle-history:user-user-2');
+    mod.migrateLegacyCycleHistory('user-2');
+    expect(localStorage.getItem('gfc-cycle-history:user-user-2')).toBeNull();
+    expect(mod.loadCycleHistoryFromStorage('user-2')).toEqual([]);
+    expect(localStorage.getItem('gfc-cycle-history')).toBe(JSON.stringify([{ id: 'legacy' }]));
+  });
+
   test('falls back to usable legacy history when signed-in scope is empty or unusable', async () => {
     jest.doMock('./outlookMapCoercion', () => ({ normalizeForecastCycle: (cycle: unknown) => cycle }));
     const mod = await import('./cycleHistoryPersistence');

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -248,6 +248,44 @@ describe('cycleHistoryPersistence', () => {
     expect(localStorage.getItem(oldScopeKey)).toBe(existingHistory);
   });
 
+  test('account switch preserves non-empty target history when listener starts after hydration', async () => {
+    const mod = await import('./cycleHistoryPersistence');
+    const oldCycle: SavedCycle = { id: 'old', timestamp: 't', cycleDate: 'd', forecastCycle: {}, stats: {} };
+    const targetCycle: SavedCycle = { id: 'target', timestamp: 't2', cycleDate: 'd2', forecastCycle: {}, stats: {} };
+    const listeners: Array<() => void> = [];
+    let state = { forecast: { savedCycles: [oldCycle] } };
+    const store: StoreLike = {
+      subscribe: (cb: () => void) => {
+        listeners.push(cb);
+        return () => {
+          const index = listeners.indexOf(cb);
+          if (index >= 0) listeners.splice(index, 1);
+        };
+      },
+      getState: () => state,
+    };
+
+    const targetKey = mod.getCycleHistoryStorageKey('target-user');
+    const targetHistory = JSON.stringify([{
+      id: targetCycle.id,
+      timestamp: targetCycle.timestamp,
+      cycleDate: targetCycle.cycleDate,
+      forecastCycle: targetCycle.forecastCycle,
+      stats: targetCycle.stats,
+    }]);
+    localStorage.setItem(targetKey, targetHistory);
+
+    const oldCleanup = mod.setupCycleHistoryListener(store as never, 'old-user');
+    oldCleanup();
+    state = { forecast: { savedCycles: [] } };
+    listeners.forEach((listener) => listener());
+
+    // The new listener is attached only after account-scoped history is hydrated.
+    state = { forecast: { savedCycles: [targetCycle] } };
+    mod.setupCycleHistoryListener(store as never, 'target-user');
+    expect(localStorage.getItem(targetKey)).toBe(targetHistory);
+  });
+
   test('loadCycleHistoryFromStorage returns empty on JSON parse error', async () => {
     localStorage.setItem('gfc-cycle-history', 'not-json');
     const mod = await import('./cycleHistoryPersistence');

--- a/src/utils/cycleHistoryPersistence.extra.test.ts
+++ b/src/utils/cycleHistoryPersistence.extra.test.ts
@@ -129,12 +129,12 @@ describe('cycleHistoryPersistence', () => {
 
     mod.migrateLegacyCycleHistory('user-1');
 
-    expect(localStorage.getItem('gfc-cycle-history')).toBeNull();
+    expect(localStorage.getItem('gfc-cycle-history')).toBe(JSON.stringify([{ id: 'legacy' }]));
     expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify([{ id: 'legacy' }]));
 
     localStorage.setItem('gfc-cycle-history', JSON.stringify([{ id: 'new-legacy' }]));
     mod.migrateLegacyCycleHistory('user-1');
-    expect(localStorage.getItem('gfc-cycle-history')).toBeNull();
+    expect(localStorage.getItem('gfc-cycle-history')).toBe(JSON.stringify([{ id: 'new-legacy' }]));
     expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify([{ id: 'new-legacy' }]));
   });
 
@@ -151,7 +151,7 @@ describe('cycleHistoryPersistence', () => {
     expect(loaded).toHaveLength(1);
     expect(loaded[0].id).toBe('legacy');
     expect(localStorage.getItem('gfc-cycle-history:user-user-1')).toBe(JSON.stringify(legacy));
-    expect(localStorage.getItem('gfc-cycle-history')).toBeNull();
+    expect(localStorage.getItem('gfc-cycle-history')).toBe(JSON.stringify(legacy));
   });
 
   test('loadCycleHistoryFromStorage returns empty on invalid stored data', async () => {

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -72,9 +72,7 @@ const fromLegacySavedCycle = (cycle: {
   };
 };
 
-/**
- * Save cycle history to localStorage
- */
+/** Returns the storage key for anonymous or account-scoped cycle history. */
 export const getCycleHistoryStorageKey = (userId?: string | null): string =>
   userId ? getScopedStorageKey(CYCLE_HISTORY_KEY, getStorageScope(userId)) : CYCLE_HISTORY_KEY;
 

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -124,6 +124,7 @@ export const migrateLegacyCycleHistory = (userId?: string | null): void => {
   }
 };
 
+/** Persists saved cycles in the anonymous or account-scoped localStorage key. */
 export const saveCycleHistoryToStorage = (cycles: SavedCycle[], userId?: string | null): void => {
   try {
     const serialized = JSON.stringify(cycles.map(toPersistedSavedCycle));
@@ -139,16 +140,28 @@ export const saveCycleHistoryToStorage = (cycles: SavedCycle[], userId?: string 
 export const loadCycleHistoryFromStorage = (userId?: string | null): SavedCycle[] => {
   try {
     const scopedKey = getCycleHistoryStorageKey(userId);
-    let serialized = localStorage.getItem(scopedKey);
-
-    if (!serialized && !userId) {
-      serialized = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
-      if (serialized) {
-        localStorage.setItem(scopedKey, serialized);
+    const scopedSerialized = localStorage.getItem(scopedKey);
+    const scopedCycles = parseStoredCycleHistory(scopedSerialized);
+    if (scopedCycles.length > 0 || !userId) {
+      if (!userId && scopedSerialized === null) {
+        const legacySerialized = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
+        if (legacySerialized) {
+          localStorage.setItem(scopedKey, legacySerialized);
+          return parseStoredCycleHistory(legacySerialized);
+        }
       }
+      return scopedCycles;
     }
 
-    return parseStoredCycleHistory(serialized);
+    // During rollout, signed-in users may still have only the pre-scope history.
+    const legacySerialized = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
+    const legacyCycles = parseStoredCycleHistory(legacySerialized);
+    if (legacyCycles.length > 0) {
+      localStorage.setItem(scopedKey, legacySerialized as string);
+      localStorage.removeItem(LEGACY_CYCLE_HISTORY_KEY);
+      return legacyCycles;
+    }
+    return scopedCycles;
   } catch {
     return [];
   }

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -78,18 +78,46 @@ const fromLegacySavedCycle = (cycle: {
 export const getCycleHistoryStorageKey = (userId?: string | null): string =>
   userId ? getScopedStorageKey(CYCLE_HISTORY_KEY, getStorageScope(userId)) : CYCLE_HISTORY_KEY;
 
-/** Moves anonymous cycle history into the signed-in account scope once, without overwriting account data. */
+/** Parses one stored history value, dropping malformed entries without throwing. */
+const parseStoredCycleHistory = (serialized: string | null): SavedCycle[] => {
+  if (!serialized) return [];
+
+  try {
+    const parsed = JSON.parse(serialized);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .map((cycle) => {
+        if (!cycle || typeof cycle !== 'object') return null;
+
+        try {
+          if ('forecastData' in cycle) return fromPersistedSavedCycle(cycle as PersistedSavedCycle);
+          if ('forecastCycle' in cycle) return fromLegacySavedCycle(cycle as SavedCycle);
+          return null;
+        } catch {
+          return null;
+        }
+      })
+      .filter((cycle): cycle is SavedCycle => cycle !== null);
+  } catch {
+    return [];
+  }
+};
+
+/** Moves usable anonymous cycle history into the signed-in account scope when its current scope is empty or unusable. */
 export const migrateLegacyCycleHistory = (userId?: string | null): void => {
   if (!userId) return;
 
   try {
     const scopedKey = getCycleHistoryStorageKey(userId);
-    if (localStorage.getItem(scopedKey) === null) {
-      const legacyValue = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
-      if (legacyValue !== null) {
-        localStorage.setItem(scopedKey, legacyValue);
-        localStorage.removeItem(LEGACY_CYCLE_HISTORY_KEY);
-      }
+    const scopedValue = localStorage.getItem(scopedKey);
+    const legacyValue = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
+    if (legacyValue === null) return;
+
+    const scopedCycles = parseStoredCycleHistory(scopedValue);
+    if (scopedValue === null || scopedCycles.length === 0) {
+      localStorage.setItem(scopedKey, legacyValue);
+      localStorage.removeItem(LEGACY_CYCLE_HISTORY_KEY);
     }
   } catch {
     // Ignore storage failures so sign-in never disrupts editing.
@@ -120,34 +148,7 @@ export const loadCycleHistoryFromStorage = (userId?: string | null): SavedCycle[
       }
     }
 
-    if (!serialized) return [];
-    
-    const parsed = JSON.parse(serialized);
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-
-    return parsed
-      .map((cycle) => {
-        if (!cycle || typeof cycle !== 'object') {
-          return null;
-        }
-
-        try {
-          if ('forecastData' in cycle) {
-            return fromPersistedSavedCycle(cycle as PersistedSavedCycle);
-          }
-
-          if ('forecastCycle' in cycle) {
-            return fromLegacySavedCycle(cycle as SavedCycle);
-          }
-
-          return null;
-        } catch {
-          return null;
-        }
-      })
-      .filter((cycle): cycle is SavedCycle => cycle !== null);
+    return parseStoredCycleHistory(serialized);
   } catch {
     return [];
   }

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -78,6 +78,24 @@ const fromLegacySavedCycle = (cycle: {
 export const getCycleHistoryStorageKey = (userId?: string | null): string =>
   userId ? getScopedStorageKey(CYCLE_HISTORY_KEY, getStorageScope(userId)) : CYCLE_HISTORY_KEY;
 
+/** Moves anonymous cycle history into the signed-in account scope once, without overwriting account data. */
+export const migrateLegacyCycleHistory = (userId?: string | null): void => {
+  if (!userId) return;
+
+  try {
+    const scopedKey = getCycleHistoryStorageKey(userId);
+    if (localStorage.getItem(scopedKey) === null) {
+      const legacyValue = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
+      if (legacyValue !== null) {
+        localStorage.setItem(scopedKey, legacyValue);
+        localStorage.removeItem(LEGACY_CYCLE_HISTORY_KEY);
+      }
+    }
+  } catch {
+    // Ignore storage failures so sign-in never disrupts editing.
+  }
+};
+
 export const saveCycleHistoryToStorage = (cycles: SavedCycle[], userId?: string | null): void => {
   try {
     const serialized = JSON.stringify(cycles.map(toPersistedSavedCycle));
@@ -144,6 +162,7 @@ export const useCycleHistoryPersistence = (userId?: string | null): void => {
   useEffect(() => {
     // Clear the previous account's history before hydrating the new scope.
     dispatch(loadCycleHistory([]));
+    migrateLegacyCycleHistory(userId);
     const savedCycles = loadCycleHistoryFromStorage(userId);
     if (savedCycles.length > 0) {
       dispatch(loadCycleHistory(savedCycles));

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -8,8 +8,10 @@ import { deserializeForecast, serializeForecast } from './fileUtils';
 import { countForecastMetrics } from './forecastMetrics';
 import { normalizeForecastCycle } from './outlookMapCoercion';
 import type { ForecastCycle, GFCForecastSaveData, CycleMetadata } from '../types/outlooks';
+import { getScopedStorageKey, getStorageScope } from './storageScope';
 
 const CYCLE_HISTORY_KEY = 'gfc-cycle-history';
+const LEGACY_CYCLE_HISTORY_KEY = CYCLE_HISTORY_KEY;
 const STORAGE_MAP_VIEW = { center: [0, 0] as [number, number], zoom: 0 };
 
 interface PersistedSavedCycle {
@@ -73,10 +75,13 @@ const fromLegacySavedCycle = (cycle: {
 /**
  * Save cycle history to localStorage
  */
-export const saveCycleHistoryToStorage = (cycles: SavedCycle[]): void => {
+export const getCycleHistoryStorageKey = (userId?: string | null): string =>
+  userId ? getScopedStorageKey(CYCLE_HISTORY_KEY, getStorageScope(userId)) : CYCLE_HISTORY_KEY;
+
+export const saveCycleHistoryToStorage = (cycles: SavedCycle[], userId?: string | null): void => {
   try {
     const serialized = JSON.stringify(cycles.map(toPersistedSavedCycle));
-    localStorage.setItem(CYCLE_HISTORY_KEY, serialized);
+    localStorage.setItem(getCycleHistoryStorageKey(userId), serialized);
   } catch {
     // Silently ignore localStorage write failures
   }
@@ -85,9 +90,18 @@ export const saveCycleHistoryToStorage = (cycles: SavedCycle[]): void => {
 /**
  * Load cycle history from localStorage
  */
-export const loadCycleHistoryFromStorage = (): SavedCycle[] => {
+export const loadCycleHistoryFromStorage = (userId?: string | null): SavedCycle[] => {
   try {
-    const serialized = localStorage.getItem(CYCLE_HISTORY_KEY);
+    const scopedKey = getCycleHistoryStorageKey(userId);
+    let serialized = localStorage.getItem(scopedKey);
+
+    if (!serialized && !userId) {
+      serialized = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
+      if (serialized) {
+        localStorage.setItem(scopedKey, serialized);
+      }
+    }
+
     if (!serialized) return [];
     
     const parsed = JSON.parse(serialized);
@@ -124,32 +138,36 @@ export const loadCycleHistoryFromStorage = (): SavedCycle[] => {
 /**
  * Hook to hydrate cycle history on app startup
  */
-export const useCycleHistoryPersistence = (): void => {
+export const useCycleHistoryPersistence = (userId?: string | null): void => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    // Load cycle history from localStorage on mount
-    const savedCycles = loadCycleHistoryFromStorage();
+    // Clear the previous account's history before hydrating the new scope.
+    dispatch(loadCycleHistory([]));
+    const savedCycles = loadCycleHistoryFromStorage(userId);
     if (savedCycles.length > 0) {
       dispatch(loadCycleHistory(savedCycles));
     }
-  }, [dispatch]);
+  }, [dispatch, userId]);
 };
 
 /**
  * Subscribe to Redux store changes and persist cycle history
  * Call this from the root component after store initialization
  */
-export const setupCycleHistoryListener = (store: Store<RootState>): void => {
-  let previousCycles: SavedCycle[] = [];
+export const setupCycleHistoryListener = (store: Store<RootState>, userId?: string | null): (() => void) => {
+  let previousCycles: SavedCycle[] = store.getState().forecast.savedCycles;
 
-  store.subscribe(() => {
+  return store.subscribe(() => {
     const state = store.getState();
     const currentCycles = state.forecast.savedCycles;
 
-    // Only save if cycles array has changed
     if (currentCycles !== previousCycles) {
-      saveCycleHistoryToStorage(currentCycles);
+      if (userId) {
+        saveCycleHistoryToStorage(currentCycles, userId);
+      } else {
+        saveCycleHistoryToStorage(currentCycles);
+      }
       previousCycles = currentCycles;
     }
   });

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -115,7 +115,6 @@ export const migrateLegacyCycleHistory = (userId?: string | null): void => {
     const scopedCycles = parseStoredCycleHistory(scopedValue);
     if (scopedValue === null || scopedCycles.length === 0) {
       localStorage.setItem(scopedKey, legacyValue);
-      localStorage.removeItem(LEGACY_CYCLE_HISTORY_KEY);
     }
   } catch {
     // Ignore storage failures so sign-in never disrupts editing.

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -12,6 +12,7 @@ import { getScopedStorageKey, getStorageScope } from './storageScope';
 
 const CYCLE_HISTORY_KEY = 'gfc-cycle-history';
 const LEGACY_CYCLE_HISTORY_KEY = CYCLE_HISTORY_KEY;
+const CYCLE_HISTORY_CLAIM_KEY = 'gfc-cycle-history-claim';
 const STORAGE_MAP_VIEW = { center: [0, 0] as [number, number], zoom: 0 };
 
 interface PersistedSavedCycle {
@@ -102,20 +103,42 @@ const parseStoredCycleHistory = (serialized: string | null): SavedCycle[] => {
   }
 };
 
+/** Returns the account that claimed the legacy cycle-history copy, if any. */
+const readLegacyCycleHistoryClaim = (): string | null => localStorage.getItem(CYCLE_HISTORY_CLAIM_KEY);
+
+/** Records which account claimed the legacy cycle-history copy. */
+const writeLegacyCycleHistoryClaim = (userId: string): void => {
+  localStorage.setItem(CYCLE_HISTORY_CLAIM_KEY, userId);
+};
+
+/** Returns true when the signed-in account may import the unscoped legacy history. */
+const canImportLegacyCycleHistory = (userId: string): boolean => {
+  const claim = readLegacyCycleHistoryClaim();
+  return claim === null || claim === userId;
+};
+
+/** Copies legacy cycle history into an account scope when it is empty and claimable. */
+const importLegacyCycleHistoryToScope = (userId: string, legacyValue: string): void => {
+  if (!canImportLegacyCycleHistory(userId)) return;
+
+  const scopedKey = getCycleHistoryStorageKey(userId);
+  const scopedValue = localStorage.getItem(scopedKey);
+  const scopedCycles = parseStoredCycleHistory(scopedValue);
+  if (scopedValue !== null && scopedCycles.length > 0) return;
+
+  localStorage.setItem(scopedKey, legacyValue);
+  writeLegacyCycleHistoryClaim(userId);
+};
+
 /** Moves usable anonymous cycle history into the signed-in account scope when its current scope is empty or unusable. */
 export const migrateLegacyCycleHistory = (userId?: string | null): void => {
   if (!userId) return;
 
   try {
-    const scopedKey = getCycleHistoryStorageKey(userId);
-    const scopedValue = localStorage.getItem(scopedKey);
     const legacyValue = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
     if (legacyValue === null) return;
 
-    const scopedCycles = parseStoredCycleHistory(scopedValue);
-    if (scopedValue === null || scopedCycles.length === 0) {
-      localStorage.setItem(scopedKey, legacyValue);
-    }
+    importLegacyCycleHistoryToScope(userId, legacyValue);
   } catch {
     // Ignore storage failures so sign-in never disrupts editing.
   }
@@ -153,8 +176,8 @@ export const loadCycleHistoryFromStorage = (userId?: string | null): SavedCycle[
     // During rollout, signed-in users may still have only the pre-scope history.
     const legacySerialized = localStorage.getItem(LEGACY_CYCLE_HISTORY_KEY);
     const legacyCycles = parseStoredCycleHistory(legacySerialized);
-    if (legacyCycles.length > 0) {
-      localStorage.setItem(scopedKey, legacySerialized as string);
+    if (legacyCycles.length > 0 && canImportLegacyCycleHistory(userId)) {
+      importLegacyCycleHistoryToScope(userId, legacySerialized as string);
       return legacyCycles;
     }
     return scopedCycles;

--- a/src/utils/cycleHistoryPersistence.ts
+++ b/src/utils/cycleHistoryPersistence.ts
@@ -155,7 +155,6 @@ export const loadCycleHistoryFromStorage = (userId?: string | null): SavedCycle[
     const legacyCycles = parseStoredCycleHistory(legacySerialized);
     if (legacyCycles.length > 0) {
       localStorage.setItem(scopedKey, legacySerialized as string);
-      localStorage.removeItem(LEGACY_CYCLE_HISTORY_KEY);
       return legacyCycles;
     }
     return scopedCycles;

--- a/src/utils/dayRolloverStorage.ts
+++ b/src/utils/dayRolloverStorage.ts
@@ -1,0 +1,65 @@
+import { getStorageScope, getScopedStorageKey } from './storageScope';
+
+export interface DayRolloverPromptState {
+  previousDay: string;
+  currentDay: string;
+}
+
+export const DAY_ROLLOVER_LAST_ACTIVE_KEY = 'gfc-last-active-local-day';
+export const DAY_ROLLOVER_PROMPTED_KEY = 'gfc-day-rollover-prompt-day';
+export const DAY_ROLLOVER_PENDING_KEY = 'gfc-day-rollover-pending';
+export const DAY_ROLLOVER_CHECK_INTERVAL_MS = 60_000;
+
+type StoredRolloverPrompt = DayRolloverPromptState;
+
+/** Returns the localStorage key for rollover state in the current workspace scope. */
+export function getRolloverStorageKey(key: string, userId?: string | null): string {
+  return getScopedStorageKey(key, getStorageScope(userId));
+}
+
+/** Reads one stored day string from localStorage, returning null when storage is unavailable. */
+export function readStoredDayValue(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** Persists one day string into localStorage, ignoring storage errors. */
+export function writeStoredDayValue(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Ignore storage write failures so the editor keeps functioning.
+  }
+}
+
+/** Reads a pending rollover prompt, ignoring malformed or unavailable storage. */
+export function readStoredRolloverPrompt(userId?: string | null): StoredRolloverPrompt | null {
+  const stored = readStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId));
+  if (!stored) return null;
+
+  try {
+    const parsed = JSON.parse(stored) as Partial<StoredRolloverPrompt>;
+    return typeof parsed.previousDay === 'string' && typeof parsed.currentDay === 'string'
+      ? { previousDay: parsed.previousDay, currentDay: parsed.currentDay }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persists a pending rollover prompt for the active workspace scope. */
+export function writeStoredRolloverPrompt(prompt: StoredRolloverPrompt, userId?: string | null): void {
+  writeStoredDayValue(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId), JSON.stringify(prompt));
+}
+
+/** Removes a pending rollover prompt for the active workspace scope. */
+export function clearStoredRolloverPrompt(userId?: string | null): void {
+  try {
+    localStorage.removeItem(getRolloverStorageKey(DAY_ROLLOVER_PENDING_KEY, userId));
+  } catch {
+    // Ignore storage failures.
+  }
+}

--- a/src/utils/storageScope.ts
+++ b/src/utils/storageScope.ts
@@ -1,0 +1,7 @@
+/** Returns a stable browser-storage scope for one account or the local anonymous workspace. */
+export const getStorageScope = (userId?: string | null): string =>
+  userId ? `user-${encodeURIComponent(userId)}` : 'anonymous';
+
+/** Adds an account scope to a storage key without exposing one account's data to another. */
+export const getScopedStorageKey = (baseKey: string, scope = 'anonymous'): string =>
+  `${baseKey}:${scope}`;


### PR DESCRIPTION
## Summary
- Add the full local rollover choice surface: download, premium cloud save, temporary keep, and explicit replacement.
- Make rollover state durable across refresh, session restoration, and account-scoped persistence.
- Prevent cloud auto-sync from overwriting rollover saves and preserve local Cycle History fallback.
- Add failure-safe behavior and browser coverage.

## Validation
- Focused Jest: 13 tests passed.
- Full Jest: 147 suites, 715 tests passed.
- Rollover E2E: 3 passed.
- Smoke E2E: 9 passed.
- Build passed; local Sentry source-map upload emitted expected 403 warning.
- `git diff --check` passed.
- Two unrelated Auto-TSTM Playwright failures reproduce on the beta baseline and are not part of this change.

## Changelog
- Preserve forecast sessions and cloud handoffs across day rollover choices.

## Feature exposure
- No feature exposure registry or server-backed exposure files changed.
- Target branch: `beta`.

## Temporary feature removal
- None.

## Review requests
- Verify all four rollover choices and failure preservation.
- Review account-scoped storage migration and anonymous legacy compatibility.
- Confirm cloud save-as-new cannot be overwritten by auto-save.
- Review the documented baseline Auto-TSTM failures.

No production exposure or merge to `main` is requested by this PR.