### PR TITLE
[WF-10] Add completion handoff guidance

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #699
+
+- Add post-completion handoff guidance for workflow and complete-cycle exports, eligible Monitor navigation, return-to-map, and duplicate-prompt suppression.
+
 ### PR #698
 
 - Add distinct workflow-scoped and complete-cycle package exports with compatibility-preserving manifests.

--- a/src/components/ForecastWorkflow/CompletionHandoff.css
+++ b/src/components/ForecastWorkflow/CompletionHandoff.css
@@ -1,0 +1,3 @@
+.completion-handoff { max-height: min(90vh, 620px); overflow-y: auto; }
+.completion-handoff__actions { display: grid; gap: 10px; margin-top: 8px; }
+@media (max-width: 560px) { .completion-handoff { width: calc(100vw - 24px); } }

--- a/src/components/ForecastWorkflow/CompletionHandoff.test.tsx
+++ b/src/components/ForecastWorkflow/CompletionHandoff.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CompletionHandoff } from './CompletionHandoff.tsx';
+
+describe('CompletionHandoff', () => {
+  const props = {
+    open: true,
+    showMonitor: true,
+    isDownloading: false,
+    onWorkflowExport: jest.fn(),
+    onCycleExport: jest.fn(),
+    onMonitor: jest.fn(),
+    onReturnToMap: jest.fn(),
+    onDismiss: jest.fn(),
+  };
+
+  it('renders all eligible actions and forwards clicks', () => {
+    render(<CompletionHandoff {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /workflow package/i }));
+    fireEvent.click(screen.getByRole('button', { name: /complete cycle/i }));
+    fireEvent.click(screen.getByRole('button', { name: /open monitor/i }));
+    fireEvent.click(screen.getByRole('button', { name: /return to map/i }));
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(props.onWorkflowExport).toHaveBeenCalled();
+    expect(props.onCycleExport).toHaveBeenCalled();
+    expect(props.onMonitor).toHaveBeenCalled();
+    expect(props.onReturnToMap).toHaveBeenCalled();
+    expect(props.onDismiss).toHaveBeenCalled();
+  });
+
+  it('omits Monitor for unsupported workflows and disables exports while downloading', () => {
+    render(<CompletionHandoff {...props} showMonitor={false} isDownloading />);
+    expect(screen.queryByRole('button', { name: /open monitor/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /workflow package/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /complete cycle/i })).toBeDisabled();
+  });
+});

