### PR TITLE
fix(workflow): preserve fresh starts and resumed workflow state

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #711
+
+- Clear scoped autosaves when users confirm a fresh blank or workflow start, restore workflow metadata from saved cycles, and keep workflow confirmation and completion dialogs usable on small screens.
+
 ### PR #699
 
 - Add post-completion handoff guidance for workflow and complete-cycle exports, eligible Monitor navigation, return-to-map, and duplicate-prompt suppression.

--- a/src/components/CompletionValidation/CompletionValidationModal.css
+++ b/src/components/CompletionValidation/CompletionValidationModal.css
@@ -1,5 +1,7 @@
 .completion-modal {
+  width: min(40rem, calc(100vw - 1rem));
   max-width: 40rem;
+  max-height: calc(100dvh - 1rem);
   gap: 0.7rem;
   border-radius: 0.75rem;
   padding: 1rem;
@@ -100,6 +102,8 @@
 }
 
 .completion-modal-footer {
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   padding-top: 0;
 }
@@ -143,4 +147,24 @@
 
 .dark-mode .completion-issue-item {
   background: rgba(255, 255, 255, 0.04);
+}
+
+@media (max-width: 560px) {
+  .completion-modal {
+    padding: 0.75rem;
+  }
+
+  .completion-issue-item {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .completion-issue-nav-btn {
+    align-self: flex-start;
+  }
+
+  .completion-modal-footer > * {
+    width: 100%;
+  }
 }

--- a/src/hooks/useAutoSave.test.tsx
+++ b/src/hooks/useAutoSave.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { act, render, waitFor } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import forecastReducer, { setMapView, setCycleDate } from '../store/forecastSlice';
-import { migrateLegacyAutoSave, pickNewestAutoSaveValue, selectPreferredAutoSaveValue, useAutoSave } from './useAutoSave';
+import { clearAutoSave, migrateLegacyAutoSave, pickNewestAutoSaveValue, selectPreferredAutoSaveValue, useAutoSave } from './useAutoSave';
 import { serializeForecast } from '../utils/fileUtils';
 
 jest.mock('../utils/fileUtils', () => ({
@@ -68,6 +68,16 @@ describe('useAutoSave', () => {
     expect(selectPreferredAutoSaveValue(scoped, legacy)).toBe(scoped);
     expect(selectPreferredAutoSaveValue(null, legacy)).toBe(legacy);
     expect(pickNewestAutoSaveValue(scoped, legacy, JSON.stringify({ live: true, timestamp: '2026-07-14T11:00:00.000Z' }))).toBe(legacy);
+  });
+
+  test('clears the active account autosave and legacy fallback for a fresh workflow', () => {
+    localStorage.setItem('forecastData:user-user-1', JSON.stringify({ account: true }));
+    localStorage.setItem('forecastData', JSON.stringify({ legacy: true }));
+
+    clearAutoSave('user-1');
+
+    expect(localStorage.getItem('forecastData:user-user-1')).toBeNull();
+    expect(localStorage.getItem('forecastData')).toBeNull();
   });
 
   test('does not overwrite an existing signed-in autosave during migration', () => {

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -12,6 +12,18 @@ const LOCAL_STORAGE_KEY = 'forecastData';
 export const getAutoSaveStorageKey = (userId?: string | null): string =>
   userId ? getScopedStorageKey(LOCAL_STORAGE_KEY, getStorageScope(userId)) : LOCAL_STORAGE_KEY;
 
+/** Clears autosave snapshots before starting a deliberately fresh forecast workflow. */
+export const clearAutoSave = (userId?: string | null): void => {
+  try {
+    localStorage.removeItem(getAutoSaveStorageKey(userId));
+    if (userId) {
+      localStorage.removeItem(LOCAL_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures so starting a workflow remains usable.
+  }
+};
+
 /** Returns the persisted autosave timestamp, or 0 when missing or malformed. */
 export const getAutoSaveTimestamp = (storedValue: string | null): number => {
   if (!storedValue) return 0;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -263,11 +263,13 @@ const LegacyHomePage: React.FC<{ logic: HomeLogic }> = ({ logic }) => {
       <CycleHistoryModal isOpen={showHistoryModal} onClose={handleCloseHistoryModal} />
       <ConfirmationModal
         isOpen={confirmNewCycle}
-        title="Start Blank Cycle"
-        message="You have unsaved changes. Start a blank forecast cycle without workflow steps?"
+        title={logic.pendingWorkflow ? 'Start Workflow' : 'Start Blank Cycle'}
+        message={logic.pendingWorkflow
+          ? `You have unsaved changes. Start the ${logic.pendingWorkflow.label} workflow and discard the current changes?`
+          : 'You have unsaved changes. Start a blank forecast cycle and discard the current changes?'}
         onConfirm={handleConfirmNewCycle}
         onCancel={handleCancelNewCycle}
-        confirmLabel="Start Blank Cycle"
+        confirmLabel={logic.pendingWorkflow ? 'Start Workflow' : 'Start Blank Cycle'}
       />
     </div>
   );
@@ -395,11 +397,13 @@ const HomePage: React.FC = () => {
       <CycleHistoryModal isOpen={showHistoryModal} onClose={handleCloseHistoryModal} />
       <ConfirmationModal
         isOpen={confirmNewCycle}
-        title="Start Blank Cycle"
-        message="You have unsaved changes. Start a blank forecast cycle without workflow steps?"
+        title={logic.pendingWorkflow ? 'Start Workflow' : 'Start Blank Cycle'}
+        message={logic.pendingWorkflow
+          ? `You have unsaved changes. Start the ${logic.pendingWorkflow.label} workflow and discard the current changes?`
+          : 'You have unsaved changes. Start a blank forecast cycle and discard the current changes?'}
         onConfirm={handleConfirmNewCycle}
         onCancel={handleCancelNewCycle}
-        confirmLabel="Start Blank Cycle"
+        confirmLabel={logic.pendingWorkflow ? 'Start Workflow' : 'Start Blank Cycle'}
       />
     </div>
   );

--- a/src/pages/home/useHomePageLogic.test.tsx
+++ b/src/pages/home/useHomePageLogic.test.tsx
@@ -70,6 +70,15 @@ describe('useHomePageLogic', () => {
           cycleDate: '2026-03-27',
         },
         stats: { forecastDays: 1, totalOutlooks: 1, totalFeatures: 1 },
+        workflowMetadata: {
+          id: 'WF-severe-day1-2026-03-27',
+          workflowId: 'severe-day1',
+          cycleDate: '2026-03-27',
+          status: 'in-progress',
+          outlookVersions: [{ version: 1, status: 'in-progress', createdAt: '2026-03-27T12:00:00Z' }],
+          createdAt: '2026-03-27T12:00:00Z',
+          updatedAt: '2026-03-27T12:00:00Z',
+        },
       },
     ];
 
@@ -110,6 +119,8 @@ describe('useHomePageLogic', () => {
     });
     expect(addToast).toHaveBeenCalledWith('Cycle loaded from history', 'success');
     expect(store.getState().forecast.forecastCycle.currentDay).toBe(8);
+    expect(store.getState().forecast.workflowMetadata?.workflowId).toBe('severe-day1');
+    expect(store.getState().forecast.isWorkflowActive).toBe(true);
 
     act(() => {
       result.current.handleNewCycle();

--- a/src/pages/home/useHomePageLogic.test.tsx
+++ b/src/pages/home/useHomePageLogic.test.tsx
@@ -53,7 +53,13 @@ describe('useHomePageLogic', () => {
     mockUseAuth.mockReturnValue({
       hostedAuthEnabled: true,
       status: 'signed_in',
+      user: { uid: 'user-1' },
     });
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
   });
 
   test('returns signed-in home state and handles quick-start, history, and cycle loading', () => {
@@ -141,6 +147,7 @@ describe('useHomePageLogic', () => {
 
   test('starts a new cycle immediately when the workspace is already saved', () => {
     const store = buildStore({ isSaved: true });
+    localStorage.setItem('forecastData:user-user-1', JSON.stringify({ stale: true }));
 
     const { result } = renderHook(() => useHomePageLogic(), { wrapper: wrapper(store) });
 
@@ -152,6 +159,7 @@ describe('useHomePageLogic', () => {
     expect(addToast).toHaveBeenCalledWith('Started new forecast cycle', 'success');
     expect(result.current.confirmNewCycle).toBe(false);
     expect(handleSave).toHaveBeenCalledTimes(0);
+    expect(localStorage.getItem('forecastData:user-user-1')).toBeNull();
   });
 
   test('ignores malformed quick-start and recent-cycle clicks', () => {

--- a/src/pages/home/useHomePageLogic.test.tsx
+++ b/src/pages/home/useHomePageLogic.test.tsx
@@ -115,10 +115,12 @@ describe('useHomePageLogic', () => {
     expect(result.current.showHistoryModal).toBe(false);
 
     act(() => {
+      localStorage.setItem('forecastData:user-user-1', JSON.stringify({ stale: true }));
       result.current.handleQuickStartClick({ currentTarget: { dataset: { day: '5' } } } as React.MouseEvent<HTMLButtonElement>);
     });
     expect(navigate).toHaveBeenCalledWith('/forecast');
     expect(store.getState().forecast.forecastCycle.currentDay).toBe(5);
+    expect(localStorage.getItem('forecastData:user-user-1')).toBeNull();
 
     act(() => {
       result.current.handleLoadRecentCycleClick({ currentTarget: { dataset: { cycleId: 'cycle-1' } } } as React.MouseEvent<HTMLButtonElement>);

--- a/src/pages/home/useHomePageLogic.ts
+++ b/src/pages/home/useHomePageLogic.ts
@@ -73,6 +73,7 @@ const useHomePageLogic = () => {
 
   /** Quickly navigate to the forecast editor for the given day. */
   const handleQuickStart = (day: DayType) => {
+    clearAutoSave(user?.uid);
     dispatch(setForecastDay(day));
     navigate('/forecast');
   };

--- a/src/pages/home/useHomePageLogic.ts
+++ b/src/pages/home/useHomePageLogic.ts
@@ -153,8 +153,8 @@ const useHomePageLogic = () => {
 
   /** Confirm starting a new cycle (discard changes). */
   const handleConfirmNewCycle = () => {
+    clearAutoSave(user?.uid);
     if (pendingWorkflow) {
-      clearAutoSave(user?.uid);
       dispatch(startBlankCycle({
         workflowTemplate: pendingWorkflow,
         cycleDate: getLocalCalendarDate(),

--- a/src/pages/home/useHomePageLogic.ts
+++ b/src/pages/home/useHomePageLogic.ts
@@ -66,6 +66,7 @@ const useHomePageLogic = () => {
       setConfirmNewCycle(true);
       return;
     }
+    clearAutoSave(user?.uid);
     dispatch(resetForecasts());
     addToast('Started new forecast cycle', 'success');
   };

--- a/src/pages/home/useHomePageLogic.ts
+++ b/src/pages/home/useHomePageLogic.ts
@@ -7,7 +7,6 @@ import {
   selectForecastCycle,
   setForecastDay,
   resetForecasts,
-  importForecastCycle,
   loadSavedCycle,
   selectWorkflowMetadata,
   selectHasActiveWorkflow,
@@ -20,6 +19,7 @@ import { computeHomeStats, formatCycleDate } from '../homeUtils';
 import { createFileHandlers } from '../../hooks/useFileLoader';
 import { useAuth } from '../../auth/AuthProvider';
 import { isFeatureExposed } from '../../config/featureExposure';
+import { clearAutoSave } from '../../hooks/useAutoSave';
 
 /** Returns today's local calendar date as YYYY-MM-DD without UTC conversion. */
 function getLocalCalendarDate(): string {
@@ -38,7 +38,7 @@ const useHomePageLogic = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { addToast } = useOutletContext<{ addToast: AddToastFn }>();
-  const { hostedAuthEnabled, status } = useAuth();
+  const { hostedAuthEnabled, status, user } = useAuth();
   const forecastCycle = useSelector(selectForecastCycle);
   const workflowMetadata = useSelector(selectWorkflowMetadata);
   const hasActiveWorkflow = useSelector(selectHasActiveWorkflow);
@@ -84,6 +84,7 @@ const useHomePageLogic = () => {
       setConfirmNewCycle(true);
       return;
     }
+    clearAutoSave(user?.uid);
     dispatch(startBlankCycle({
       workflowTemplate,
       cycleDate: getLocalCalendarDate(),
@@ -138,7 +139,7 @@ const useHomePageLogic = () => {
       return;
     }
 
-    dispatch(importForecastCycle(cycle.forecastCycle));
+    dispatch(loadSavedCycle(cycleId));
     addToast('Cycle loaded from history', 'success');
   };
 
@@ -153,6 +154,7 @@ const useHomePageLogic = () => {
   /** Confirm starting a new cycle (discard changes). */
   const handleConfirmNewCycle = () => {
     if (pendingWorkflow) {
+      clearAutoSave(user?.uid);
       dispatch(startBlankCycle({
         workflowTemplate: pendingWorkflow,
         cycleDate: getLocalCalendarDate(),
@@ -199,6 +201,7 @@ const useHomePageLogic = () => {
     savedCycles,
     forecastCycle,
     workflowMetadata,
+    pendingWorkflow,
     hasActiveWorkflow,
     isSaved,
     workflowEnabled,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -28,6 +28,7 @@ export const store = configureStore({
         // Use regex to match all days and outlook types
         ignoredPaths: [
           /^forecast\.forecastCycle\.days\.\d+\.data\.(categorical|tornado|wind|hail|totalSevere|day4-8)$/,
+          /^forecast\.savedCycles\.\d+\.forecastCycle\.days\.\d+\.data\.(categorical|tornado|wind|hail|totalSevere|day4-8)$/,
           /^forecast\.historyByDay\.\d+\.(undoStack|redoStack)\.\d+\.snapshot\.data\.(categorical|tornado|wind|hail|totalSevere|day4-8)$/,
           /^verification\.loadedForecast\.days\.\d+\.data\.(categorical|tornado|wind|hail|totalSevere|day4-8)$/,
           'forecast.outlooks',
@@ -37,6 +38,9 @@ export const store = configureStore({
           'forecast/removeFeature',
           'forecast/importForecasts',
           'forecast/importForecastCycle',
+          'forecast/loadCycleHistory',
+          'forecast/loadSavedCycle',
+          'forecast/restoreForecastCycle',
           'forecast/setOutlookMap',
           'forecast/applyAutoCategoricalSync',
           'forecast/resetCategorical',


### PR DESCRIPTION
## Changelog

- Workflow beta fixes and test-only access hardening.

## Summary
- clear stale autosave snapshots before deliberately fresh workflow starts
- restore workflow metadata when resuming a saved cycle from Home
- preserve workflow-specific confirmation copy
- narrow Redux serializability ignores for saved-cycle map payloads and restore actions
- keep completion validation dialogs within small viewports

## Verification
- targeted workflow and autosave tests
- full Jest validation completed on the audited workspace
- no Firestore or entitlement behavior changed