### PR TITLE
fix(actions): preserve OpenCode push credentials

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Configure git author
         run: |


### PR DESCRIPTION
## Summary

- Preserve the GitHub Actions token in the trusted OpenCode write job's checkout remote.
- Allow OpenCode to push a commit after resolving a trusted PR's conflicts.

## Changelog

- Fixed OpenCode runs failing at `git push` after completing requested changes.

## Verification

- `git diff --check`
- Parsed `.github/workflows/opencode.yml` and asserted that only the trusted write job persists credentials.
