### PR TITLE
[Port][Conflicts] fix(actions): authorize OpenCode workflow pushes → beta

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+<<<<<<< HEAD
+=======
+          ref: ${{ needs.classify-request.outputs.branch || github.sha }}
+          token: ${{ secrets.GH_PAT }}
+>>>>>>> 5cb0ee7 (fix(actions): authorize opencode workflow pushes)
           persist-credentials: true
 
       - name: Run opencode


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #738 — fix(actions): authorize OpenCode workflow pushes |
| Source branch | `hotfix/opencode-workflow-push-token` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `.github/workflows/opencode.yml`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/738-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #738, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.