### PR TITLE
fix(actions): lease OpenCode pushes after rebase

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -19,6 +19,7 @@ jobs:
       pull-requests: read
     outputs:
       mode: ${{ steps.classify.outputs.result }}
+      branch: ${{ steps.classify.outputs.branch }}
     steps:
       - id: classify
         uses: actions/github-script@v7
@@ -34,11 +35,13 @@ jobs:
                 pull_number: pullNumber,
               })
               const head = pull.head.repo
+              core.setOutput('branch', pull.head.ref)
               return head?.full_name === `${context.repo.owner}/${context.repo.repo}` && !head.fork
                 ? 'trusted-pr'
                 : 'blocked'
             }
 
+            core.setOutput('branch', '')
             return context.payload.issue?.user?.login === 'WxboySuper'
               ? 'trusted-issue'
               : 'triage-issue'
@@ -61,6 +64,33 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Guard rebased PR pushes
+        if: needs.classify-request.outputs.mode == 'trusted-pr'
+        env:
+          PR_BRANCH: ${{ needs.classify-request.outputs.branch }}
+        run: |
+          git fetch origin "$PR_BRANCH"
+          printf 'OPENCODE_FORCE_PUSH_BRANCH=%s\n' "$PR_BRANCH" >> "$GITHUB_ENV"
+          printf 'OPENCODE_FORCE_PUSH_EXPECTED_SHA=%s\n' "$(git rev-parse FETCH_HEAD)" >> "$GITHUB_ENV"
+
+          mkdir -p "$RUNNER_TEMP/opencode-git"
+          cat > "$RUNNER_TEMP/opencode-git/git" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          if [[ "${1:-}" == "push" && "$#" -eq 1 && -n "${OPENCODE_FORCE_PUSH_BRANCH:-}" ]] &&
+             [[ "$(/usr/bin/git rev-parse --abbrev-ref HEAD)" == "$OPENCODE_FORCE_PUSH_BRANCH" ]]; then
+            remote_ref="refs/heads/$OPENCODE_FORCE_PUSH_BRANCH"
+            exec /usr/bin/git push \
+              "--force-with-lease=$remote_ref:$OPENCODE_FORCE_PUSH_EXPECTED_SHA" \
+              origin "HEAD:$remote_ref"
+          fi
+
+          exec /usr/bin/git "$@"
+          EOF
+          chmod +x "$RUNNER_TEMP/opencode-git/git"
+          echo "$RUNNER_TEMP/opencode-git" >> "$GITHUB_PATH"
 
       - name: Run opencode
         uses: anomalyco/opencode/github@a3b97d9090ccf4aa9ac32268486283e3131e36b4 # fix(github): enforce existing git author identity


### PR DESCRIPTION
## Summary

- Capture the original trusted PR branch SHA before OpenCode begins work.
- Route OpenCode's final bare push through `--force-with-lease` only when it rebases that trusted PR branch.
- Keep issue-created branches and the read-only triage path unchanged.

## Changelog

- Fixed OpenCode conflict-resolution runs failing after an intentional rebase.

## Verification

- `git diff --check`
- Parsed `.github/workflows/opencode.yml` and asserted that the lease wrapper is restricted to trusted PR runs.
- Validated the guard-step shell syntax with Git Bash.
