### PR TITLE
security(cloud): enforce premium entitlement for full cloud cycles

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #713
+
+- Enforce premium entitlement for hosted full-package workflow restore and cloud-cycle Firestore access, including defense-in-depth Rules authorization.
+
 ### PR #699
 
 - Add post-completion handoff guidance for workflow and complete-cycle exports, eligible Monitor navigation, return-to-map, and duplicate-prompt suppression.

--- a/docs/firestore-rules-verification.md
+++ b/docs/firestore-rules-verification.md
@@ -42,10 +42,14 @@ Exact dashboard steps:
 3. Open **Rules Playground** (or the simulator in the Rules editor), choose
    Firestore, and create authenticated test contexts for UIDs `wf07-alice` and
    `wf07-bob`. Also run one unauthenticated context.
-4. Run the matrix below against the document paths shown. For queries, use the
+4. Create entitlement documents for `wf07-premium` with `premiumActive: true`
+   and `wf07-free` with `premiumActive: false`. The entitlement documents must
+   be created through the trusted server/admin path; Rules Playground writes to
+   `userEntitlements` must be denied.
+5. Run the matrix below against the document paths shown. For queries, use the
    Firestore query simulator with `where('userId', '==', request.auth.uid)` for
    `cloudCycles`; also try a query for another user's UID.
-5. Record each simulator result (Allow or Deny) in the PR/checklist before
+6. Record each simulator result (Allow or Deny) in the PR/checklist before
    promoting rules. Do not treat the Jest result or a successful client build
    as proof of Firebase authorization.
 
@@ -106,18 +110,20 @@ Run the following matrix and record the result before promoting rules:
 
 | Auth / operation | Expected result |
 | --- | --- |
-| Alice creates `cycle-a` with the valid document | Allow |
-| Alice reads `cycle-a` | Allow |
-| Alice updates label or appends a valid metadata-only version | Allow |
-| Alice deletes `cycle-a` | Allow |
+| Premium Alice creates `cycle-a` with the valid document | Allow |
+| Premium Alice reads `cycle-a` | Allow |
+| Premium Alice updates label or appends a valid metadata-only version | Allow |
+| Premium Alice deletes `cycle-a` | Allow |
+| Free Alice reads or queries `cycle-a` | Deny |
+| Free Alice creates, updates, or deletes a cloud cycle | Deny |
 | Bob reads `cycle-a` | Deny |
 | Bob updates `cycle-a`, including changing only `label` | Deny |
 | Bob deletes `cycle-a` | Deny |
-| Alice creates with `userId: wf07-bob` | Deny |
-| Alice updates `userId` to `wf07-bob` | Deny |
-| Alice creates with `outlookVersions` containing `payloadJson` or `geometry` | Deny |
-| Alice creates with 33 `outlookVersions` entries | Deny |
-| Alice creates with a top-level unknown field | Deny |
+| Premium Alice creates with `userId: wf07-bob` | Deny |
+| Premium Alice updates `userId` to `wf07-bob` | Deny |
+| Premium Alice creates with `outlookVersions` containing `payloadJson` or `geometry` | Deny |
+| Premium Alice creates with 33 `outlookVersions` entries | Deny |
+| Premium Alice creates with a top-level unknown field | Deny |
 | Alice creates, reads, updates, or deletes her awareness document | Allow |
 | Bob reads, updates, or deletes Alice's awareness document | Deny |
 | Alice creates awareness metadata containing `payloadJson`, `geometry`, or another nested unknown field | Deny |

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,6 +10,15 @@ service cloud.firestore {
       return isSignedIn() && request.auth.uid == userId;
     }
 
+    // Cloud-cycle documents contain the full forecast package. Premium access
+    // is enforced here as the authorization boundary; client-side entitlement
+    // checks are only UX guards and must not be trusted for data protection.
+    function hasPremiumAccess() {
+      return isSignedIn() &&
+        exists(/databases/$(database)/documents/userEntitlements/$(request.auth.uid)) &&
+        get(/databases/$(database)/documents/userEntitlements/$(request.auth.uid)).data.premiumActive == true;
+    }
+
     function hasOnlyKeys(value, allowed) {
       return value is map && value.keys().hasOnly(allowed);
     }
