### PR TITLE
test(auth): add development-only local account fixtures

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #712
+
+- Add guarded localhost free and premium account fixtures for authenticated workflow E2E testing without hosted Firebase sessions or cloud writes.
+
 ### PR #699
 
 - Add post-completion handoff guidance for workflow and complete-cycle exports, eligible Monitor navigation, return-to-map, and duplicate-prompt suppression.

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -880,6 +880,14 @@ export const localSignOutUser = async (deps: {
   setBetaAccess: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const { setUser, setStatus, setSyncedSettings, setSettingsSyncStatus, setBetaAccess } = deps;
+  const fixtureActive = Boolean(readLocalTestAccount());
+  if (fixtureActive && auth) {
+    try {
+      await signOut(auth);
+    } catch {
+      // Fixture sign-out must still clear the local session if hosted auth is unavailable.
+    }
+  }
   try {
     await postLocalJson('/api/local/signout', { failureMessage: 'Unable to sign out right now.' });
   } catch {

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -23,7 +23,7 @@ import { applyOverlaySettings } from '../store/overlaysSlice';
 import type { OverlaysState } from '../store/overlaysSlice';
 import { applyMonitorSettings } from '../store/monitorSlice';
 import { auth, db, googleAuthProvider, isHostedAuthEnabled, requireAuth, requireDb } from '../lib/firebase';
-import { createLocalTestUser, readLocalTestAccount } from '../lib/localTestAccount';
+import { clearLocalTestAccount, createLocalTestUser, readLocalTestAccount } from '../lib/localTestAccount';
 import { queueProductMetric } from '../utils/productMetrics';
 import type { MonitorSettings } from '../monitor/types';
 import { DEFAULT_MONITOR_SETTINGS, areMonitorSettingsEqual } from '../monitor/types';
@@ -887,6 +887,7 @@ export const localSignOutUser = async (deps: {
   }
 
   setUser(null);
+  clearLocalTestAccount();
   setStatus('signed_out');
   setSyncedSettings(null);
   setSettingsSyncStatus('idle');
@@ -1453,17 +1454,25 @@ const useHostedAuthState = (): AuthContextValue => {
 };
 
 /** Provides hosted-auth state and actions while gracefully falling back to local-only mode. */
-export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const LocalAuthContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const value = useLocalAuthState();
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+const HostedAuthContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const hostedValue = useHostedAuthState();
   const localValue = useLocalAuthState();
-  // Local test accounts must take precedence on localhost so the fixture remains
-  // usable even when a developer has Firebase variables in their .env file.
-  const value = readLocalTestAccount()
-    ? localValue
-    : (isHostedAuthEnabled ? hostedValue : localValue);
+  const value = isHostedAuthEnabled ? hostedValue : localValue;
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
+
+/** Exposes exactly one auth implementation so fixture sessions never run hosted listeners. */
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  readLocalTestAccount()
+    ? <LocalAuthContextProvider>{children}</LocalAuthContextProvider>
+    : <HostedAuthContextProvider>{children}</HostedAuthContextProvider>
+);
 
 /** Reads the current hosted-auth state and actions for the app. */
 export const useAuth = (): AuthContextValue => {

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1467,6 +1467,7 @@ const LocalAuthContextProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
+/** Provides hosted auth state and listeners when no local fixture is active. */
 const HostedAuthContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const hostedValue = useHostedAuthState();
   const localValue = useLocalAuthState();

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -23,6 +23,7 @@ import { applyOverlaySettings } from '../store/overlaysSlice';
 import type { OverlaysState } from '../store/overlaysSlice';
 import { applyMonitorSettings } from '../store/monitorSlice';
 import { auth, db, googleAuthProvider, isHostedAuthEnabled, requireAuth, requireDb } from '../lib/firebase';
+import { createLocalTestUser, readLocalTestAccount } from '../lib/localTestAccount';
 import { queueProductMetric } from '../utils/productMetrics';
 import type { MonitorSettings } from '../monitor/types';
 import { DEFAULT_MONITOR_SETTINGS, areMonitorSettingsEqual } from '../monitor/types';
@@ -600,6 +601,27 @@ export const initLocalAuthState = async (opts: {
   } = opts;
 
   try {
+    const localTestAccount = readLocalTestAccount();
+    if (localTestAccount) {
+      applyLocalAuthData({
+        ...createLocalTestUser(localTestAccount),
+        betaAccess: true,
+      }, {
+        dispatch,
+        currentDarkModeRef,
+        currentOverlaysRef,
+        setUser,
+        setStatus,
+        setSyncedSettings,
+        setSettingsSyncStatus,
+        lastSyncedSettingsRef,
+        setBetaAccess,
+        setBetaAccessLoading,
+        setError,
+      });
+      return;
+    }
+
     const resp = await fetch('/api/local/profile', { method: 'GET', credentials: 'include' });
     if (!isActive()) return;
 
@@ -1434,7 +1456,11 @@ const useHostedAuthState = (): AuthContextValue => {
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const hostedValue = useHostedAuthState();
   const localValue = useLocalAuthState();
-  const value = isHostedAuthEnabled ? hostedValue : localValue;
+  // Local test accounts must take precedence on localhost so the fixture remains
+  // usable even when a developer has Firebase variables in their .env file.
+  const value = readLocalTestAccount()
+    ? localValue
+    : (isHostedAuthEnabled ? hostedValue : localValue);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/src/billing/EntitlementProvider.tsx
+++ b/src/billing/EntitlementProvider.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 import { doc, onSnapshot, type Timestamp } from 'firebase/firestore';
 import { db, requireDb } from '../lib/firebase';
 import { useAuth } from '../auth/AuthProvider';
+import { readLocalTestAccount } from '../lib/localTestAccount';
 
 export type EntitlementStatus = 'disabled' | 'loading' | 'free' | 'premium' | 'error';
 export type PlanInterval = 'monthly' | 'annual' | null;
@@ -260,6 +261,21 @@ const resolveEntitlementEffect = (
     setError: React.Dispatch<React.SetStateAction<string | null>>;
   }
 ) => {
+  const localTestAccount = readLocalTestAccount();
+  if (localTestAccount) {
+    handlers.setEntitlement({
+      ...DEFAULT_ENTITLEMENT,
+      uid: `local-test-${localTestAccount}`,
+      premiumActive: localTestAccount === 'premium',
+      effectiveSource: localTestAccount === 'premium' ? 'stripe' : 'none',
+      planInterval: localTestAccount === 'premium' ? 'monthly' : null,
+      billingStatus: localTestAccount === 'premium' ? 'active' : 'inactive',
+    });
+    handlers.setEntitlementStatus(localTestAccount === 'premium' ? 'premium' : 'free');
+    handlers.setError(null);
+    return null;
+  }
+
   if (!isHostedEntitlementMode(args.hostedAuthEnabled)) {
     applyDisabledEntitlementState(handlers.setEntitlement, handlers.setEntitlementStatus, handlers.setError);
     return null;

--- a/src/billing/EntitlementProvider.tsx
+++ b/src/billing/EntitlementProvider.tsx
@@ -317,7 +317,7 @@ const createEntitlementContextValue = (args: {
   currentPeriodEnd: args.entitlement.currentPeriodEnd?.toDate?.() ?? null,
   stripeCustomerId: args.entitlement.stripeCustomerId,
   betaOverrideActive: args.entitlement.betaOverrideActive,
-  checkoutEnabled: args.billingConfig.checkoutEnabled && args.hostedAuthEnabled,
+  checkoutEnabled: args.billingConfig.checkoutEnabled && args.hostedAuthEnabled && !readLocalTestAccount(),
   billingEnabled: args.billingConfig.billingEnabled,
   annualPromoActive: args.billingConfig.annualPromoActive,
   monthlyDisplayPrice: args.billingConfig.monthlyDisplayPrice,

--- a/src/billing/EntitlementProvider.tsx
+++ b/src/billing/EntitlementProvider.tsx
@@ -360,16 +360,20 @@ const fetchBillingAction = async (
 /** Creates the billing action callbacks used by the entitlement provider. */
 const useBillingActions = (
   user: ReturnType<typeof useAuth>['user'],
-  checkoutEnabled: boolean
+  checkoutEnabled: boolean,
+  localFixtureActive: boolean,
 ) => {
   /** Returns the current signed-in user or throws a user-facing error for billing actions. */
   const requireBillingUser = useCallback(() => {
+    if (localFixtureActive) {
+      throw new Error('Billing is unavailable for local test accounts.');
+    }
     if (!user) {
       throw new Error('Sign in before starting billing actions.');
     }
 
     return user;
-  }, [user]);
+  }, [localFixtureActive, user]);
 
   /** Returns billing availability or throws a user-facing error for checkout attempts. */
   const requireCheckoutEnabled = useCallback(() => {
@@ -433,7 +437,11 @@ export const EntitlementProvider: React.FC<{ children: React.ReactNode }> = ({ c
       unsubscribe();
     };
   }, [hostedAuthEnabled, status, user]);
-  const { openCheckout, openBillingPortal } = useBillingActions(user, billingConfig.checkoutEnabled);
+  const { openCheckout, openBillingPortal } = useBillingActions(
+    user,
+    billingConfig.checkoutEnabled,
+    Boolean(readLocalTestAccount()),
+  );
 
   const value = useMemo<EntitlementContextValue>(
     () =>

--- a/src/billing/EntitlementProvider.tsx
+++ b/src/billing/EntitlementProvider.tsx
@@ -248,6 +248,27 @@ const startSignedInEntitlementSubscription = (
   return subscribeToEntitlements(userId, handlers);
 };
 
+const applyLocalTestEntitlementState = (
+  tier: 'free' | 'premium',
+  handlers: {
+    setEntitlement: React.Dispatch<React.SetStateAction<UserEntitlementDocument>>;
+    setEntitlementStatus: React.Dispatch<React.SetStateAction<EntitlementStatus>>;
+    setError: React.Dispatch<React.SetStateAction<string | null>>;
+  },
+): void => {
+  const premium = tier === 'premium';
+  handlers.setEntitlement({
+    ...DEFAULT_ENTITLEMENT,
+    uid: `local-test-${tier}`,
+    premiumActive: premium,
+    effectiveSource: premium ? 'stripe' : 'none',
+    planInterval: premium ? 'monthly' : null,
+    billingStatus: premium ? 'active' : 'inactive',
+  });
+  handlers.setEntitlementStatus(premium ? 'premium' : 'free');
+  handlers.setError(null);
+};
+
 /** Resolves the next entitlement effect outcome for the current auth snapshot. */
 const resolveEntitlementEffect = (
   args: {
@@ -263,16 +284,7 @@ const resolveEntitlementEffect = (
 ) => {
   const localTestAccount = readLocalTestAccount();
   if (localTestAccount) {
-    handlers.setEntitlement({
-      ...DEFAULT_ENTITLEMENT,
-      uid: `local-test-${localTestAccount}`,
-      premiumActive: localTestAccount === 'premium',
-      effectiveSource: localTestAccount === 'premium' ? 'stripe' : 'none',
-      planInterval: localTestAccount === 'premium' ? 'monthly' : null,
-      billingStatus: localTestAccount === 'premium' ? 'active' : 'inactive',
-    });
-    handlers.setEntitlementStatus(localTestAccount === 'premium' ? 'premium' : 'free');
-    handlers.setError(null);
+    applyLocalTestEntitlementState(localTestAccount, handlers);
     return null;
   }
 

--- a/src/billing/EntitlementProvider.tsx
+++ b/src/billing/EntitlementProvider.tsx
@@ -248,6 +248,7 @@ const startSignedInEntitlementSubscription = (
   return subscribeToEntitlements(userId, handlers);
 };
 
+/** Applies deterministic entitlement state for a local account fixture. */
 const applyLocalTestEntitlementState = (
   tier: 'free' | 'premium',
   handlers: {

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -41,6 +41,7 @@ export interface UseCloudCyclesResult {
 interface CloudAccessContext {
   userId?: string;
   canWrite: boolean;
+  localFixtureActive: boolean;
 }
 
 interface CloudStateContext {
@@ -54,7 +55,10 @@ interface CloudStateContext {
 }
 
 /** Returns the shared error message for cloud write actions when the user cannot save. */
-function getCloudWriteBlockedMessage({ userId, canWrite }: CloudAccessContext): string {
+function getCloudWriteBlockedMessage({ userId, canWrite, localFixtureActive }: CloudAccessContext): string {
+  if (localFixtureActive) {
+    return 'Cloud cycles are unavailable for local test accounts';
+  }
   if (!userId) {
     return 'Not signed in';
   }
@@ -253,7 +257,7 @@ function useCloudCycleMutation<TArgs extends unknown[]>({
 }) {
   return useCallback(
     async (...args: TArgs): Promise<boolean> => {
-      if (!userId || !canWrite) {
+      if (!userId || !canWrite || localFixtureActive) {
         setError(blockedMessage);
         return false;
       }
@@ -268,13 +272,13 @@ function useCloudCycleMutation<TArgs extends unknown[]>({
       onSuccess?.(...args);
       return true;
     },
-    [action, blockedMessage, canWrite, fallbackError, onSuccess, setError, userId]
+    [action, blockedMessage, canWrite, fallbackError, localFixtureActive, onSuccess, setError, userId]
   );
 }
 
 /** Returns true when a cloud save can proceed for the current access context. */
-function canSaveCloudCycle({ userId, canWrite }: CloudAccessContext): boolean {
-  return Boolean(userId && canWrite);
+function canSaveCloudCycle({ userId, canWrite, localFixtureActive }: CloudAccessContext): boolean {
+  return Boolean(userId && canWrite && !localFixtureActive);
 }
 
 /** Handles a failed cloud save and updates the active sync state. */
@@ -296,6 +300,7 @@ function handleCloudSaveFailure({
 function useCloudSaveCycle({
   userId,
   canWrite,
+  localFixtureActive,
   user,
   currentCloudRef,
   setCurrentCloud,
@@ -314,8 +319,8 @@ function useCloudSaveCycle({
       workflowMetadata?: CycleMetadata,
       options?: { saveAsNew?: boolean },
     ): Promise<boolean> => {
-      if (!canSaveCloudCycle({ userId, canWrite })) {
-        setError(getCloudWriteBlockedMessage({ userId, canWrite }));
+      if (!canSaveCloudCycle({ userId, canWrite, localFixtureActive })) {
+        setError(getCloudWriteBlockedMessage({ userId, canWrite, localFixtureActive }));
         return false;
       }
 
@@ -345,7 +350,7 @@ function useCloudSaveCycle({
       updateSyncState('saved');
       return true;
     },
-    [canWrite, currentCloudRef, setCurrentCloud, setError, updateSyncState, user, userId]
+    [canWrite, currentCloudRef, localFixtureActive, setCurrentCloud, setError, updateSyncState, user, userId]
   );
 }
 
@@ -364,19 +369,24 @@ export const buildLoadedCloudForecastPayload = (
 /** Returns the load callback for hosted cloud cycles. */
 function useCloudLoadCycle({
   userId,
+  localFixtureActive,
   user,
   cycles,
   setCurrentCloud,
   setError,
   updateSyncState,
 }: Pick<CloudStateContext, 'cycles' | 'setCurrentCloud' | 'setError' | 'updateSyncState'> &
-  Pick<CloudAccessContext, 'userId'> & {
+  Pick<CloudAccessContext, 'userId' | 'localFixtureActive'> & {
     user: ReturnType<typeof useAuth>['user'];
   }) {
   return useCallback(
     async (cycleId: string): Promise<GFCForecastSaveData | null> => {
       if (!userId) {
         setError('Not signed in');
+        return null;
+      }
+      if (localFixtureActive) {
+        setError('Cloud cycles are unavailable for local test accounts');
         return null;
       }
 
@@ -395,7 +405,7 @@ function useCloudLoadCycle({
       updateSyncState('saved');
       return buildLoadedCloudForecastPayload(result.data);
     },
-    [cycles, setCurrentCloud, setError, updateSyncState, user, userId]
+    [cycles, localFixtureActive, setCurrentCloud, setError, updateSyncState, user, userId]
   );
 }
 
@@ -454,12 +464,13 @@ function useCloudRenameCycle({
 /** Returns the explicit refresh callback for cloud-cycle metadata. */
 function useCloudRefreshCycles({
   userId,
+  localFixtureActive,
   setCycles,
   setError,
   setLoading,
-}: Pick<CloudStateContext, 'setCycles' | 'setError' | 'setLoading'> & Pick<CloudAccessContext, 'userId'>) {
+}: Pick<CloudStateContext, 'setCycles' | 'setError' | 'setLoading'> & Pick<CloudAccessContext, 'userId' | 'localFixtureActive'>) {
   return useCallback(async (): Promise<void> => {
-    if (!userId) {
+    if (!userId || localFixtureActive) {
       return;
     }
 
@@ -471,7 +482,7 @@ function useCloudRefreshCycles({
       setError(result.error || 'Failed to refresh cloud cycles');
     }
     setLoading(false);
-  }, [setCycles, setError, setLoading, userId]);
+  }, [localFixtureActive, setCycles, setError, setLoading, userId]);
 }
 
 /** Creates the hosted cloud-cycle CRUD callbacks used by the forecast and library pages. */
@@ -567,6 +578,7 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
   const unsubscribeRef = useRef<(() => void) | null>(null);
   const currentCloudRef = useCurrentCloudRef(currentCloud);
   const canWrite = premiumActive;
+  const localFixtureActive = Boolean(readLocalTestAccount());
 
   useResetCloudStateOnSignOut({
     userId: user?.uid,
@@ -591,6 +603,7 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
   const operations = useCloudCycleOperations({
     userId: user?.uid,
     canWrite,
+    localFixtureActive,
     user,
     cycles,
     currentCloudRef,

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -14,6 +14,7 @@ import { GFCForecastSaveData } from '../types/outlooks';
 import type { CycleMetadata } from '../types/workflow';
 import { SavedCycleStats } from '../store/forecastSlice';
 import { queueProductMetric } from '../utils/productMetrics';
+import { readLocalTestAccount } from '../lib/localTestAccount';
 
 export interface UseCloudCyclesResult {
   cycles: CloudCycleMetadata[];
@@ -197,6 +198,17 @@ function useCloudCycleSubscription({
   unsubscribeRef: MutableRefObject<(() => void) | null>;
 }): void {
   useEffect(() => {
+    // Local account fixtures exercise entitlement and UI access without touching
+    // a developer's Firebase project or requiring seeded cloud data.
+    if (readLocalTestAccount()) {
+      setCycles([]);
+      setLoading(false);
+      setError(null);
+      unsubscribeRef.current?.();
+      unsubscribeRef.current = null;
+      return;
+    }
+
     if (!userId) {
       setCycles([]);
       setLoading(false);

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -66,6 +66,7 @@ function getCloudWriteBlockedMessage({ userId, canWrite, localFixtureActive }: C
   return canWrite ? 'Action not allowed' : 'Premium subscription required to save cloud cycles';
 }
 
+/** Returns whether a hosted cloud mutation is allowed for the current access context. */
 function isCloudMutationAllowed({ userId, canWrite, localFixtureActive }: CloudAccessContext): boolean {
   return Boolean(userId && canWrite && !localFixtureActive);
 }

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -244,6 +244,7 @@ function useCloudCycleSubscription({
 function useCloudCycleMutation<TArgs extends unknown[]>({
   userId,
   canWrite,
+  localFixtureActive,
   setError,
   action,
   onSuccess,

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -66,6 +66,10 @@ function getCloudWriteBlockedMessage({ userId, canWrite, localFixtureActive }: C
   return canWrite ? 'Action not allowed' : 'Premium subscription required to save cloud cycles';
 }
 
+function isCloudMutationAllowed({ userId, canWrite, localFixtureActive }: CloudAccessContext): boolean {
+  return Boolean(userId && canWrite && !localFixtureActive);
+}
+
 /** Returns true when the requested sync state already matches the current cloud context. */
 function hasMatchingSyncState({
   currentCloud,
@@ -258,7 +262,7 @@ function useCloudCycleMutation<TArgs extends unknown[]>({
 }) {
   return useCallback(
     async (...args: TArgs): Promise<boolean> => {
-      if (!userId || !canWrite || localFixtureActive) {
+      if (!isCloudMutationAllowed({ userId, canWrite, localFixtureActive })) {
         setError(blockedMessage);
         return false;
       }

--- a/src/lib/localTestAccount.test.ts
+++ b/src/lib/localTestAccount.test.ts
@@ -1,4 +1,4 @@
-import { createLocalTestUser, isLocalTestAccountEnabled, readLocalTestAccount } from './localTestAccount';
+import { clearLocalTestAccount, createLocalTestUser, isLocalTestAccountEnabled, readLocalTestAccount } from './localTestAccount';
 
 describe('local test account fixture', () => {
   beforeEach(() => {
@@ -38,6 +38,16 @@ describe('local test account fixture', () => {
 
     window.history.replaceState({}, '', '/account');
     expect(readLocalTestAccount()).toBe('free');
+  });
+
+  test('clears both persisted fixture state and the activation query', () => {
+    window.history.replaceState({}, '', '/?localTestAccount=premium');
+    expect(readLocalTestAccount()).toBe('premium');
+
+    clearLocalTestAccount();
+
+    expect(window.location.search).toBe('');
+    expect(readLocalTestAccount()).toBeNull();
   });
 
   test('creates a stable disposable identity', () => {

--- a/src/lib/localTestAccount.test.ts
+++ b/src/lib/localTestAccount.test.ts
@@ -1,0 +1,50 @@
+import { createLocalTestUser, isLocalTestAccountEnabled, readLocalTestAccount } from './localTestAccount';
+
+describe('local test account fixture', () => {
+  beforeEach(() => {
+    globalThis.__GFC_DEV_MODE__ = true;
+  });
+
+  afterEach(() => {
+    globalThis.__GFC_DEV_MODE__ = false;
+    window.history.replaceState({}, '', '/');
+    window.sessionStorage.clear();
+  });
+
+  test('requires development mode and an exact local hostname', () => {
+    expect(isLocalTestAccountEnabled('localhost', true)).toBe(true);
+    expect(isLocalTestAccountEnabled('127.0.0.1', true)).toBe(true);
+    expect(isLocalTestAccountEnabled('localhost', false)).toBe(false);
+    expect(isLocalTestAccountEnabled('beta.weatherboysuper.com', true)).toBe(false);
+    expect(isLocalTestAccountEnabled('localhost.evil.example', true)).toBe(false);
+  });
+
+  test('reads free and premium fixtures only from local URLs', () => {
+    window.history.replaceState({}, '', '/?localTestAccount=free');
+    expect(readLocalTestAccount()).toBe('free');
+
+    window.sessionStorage.clear();
+    window.history.replaceState({}, '', '/?localTestAccount=premium');
+    expect(readLocalTestAccount()).toBe('premium');
+
+    window.sessionStorage.clear();
+    window.history.replaceState({}, '', '/?localTestAccount=unknown');
+    expect(readLocalTestAccount()).toBeNull();
+  });
+
+  test('keeps the fixture active after local SPA navigation removes the query string', () => {
+    window.history.replaceState({}, '', '/?localTestAccount=free');
+    expect(readLocalTestAccount()).toBe('free');
+
+    window.history.replaceState({}, '', '/account');
+    expect(readLocalTestAccount()).toBe('free');
+  });
+
+  test('creates a stable disposable identity', () => {
+    expect(createLocalTestUser('premium')).toMatchObject({
+      uid: 'local-test-premium',
+      email: 'premium@local.test',
+      displayName: 'Local premium test account',
+    });
+  });
+});

--- a/src/lib/localTestAccount.ts
+++ b/src/lib/localTestAccount.ts
@@ -22,6 +22,12 @@ export const readLocalTestAccount = (): LocalTestAccountTier | null => {
   return storedTier === 'free' || storedTier === 'premium' ? storedTier : null;
 };
 
+/** Clears the disposable fixture so a developer can return to normal local or hosted auth. */
+export const clearLocalTestAccount = (): void => {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.removeItem(LOCAL_TEST_ACCOUNT_STORAGE_KEY);
+};
+
 /** Builds the stable identity used by the disposable local account fixture. */
 export const createLocalTestUser = (tier: LocalTestAccountTier) => ({
   uid: `local-test-${tier}`,

--- a/src/lib/localTestAccount.ts
+++ b/src/lib/localTestAccount.ts
@@ -26,6 +26,10 @@ export const readLocalTestAccount = (): LocalTestAccountTier | null => {
 export const clearLocalTestAccount = (): void => {
   if (typeof window === 'undefined') return;
   window.sessionStorage.removeItem(LOCAL_TEST_ACCOUNT_STORAGE_KEY);
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has('localTestAccount')) return;
+  url.searchParams.delete('localTestAccount');
+  window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
 };
 
 /** Builds the stable identity used by the disposable local account fixture. */

--- a/src/lib/localTestAccount.ts
+++ b/src/lib/localTestAccount.ts
@@ -1,0 +1,33 @@
+export type LocalTestAccountTier = 'free' | 'premium';
+
+const LOCAL_TEST_ACCOUNT_STORAGE_KEY = 'gfc-local-test-account';
+
+/** Keeps test-account fixtures out of production/staging builds even when served from a local hostname. */
+export const isLocalTestAccountEnabled = (hostname: string, developmentMode: boolean): boolean =>
+  developmentMode && ['localhost', '127.0.0.1'].includes(hostname);
+
+/** Returns the disposable local account fixture requested by the browser URL. */
+export const readLocalTestAccount = (): LocalTestAccountTier | null => {
+  if (typeof window === 'undefined' || !isLocalTestAccountEnabled(window.location.hostname, __GFC_DEV_MODE__)) {
+    return null;
+  }
+
+  const queryTier = new URLSearchParams(window.location.search).get('localTestAccount');
+  if (queryTier === 'free' || queryTier === 'premium') {
+    window.sessionStorage.setItem(LOCAL_TEST_ACCOUNT_STORAGE_KEY, queryTier);
+    return queryTier;
+  }
+
+  const storedTier = window.sessionStorage.getItem(LOCAL_TEST_ACCOUNT_STORAGE_KEY);
+  return storedTier === 'free' || storedTier === 'premium' ? storedTier : null;
+};
+
+/** Builds the stable identity used by the disposable local account fixture. */
+export const createLocalTestUser = (tier: LocalTestAccountTier) => ({
+  uid: `local-test-${tier}`,
+  email: `${tier}@local.test`,
+  displayName: `Local ${tier} test account`,
+  photoURL: null,
+  providerData: [],
+  isAnonymous: false,
+});


### PR DESCRIPTION
## Changelog

- Workflow beta fixes and test-only access hardening.

## Summary
- add disposable free and premium fixtures for localhost development testing
- require compile-time development mode and exact localhost or 127.0.0.1 hostname
- keep fixture identities local-only and prevent local fixture cloud subscriptions

## Security boundary
This fixture is test instrumentation only. It is not an entitlement source for deployed builds. Production and beta builds compile with development mode disabled, and Firebase authorization remains the authority for hosted data.

## Verification
- local fixture, hosted auth, entitlement, and cloud-cycle tests passed