### PR TITLE
feat(workflow): add scoped workflow and cycle package exports (WF-09)

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #698
+
+- Add distinct workflow-scoped and complete-cycle package exports with compatibility-preserving manifests.
+
 ### PR #696
 
 - Preserve forecast sessions and cloud handoffs across day rollover choices.

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -500,6 +500,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
         forecastCycle,
         { center: [39.8283, -98.5795], zoom: 4 },
         workflowMetadata,
+        'workflow',
       );
     } finally {
       setIsPackageDownloading(false);

--- a/src/components/ForecastWorkspace/forecastWorkspaceActions.test.tsx
+++ b/src/components/ForecastWorkspace/forecastWorkspaceActions.test.tsx
@@ -96,8 +96,8 @@ describe('useForecastWorkspaceActionHandlers', () => {
       await Promise.resolve();
     });
 
-    expect(downloadGfcPackage).toHaveBeenCalledWith(forecastCycle, { center: [1, 2], zoom: 7 }, undefined);
-    expect(first.addToast).toHaveBeenCalledWith('Package downloaded!', 'success');
+    expect(downloadGfcPackage).toHaveBeenCalledWith(forecastCycle, { center: [1, 2], zoom: 7 }, undefined, 'cycle');
+    expect(first.addToast).toHaveBeenCalledWith('Cycle package downloaded!', 'success');
     expect(first.setIsPackageDownloading).toHaveBeenLastCalledWith(false);
 
     (downloadGfcPackage as jest.Mock).mockRejectedValueOnce(new Error('zip failed'));
@@ -108,7 +108,16 @@ describe('useForecastWorkspaceActionHandlers', () => {
       await Promise.resolve();
     });
 
-    expect(downloadGfcPackage).toHaveBeenLastCalledWith(forecastCycle, { center: [39.8283, -98.5795], zoom: 4 }, undefined);
+    expect(downloadGfcPackage).toHaveBeenLastCalledWith(forecastCycle, { center: [39.8283, -98.5795], zoom: 4 }, undefined, 'cycle');
     expect(second.addToast).toHaveBeenCalledWith('Failed to create package.', 'error');
+  });
+
+  test('exports the active workflow as a scoped package', async () => {
+    const { result } = setup();
+    await act(async () => {
+      result.current.onWorkflowPackageDownload();
+      await Promise.resolve();
+    });
+    expect(downloadGfcPackage).toHaveBeenCalledWith(forecastCycle, { center: [1, 2], zoom: 7 }, undefined, 'workflow');
   });
 });

--- a/src/components/ForecastWorkspace/forecastWorkspaceActions.tsx
+++ b/src/components/ForecastWorkspace/forecastWorkspaceActions.tsx
@@ -62,14 +62,14 @@ const dispatchHistoryAction = (
 };
 
 /** Downloads one package scope and reports success or failure without leaking errors to the caller. */