@@ -177,15 +186,15 @@ service cloud.firestore {
     }
 
     match /cloudCycles/{cycleId} {
-      allow read: if isSignedIn() && resource.data.userId == request.auth.uid;
-      allow create: if isSignedIn() &&
+      allow read: if hasPremiumAccess() && resource.data.userId == request.auth.uid;
+      allow create: if hasPremiumAccess() &&
         request.resource.data.userId == request.auth.uid &&
         isValidCloudCycle(request.resource.data, cycleId);
-      allow update: if isSignedIn() &&
+      allow update: if hasPremiumAccess() &&
         resource.data.userId == request.auth.uid &&
         request.resource.data.userId == resource.data.userId &&
         isValidCloudCycle(request.resource.data, cycleId);
-      allow delete: if isSignedIn() && resource.data.userId == request.auth.uid;
+      allow delete: if hasPremiumAccess() && resource.data.userId == request.auth.uid;
     }
 
     match /adminDailyMetrics/{documentId} {

--- a/src/hooks/useCloudCycles.test.ts
+++ b/src/hooks/useCloudCycles.test.ts
@@ -1,4 +1,4 @@
-import { buildLoadedCloudForecastPayload, getCloudLoadBlockedMessage } from './useCloudCycles';
+import { buildLoadedCloudForecastPayload, canAccessHostedCloudCycles, getCloudLoadBlockedMessage } from './useCloudCycles';
 import type { CloudCycle } from '../types/cloudCycles';
 import type { GFCForecastSaveData } from '../types/outlooks';
 
@@ -58,6 +58,12 @@ describe('buildLoadedCloudForecastPayload', () => {
 });
 
 describe('getCloudLoadBlockedMessage', () => {
+  test('requires both an authenticated identity and premium entitlement for hosted cycles', () => {
+    expect(canAccessHostedCloudCycles(undefined, true)).toBe(false);
+    expect(canAccessHostedCloudCycles('free-user', false)).toBe(false);
+    expect(canAccessHostedCloudCycles('premium-user', true)).toBe(true);
+  });
+
   test('keeps signed-out users out of cloud package restore', () => {
     expect(getCloudLoadBlockedMessage({ userId: undefined, canWrite: false })).toBe('Not signed in');
   });

--- a/src/hooks/useCloudCycles.test.ts
+++ b/src/hooks/useCloudCycles.test.ts
@@ -1,4 +1,4 @@
-import { buildLoadedCloudForecastPayload } from './useCloudCycles';
+import { buildLoadedCloudForecastPayload, getCloudLoadBlockedMessage } from './useCloudCycles';
 import type { CloudCycle } from '../types/cloudCycles';
 import type { GFCForecastSaveData } from '../types/outlooks';
 
@@ -54,5 +54,19 @@ describe('buildLoadedCloudForecastPayload', () => {
 
     expect(payload.cycleMetadata).toBeNull();
     expect(payload).not.toHaveProperty('cycleMetadata', expect.objectContaining({ id: 'stale-cycle' }));
+  });
+});
+
+describe('getCloudLoadBlockedMessage', () => {
+  test('keeps signed-out users out of cloud package restore', () => {
+    expect(getCloudLoadBlockedMessage({ userId: undefined, canWrite: false })).toBe('Not signed in');
+  });
+
+  test('keeps full package restore premium-only for signed-in free users', () => {
+    expect(getCloudLoadBlockedMessage({ userId: 'free-user', canWrite: false })).toMatch(/Premium subscription required/);
+  });
+
+  test('does not block premium accounts', () => {
+    expect(getCloudLoadBlockedMessage({ userId: 'premium-user', canWrite: true })).toBe('Action not allowed');
   });
 });

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -185,21 +185,24 @@ function clearDeletedCloudSelection({
 /** Starts the realtime hosted-cycle subscription for the signed-in user. */
 function useCloudCycleSubscription({
   userId,
+  canWrite,
   setCycles,
   setLoading,
   setError,
   unsubscribeRef,
 }: {
   userId?: string;
+  canWrite: boolean;
   setCycles: Dispatch<SetStateAction<CloudCycleMetadata[]>>;
   setLoading: Dispatch<SetStateAction<boolean>>;
   setError: Dispatch<SetStateAction<string | null>>;
   unsubscribeRef: MutableRefObject<(() => void) | null>;
 }): void {
   useEffect(() => {
-    if (!userId) {
+    if (!canAccessHostedCloudCycles(userId, canWrite)) {
       setCycles([]);
       setLoading(false);
+      setError(null);
       return;
     }
 
@@ -221,7 +224,7 @@ function useCloudCycleSubscription({
     return function cleanupCloudCycleSubscription() {
       unsubscribeRef.current?.();
     };
-  }, [userId, setCycles, setError, setLoading, unsubscribeRef]);
+  }, [canWrite, userId, setCycles, setError, setLoading, unsubscribeRef]);
 }
 
 /** Shared mutation hook for guarded cloud-cycle write actions like rename and delete. */
@@ -354,6 +357,10 @@ export const getCloudLoadBlockedMessage = ({ userId, canWrite }: Pick<CloudAcces
   if (!userId) return 'Not signed in';
   return canWrite ? 'Action not allowed' : 'Premium subscription required to restore full cloud packages';
 };
+
+/** Returns true only when an authenticated premium user may access hosted cycles. */
+export const canAccessHostedCloudCycles = (userId: string | undefined, premiumActive: boolean): boolean =>
+  Boolean(userId && premiumActive);
 
 /** Returns the load callback for hosted cloud cycles. */
 function useCloudLoadCycle({
@@ -582,6 +589,7 @@ export const useCloudCycles = (): UseCloudCyclesResult => {
 
   useCloudCycleSubscription({
     userId: user?.uid,
+    canWrite,
     setCycles,
     setLoading,
     setError,

--- a/src/hooks/useCloudCycles.ts
+++ b/src/hooks/useCloudCycles.ts
@@ -349,22 +349,34 @@ export const buildLoadedCloudForecastPayload = (
   return { ...plainPayload, cycleMetadata: null };
 };
 
+/** Returns the access message shown when a non-premium account tries to restore a full package. */
+export const getCloudLoadBlockedMessage = ({ userId, canWrite }: Pick<CloudAccessContext, 'userId' | 'canWrite'>): string => {
+  if (!userId) return 'Not signed in';
+  return canWrite ? 'Action not allowed' : 'Premium subscription required to restore full cloud packages';
+};
+
 /** Returns the load callback for hosted cloud cycles. */
 function useCloudLoadCycle({
   userId,
+  canWrite,
   user,
   cycles,
   setCurrentCloud,
   setError,
   updateSyncState,
 }: Pick<CloudStateContext, 'cycles' | 'setCurrentCloud' | 'setError' | 'updateSyncState'> &
-  Pick<CloudAccessContext, 'userId'> & {
+  Pick<CloudAccessContext, 'userId' | 'canWrite'> & {
     user: ReturnType<typeof useAuth>['user'];
   }) {
   return useCallback(
     async (cycleId: string): Promise<GFCForecastSaveData | null> => {
       if (!userId) {
         setError('Not signed in');
+        return null;
+      }
+
+      if (!canWrite) {
+        setError(getCloudLoadBlockedMessage({ userId, canWrite }));
         return null;
       }
 
@@ -383,7 +395,7 @@ function useCloudLoadCycle({
       updateSyncState('saved');
       return buildLoadedCloudForecastPayload(result.data);
     },
-    [cycles, setCurrentCloud, setError, updateSyncState, user, userId]
+    [canWrite, cycles, setCurrentCloud, setError, updateSyncState, user, userId]
   );
 }
 

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -44,7 +44,7 @@ const CloudLibraryHero: React.FC<{
       </div>
       <div className="cloud-library-hero-text">
         <h1>Your saved cloud cycles.</h1>
-        <p>Load a hosted package back into the editor, rename it, or clean up old saves without digging through menus.</p>
+        <p>Premium restores hosted packages. Free accounts can see workflow metadata, while forecast content remains local.</p>
       </div>
     </div>
 
@@ -71,7 +71,7 @@ const ExpiredPremiumNotice: React.FC = () => (
       <div>
         <strong>Premium expired</strong>
         <p>
-          Your library is still readable, but new saves, renames, and deletes are locked until premium is active again.
+          Workflow metadata remains visible, but full package restore and cloud writes are locked until premium is active again.
         </p>
       </div>
     </CardContent>
@@ -98,10 +98,10 @@ const getUtilityCardCopy = (premiumActive: boolean, isExpiredPremium: boolean): 
   }
 
   if (isExpiredPremium) {
-    return 'Your saved cycles are still available to open, but writes stay off until premium is active again.';
+    return 'Workflow metadata remains available, but package restore and writes stay off until premium is active again.';
   }
 
-  return 'Premium unlocks hosted saves. Until then, your forecast workflow stays local.';
+    return 'Free accounts retain metadata-only workflow awareness. Premium unlocks full hosted package restore.';
 };
 
 /** Support actions rendered in the right-side cloud utility card. */
@@ -356,9 +356,14 @@ const CloudCycleActions: React.FC<{
   onConfirmDelete,
 }) => (
   <div className="cloud-cycle-actions">
-    <Button className="cloud-cycle-button cloud-cycle-button--load" onClick={onLoad} disabled={loading || isDeleting || isSavingRename}>
+    <Button
+      className="cloud-cycle-button cloud-cycle-button--load"
+      onClick={onLoad}
+      disabled={!canWrite || loading || isDeleting || isSavingRename}
+      title={canWrite ? 'Restore the full cloud package' : 'Premium is required to restore the full cloud package'}
+    >
       <Download className="mr-2 h-4 w-4" />
-      Load
+      {canWrite ? 'Load package' : 'Premium required'}
     </Button>
     <CloudCycleWriteActions
       cycle={cycle}
@@ -535,8 +540,12 @@ const CloudLibraryMainCard: React.FC<{
 }) => (
   <Card className="cloud-library-surface-card">
     <CardHeader className="cloud-library-section-header">
-      <CardTitle>Your cloud cycles</CardTitle>
-      <CardDescription>Open a saved package, rename it, or clear out older copies.</CardDescription>
+      <CardTitle>Your workflow records</CardTitle>
+      <CardDescription>
+        {premiumActive
+          ? 'Restore a full package, rename it, or clear out older copies.'
+          : 'Free accounts retain metadata-only workflow records. Full package restore requires premium.'}
+      </CardDescription>
     </CardHeader>
     <CardContent className="cloud-library-list-content">
       {loading && cycles.length === 0 ? (
@@ -549,7 +558,7 @@ const CloudLibraryMainCard: React.FC<{
         <>
           <div className="cloud-library-list-header">
             <strong>{cycleCountLabel}</strong>
-            {!premiumActive ? <Badge variant="outline">Read-only</Badge> : null}
+            {!premiumActive ? <Badge variant="outline">Metadata only</Badge> : null}
           </div>
 
           <div className="cloud-library-list">

--- a/src/pages/CloudLibraryPage.tsx
+++ b/src/pages/CloudLibraryPage.tsx
@@ -44,7 +44,7 @@ const CloudLibraryHero: React.FC<{
       </div>
       <div className="cloud-library-hero-text">
         <h1>Your saved cloud cycles.</h1>
-        <p>Premium restores hosted packages. Free accounts can see workflow metadata, while forecast content remains local.</p>
+        <p>Premium restores hosted packages. Free accounts keep forecast content local and can use separate metadata-only workflow awareness.</p>
       </div>
     </div>
 
@@ -71,7 +71,7 @@ const ExpiredPremiumNotice: React.FC = () => (
       <div>
         <strong>Premium expired</strong>
         <p>
-          Workflow metadata remains visible, but full package restore and cloud writes are locked until premium is active again.
+          Metadata-only workflow awareness remains available, but full package restore and cloud writes are locked until premium is active again.
         </p>
       </div>
     </CardContent>
@@ -101,7 +101,7 @@ const getUtilityCardCopy = (premiumActive: boolean, isExpiredPremium: boolean): 
     return 'Workflow metadata remains available, but package restore and writes stay off until premium is active again.';
   }
 
-    return 'Free accounts retain metadata-only workflow awareness. Premium unlocks full hosted package restore.';
+  return 'Free accounts retain metadata-only workflow awareness. Premium unlocks full hosted package restore.';
 };
 
 /** Support actions rendered in the right-side cloud utility card. */
@@ -131,8 +131,8 @@ const CloudLibraryUtilityCard: React.FC<{
     <CloudLibraryUtilityHeader />
     <CardContent className="cloud-library-support-content">
       <div className="cloud-library-support-grid">
-        <CloudLibraryStat label="Mode" value={premiumActive ? 'Full access' : isExpiredPremium ? 'Read-only' : 'Locked'} />
-        <CloudLibraryStat label="Library" value={premiumActive ? 'Writable' : 'Readable'} />
+        <CloudLibraryStat label="Mode" value={premiumActive ? 'Full access' : 'Metadata only'} />
+        <CloudLibraryStat label="Library" value={premiumActive ? 'Writable' : 'Awareness only'} />
       </div>
       <p className="cloud-library-support-copy">{getUtilityCardCopy(premiumActive, isExpiredPremium)}</p>
       <div className="cloud-library-divider" />
@@ -544,7 +544,7 @@ const CloudLibraryMainCard: React.FC<{
       <CardDescription>
         {premiumActive
           ? 'Restore a full package, rename it, or clear out older copies.'
-          : 'Free accounts retain metadata-only workflow records. Full package restore requires premium.'}
+          : 'Hosted forecast packages are premium-only. Free accounts continue locally with optional metadata-only awareness.'}
       </CardDescription>
     </CardHeader>
     <CardContent className="cloud-library-list-content">

--- a/src/pages/PricingPage.tsx
+++ b/src/pages/PricingPage.tsx
@@ -35,8 +35,9 @@ const comparisonRows: ComparisonRow[] = [
   { label: 'Local autosave and cycle history', freeIncluded: true, premiumIncluded: true },
   { label: 'JSON export and packaged downloads', freeIncluded: true, premiumIncluded: true },
   { label: 'Account settings sync', freeIncluded: true, premiumIncluded: true },
+  { label: 'Metadata-only workflow awareness', freeIncluded: true, premiumIncluded: true },
   { label: 'Hosted cloud cycle storage', freeIncluded: false, premiumIncluded: true },
-  { label: 'Cross-device cloud access', freeIncluded: false, premiumIncluded: true },
+  { label: 'Full package restore across devices', freeIncluded: false, premiumIncluded: true },
 ];
 
 /** Returns the premium-card badge for the current entitlement state. */
@@ -293,7 +294,7 @@ const ComparisonTable: React.FC = () => (
     <CardHeader className="pricing-section-header">
       <CardTitle>Compare plans</CardTitle>
       <CardDescription>
-        Free covers the full local workflow. Premium adds the hosted service on top of it.
+        Anyone can use the full local workflow. Free accounts can optionally preserve metadata-only awareness; premium adds full package storage and restore.
       </CardDescription>
     </CardHeader>
     <CardContent className="pricing-comparison-content">


### PR DESCRIPTION
## Changelog

- Workflow beta fixes and test-only access hardening.

## Summary
- keep full package restore premium-only in the client
- stop non-premium clients from subscribing to hosted cloud-cycle documents
- enforce premium entitlement in Firestore rules for cloud-cycle read, create, update, and delete operations
- update pricing, cloud-library, and Rules Playground verification guidance

## Security note
The client gate is not trusted as an authorization boundary. Firestore now requires a trusted userEntitlements/{uid} document with premiumActive == true, while user entitlement writes remain denied to clients.

## Required before merge
Run the documented Firebase Rules Playground matrix with premium, free, cross-user, and signed-out contexts. This workspace has no Java/Firebase emulator, so Jest and build validation cannot replace that runtime rules check.

## Verification
- cloud-cycle and pricing tests passed
- full Jest suite passed on this branch
- build passed; known Sentry upload permission warning remains non-blocking