### PR TITLE
[Port] synchronize complete OpenCode workflow to beta

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -25,7 +25,26 @@ jobs:
         with:
           persist-credentials: true
 
+<<<<<<< HEAD
+=======
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Record trusted PR branch tip
+        if: needs.classify-request.outputs.mode == 'trusted-pr'
+        env:
+          PR_BRANCH: ${{ needs.classify-request.outputs.branch }}
+        run: |
+          git fetch origin "$PR_BRANCH"
+          printf 'OPENCODE_FORCE_PUSH_BRANCH=%s\n' "$PR_BRANCH" >> "$GITHUB_ENV"
+          printf 'OPENCODE_FORCE_PUSH_EXPECTED_SHA=%s\n' "$(git rev-parse FETCH_HEAD)" >> "$GITHUB_ENV"
+
+>>>>>>> ed91d61 (fix(actions): recover rebased opencode pushes)
       - name: Run opencode
+        id: run-opencode
+        continue-on-error: true
         uses: anomalyco/opencode/github@a3b97d9090ccf4aa9ac32268486283e3131e36b4 # fix(github): enforce existing git author identity
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,3 +52,71 @@ jobs:
         with:
           model: opencode/deepseek-v4-flash-free
           use_github_token: true
+<<<<<<< HEAD
+=======
+          mentions: /oc,/opencode
+
+      - name: Push a rebased trusted PR branch
+        id: push-rebased-pr
+        if: always() && needs.classify-request.outputs.mode == 'trusted-pr'
+        env:
+          PR_BRANCH: ${{ needs.classify-request.outputs.branch }}
+        run: |
+          set -euo pipefail
+          remote_ref="refs/heads/$PR_BRANCH"
+          local_sha="$(git rev-parse HEAD)"
+          remote_sha="$(git ls-remote origin "$remote_ref" | awk '{print $1}')"
+
+          if [[ "$remote_sha" == "$local_sha" ]]; then
+            echo "OpenCode already pushed this commit."
+            exit 0
+          fi
+
+          if [[ "$local_sha" == "$OPENCODE_FORCE_PUSH_EXPECTED_SHA" ]]; then
+            echo "OpenCode did not create a commit to recover."
+            exit 0
+          fi
+
+          if [[ "$remote_sha" != "$OPENCODE_FORCE_PUSH_EXPECTED_SHA" ]]; then
+            echo "Refusing to overwrite $PR_BRANCH because it changed during the OpenCode run."
+            exit 1
+          fi
+
+          git push \
+            "--force-with-lease=$remote_ref:$OPENCODE_FORCE_PUSH_EXPECTED_SHA" \
+            origin "HEAD:$remote_ref"
+          echo "recovered=true" >> "$GITHUB_OUTPUT"
+
+      - name: Fail unrecovered OpenCode errors
+        if: steps.run-opencode.outcome == 'failure' && steps.push-rebased-pr.outputs.recovered != 'true'
+        run: |
+          echo "OpenCode failed before its rewritten branch could be safely pushed."
+          exit 1
+
+  opencode-triage:
+    needs: classify-request
+    if: needs.classify-request.outputs.mode == 'triage-issue'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run opencode triage
+        uses: anomalyco/opencode/github@a3b97d9090ccf4aa9ac32268486283e3131e36b4 # fix(github): enforce existing git author identity
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/deepseek-v4-flash-free
+          use_github_token: true
+          mentions: /oc,/opencode
+          prompt: >-
+            Triage this issue. Do not edit repository files, create branches or pull requests,
+            commit, or push. Reply with a concise assessment, reproduction questions, labels, and
+            recommended next steps.
+>>>>>>> ed91d61 (fix(actions): recover rebased opencode pushes)

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 jobs:
-  opencode:
+  classify-request:
     if: |
       github.event.comment.user.login == 'WxboySuper' &&
       (github.event.comment.body == '/oc' ||
@@ -16,21 +16,65 @@ jobs:
        startsWith(github.event.comment.body, '/opencode '))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      pull-requests: read
+    outputs:
+      mode: ${{ steps.classify.outputs.result }}
+      branch: ${{ steps.classify.outputs.branch }}
+    steps:
+      - id: classify
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const pullNumber = context.payload.pull_request?.number ??
+              (context.payload.issue?.pull_request ? context.payload.issue.number : undefined)
+            if (pullNumber) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber,
+              })
+              const head = pull.head.repo
+              core.setOutput('branch', pull.head.ref)
+              return head?.full_name === `${context.repo.owner}/${context.repo.repo}` && !head.fork
+                ? 'trusted-pr'
+                : 'blocked'
+            }
+
+            core.setOutput('branch', '')
+            return context.payload.issue?.user?.login === 'WxboySuper'
+              ? 'trusted-issue'
+              : 'triage-issue'
+
+  opencode-write:
+    needs: classify-request
+    if: needs.classify-request.outputs.mode == 'trusted-pr' || needs.classify-request.outputs.mode == 'trusted-issue'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
       issues: write
       pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ needs.classify-request.outputs.branch || github.sha }}
           persist-credentials: true
 
