### PR TITLE
[Port][Conflicts] fix(actions): configure OpenCode commit identity → beta

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 jobs:
-  classify-pr:
+  classify-request:
     if: |
       github.event.comment.user.login == 'WxboySuper' &&
       (github.event.comment.body == '/oc' ||
@@ -18,27 +18,33 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      trusted: ${{ steps.trust.outputs.result }}
+      mode: ${{ steps.classify.outputs.result }}
     steps:
-      - id: trust
+      - id: classify
         uses: actions/github-script@v7
         with:
           script: |
             const pullNumber = context.payload.pull_request?.number ??
               (context.payload.issue?.pull_request ? context.payload.issue.number : undefined)
-            if (!pullNumber) return false
+            if (pullNumber) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber,
+              })
+              const head = pull.head.repo
+              return head?.full_name === `${context.repo.owner}/${context.repo.repo}` && !head.fork
+                ? 'trusted-pr'
+                : 'blocked'
+            }
 
-            const { data: pull } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-            })
-            const head = pull.head.repo
-            return head?.full_name === `${context.repo.owner}/${context.repo.repo}` && !head.fork
+            return context.payload.issue?.user?.login === 'WxboySuper'
+              ? 'trusted-issue'
+              : 'triage-issue'
 
-  opencode:
-    needs: classify-pr
-    if: needs.classify-pr.outputs.trusted == 'true'
+  opencode-write:
+    needs: classify-request
+    if: needs.classify-request.outputs.mode == 'trusted-pr' || needs.classify-request.outputs.mode == 'trusted-issue'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -63,3 +69,34 @@ jobs:
         with:
           model: opencode/deepseek-v4-flash-free
           use_github_token: true
+<<<<<<< HEAD
+=======
+          mentions: /oc,/opencode
+
+  opencode-triage:
+    needs: classify-request
+    if: needs.classify-request.outputs.mode == 'triage-issue'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run opencode triage
+        uses: anomalyco/opencode/github@a3b97d9090ccf4aa9ac32268486283e3131e36b4 # fix(github): enforce existing git author identity
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/deepseek-v4-flash-free
+          use_github_token: true
+          mentions: /oc,/opencode
+          prompt: >-
+            Triage this issue. Do not edit repository files, create branches or pull requests,
+            commit, or push. Reply with a concise assessment, reproduction questions, labels, and
+            recommended next steps.
+>>>>>>> 4397ef9 (feat(actions): add constrained opencode issue triage)

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -7,13 +7,38 @@ on:
     types: [created]
 
 jobs:
-  opencode:
+  classify-pr:
     if: |
       github.event.comment.user.login == 'WxboySuper' &&
       (github.event.comment.body == '/oc' ||
        github.event.comment.body == '/opencode' ||
        startsWith(github.event.comment.body, '/oc ') ||
        startsWith(github.event.comment.body, '/opencode '))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      trusted: ${{ steps.trust.outputs.result }}
+    steps:
+      - id: trust
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullNumber = context.payload.pull_request?.number ??
+              (context.payload.issue?.pull_request ? context.payload.issue.number : undefined)
+            if (!pullNumber) return false
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            })
+            const head = pull.head.repo
+            return head?.full_name === `${context.repo.owner}/${context.repo.repo}` && !head.fork
+
+  opencode:
+    needs: classify-pr
+    if: needs.classify-pr.outputs.trusted == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -16,7 +16,7 @@ jobs:
        startsWith(github.event.comment.body, '/opencode '))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
     steps:
@@ -24,6 +24,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run opencode
         uses: anomalyco/opencode/github@a3b97d9090ccf4aa9ac32268486283e3131e36b4 # fix(github): enforce existing git author identity


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #727 — fix(actions): configure OpenCode commit identity |
| Source branch | `hotfix/opencode-commit-identity` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `.github/workflows/opencode.yml`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/727-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #727, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.