### PR TITLE
feat(workflows): enable beta tester exposure

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #729
+
+- Enable the validated forecast workflow v2 surfaces for beta testers while keeping staging and production disabled.
+
 ### PR #720
 
 - Add authenticated workflow continuity E2E coverage across all built-in scopes, discussion grouping, package transfer, and second-page restore paths.

--- a/src/config/featureExposure.acknowledgements.json
+++ b/src/config/featureExposure.acknowledgements.json
@@ -13,9 +13,10 @@
     "trackingIssue": 529
   },
   "forecastWorkflowV2": {
-    "reason": "WF-05 workflow surfaces are enabled on local only for development; signed-in home interaction coverage is in src/pages/home/HomePage.test.tsx and the adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts",
+    "reason": "WF-05 workflow surfaces are enabled on local and beta for the beta tester pilot; signed-in home interaction coverage is in src/pages/home/HomePage.test.tsx, workflow continuity E2E coverage is in e2e/workflows.spec.ts, and the adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts",
     "trackingIssue": 530,
-    "localDevelopmentApproved": true
+    "localDevelopmentApproved": true,
+    "betaEnablementApproved": true
   },
   "verificationRelaunch": {
     "reason": "Registry-only until verification relaunch surfaces merge; core /verification is separate; adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -112,7 +112,7 @@ describe('featureExposure registry', () => {
     }
   });
 
-  test('keeps unreleased v1.7 workstream keys disabled while local exposes forecast workflow v2', () => {
+  test('keeps unreleased v1.7 workstream keys disabled while local and beta expose forecast workflow v2', () => {
     const workstreamKeys = [
       'forecastWorkflowV2',
       'verificationRelaunch',
@@ -128,7 +128,7 @@ describe('featureExposure registry', () => {
     }
 
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'local')).toBe(true);
-    expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'beta')).toBe(false);
+    expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'beta')).toBe(true);
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'staging')).toBe(false);
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'production')).toBe(false);
 

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -115,7 +115,7 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 427,
   },
   forecastWorkflowV2: {
-    exposure: { ...ALL_TARGETS_OFF, local: true },
+    exposure: { ...ALL_TARGETS_OFF, local: true, beta: true },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,

--- a/src/config/v17WorkstreamAdoption.exposure.test.ts
+++ b/src/config/v17WorkstreamAdoption.exposure.test.ts
@@ -19,9 +19,9 @@ export const V17_WORKSTREAM_KEYS = [
 type V17WorkstreamKey = (typeof V17_WORKSTREAM_KEYS)[number];
 
 describe('v1.7 workstream adoption contract', () => {
-  test('forecastWorkflowV2 is enabled only for local development', () => {
+  test('forecastWorkflowV2 is enabled for local development and beta testers', () => {
     for (const target of BUILD_TARGETS) {
-      const expected = target === 'local';
+      const expected = target === 'local' || target === 'beta';
       expect(isFeatureExposedOnTarget('forecastWorkflowV2', target)).toBe(expected);
       expect(FEATURE_EXPOSURE_REGISTRY.forecastWorkflowV2.exposure[target]).toBe(expected);
     }


### PR DESCRIPTION
## Summary
- enable forecast workflow v2 on beta while keeping staging and production disabled
- require and record explicit beta enablement approval
- update exposure adoption tests and acknowledgements
- add the beta tester checklist at docs/personal/plans/workflows-beta-tester-checklist.html

## Verification
- pnpm run validate:feature-exposure
- pnpm test -- --runInBand
- pnpm run build
- workflow continuity E2E verified on the merged implementation in #720

## Known limitation
- workflow package upload/restore remains a tracked limitation from #720 and is called out in the tester checklist.