-<<<<<<< HEAD
-=======
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Require trusted workflow push credential
+        if: needs.classify-request.outputs.mode == 'trusted-pr'
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [[ -z "$GH_PAT" ]]; then
+            echo "GH_PAT is required before OpenCode can safely update workflow files."
+            exit 1
+          fi
 
       - name: Record trusted PR branch tip
         if: needs.classify-request.outputs.mode == 'trusted-pr'
@@ -38,10 +82,17 @@ jobs:
           PR_BRANCH: ${{ needs.classify-request.outputs.branch }}
         run: |
           git fetch origin "$PR_BRANCH"
-          printf 'OPENCODE_FORCE_PUSH_BRANCH=%s\n' "$PR_BRANCH" >> "$GITHUB_ENV"
-          printf 'OPENCODE_FORCE_PUSH_EXPECTED_SHA=%s\n' "$(git rev-parse FETCH_HEAD)" >> "$GITHUB_ENV"
+          expected_sha="$(git rev-parse FETCH_HEAD)"
+          start_sha="$(git rev-parse HEAD)"
+          if [[ "$start_sha" != "$expected_sha" ]]; then
+            echo "Refusing recovery because the checked-out commit is not the PR branch tip."
+            exit 1
+          fi
 
->>>>>>> ed91d61 (fix(actions): recover rebased opencode pushes)
+          printf 'OPENCODE_FORCE_PUSH_BRANCH=%s\n' "$PR_BRANCH" >> "$GITHUB_ENV"
+          printf 'OPENCODE_FORCE_PUSH_EXPECTED_SHA=%s\n' "$expected_sha" >> "$GITHUB_ENV"
+          printf 'OPENCODE_FORCE_PUSH_START_SHA=%s\n' "$start_sha" >> "$GITHUB_ENV"
+
       - name: Run opencode
         id: run-opencode
         continue-on-error: true
@@ -52,8 +103,6 @@ jobs:
         with:
           model: opencode/deepseek-v4-flash-free
           use_github_token: true
-<<<<<<< HEAD
-=======
           mentions: /oc,/opencode
 
       - name: Push a rebased trusted PR branch
@@ -61,6 +110,7 @@ jobs:
         if: always() && needs.classify-request.outputs.mode == 'trusted-pr'
         env:
           PR_BRANCH: ${{ needs.classify-request.outputs.branch }}
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           remote_ref="refs/heads/$PR_BRANCH"
@@ -72,7 +122,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "$local_sha" == "$OPENCODE_FORCE_PUSH_EXPECTED_SHA" ]]; then
+          if [[ "$local_sha" == "$OPENCODE_FORCE_PUSH_START_SHA" ]]; then
             echo "OpenCode did not create a commit to recover."
             exit 0
           fi
@@ -82,6 +132,8 @@ jobs:
             exit 1
           fi
 
+          git config --local --replace-all http.https://github.com/.extraheader \
+            "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_PAT" | base64 -w 0)"
           git push \
             "--force-with-lease=$remote_ref:$OPENCODE_FORCE_PUSH_EXPECTED_SHA" \
             origin "HEAD:$remote_ref"
@@ -119,4 +171,3 @@ jobs:
             Triage this issue. Do not edit repository files, create branches or pull requests,
             commit, or push. Reply with a concise assessment, reproduction questions, labels, and
             recommended next steps.
->>>>>>> ed91d61 (fix(actions): recover rebased opencode pushes)


### PR DESCRIPTION
## Summary

- Ports the complete current OpenCode workflow from main to beta.
- Includes the trusted-PR classifier, issue triage path, safe rebase recovery, and isolated workflow-push credential.
- Replaces the incomplete automated conflict resolution for the earlier OpenCode ports.

## Changelog

- Fixed the beta OpenCode workflow so trusted PR conflict-resolution requests can safely update port branches.

## Verification

- The ported workflow file exactly matches current main.
- Live OpenCode run 29535944224 removed the conflict markers and pushed the resolved beta-port branch.

## Related ports

This consolidates the workflow changes represented by #728, #731, #735, and #739. Those drafts are left unmerged and are not needed once this PR lands.