-const downloadPackageForScope = async (
-  scope: WorkflowExportScope,
-  forecastCycle: ForecastCycle,
-  cycleMetadata: CycleMetadata | undefined,
-  mapRef: React.RefObject<ForecastMapHandle | null>,
-  addToast: AddToastFn,
-  setIsPackageDownloading: React.Dispatch<React.SetStateAction<boolean>>,
-): Promise<void> => {
+const downloadPackageForScope = async ({ scope, forecastCycle, cycleMetadata, mapRef, addToast, setIsPackageDownloading }: {
+  scope: WorkflowExportScope;
+  forecastCycle: ForecastCycle;
+  cycleMetadata?: CycleMetadata;
+  mapRef: React.RefObject<ForecastMapHandle | null>;
+  addToast: AddToastFn;
+  setIsPackageDownloading: React.Dispatch<React.SetStateAction<boolean>>;
+}): Promise<void> => {
   setIsPackageDownloading(true);
   try {
     const mapView = mapRef.current?.getView() ?? ({ center: [39.8283, -98.5795] as [number, number], zoom: 4 });
@@ -99,9 +99,9 @@ export const useForecastWorkspaceActionHandlers = ({
   fileInputRef,
   handleCancelReset,
 }: ForecastWorkspaceActionParams) => {
-  const handlePackageDownload = useCallback((scope: WorkflowExportScope) => downloadPackageForScope(
+  const handlePackageDownload = useCallback((scope: WorkflowExportScope) => downloadPackageForScope({
     scope, forecastCycle, cycleMetadata, mapRef, addToast, setIsPackageDownloading,
-  ), [mapRef, forecastCycle, cycleMetadata, addToast, setIsPackageDownloading]);
+  }), [mapRef, forecastCycle, cycleMetadata, addToast, setIsPackageDownloading]);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = getSelectedFile(e);

--- a/src/components/ForecastWorkspace/forecastWorkspaceActions.tsx
+++ b/src/components/ForecastWorkspace/forecastWorkspaceActions.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { downloadGfcPackage } from '../../utils/fileUtils';
+import type { WorkflowExportScope } from '../../utils/workflowPackage';
 import {
   redoLastEdit,
   resetForecasts,
@@ -77,12 +78,12 @@ export const useForecastWorkspaceActionHandlers = ({
   fileInputRef,
   handleCancelReset,
 }: ForecastWorkspaceActionParams) => {
-  const handlePackageDownload = useCallback(async () => {
+  const handlePackageDownload = useCallback(async (scope: WorkflowExportScope) => {
     setIsPackageDownloading(true);
     try {
       const mapView = mapRef.current?.getView() ?? ({ center: [39.8283, -98.5795] as [number, number], zoom: 4 });
-      await downloadGfcPackage(forecastCycle, mapView, cycleMetadata);
-      addToast('Package downloaded!', 'success');
+      await downloadGfcPackage(forecastCycle, mapView, cycleMetadata, scope);
+      addToast(`${scope === 'workflow' ? 'Workflow' : 'Cycle'} package downloaded!`, 'success');
     } catch {
       addToast('Failed to create package.', 'error');
     } finally {
@@ -142,7 +143,9 @@ export const useForecastWorkspaceActionHandlers = ({
     onUndo: handleUndo,
     onRedo: handleRedo,
     onLoadClick: handleLoadClick,
-    onPackageDownload: () => { handlePackageDownload().catch((err) => { console.debug('Package download failed (ignored):', err); }); },
+    onPackageDownload: () => { handlePackageDownload('cycle').catch((err) => { console.debug('Package download failed (ignored):', err); }); },
+    onWorkflowPackageDownload: () => { handlePackageDownload('workflow').catch((err) => { console.debug('Workflow package download failed (ignored):', err); }); },
+    onCyclePackageDownload: () => { handlePackageDownload('cycle').catch((err) => { console.debug('Cycle package download failed (ignored):', err); }); },
     onDateSave: handleDateSave,
     onDayButtonClick: handleDayButtonClick,
     onPrevDay: handlePrevDay,

--- a/src/components/ForecastWorkspace/forecastWorkspaceActions.tsx
+++ b/src/components/ForecastWorkspace/forecastWorkspaceActions.tsx
@@ -61,6 +61,27 @@ const dispatchHistoryAction = (
   }
 };
 
+/** Downloads one package scope and reports success or failure without leaking errors to the caller. */
+const downloadPackageForScope = async (
+  scope: WorkflowExportScope,
+  forecastCycle: ForecastCycle,
+  cycleMetadata: CycleMetadata | undefined,
+  mapRef: React.RefObject<ForecastMapHandle | null>,
+  addToast: AddToastFn,
+  setIsPackageDownloading: React.Dispatch<React.SetStateAction<boolean>>,
+): Promise<void> => {
+  setIsPackageDownloading(true);
+  try {
+    const mapView = mapRef.current?.getView() ?? ({ center: [39.8283, -98.5795] as [number, number], zoom: 4 });
+    await downloadGfcPackage(forecastCycle, mapView, cycleMetadata, scope);
+    addToast(scope === 'workflow' ? 'Workflow package downloaded!' : 'Cycle package downloaded!', 'success');
+  } catch {
+    addToast('Failed to create package.', 'error');
+  } finally {
+    setIsPackageDownloading(false);
+  }
+};
+
 /** Constructs all event-handler callbacks for workspace actions. */
 export const useForecastWorkspaceActionHandlers = ({
   dispatch,
@@ -78,18 +99,9 @@ export const useForecastWorkspaceActionHandlers = ({
   fileInputRef,
   handleCancelReset,
 }: ForecastWorkspaceActionParams) => {
-  const handlePackageDownload = useCallback(async (scope: WorkflowExportScope) => {
-    setIsPackageDownloading(true);
-    try {
-      const mapView = mapRef.current?.getView() ?? ({ center: [39.8283, -98.5795] as [number, number], zoom: 4 });
-      await downloadGfcPackage(forecastCycle, mapView, cycleMetadata, scope);
-      addToast(`${scope === 'workflow' ? 'Workflow' : 'Cycle'} package downloaded!`, 'success');
-    } catch {
-      addToast('Failed to create package.', 'error');
-    } finally {
-      setIsPackageDownloading(false);
-    }
-  }, [mapRef, forecastCycle, cycleMetadata, addToast, setIsPackageDownloading]);
+  const handlePackageDownload = useCallback((scope: WorkflowExportScope) => downloadPackageForScope(
+    scope, forecastCycle, cycleMetadata, mapRef, addToast, setIsPackageDownloading,
+  ), [mapRef, forecastCycle, cycleMetadata, addToast, setIsPackageDownloading]);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = getSelectedFile(e);

--- a/src/components/ForecastWorkspace/useForecastWorkspaceController.tsx
+++ b/src/components/ForecastWorkspace/useForecastWorkspaceController.tsx
@@ -92,6 +92,8 @@ export interface ForecastWorkspaceController {
   onSave: () => void;
   onLoadClick: () => void;
   onPackageDownload: () => void;
+  onWorkflowPackageDownload: () => void;
+  onCyclePackageDownload: () => void;
   onOpenHistoryModal: () => void;
   onOpenCopyModal: () => void;
   onOpenResetConfirm: () => void;

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -17,6 +17,7 @@ import {
   Undo2,
   Upload,
   Wrench,
+  PackageOpen,
 } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
@@ -113,9 +114,17 @@ const ToolbarToolsSection: React.FC<{ controller: ForecastWorkspaceController }>
       />
       <ToolbarTooltipButton
         icon={<Archive className="h-6 w-6" />}
-        tooltip={<p>Download Package <span className="text-muted-foreground">(JSON + Discussions)</span></p>}
+        tooltip={<p>Export complete cycle <span className="text-muted-foreground">(JSON + discussions)</span></p>}
         className="h-14 w-14 lg:h-16 lg:w-16 bg-violet-500/20 hover:bg-violet-500/30 border-violet-500/50 text-violet-700 dark:!bg-violet-500/20 dark:hover:!bg-violet-500/30 dark:border-violet-500/50 dark:text-violet-400"
         onClick={controller.onPackageDownload}
+        disabled={controller.isPackageDownloading}
+      />
+      <ToolbarTooltipButton
+        icon={<PackageOpen className="h-6 w-6" />}
+        tooltip={<p>Export current workflow <span className="text-muted-foreground">(scoped package)</span></p>}
+        className="h-14 w-14 lg:h-16 lg:w-16 bg-violet-500/20 hover:bg-violet-500/30 border-violet-500/50 text-violet-700 dark:!bg-violet-500/20 dark:hover:!bg-violet-500/30 dark:border-violet-500/50 dark:text-violet-400"
+        ariaLabel="Export current workflow package"
+        onClick={controller.onWorkflowPackageDownload}
         disabled={controller.isPackageDownloading}
       />
       <ToolbarTooltipButton
@@ -842,6 +851,16 @@ const getTabbedToolbarActionItems = (
     accentClass: 'bg-violet-500/15 text-violet-700',
   },
   {
+    key: 'workflow-package',
+    label: 'Workflow package',
+    description: 'Export the current workflow only',
+    icon: <PackageOpen className="h-4 w-4" />,
+    onClick: controller.onWorkflowPackageDownload,
+    disabled: controller.isPackageDownloading,
+    tone: 'primary',
+    accentClass: 'bg-violet-500/15 text-violet-700',
+  },
+  {
     key: 'history',
     label: 'History',
     description: 'Reopen saved sessions',
@@ -942,7 +961,7 @@ const TabbedToolbarToolsTab: React.FC<{
 }> = ({ controller, autoTstmTools = null }) => {
   const actionItems = getTabbedToolbarActionItems(controller);
   const historyItems = actionItems.filter((item) => ['undo', 'redo', 'history', 'copy'].includes(item.key));
-  const fileItems = actionItems.filter((item) => ['save', 'load', 'export', 'package'].includes(item.key));
+  const fileItems = actionItems.filter((item) => ['save', 'load', 'export', 'package', 'workflow-package'].includes(item.key));
   const completionItems = actionItems.filter((item) => item.key === 'complete');
   const destructiveItems = actionItems.filter((item) => item.key === 'reset');
 

--- a/src/hooks/useFileLoader.ts
+++ b/src/hooks/useFileLoader.ts
@@ -1,4 +1,5 @@
 import { exportForecastToJson, deserializeForecast, validateForecastData } from '../utils/fileUtils';
+import { isWorkflowExportPackage } from '../utils/workflowPackage';
 import {
   markAsSaved,
   importForecastCycle,
@@ -37,8 +38,9 @@ export function createFileHandlers({ addToast, dispatch, forecastCycle, cycleMet
 
       const deserializedCycle = deserializeForecast(data);
       dispatch(importForecastCycle(deserializedCycle));
-      if (data.cycleMetadata) {
-        dispatch(setWorkflowMetadata(data.cycleMetadata));
+      const packageMetadata = isWorkflowExportPackage(data) ? data.metadata : data.cycleMetadata;
+      if (packageMetadata) {
+        dispatch(setWorkflowMetadata(packageMetadata));
       } else if (data.cycleMetadata === null) {
         dispatch(clearWorkflowMetadata());
       }

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -34,7 +34,6 @@ import {
 } from '../store/forecastSlice';
 import { OutlookType, Probability, DayType, GFCForecastSaveData } from '../types/outlooks';
 import { deserializeForecast, validateForecastData, exportForecastToJson, serializeForecast } from '../utils/fileUtils';
-import { isWorkflowExportPackage } from '../utils/workflowPackage';
 import {
   getFirstExposedOutlookType,
   shouldActivateEmergencyMode,
@@ -317,16 +316,14 @@ const applyLoadedForecast = (
   mapRef: React.RefObject<ForecastMapHandle | null>
 ) => {
   dispatch(importForecastCycle(payload.deserializedCycle));
-  const packageMetadata = isWorkflowExportPackage(payload.rawData) ? payload.rawData.metadata : payload.rawData.cycleMetadata;
-  if (packageMetadata) {
-    dispatch(setWorkflowMetadata(packageMetadata));
+  if (payload.rawData.cycleMetadata) {
+    dispatch(setWorkflowMetadata(payload.rawData.cycleMetadata));
   } else if (payload.rawData.cycleMetadata === null) {
     dispatch(clearWorkflowMetadata());
   }
 
-  const savedMapView = isWorkflowExportPackage(payload.rawData) ? payload.rawData.forecast.mapView : payload.rawData.mapView;
-  if (savedMapView) {
-    dispatch(setMapView(savedMapView));
+  if (payload.rawData.mapView) {
+    dispatch(setMapView(payload.rawData.mapView));
     return;
   }
 

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -324,8 +324,9 @@ const applyLoadedForecast = (
     dispatch(clearWorkflowMetadata());
   }
 
-  if (payload.rawData.mapView) {
-    dispatch(setMapView(payload.rawData.mapView));
+  const savedMapView = isWorkflowExportPackage(payload.rawData) ? payload.rawData.forecast.mapView : payload.rawData.mapView;
+  if (savedMapView) {
+    dispatch(setMapView(savedMapView));
     return;
   }
 

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -34,6 +34,7 @@ import {
 } from '../store/forecastSlice';
 import { OutlookType, Probability, DayType, GFCForecastSaveData } from '../types/outlooks';
 import { deserializeForecast, validateForecastData, exportForecastToJson, serializeForecast } from '../utils/fileUtils';
+import { isWorkflowExportPackage } from '../utils/workflowPackage';
 import {
   getFirstExposedOutlookType,
   shouldActivateEmergencyMode,
@@ -316,8 +317,9 @@ const applyLoadedForecast = (
   mapRef: React.RefObject<ForecastMapHandle | null>
 ) => {
   dispatch(importForecastCycle(payload.deserializedCycle));
-  if (payload.rawData.cycleMetadata) {
-    dispatch(setWorkflowMetadata(payload.rawData.cycleMetadata));
+  const packageMetadata = isWorkflowExportPackage(payload.rawData) ? payload.rawData.metadata : payload.rawData.cycleMetadata;
+  if (packageMetadata) {
+    dispatch(setWorkflowMetadata(packageMetadata));
   } else if (payload.rawData.cycleMetadata === null) {
     dispatch(clearWorkflowMetadata());
   }

--- a/src/utils/fileUtils.extra.test.ts
+++ b/src/utils/fileUtils.extra.test.ts
@@ -121,6 +121,7 @@ describe('fileUtils extra', () => {
       'discussion_day1.txt',
       'discussion_day2.txt',
       'forecast_cycle.json',
+      'workflow_package.json',
     ]);
   });
 
@@ -161,9 +162,8 @@ describe('fileUtils extra', () => {
 
     expect(clickMock).toHaveBeenCalled();
     expect(urlHelpers.createObjectURL).toHaveBeenCalled();
-    expect(Object.keys(generatedFiles).sort()).toEqual(['discussion_day1.txt', 'forecast_cycle.json']);
-    expect(generatedFiles.workflow_package_json).toBeUndefined();
-    expect(generatedFiles['workflow_package.json']).toBeUndefined();
+    expect(Object.keys(generatedFiles).sort()).toEqual(['discussion_day1.txt', 'forecast_cycle.json', 'workflow_package.json']);
+    expect(generatedFiles['workflow_package.json']).toBeDefined();
     spy.mockRestore();
   });
 });

--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -1,4 +1,5 @@
 import { serializeForecast, deserializeForecast, validateForecastData } from './fileUtils';
+import { buildWorkflowExportPackage } from './workflowPackage';
 
 describe('fileUtils', () => {
   type ForecastCycle = {
@@ -34,6 +35,15 @@ describe('fileUtils', () => {
     expect(validateForecastData(ser)).toBe(true);
     const des = deserializeForecast(ser);
     expect(des.days[1].data.categorical instanceof Map).toBe(true);
+  });
+
+  test('validates and deserializes a workflow package wrapper', () => {
+    const serialized = serializeForecast({
+      days: {}, currentDay: 1, cycleDate: '2026-04-21',
+    }, { center: [0, 0], zoom: 0 });
+    const wrapper = buildWorkflowExportPackage({ scope: 'cycle', forecast: serialized });
+    expect(validateForecastData(wrapper)).toBe(true);
+    expect(deserializeForecast(wrapper).cycleDate).toBe('2026-04-21');
   });
 
   test('serialize/deserialize preserves discussion scopes without changing day data', () => {

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -13,6 +13,7 @@ import { coerceOutlookProbabilityMap } from './outlookMapCoercion';
 import { completionMetadataFromForecastCycle } from './forecastCompletionMetadata';
 import { deserializeForecastCycleDays } from './forecastCycleDeserialize';
 import { getWorkflowTemplateById } from '../components/ForecastWorkflow/workflowTemplates';
+import { buildWorkflowExportPackage, isWorkflowExportPackage, type WorkflowExportScope } from './workflowPackage';
 
 const CURRENT_VERSION = '1.0.0';
 
@@ -164,7 +165,9 @@ const deserializeLegacyForecast = (data: GFCForecastSaveData): ForecastCycle => 
  * Deserializes the saved JSON data back into ForecastCycle.
  * Handles migration from single-day format and v1.0.0 cycleMetadata embedding.
  */
-export const deserializeForecast = (data: GFCForecastSaveData): ForecastCycle => {
+export const deserializeForecast = (data: GFCForecastSaveData | unknown): ForecastCycle => {
+  if (isWorkflowExportPackage(data)) return deserializeForecast(data.forecast);
+  if (!data || typeof data !== 'object') return deserializeLegacyForecast({} as GFCForecastSaveData);
   if (!data.forecastCycle) return deserializeLegacyForecast(data);
   const cycle = data.forecastCycle;
   return {
@@ -251,12 +254,15 @@ export const downloadGfcPackage = async (
   forecastCycle: ForecastCycle,
   mapView: { center: [number, number]; zoom: number },
   cycleMetadata?: CycleMetadata,
+  scope: WorkflowExportScope = 'cycle',
 ): Promise<void> => {
   const zip = new JSZip();
 
   // 1. Forecast JSON
-  const data = serializeForecast(forecastCycle, mapView, cycleMetadata);
+  const pkg = buildWorkflowExportPackage({ scope, forecast: serializeForecast(forecastCycle, mapView, cycleMetadata), cycleMetadata });
+  const data = pkg.forecast;
   zip.file('forecast_cycle.json', JSON.stringify(data, null, 2));
+  zip.file('workflow_package.json', JSON.stringify(pkg, null, 2));
 
   // 2. Discussion text for configured scopes, with every ungrouped legacy day retained.
   const workflowTemplate = cycleMetadata ? getWorkflowTemplateById(cycleMetadata.workflowId) : undefined;
@@ -295,7 +301,7 @@ export const downloadGfcPackage = async (
   const url = URL.createObjectURL(blob);
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-  const filename = `gfc-package-${timestamp}.zip`;
+  const filename = `gfc-${scope}-package-${timestamp}.zip`;
 
   const link = document.createElement('a');
   link.href = url;

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -194,6 +194,7 @@ export const cloneForecastCycle = (forecastCycle: ForecastCycle): ForecastCycle 
  * Validates that the input data conforms to the GFCForecastSaveData schema.
  */
 export const validateForecastData = (data: unknown): data is GFCForecastSaveData => {
+  if (isWorkflowExportPackage(data)) return validateForecastData(data.forecast);
   if (typeof data !== 'object' || data === null) return false;
   const candidate = data as Partial<GFCForecastSaveData>;
 
@@ -263,21 +264,23 @@ export const downloadGfcPackage = async (
   const data = pkg.forecast;
   zip.file('forecast_cycle.json', JSON.stringify(data, null, 2));
   zip.file('workflow_package.json', JSON.stringify(pkg, null, 2));
+  const exportedCycle = data.forecastCycle;
+  const exportedForecastCycle = deserializeForecast(data);
 
   // 2. Discussion text for configured scopes, with every ungrouped legacy day retained.
   const workflowTemplate = cycleMetadata ? getWorkflowTemplateById(cycleMetadata.workflowId) : undefined;
   const hasStandardWorkflowGrouping = workflowTemplate?.groupings.some((grouping) =>
     grouping === 'day1' || grouping === 'day2' || grouping === 'day3' || grouping === 'day4-8',
   );
-  const hasValidPersistedGrouping = isValidDiscussionGroupings(forecastCycle.discussionGroupings);
+  const hasValidPersistedGrouping = isValidDiscussionGroupings(exportedCycle?.discussionGroupings);
   const exportedDays = new Set<DayType>();
   const usedEntryNames = new Set<string>(['forecast_cycle.json']);
 
   if (hasValidPersistedGrouping || hasStandardWorkflowGrouping) {
-    getDiscussionGroupings(forecastCycle, workflowTemplate).forEach((grouping) => {
-      const ownerDay = getDiscussionOwnerDay(forecastCycle, grouping);
+    getDiscussionGroupings(exportedForecastCycle, workflowTemplate).forEach((grouping) => {
+      const ownerDay = getDiscussionOwnerDay(exportedForecastCycle, grouping);
       addDiscussionToZip(zip, usedEntryNames, exportedDays, {
-        discussion: getDiscussionForGrouping(forecastCycle, grouping),
+        discussion: getDiscussionForGrouping(exportedForecastCycle, grouping),
         day: ownerDay,
         identifier: grouping.id,
       });
@@ -285,12 +288,12 @@ export const downloadGfcPackage = async (
   }
 
   // A malformed grouping must never make its covered legacy discussions disappear.
-  (Object.keys(forecastCycle.days) as unknown as DayType[])
+  (Object.keys(exportedCycle?.days ?? {}) as unknown as DayType[])
     .sort((a, b) => a - b)
     .forEach((day) => {
       if (!exportedDays.has(day)) {
         addDiscussionToZip(zip, usedEntryNames, exportedDays, {
-          discussion: forecastCycle.days[day]?.discussion,
+          discussion: exportedCycle?.days[day]?.discussion,
           day,
           identifier: `day${day}`,
         });

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -250,29 +250,18 @@ const addDiscussionToZip = (
   exportedDays.add(day);
 };
 
-/** Bundles the forecast JSON and all day discussions into a single .zip package. */
-export const downloadGfcPackage = async (
-  forecastCycle: ForecastCycle,
-  mapView: { center: [number, number]; zoom: number },
-  cycleMetadata?: CycleMetadata,
-  scope: WorkflowExportScope = 'cycle',
-): Promise<void> => {
-  const zip = new JSZip();
-
-  // 1. Forecast JSON
-  const pkg = buildWorkflowExportPackage({ scope, forecast: serializeForecast(forecastCycle, mapView, cycleMetadata), cycleMetadata });
-  const data = pkg.forecast;
-  zip.file('forecast_cycle.json', JSON.stringify(data, null, 2));
-  zip.file('workflow_package.json', JSON.stringify(pkg, null, 2));
-  const exportedCycle = data.forecastCycle;
-  const exportedForecastCycle = deserializeForecast(data);
-
-  // 2. Discussion text for configured scopes, with every ungrouped legacy day retained.
+/** Adds only discussions belonging to the forecast scope represented by the package. */
+const addPackageDiscussions = (
+  zip: JSZip,
+  forecast: GFCForecastSaveData,
+  cycleMetadata: CycleMetadata | undefined,
+): void => {
+  const exportedForecastCycle = deserializeForecast(forecast);
   const workflowTemplate = cycleMetadata ? getWorkflowTemplateById(cycleMetadata.workflowId) : undefined;
   const hasStandardWorkflowGrouping = workflowTemplate?.groupings.some((grouping) =>
     grouping === 'day1' || grouping === 'day2' || grouping === 'day3' || grouping === 'day4-8',
   );
-  const hasValidPersistedGrouping = isValidDiscussionGroupings(exportedCycle?.discussionGroupings);
+  const hasValidPersistedGrouping = isValidDiscussionGroupings(exportedForecastCycle.discussionGroupings);
   const exportedDays = new Set<DayType>();
   const usedEntryNames = new Set<string>(['forecast_cycle.json']);
 
@@ -287,18 +276,34 @@ export const downloadGfcPackage = async (
     });
   }
 
-  // A malformed grouping must never make its covered legacy discussions disappear.
-  (Object.keys(exportedCycle?.days ?? {}) as unknown as DayType[])
+  (Object.keys(exportedForecastCycle.days) as unknown as DayType[])
     .sort((a, b) => a - b)
     .forEach((day) => {
       if (!exportedDays.has(day)) {
         addDiscussionToZip(zip, usedEntryNames, exportedDays, {
-          discussion: exportedCycle?.days[day]?.discussion,
+          discussion: exportedForecastCycle.days[day]?.discussion,
           day,
           identifier: `day${day}`,
         });
       }
     });
+};
+
+/** Bundles the forecast JSON and all day discussions into a single .zip package. */
+export const downloadGfcPackage = async (
+  forecastCycle: ForecastCycle,
+  mapView: { center: [number, number]; zoom: number },
+  cycleMetadata?: CycleMetadata,
+  scope: WorkflowExportScope = 'cycle',
+): Promise<void> => {
+  const zip = new JSZip();
+
+  // 1. Forecast JSON
+  const pkg = buildWorkflowExportPackage({ scope, forecast: serializeForecast(forecastCycle, mapView, cycleMetadata), cycleMetadata });
+  const data = pkg.forecast;
+  zip.file('forecast_cycle.json', JSON.stringify(data, null, 2));
+  zip.file('workflow_package.json', JSON.stringify(pkg, null, 2));
+  addPackageDiscussions(zip, data, cycleMetadata);
 
   const blob = await zip.generateAsync({ type: 'blob' });
   const url = URL.createObjectURL(blob);

--- a/src/utils/workflowPackage.test.ts
+++ b/src/utils/workflowPackage.test.ts
@@ -34,5 +34,12 @@ test('fails closed when a workflow template is unknown', () => {
     scope: 'workflow',
     forecast: { version: '1.0.0', type: 'forecast-cycle', timestamp: '2026-07-15T00:00:00.000Z', forecastCycle: cycle },
     cycleMetadata: { ...metadata, workflowId: 'retired-workflow' },
-  })).toThrow('Unknown workflow template');
+})).toThrow('Unknown workflow template');
+});
+
+test('requires metadata for a workflow-scoped export', () => {
+  expect(() => buildWorkflowExportPackage({
+    scope: 'workflow',
+    forecast: { version: '1.0.0', type: 'forecast-cycle', timestamp: '2026-07-15T00:00:00.000Z', forecastCycle: cycle },
+  })).toThrow('Workflow export requires workflow metadata');
 });

--- a/src/utils/workflowPackage.test.ts
+++ b/src/utils/workflowPackage.test.ts
@@ -17,6 +17,7 @@ test.each(['workflow', 'cycle'] as const)('builds a discriminated %s package', (
   expect(pkg.packageType).toBe(scope);
   expect(isWorkflowExportPackage(pkg)).toBe(true);
   expect(pkg.exportedAt).toBe('2026-07-15T12:00:00.000Z');
+  expect(pkg.cycleMetadata).toEqual(metadata);
 });
 
 test('converts packages into the existing v2 serialized package contract', () => {

--- a/src/utils/workflowPackage.test.ts
+++ b/src/utils/workflowPackage.test.ts
@@ -28,3 +28,11 @@ test('converts packages into the existing v2 serialized package contract', () =>
 test('rejects lookalike packages with missing export markers', () => {
   expect(isWorkflowExportPackage({ forecast: {} })).toBe(false);
 });
+
+test('fails closed when a workflow template is unknown', () => {
+  expect(() => buildWorkflowExportPackage({
+    scope: 'workflow',
+    forecast: { version: '1.0.0', type: 'forecast-cycle', timestamp: '2026-07-15T00:00:00.000Z', forecastCycle: cycle },
+    cycleMetadata: { ...metadata, workflowId: 'retired-workflow' },
+  })).toThrow('Unknown workflow template');
+});

--- a/src/utils/workflowPackage.test.ts
+++ b/src/utils/workflowPackage.test.ts
@@ -1,0 +1,30 @@
+import { buildWorkflowExportPackage, isWorkflowExportPackage, toSerializedWorkflowPackage } from './workflowPackage';
+
+const cycle = {
+  days: { 1: { day: 1, data: { categorical: new Map([['TSTM', []]]) }, metadata: { issueDate: '2026-07-15', validDate: '2026-07-15', issuanceTime: '0600', createdAt: '2026-07-15T00:00:00.000Z', lastModified: '2026-07-15T00:00:00.000Z' } } },
+  currentDay: 1,
+  cycleDate: '2026-07-15',
+} as never;
+
+const metadata = {
+  id: 'WF-severe-2026-07-15', workflowId: 'severe-day1', cycleDate: '2026-07-15', status: 'in-progress',
+  outlookVersions: [{ version: 1, status: 'in-progress', createdAt: '2026-07-15T00:00:00.000Z' }],
+  createdAt: '2026-07-15T00:00:00.000Z', updatedAt: '2026-07-15T00:00:00.000Z',
+} as never;
+
+test.each(['workflow', 'cycle'] as const)('builds a discriminated %s package', (scope) => {
+  const pkg = buildWorkflowExportPackage({ scope, forecast: { version: '1.0.0', type: 'forecast-cycle', timestamp: '2026-07-15T00:00:00.000Z', forecastCycle: cycle }, cycleMetadata: metadata, exportedAt: '2026-07-15T12:00:00.000Z' });
+  expect(pkg.packageType).toBe(scope);
+  expect(isWorkflowExportPackage(pkg)).toBe(true);
+  expect(pkg.exportedAt).toBe('2026-07-15T12:00:00.000Z');
+});
+
+test('converts packages into the existing v2 serialized package contract', () => {
+  const pkg = buildWorkflowExportPackage({ scope: 'cycle', forecast: { version: '1.0.0', type: 'forecast-cycle', timestamp: '2026-07-15T00:00:00.000Z', forecastCycle: cycle }, cycleMetadata: metadata });
+  expect(toSerializedWorkflowPackage(pkg)?.cycles[0].id).toBe(metadata.id);
+  expect(toSerializedWorkflowPackage(pkg)?.metadata.workflowId).toBe(metadata.workflowId);
+});
+
+test('rejects lookalike packages with missing export markers', () => {
+  expect(isWorkflowExportPackage({ forecast: {} })).toBe(false);
+});

--- a/src/utils/workflowPackage.ts
+++ b/src/utils/workflowPackage.ts
@@ -24,8 +24,26 @@ const WORKFLOW_GROUPING_DAYS: Record<string, DayType[]> = {
 /** Returns the day slots owned by a workflow template. */
 const getWorkflowDays = (workflowId: string): Set<DayType> => {
   const template = getWorkflowTemplateById(workflowId);
-  return new Set(template?.groupings.flatMap((grouping) => WORKFLOW_GROUPING_DAYS[grouping] ?? []) ?? []);
+  if (!template) throw new Error(`Unknown workflow template: ${workflowId}`);
+  return new Set(template.groupings.flatMap((grouping) => WORKFLOW_GROUPING_DAYS[grouping] ?? []));
 };
+
+/** Removes cycle-wide completion and discussion metadata that refers to excluded days. */
+const restrictCycleMetadataToDays = (cycle: NonNullable<GFCForecastSaveData['forecastCycle']>, allowedDays: Set<DayType>) => ({
+  ...cycle,
+  discussionGroupings: cycle.discussionGroupings
+    ?.map((grouping) => ({
+      ...grouping,
+      days: grouping.days.filter((day) => allowedDays.has(day)),
+      discussionDay: allowedDays.has(grouping.discussionDay)
+        ? grouping.discussionDay
+        : grouping.days.find((day) => allowedDays.has(day)),
+    }))
+    .filter((grouping) => grouping.days.length > 0 && grouping.discussionDay !== undefined),
+  omittedDayReasons: cycle.omittedDayReasons
+    ? Object.fromEntries(Object.entries(cycle.omittedDayReasons).filter(([day]) => allowedDays.has(Number(day) as DayType)))
+    : undefined,
+});
 
 /** Keeps a workflow-scoped export limited to the days owned by its workflow template. */
 export const restrictForecastToWorkflow = (
@@ -41,7 +59,7 @@ export const restrictForecastToWorkflow = (
   return {
     ...forecast,
     forecastCycle: {
-      ...forecast.forecastCycle,
+      ...restrictCycleMetadataToDays(forecast.forecastCycle, allowedDays),
       days,
       currentDay: allowedDays.has(forecast.forecastCycle.currentDay)
         ? forecast.forecastCycle.currentDay

--- a/src/utils/workflowPackage.ts
+++ b/src/utils/workflowPackage.ts
@@ -50,7 +50,8 @@ export const restrictForecastToWorkflow = (
   forecast: GFCForecastSaveData,
   cycleMetadata?: CycleMetadata,
 ): GFCForecastSaveData => {
-  if (!cycleMetadata?.workflowId || !forecast.forecastCycle) return forecast;
+  if (!forecast.forecastCycle) return forecast;
+  if (!cycleMetadata?.workflowId) throw new Error('Workflow export requires workflow metadata');
   const allowedDays = getWorkflowDays(cycleMetadata.workflowId);
   if (allowedDays.size === 0 || allowedDays.size === 8) return forecast;
   const days = Object.fromEntries(

--- a/src/utils/workflowPackage.ts
+++ b/src/utils/workflowPackage.ts
@@ -1,0 +1,114 @@
+import type { GFCForecastSaveData } from '../types/outlooks';
+import type { CycleMetadata, SerializedWorkflowPackage } from '../types/workflow';
+import { WORKFLOW_SCHEMA_VERSION } from '../types/workflow';
+import { getWorkflowTemplateById } from '../components/ForecastWorkflow/workflowTemplates';
+import type { DayType } from '../types/outlooks';
+
+export type WorkflowExportScope = 'workflow' | 'cycle';
+
+export interface WorkflowExportPackage {
+  packageType: WorkflowExportScope;
+  schemaVersion: typeof WORKFLOW_SCHEMA_VERSION;
+  exportedAt: string;
+  metadata?: CycleMetadata;
+  forecast: GFCForecastSaveData;
+  styleSnapshots?: Record<string, unknown>;
+}
+
+const packageTypeFor = (scope: WorkflowExportScope): WorkflowExportScope => scope;
+
+/** Keeps a workflow-scoped export limited to the days owned by its workflow template. */
+export const restrictForecastToWorkflow = (
+  forecast: GFCForecastSaveData,
+  cycleMetadata?: CycleMetadata,
+): GFCForecastSaveData => {
+  if (!cycleMetadata?.workflowId || !forecast.forecastCycle) return forecast;
+  const template = getWorkflowTemplateById(cycleMetadata.workflowId);
+  if (!template || template.groupings.length === 0 || template.groupings.length === 4) return forecast;
+
+  const allowedDays = new Set<DayType>();
+  template.groupings.forEach((grouping) => {
+    if (grouping === 'day1') allowedDays.add(1);
+    if (grouping === 'day2') allowedDays.add(2);
+    if (grouping === 'day3') allowedDays.add(3);
+    if (grouping === 'day4-8') [4, 5, 6, 7, 8].forEach((day) => allowedDays.add(day as DayType));
+  });
+  const days = Object.fromEntries(
+    Object.entries(forecast.forecastCycle.days).filter(([day]) => allowedDays.has(Number(day) as DayType)),
+  );
+  return {
+    ...forecast,
+    forecastCycle: {
+      ...forecast.forecastCycle,
+      days,
+      currentDay: allowedDays.has(forecast.forecastCycle.currentDay)
+        ? forecast.forecastCycle.currentDay
+        : (Array.from(allowedDays)[0] ?? forecast.forecastCycle.currentDay),
+    },
+  };
+};
+
+/** Builds the JSON payload used by both workflow- and cycle-scoped exports. */
+export const buildWorkflowExportPackage = ({
+  scope,
+  forecast,
+  cycleMetadata,
+  styleSnapshots,
+  exportedAt = new Date().toISOString(),
+}: {
+  scope: WorkflowExportScope;
+  forecast: GFCForecastSaveData;
+  cycleMetadata?: CycleMetadata;
+  styleSnapshots?: Record<string, unknown>;
+  exportedAt?: string;
+}): WorkflowExportPackage => ({
+  packageType: packageTypeFor(scope),
+  schemaVersion: WORKFLOW_SCHEMA_VERSION,
+  exportedAt,
+  ...(cycleMetadata ? { metadata: cycleMetadata } : {}),
+  forecast: scope === 'workflow' ? restrictForecastToWorkflow(forecast, cycleMetadata) : forecast,
+  ...(styleSnapshots ? { styleSnapshots } : {}),
+});
+
+/** Returns true only for the exact top-level markers of a workflow export package. */
+export const isWorkflowExportPackage = (value: unknown): value is WorkflowExportPackage => {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<WorkflowExportPackage>;
+  return (candidate.packageType === 'workflow' || candidate.packageType === 'cycle')
+    && candidate.schemaVersion === WORKFLOW_SCHEMA_VERSION
+    && typeof candidate.exportedAt === 'string'
+    && Boolean(candidate.forecast && typeof candidate.forecast === 'object');
+};
+
+/** Converts the local package into the v2 package shape used for future readers. */
+export const toSerializedWorkflowPackage = (pkg: WorkflowExportPackage): SerializedWorkflowPackage | null => {
+  const metadata = pkg.metadata;
+  if (!metadata) return null;
+  const groupingData = Object.fromEntries(
+    Object.entries(pkg.forecast.forecastCycle?.days ?? {}).map(([day, value]) => [String(day), value]),
+  );
+  return {
+    schemaVersion: pkg.schemaVersion,
+    version: pkg.schemaVersion,
+    metadata: {
+      workflowId: metadata.workflowId,
+      cycleId: metadata.id,
+      version: metadata.outlookVersions.at(-1)?.version ?? 1,
+      status: metadata.status,
+      includesDiscussions: Object.values(groupingData).some((day) => Boolean((day as { discussion?: unknown }).discussion)),
+      includesStyleSnapshots: Boolean(pkg.styleSnapshots),
+    },
+    cycles: [{
+      id: metadata.id,
+      workflowId: metadata.workflowId,
+      cycleDate: metadata.cycleDate,
+      status: metadata.status,
+      outlookVersions: metadata.outlookVersions,
+      createdAt: metadata.createdAt,
+      updatedAt: metadata.updatedAt,
+      groupings: Object.keys(groupingData).map((day) => ({ grouping: day, day: Number(day) as never })),
+      groupingData,
+    }],
+    ...(pkg.styleSnapshots ? { styleSnapshots: pkg.styleSnapshots } : {}),
+  };
+};

--- a/src/utils/workflowPackage.ts
+++ b/src/utils/workflowPackage.ts
@@ -11,6 +11,8 @@ export interface WorkflowExportPackage {
   exportedAt: string;
   metadata?: CycleMetadata;
   forecast: GFCForecastSaveData;
+  cycleMetadata?: CycleMetadata;
+  mapView?: GFCForecastSaveData['mapView'];
   styleSnapshots?: Record<string, unknown>;
 }
 
@@ -87,6 +89,8 @@ export const buildWorkflowExportPackage = ({
   schemaVersion: WORKFLOW_SCHEMA_VERSION,
   exportedAt,
   ...(cycleMetadata ? { metadata: cycleMetadata } : {}),
+  ...(cycleMetadata ? { cycleMetadata } : {}),
+  ...(forecast.mapView ? { mapView: forecast.mapView } : {}),
   forecast: scope === 'workflow' ? restrictForecastToWorkflow(forecast, cycleMetadata) : forecast,
   ...(styleSnapshots ? { styleSnapshots } : {}),
 });

--- a/src/utils/workflowPackage.ts
+++ b/src/utils/workflowPackage.ts
@@ -1,8 +1,7 @@
-import type { GFCForecastSaveData } from '../types/outlooks';
+import type { DayType, GFCForecastSaveData } from '../types/outlooks';
 import type { CycleMetadata, SerializedWorkflowPackage } from '../types/workflow';
 import { WORKFLOW_SCHEMA_VERSION } from '../types/workflow';
 import { getWorkflowTemplateById } from '../components/ForecastWorkflow/workflowTemplates';
-import type { DayType } from '../types/outlooks';
 
 export type WorkflowExportScope = 'workflow' | 'cycle';
 
@@ -15,7 +14,18 @@ export interface WorkflowExportPackage {
   styleSnapshots?: Record<string, unknown>;
 }
 
-const packageTypeFor = (scope: WorkflowExportScope): WorkflowExportScope => scope;
+const WORKFLOW_GROUPING_DAYS: Record<string, DayType[]> = {
+  day1: [1],
+  day2: [2],
+  day3: [3],
+  'day4-8': [4, 5, 6, 7, 8],
+};
+
+/** Returns the day slots owned by a workflow template. */
+const getWorkflowDays = (workflowId: string): Set<DayType> => {
+  const template = getWorkflowTemplateById(workflowId);
+  return new Set(template?.groupings.flatMap((grouping) => WORKFLOW_GROUPING_DAYS[grouping] ?? []) ?? []);
+};
 
 /** Keeps a workflow-scoped export limited to the days owned by its workflow template. */
 export const restrictForecastToWorkflow = (
@@ -23,16 +33,8 @@ export const restrictForecastToWorkflow = (
   cycleMetadata?: CycleMetadata,
 ): GFCForecastSaveData => {
   if (!cycleMetadata?.workflowId || !forecast.forecastCycle) return forecast;
-  const template = getWorkflowTemplateById(cycleMetadata.workflowId);
-  if (!template || template.groupings.length === 0 || template.groupings.length === 4) return forecast;
-
-  const allowedDays = new Set<DayType>();
-  template.groupings.forEach((grouping) => {
-    if (grouping === 'day1') allowedDays.add(1);
-    if (grouping === 'day2') allowedDays.add(2);
-    if (grouping === 'day3') allowedDays.add(3);
-    if (grouping === 'day4-8') [4, 5, 6, 7, 8].forEach((day) => allowedDays.add(day as DayType));
-  });
+  const allowedDays = getWorkflowDays(cycleMetadata.workflowId);
+  if (allowedDays.size === 0 || allowedDays.size === 8) return forecast;
   const days = Object.fromEntries(
     Object.entries(forecast.forecastCycle.days).filter(([day]) => allowedDays.has(Number(day) as DayType)),
   );
@@ -62,7 +64,7 @@ export const buildWorkflowExportPackage = ({
   styleSnapshots?: Record<string, unknown>;
   exportedAt?: string;
 }): WorkflowExportPackage => ({
-  packageType: packageTypeFor(scope),
+  packageType: scope,
   schemaVersion: WORKFLOW_SCHEMA_VERSION,
   exportedAt,
   ...(cycleMetadata ? { metadata: cycleMetadata } : {}),


### PR DESCRIPTION
## Summary

Implements WF-09 #459 on the shared origin/beta baseline.

- Adds discriminated workflow and cycle package manifests.
- Restricts workflow-scoped exports to the active workflow grouping.
- Preserves legacy JSON import and ZIP discussion behavior.
- Adds explicit Workflow package and complete Cycle package actions.
- Includes export timestamps, cycle metadata, discussion grouping, version lineage, and optional style snapshot fields.

## Verification

- Focused: 4 suites, 19 tests passed.
- Full Jest: 155 suites, 770 tests passed.
- Vite production build completed; Sentry source-map upload remains blocked by the configured token returning HTTP 403.
- Browser verified the Workflow package action at desktop and mobile widths and captured a real ZIP download.

## Parallel work

This PR is independent of WF-11 and targets beta directly. WF-11 should remain independently reviewable and be rebased after this PR is merged.