### PR TITLE
fix(actions): authorize OpenCode workflow pushes

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.classify-request.outputs.branch || github.sha }}
+          token: ${{ secrets.GH_PAT }}
           persist-credentials: true
 
       - name: Configure git author

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -59,13 +59,22 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.classify-request.outputs.branch || github.sha }}
-          token: ${{ secrets.GH_PAT }}
           persist-credentials: true
 
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Require trusted workflow push credential
+        if: needs.classify-request.outputs.mode == 'trusted-pr'
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [[ -z "$GH_PAT" ]]; then
+            echo "GH_PAT is required before OpenCode can safely update workflow files."
+            exit 1
+          fi
 
       - name: Record trusted PR branch tip
         if: needs.classify-request.outputs.mode == 'trusted-pr'
@@ -101,6 +110,7 @@ jobs:
         if: always() && needs.classify-request.outputs.mode == 'trusted-pr'
         env:
           PR_BRANCH: ${{ needs.classify-request.outputs.branch }}
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           remote_ref="refs/heads/$PR_BRANCH"
@@ -122,6 +132,8 @@ jobs:
             exit 1
           fi
 
+          git config --local --replace-all http.https://github.com/.extraheader \
+            "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_PAT" | base64 -w 0)"
           git push \
             "--force-with-lease=$remote_ref:$OPENCODE_FORCE_PUSH_EXPECTED_SHA" \
             origin "HEAD:$remote_ref"


### PR DESCRIPTION
## Summary

- Use the existing GH_PAT for trusted OpenCode write-job checkout credentials.
- Allow OpenCode to update a PR that includes workflow files.

## Changelog

- Fixed OpenCode workflow updates so rebased port PRs can be pushed safely.

## Verification

- Workflow YAML parsed with PyYAML.
- git diff --check.