### PR TITLE
fix: harden emergency beta promotion governance

### DIFF
--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -14,7 +14,9 @@ permissions:
 # It remains only for documented emergency recovery when a PAT push to main is required.
 #
 # Required secrets:
-#   GH_PAT — Personal Access Token with `repo` scope.
+#   GH_PAT — Fine-grained personal access token restricted to this repository
+#            with Contents: Read and write. This token authorizes the legacy
+#            direct push; it is intentionally outside GITHUB_TOKEN permissions.
 on:
   workflow_dispatch:
     inputs:
@@ -27,6 +29,8 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.confirm_legacy == 'LEGACY-DIRECT-PROMOTE' }}
+    environment:
+      name: production-promote
 
     steps:
       - name: Checkout with full history
@@ -39,6 +43,28 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.x'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate beta before direct promotion
+        run: |
+          pnpm run build
+          pnpm test --silent
+        env:
+          CI: true
+          VITE_BUILD_TARGET: local
 
       - name: Merge beta into main
         run: |

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Checkout with full history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: beta
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
+
+      - name: Record the beta revision to validate and promote
+        run: echo "VALIDATED_BETA_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Configure git identity
         run: |
@@ -56,21 +60,35 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install --frozen-lockfile
+          npm --prefix server ci
 
       - name: Validate beta before direct promotion
         run: |
           pnpm run build
           pnpm test --silent
+          npm --prefix server test
         env:
-          CI: true
-          VITE_BUILD_TARGET: local
+          VITE_BUILD_TARGET: production
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_BETA_MODE: false
+          VITE_BETA_INVITE_PATH: ''
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_SENTRY_ENVIRONMENT: production
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          CI: false
 
-      - name: Merge beta into main
+      - name: Merge the validated beta revision into main
         run: |
-          git fetch origin beta main
+          git fetch origin main
           git checkout main
-          git merge --no-ff origin/beta -m "chore: promote beta → main [legacy direct]"
+          git merge --no-ff "$VALIDATED_BETA_SHA" -m "chore: promote beta → main [legacy direct]"
 
       - name: Strip beta prerelease from package version on main
         run: node scripts/strip-beta-prerelease-version.mjs

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #740
+
+- Require protected reviewer approval and pre-promotion build/test validation for the legacy direct beta-to-main emergency workflow.
+
 ### PR #741
 
 - Prevent replayed Stripe webhook deliveries from double-counting premium upgrade and cancellation metrics.


### PR DESCRIPTION
## Summary

Closes #605.

The deprecated direct beta-to-main promotion now requires the repository `production-promote` Environment, whose required-reviewer rule prevents an accidental or unreviewed dispatch from proceeding. The workflow also validates the checked-out beta revision with the production build and Jest suite before it merges or pushes anything to `main`.

`GH_PAT` is now documented as a repository-scoped fine-grained token with only Contents read/write access. The comment explicitly explains why this authorization is separate from the workflow's read-only `GITHUB_TOKEN` permissions.

## Verification

- `pnpm run build`
- `pnpm test --silent` (804 tests)
- `server/npm test` (94 tests)
- Confirmed `production-promote` has the repository owner configured as a required reviewer with self-review prevention.