--- a/src/components/ForecastWorkflow/CompletionHandoff.tsx
+++ b/src/components/ForecastWorkflow/CompletionHandoff.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import './CompletionHandoff.css';
+
+interface CompletionHandoffProps {
+  open: boolean;
+  showMonitor: boolean;
+  isDownloading: boolean;
+  onWorkflowExport: () => void;
+  onCycleExport: () => void;
+  onMonitor: () => void;
+  onReturnToMap: () => void;
+  onDismiss: () => void;
+}
+
+/** Offers useful next steps after a workflow is completed without changing completion state. */
+export const CompletionHandoff: React.FC<CompletionHandoffProps> = ({
+  open,
+  showMonitor,
+  isDownloading,
+  onWorkflowExport,
+  onCycleExport,
+  onMonitor,
+  onReturnToMap,
+  onDismiss,
+}) => {
+  if (!open) return null;
+  return (
+    <div className="completion-handoff" role="dialog" aria-modal="true" aria-labelledby="completion-handoff-title" aria-describedby="completion-handoff-description">
+      <div>
+        <h2 id="completion-handoff-title">Workflow complete</h2>
+        <p id="completion-handoff-description">
+          Your review is saved. Choose what you want to do next, or return to the map.
+        </p>
+      </div>
+      <div className="completion-handoff__actions">
+        <button type="button" onClick={onWorkflowExport} disabled={isDownloading}>Export workflow package</button>
+        <button type="button" onClick={onCycleExport} disabled={isDownloading}>Export complete cycle</button>
+        {showMonitor ? (
+          <button type="button" onClick={onMonitor}>Open Monitor</button>
+        ) : null}
+        <button type="button" onClick={onReturnToMap}>Return to map</button>
+      </div>
+      <div>
+        <button type="button" onClick={onDismiss}>Dismiss</button>
+      </div>
+    </div>
+  );
+};
+
+export default CompletionHandoff;

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -546,7 +546,13 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   function handleOpenMonitor(): void {
     markCompletionHandoffHandled(handoffIdentity);
     setShowCompletionHandoff(false);
-    const savedCycle = savedCycles.find((cycle) => cycle.workflowMetadata?.id === activeWorkflowMetadata.id);
+    const savedCycle = savedCycles
+      .filter((cycle) => cycle.workflowMetadata?.id === activeWorkflowMetadata.id)
+      .sort((left, right) => {
+        const leftRevision = new Date(left.workflowMetadata?.updatedAt ?? left.timestamp).getTime();
+        const rightRevision = new Date(right.workflowMetadata?.updatedAt ?? right.timestamp).getTime();
+        return rightRevision - leftRevision || right.id.localeCompare(left.id);
+      })[0];
     const sourceKind = savedCycle ? 'local-cycle' : 'current';
     const sourceId = savedCycle?.id ?? 'current';
     navigate(`/monitor?workflowId=${encodeURIComponent(activeWorkflowMetadata.workflowId)}&sourceKind=${sourceKind}&sourceId=${encodeURIComponent(sourceId)}`);

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { Archive, CheckCircle2, Clock3, FileText, GitBranch, Map, RefreshCw } from 'lucide-react';
@@ -36,6 +36,13 @@ import {
 } from '../../utils/discussionGrouping';
 import type { ForecastWorkspaceController } from '../ForecastWorkspace/useForecastWorkspaceController';
 import CompletionValidationModal from '../CompletionValidation/CompletionValidationModal';
+import CompletionHandoff from './CompletionHandoff';
+import {
+  getCompletionHandoffEligibility,
+  getCompletionHandoffIdentity,
+  hasHandledCompletionHandoff,
+  markCompletionHandoffHandled,
+} from './completionHandoffPolicy';
 import './ForecastWorkflowPanel.css';
 
 interface ForecastWorkflowPanelProps {
@@ -430,6 +437,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const [isPackageDownloading, setIsPackageDownloading] = useState(false);
+  const [showCompletionHandoff, setShowCompletionHandoff] = useState(false);
   const forecastCycle = useSelector(selectForecastCycle);
   const hasActiveWorkflow = useSelector(selectHasActiveWorkflow);
   const workflowMetadata = useSelector(selectWorkflowMetadata);
@@ -437,8 +445,16 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const validationResult = useSelector(selectCompletionValidationResult);
   const omittedDays = useSelector(selectOmittedDays);
   const previousSuggestion = usePreviousOutlookSuggestion();
+  const handoffEligibility = getCompletionHandoffEligibility(workflowTemplate, workflowMetadata);
+  const handoffIdentity = workflowMetadata ? getCompletionHandoffIdentity(workflowMetadata) : '';
 
-  if (shouldHideWorkflowPanel(isFeatureExposed('forecastWorkflowV2'), hasActiveWorkflow, workflowMetadata)) {
+  useEffect(() => {
+    setShowCompletionHandoff(
+      Boolean(handoffIdentity) && handoffEligibility.showHandoff && !hasHandledCompletionHandoff(handoffIdentity),
+    );
+  }, [handoffEligibility.showHandoff, handoffIdentity]);
+
+  if (!workflowMetadata || shouldHideWorkflowPanel(isFeatureExposed('forecastWorkflowV2'), hasActiveWorkflow, workflowMetadata)) {
     return null;
   }
 
@@ -462,7 +478,6 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const isReviewed = Boolean(forecastCycle.completionAcknowledgedAt);
   const hasSameDayWork = hasSameDayWorkflowWork(forecastCycle.cycleDate, currentDay);
   const currentVersion = getCurrentWorkflowVersion(workflowMetadata.outlookVersions);
-
   const statusLabel = getWorkflowStatusLabel({
     hasMapStarted,
     isUpdating,
@@ -505,6 +520,34 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
     } finally {
       setIsPackageDownloading(false);
     }
+  }
+  /** Exports the complete cycle through the existing WF-09 package path. */
+  function handleCycleExport(): void {
+    if (controller) {
+      controller.onCyclePackageDownload();
+      return;
+    }
+    setIsPackageDownloading(true);
+    downloadGfcPackage(
+      forecastCycle,
+      { center: [39.8283, -98.5795], zoom: 4 },
+      workflowMetadata,
+      'cycle',
+    ).finally(() => setIsPackageDownloading(false)).catch(() => undefined);
+  }
+  function handleDismissHandoff(): void {
+    markCompletionHandoffHandled(handoffIdentity);
+    setShowCompletionHandoff(false);
+  }
+  function handleOpenMonitor(): void {
+    markCompletionHandoffHandled(handoffIdentity);
+    setShowCompletionHandoff(false);
+    navigate(`/monitor?workflowId=${encodeURIComponent(workflowMetadata!.workflowId)}&cycleId=${encodeURIComponent(workflowMetadata!.id)}`);
+  }
+  function handleReturnToMap(): void {
+    markCompletionHandoffHandled(handoffIdentity);
+    setShowCompletionHandoff(false);
+    navigate('/forecast');
   }
   /** Starts today's workflow from the suggested previous-cycle outlook. */
   function handleStartFromPrevious(): void {
@@ -582,6 +625,16 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
           navigate('/forecast');
         }}
         onExport={() => { handleWorkflowExport().catch(() => undefined); }}
+      />
+      <CompletionHandoff
+        open={showCompletionHandoff}
+        showMonitor={handoffEligibility.showMonitor}
+        isDownloading={isPackageDownloading || Boolean(controller?.isPackageDownloading)}
+        onWorkflowExport={controller?.onWorkflowPackageDownload ?? (() => { handleWorkflowExport().catch(() => undefined); })}
+        onCycleExport={handleCycleExport}
+        onMonitor={handleOpenMonitor}
+        onReturnToMap={handleReturnToMap}
+        onDismiss={handleDismissHandoff}
       />
     </section>
   );

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -439,6 +439,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const [isPackageDownloading, setIsPackageDownloading] = useState(false);
   const [showCompletionHandoff, setShowCompletionHandoff] = useState(false);
   const forecastCycle = useSelector(selectForecastCycle);
+  const savedCycles = useSelector(selectSavedCycles);
   const hasActiveWorkflow = useSelector(selectHasActiveWorkflow);
   const workflowMetadata = useSelector(selectWorkflowMetadata);
   const workflowTemplate = useSelector(selectWorkflowTemplate);
@@ -447,6 +448,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const previousSuggestion = usePreviousOutlookSuggestion();
   const handoffEligibility = getCompletionHandoffEligibility(workflowTemplate, workflowMetadata);
   const handoffIdentity = workflowMetadata ? getCompletionHandoffIdentity(workflowMetadata) : '';
+  const activeWorkflowMetadata = workflowMetadata;
 
   useEffect(() => {
     setShowCompletionHandoff(
@@ -535,15 +537,22 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
       'cycle',
     ).finally(() => setIsPackageDownloading(false)).catch(() => undefined);
   }
+  /** Dismisses guidance while leaving the completed workflow untouched. */
   function handleDismissHandoff(): void {
     markCompletionHandoffHandled(handoffIdentity);
     setShowCompletionHandoff(false);
   }
+  /** Opens Monitor with the active cycle's actual source-option namespace. */
   function handleOpenMonitor(): void {
     markCompletionHandoffHandled(handoffIdentity);
     setShowCompletionHandoff(false);
-    navigate(`/monitor?workflowId=${encodeURIComponent(workflowMetadata!.workflowId)}&cycleId=${encodeURIComponent(workflowMetadata!.id)}`);
+    if (!activeWorkflowMetadata) return;
+    const savedCycle = savedCycles.find((cycle) => cycle.workflowMetadata?.id === activeWorkflowMetadata.id);
+    const sourceKind = savedCycle ? 'local-cycle' : 'current';
+    const sourceId = savedCycle?.id ?? 'current';
+    navigate(`/monitor?workflowId=${encodeURIComponent(activeWorkflowMetadata.workflowId)}&sourceKind=${sourceKind}&sourceId=${encodeURIComponent(sourceId)}`);
   }
+  /** Closes guidance and returns the user to the forecast map. */
   function handleReturnToMap(): void {
     markCompletionHandoffHandled(handoffIdentity);
     setShowCompletionHandoff(false);

--- a/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
+++ b/src/components/ForecastWorkflow/ForecastWorkflowPanel.tsx
@@ -448,7 +448,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const previousSuggestion = usePreviousOutlookSuggestion();
   const handoffEligibility = getCompletionHandoffEligibility(workflowTemplate, workflowMetadata);
   const handoffIdentity = workflowMetadata ? getCompletionHandoffIdentity(workflowMetadata) : '';
-  const activeWorkflowMetadata = workflowMetadata;
+  const activeWorkflowMetadata = workflowMetadata as NonNullable<typeof workflowMetadata>;
 
   useEffect(() => {
     setShowCompletionHandoff(
@@ -456,7 +456,7 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
     );
   }, [handoffEligibility.showHandoff, handoffIdentity]);
 
-  if (!workflowMetadata || shouldHideWorkflowPanel(isFeatureExposed('forecastWorkflowV2'), hasActiveWorkflow, workflowMetadata)) {
+  if (shouldHideWorkflowPanel(isFeatureExposed('forecastWorkflowV2'), hasActiveWorkflow, workflowMetadata)) {
     return null;
   }
 
@@ -476,10 +476,10 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   const activeUpdateVersion = forecastCycle.updateInProgressVersion;
   const isUpdating = typeof activeUpdateVersion === 'number';
   const canReviewPackage = canReviewWorkflowPackage(mapIsComplete, discussionIsComplete, isUpdating, Boolean(controller), context);
-  const canExportPackage = canExportWorkflowPackage(hasMapStarted, hasDiscussion, workflowMetadata.outlookVersions.length);
+  const canExportPackage = canExportWorkflowPackage(hasMapStarted, hasDiscussion, activeWorkflowMetadata.outlookVersions.length);
   const isReviewed = Boolean(forecastCycle.completionAcknowledgedAt);
   const hasSameDayWork = hasSameDayWorkflowWork(forecastCycle.cycleDate, currentDay);
-  const currentVersion = getCurrentWorkflowVersion(workflowMetadata.outlookVersions);
+  const currentVersion = getCurrentWorkflowVersion(activeWorkflowMetadata.outlookVersions);
   const statusLabel = getWorkflowStatusLabel({
     hasMapStarted,
     isUpdating,
@@ -546,7 +546,6 @@ export const ForecastWorkflowPanel: React.FC<ForecastWorkflowPanelProps> = ({ co
   function handleOpenMonitor(): void {
     markCompletionHandoffHandled(handoffIdentity);
     setShowCompletionHandoff(false);
-    if (!activeWorkflowMetadata) return;
     const savedCycle = savedCycles.find((cycle) => cycle.workflowMetadata?.id === activeWorkflowMetadata.id);
     const sourceKind = savedCycle ? 'local-cycle' : 'current';
     const sourceId = savedCycle?.id ?? 'current';

--- a/src/components/ForecastWorkflow/completionHandoff.test.ts
+++ b/src/components/ForecastWorkflow/completionHandoff.test.ts
@@ -1,0 +1,34 @@
+import { getCompletionHandoffEligibility, getCompletionHandoffIdentity } from './completionHandoffPolicy';
+import type { CycleMetadata, WorkflowMetadata } from '../../types/workflow';
+
+const cycle: CycleMetadata = {
+  id: 'cycle-1', workflowId: 'severe-day1', cycleDate: '2026-07-15', status: 'completed',
+  outlookVersions: [{ version: 1, status: 'completed', createdAt: '2026-07-15T00:00:00Z' }],
+  createdAt: '2026-07-15T00:00:00Z', updatedAt: '2026-07-15T01:00:00Z',
+};
+const workflow = (groupings: WorkflowMetadata['groupings']): WorkflowMetadata => ({ id: 'wf', label: 'Workflow', groupings });
+
+describe('completion handoff policy', () => {
+  it('supports a completed Day 1 workflow and Monitor', () => {
+    expect(getCompletionHandoffEligibility(workflow(['day1']), cycle)).toEqual({ showHandoff: true, showMonitor: true });
+  });
+
+  it('supports short-term workflows without offering Monitor when Day 1 is absent', () => {
+    expect(getCompletionHandoffEligibility(workflow(['day2', 'day3']), cycle)).toEqual({ showHandoff: true, showMonitor: false });
+  });
+
+  it('fails closed for incomplete, long-range, custom, and malformed workflows', () => {
+    expect(getCompletionHandoffEligibility(workflow(['day1']), { ...cycle, status: 'in-progress' })).toEqual({ showHandoff: false, showMonitor: false });
+    expect(getCompletionHandoffEligibility(workflow(['day4-8']), cycle)).toEqual({ showHandoff: false, showMonitor: false });
+    expect(getCompletionHandoffEligibility(workflow(['custom' as never]), cycle)).toEqual({ showHandoff: false, showMonitor: false });
+    expect(getCompletionHandoffEligibility(undefined, cycle)).toEqual({ showHandoff: false, showMonitor: false });
+  });
+
+  it('changes identity when the completion revision changes', () => {
+    expect(getCompletionHandoffIdentity(cycle)).not.toBe(getCompletionHandoffIdentity({
+      ...cycle,
+      updatedAt: '2026-07-15T02:00:00Z',
+      outlookVersions: [...cycle.outlookVersions, { version: 2, status: 'completed', createdAt: '2026-07-15T02:00:00Z' }],
+    }));
+  });
+});

--- a/src/components/ForecastWorkflow/completionHandoffPolicy.ts
+++ b/src/components/ForecastWorkflow/completionHandoffPolicy.ts
@@ -1,0 +1,40 @@
+import type { CycleMetadata, WorkflowMetadata } from '../../types/workflow';
+
+export interface CompletionHandoffEligibility { showHandoff: boolean; showMonitor: boolean; }
+
+const MONITOR_SUPPORTED_GROUPINGS = new Set(['day1']);
+const COMPLETED_STATUSES = new Set(['completed', 'completed-with-omissions']);
+
+/** Returns the post-completion actions allowed for a known workflow shape. */
+export const getCompletionHandoffEligibility = (
+  workflow: WorkflowMetadata | undefined,
+  cycle: CycleMetadata | undefined,
+): CompletionHandoffEligibility => {
+  if (!workflow || !cycle || !COMPLETED_STATUSES.has(cycle.status)) {
+    return { showHandoff: false, showMonitor: false };
+  }
+  const groupings = workflow.groupings;
+  const isKnownShortTermWorkflow = groupings.length > 0 && groupings.every(
+    (grouping) => grouping === 'day1' || grouping === 'day2' || grouping === 'day3',
+  );
+  return {
+    showHandoff: isKnownShortTermWorkflow,
+    showMonitor: isKnownShortTermWorkflow && groupings.some((grouping) => MONITOR_SUPPORTED_GROUPINGS.has(grouping)),
+  };
+};
+
+/** Stable identity used to suppress a handoff only for one completion revision. */
+export const getCompletionHandoffIdentity = (cycle: CycleMetadata): string => {
+  const version = cycle.outlookVersions.reduce((highest, item) => Math.max(highest, item.version), 1);
+  return `${cycle.id}:${cycle.workflowId}:${version}:${cycle.updatedAt}`;
+};
+
+export const COMPLETION_HANDOFF_STORAGE_KEY = 'gfc-completion-handoff-handled';
+
+export const hasHandledCompletionHandoff = (identity: string): boolean => {
+  try { return sessionStorage.getItem(`${COMPLETION_HANDOFF_STORAGE_KEY}:${identity}`) === 'true'; } catch { return false; }
+};
+
+export const markCompletionHandoffHandled = (identity: string): void => {
+  try { sessionStorage.setItem(`${COMPLETION_HANDOFF_STORAGE_KEY}:${identity}`, 'true'); } catch { /* best effort */ }
+};

--- a/src/components/ForecastWorkflow/completionHandoffPolicy.ts
+++ b/src/components/ForecastWorkflow/completionHandoffPolicy.ts
@@ -5,9 +5,11 @@ export interface CompletionHandoffEligibility { showHandoff: boolean; showMonito
 const MONITOR_SUPPORTED_GROUPINGS = new Set(['day1']);
 const COMPLETED_STATUSES = new Set(['completed', 'completed-with-omissions']);
 
+/** Returns whether the cycle reached a completion status eligible for handoff guidance. */
 const isCompletedCycle = (cycle: CycleMetadata | undefined): cycle is CycleMetadata =>
   Boolean(cycle && COMPLETED_STATUSES.has(cycle.status));
 
+/** Returns whether the workflow uses one of the supported short-term groupings. */
 const isSupportedShortTermWorkflow = (workflow: WorkflowMetadata | undefined): workflow is WorkflowMetadata =>
   Boolean(
     workflow
@@ -15,6 +17,7 @@ const isSupportedShortTermWorkflow = (workflow: WorkflowMetadata | undefined): w
     && workflow.groupings.every((grouping) => ['day1', 'day2', 'day3'].includes(grouping)),
   );
 
+/** Returns whether Monitor is supported for at least one grouping in the workflow. */
 const supportsMonitor = (workflow: WorkflowMetadata): boolean =>
   workflow.groupings.some((grouping) => MONITOR_SUPPORTED_GROUPINGS.has(grouping));
 

--- a/src/components/ForecastWorkflow/completionHandoffPolicy.ts
+++ b/src/components/ForecastWorkflow/completionHandoffPolicy.ts
@@ -5,21 +5,33 @@ export interface CompletionHandoffEligibility { showHandoff: boolean; showMonito
 const MONITOR_SUPPORTED_GROUPINGS = new Set(['day1']);
 const COMPLETED_STATUSES = new Set(['completed', 'completed-with-omissions']);
 
+const isCompletedCycle = (cycle: CycleMetadata | undefined): cycle is CycleMetadata =>
+  Boolean(cycle && COMPLETED_STATUSES.has(cycle.status));
+
+const isSupportedShortTermWorkflow = (workflow: WorkflowMetadata | undefined): workflow is WorkflowMetadata =>
+  Boolean(
+    workflow
+    && workflow.groupings.length > 0
+    && workflow.groupings.every((grouping) => ['day1', 'day2', 'day3'].includes(grouping)),
+  );
+
+const supportsMonitor = (workflow: WorkflowMetadata): boolean =>
+  workflow.groupings.some((grouping) => MONITOR_SUPPORTED_GROUPINGS.has(grouping));
+
 /** Returns the post-completion actions allowed for a known workflow shape. */
 export const getCompletionHandoffEligibility = (
   workflow: WorkflowMetadata | undefined,
   cycle: CycleMetadata | undefined,
 ): CompletionHandoffEligibility => {
-  if (!workflow || !cycle || !COMPLETED_STATUSES.has(cycle.status)) {
+  if (!isCompletedCycle(cycle)) {
     return { showHandoff: false, showMonitor: false };
   }
-  const groupings = workflow.groupings;
-  const isKnownShortTermWorkflow = groupings.length > 0 && groupings.every(
-    (grouping) => grouping === 'day1' || grouping === 'day2' || grouping === 'day3',
-  );
+  if (!isSupportedShortTermWorkflow(workflow)) {
+    return { showHandoff: false, showMonitor: false };
+  }
   return {
-    showHandoff: isKnownShortTermWorkflow,
-    showMonitor: isKnownShortTermWorkflow && groupings.some((grouping) => MONITOR_SUPPORTED_GROUPINGS.has(grouping)),
+    showHandoff: true,
+    showMonitor: supportsMonitor(workflow),
   };
 };
 
@@ -31,10 +43,12 @@ export const getCompletionHandoffIdentity = (cycle: CycleMetadata): string => {
 
 export const COMPLETION_HANDOFF_STORAGE_KEY = 'gfc-completion-handoff-handled';
 
+/** Reads whether this completion revision was already handled in this session. */
 export const hasHandledCompletionHandoff = (identity: string): boolean => {
   try { return sessionStorage.getItem(`${COMPLETION_HANDOFF_STORAGE_KEY}:${identity}`) === 'true'; } catch { return false; }
 };
 
+/** Records a handled completion revision without making storage a hard dependency. */
 export const markCompletionHandoffHandled = (identity: string): void => {
   try { sessionStorage.setItem(`${COMPLETION_HANDOFF_STORAGE_KEY}:${identity}`, 'true'); } catch { /* best effort */ }
 };

--- a/src/pages/MonitorPage.tsx
+++ b/src/pages/MonitorPage.tsx
@@ -47,6 +47,22 @@ interface PageContext {
   addToast: AddToastFn;
 }
 
+/** Resolves a handoff source only when its kind and ID match a real Monitor option. */
+const resolveHandoffSource = (
+  searchParams: URLSearchParams,
+  options: MonitorOutlookSourceOption[],
+): MonitorOutlookSourceOption | undefined => {
+  const sourceKind = searchParams.get('sourceKind');
+  const sourceId = searchParams.get('sourceId');
+  if (sourceKind && sourceId) {
+    return options.find((option) => option.kind === sourceKind && option.id === sourceId);
+  }
+  if (searchParams.get('workflowId')) {
+    return options.find((option) => option.kind === 'current' && option.id === 'current');
+  }
+  return undefined;
+};
+
 interface MonitorPageWorkspaceProps {
   settings: MonitorSettings;
   outlookOptions: MonitorOutlookSourceOption[];
@@ -171,16 +187,11 @@ export const MonitorPage: React.FC = () => {
 
   useEffect(() => {
     if (didApplyHandoffSource.current) return;
-    const cycleId = searchParams.get('cycleId');
-    const matchingCycle = cycleId && outlookOptions.find((option) => option.id === cycleId);
-    if (matchingCycle) {
-      dispatch(setMonitorOutlookSource({ kind: matchingCycle.kind, id: matchingCycle.id }));
+    const matchingSource = resolveHandoffSource(searchParams, outlookOptions);
+    if (matchingSource) {
+      dispatch(setMonitorOutlookSource({ kind: matchingSource.kind, id: matchingSource.id }));
       didApplyHandoffSource.current = true;
       return;
-    }
-    if (searchParams.get('workflowId') && outlookOptions.some((option) => option.id === 'current')) {
-      dispatch(setMonitorOutlookSource({ kind: 'current', id: 'current' }));
-      didApplyHandoffSource.current = true;
     }
   }, [dispatch, outlookOptions, searchParams]);
   const selectedOutlook = useMonitorCloudOutlook({ selectedOption, today, addToast });

--- a/src/pages/MonitorPage.tsx
+++ b/src/pages/MonitorPage.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext, useSearchParams } from 'react-router-dom';
 import type { RootState, AppDispatch } from '../store';
 import {
   setAnimationEnabled,
@@ -144,6 +144,8 @@ const MonitorPageWorkspace: React.FC<MonitorPageWorkspaceProps> = ({
 export const MonitorPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const { addToast } = useOutletContext<PageContext>();
+  const [searchParams] = useSearchParams();
+  const didApplyHandoffSource = useRef(false);
   const settings = useSelector((state: RootState) => state.monitor);
   const currentCycle = useSelector(selectForecastCycle);
   const savedCycles = useSelector(selectSavedCycles);
@@ -166,6 +168,21 @@ export const MonitorPage: React.FC = () => {
     () => resolveSelectedOutlookOption(outlookOptions, settings.outlookSource),
     [outlookOptions, settings.outlookSource]
   );
+
+  useEffect(() => {
+    if (didApplyHandoffSource.current) return;
+    const cycleId = searchParams.get('cycleId');
+    const matchingCycle = cycleId && outlookOptions.find((option) => option.id === cycleId);
+    if (matchingCycle) {
+      dispatch(setMonitorOutlookSource({ kind: matchingCycle.kind, id: matchingCycle.id }));
+      didApplyHandoffSource.current = true;
+      return;
+    }
+    if (searchParams.get('workflowId') && outlookOptions.some((option) => option.id === 'current')) {
+      dispatch(setMonitorOutlookSource({ kind: 'current', id: 'current' }));
+      didApplyHandoffSource.current = true;
+    }
+  }, [dispatch, outlookOptions, searchParams]);
   const selectedOutlook = useMonitorCloudOutlook({ selectedOption, today, addToast });
 
   const radarConfig = useMemo(() => buildRadarLayerConfig(settings), [settings]);

--- a/src/pages/MonitorPage.tsx
+++ b/src/pages/MonitorPage.tsx
@@ -190,7 +190,6 @@ export const MonitorPage: React.FC = () => {
     if (matchingSource) {
       dispatch(setMonitorOutlookSource({ kind: matchingSource.kind, id: matchingSource.id }));
       didApplyHandoffSource.current = true;
-      return;
     }
   }, [dispatch, outlookOptions, searchParams]);
   const selectedOutlook = useMonitorCloudOutlook({ selectedOption, today, addToast });

--- a/src/pages/MonitorPage.tsx
+++ b/src/pages/MonitorPage.tsx
@@ -60,6 +60,7 @@ const resolveHandoffSource = (
   if (searchParams.get('workflowId')) {
     return options.find((option) => option.kind === 'current' && option.id === 'current');
   }
+  return undefined;
 };
 
 interface MonitorPageWorkspaceProps {

--- a/src/pages/MonitorPage.tsx
+++ b/src/pages/MonitorPage.tsx
@@ -60,7 +60,6 @@ const resolveHandoffSource = (
   if (searchParams.get('workflowId')) {
     return options.find((option) => option.kind === 'current' && option.id === 'current');
   }
-  return undefined;
 };
 
 interface MonitorPageWorkspaceProps {


### PR DESCRIPTION
## Summary

- add a post-completion handoff for supported workflow packages
- reuse WF-09 workflow/cycle package export callbacks
- carry workflow/cycle hints into Monitor with safe source fallback
- suppress repeated guidance per completion revision

## Verification

- `pnpm test -- --runInBand src/components/ForecastWorkflow/completionHandoff.test.ts src/components/ForecastWorkflow/CompletionHandoff.test.tsx src/pages/MonitorPage.test.tsx src/components/ForecastWorkspace/forecastWorkspaceActions.test.tsx`
- `pnpm exec playwright test e2e/smoke.spec.ts --project=chromium` (9 passed)
- `pnpm run build` (bundle completed; existing Sentry upload reports 403)
- `git diff --check`

Closes #495
