### PR TITLE
fix(actions): emit plain OpenCode classifier output

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -23,6 +23,7 @@ jobs:
       - id: classify
         uses: actions/github-script@v7
         with:
+          result-encoding: string
           script: |
             const pullNumber = context.payload.pull_request?.number ??
               (context.payload.issue?.pull_request ? context.payload.issue.number : undefined)


### PR DESCRIPTION
## Summary

- Emit the OpenCode request-classifier output as a plain string instead of a JSON-encoded string.
- Allow trusted internal PR commands to reach the write-capable OpenCode job.

## Changelog

- Fixed OpenCode slash commands on trusted PRs being skipped after classification.

## Verification

- `git diff --check`
- Parsed `.github/workflows/opencode.yml` and asserted the classifier output encoding.
