### PR TITLE
fix: dedupe Stripe billing metric events

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #741
+
+- Prevent replayed Stripe webhook deliveries from double-counting premium upgrade and cancellation metrics.
+
 ### PR #729
 
 - Enable the validated forecast workflow v2 surfaces for beta testers while keeping staging and production disabled.

--- a/server/billing.js
+++ b/server/billing.js
@@ -392,9 +392,12 @@ const createInvoiceEntitlementWrite = (eventType, invoice) => {
 };
 
 /** Applies the checkout-complete event to the entitlement document. */
-const recordBillingMetricEventSafely = async (eventType) => {
+const recordBillingMetricEventSafely = async (eventType, webhookEventId) => {
   try {
-    await recordBillingMetricEvent(eventType);
+    const recorded = await recordBillingMetricEvent(eventType, webhookEventId);
+    if (!recorded) {
+      console.log('[billing] metrics:duplicate-or-skipped', { eventType, webhookEventId });
+    }
   } catch (error) {
     console.warn('[billing] metrics:nonfatal', {
       eventType,
@@ -404,16 +407,18 @@ const recordBillingMetricEventSafely = async (eventType) => {
 };
 
 /** Applies the checkout-complete event to the entitlement document. */
-const handleCheckoutSessionCompleted = async (session) => {
+const handleCheckoutSessionCompleted = async (event) => {
+  const session = event.data.object;
   await writeEntitlement(createCheckoutEntitlementWrite(session));
-  await recordBillingMetricEventSafely('premium_upgrade');
+  await recordBillingMetricEventSafely('premium_upgrade', event.id);
 };
 
 /** Applies the subscription lifecycle event to the entitlement document. */
-const handleSubscriptionEvent = async (subscription, eventType) => {
+const handleSubscriptionEvent = async (event) => {
+  const subscription = event.data.object;
   await writeEntitlement(createSubscriptionEntitlementWrite(subscription));
-  if (eventType === 'customer.subscription.deleted') {
-    await recordBillingMetricEventSafely('premium_cancellation');
+  if (event.type === 'customer.subscription.deleted') {
+    await recordBillingMetricEventSafely('premium_cancellation', event.id);
   }
 };
 
@@ -421,9 +426,9 @@ const handleSubscriptionEvent = async (subscription, eventType) => {
 const handleInvoiceEvent = (eventType, invoice) => writeEntitlement(createInvoiceEntitlementWrite(eventType, invoice));
 
 const webhookHandlers = {
-  'checkout.session.completed': (event) => handleCheckoutSessionCompleted(event.data.object),
-  'customer.subscription.updated': (event) => handleSubscriptionEvent(event.data.object, event.type),
-  'customer.subscription.deleted': (event) => handleSubscriptionEvent(event.data.object, event.type),
+  'checkout.session.completed': handleCheckoutSessionCompleted,
+  'customer.subscription.updated': handleSubscriptionEvent,
+  'customer.subscription.deleted': handleSubscriptionEvent,
   'invoice.paid': (event) => handleInvoiceEvent(event.type, event.data.object),
   'invoice.payment_failed': (event) => handleInvoiceEvent(event.type, event.data.object),
 };

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -58,6 +58,7 @@ const STORAGE_COLLECTIONS = [
   'userMetrics',
   'adminDailyMetrics',
   'adminMetricDedupes',
+  'processedBillingWebhookEvents',
 ];
 const STORAGE_CACHE_TTL_MS = 5 * 60 * 1000;
 let storageBytesCache = {
@@ -587,20 +588,37 @@ const recordMetricEvent = async ({ eventType, installationId, uid }) => {
   return true;
 };
 
-/** Records admin-only billing metric events that come from trusted Stripe webhooks. */
-const recordBillingMetricEvent = async (eventType) => {
+/** Returns a bounded Stripe event id suitable for a Firestore document id. */
+const normalizeBillingWebhookEventId = (value) =>
+  typeof value === 'string' && value.trim() ? value.trim().slice(0, 256) : null;
+
+/** Records admin-only billing metric events once per trusted Stripe webhook delivery id. */
+const recordBillingMetricEvent = async (eventType, webhookEventId) => {
   const normalizedEventType = normalizeBillingMetricEventType(eventType);
+  const normalizedWebhookEventId = normalizeBillingWebhookEventId(webhookEventId);
   const db = getAdminDb();
-  if (!db || !normalizedEventType) {
-    return;
+  if (!db || !normalizedEventType || !normalizedWebhookEventId) {
+    return false;
   }
 
   const dayKey = getDayKey();
   const dailyRef = db.collection('adminDailyMetrics').doc(dayKey);
+  const processedEventRef = db.collection('processedBillingWebhookEvents').doc(normalizedWebhookEventId);
   const premiumSubscriptions = await countPremiumSubscriptions();
 
-  await db.runTransaction(async (transaction) => {
-    const dailySnapshot = await transaction.get(dailyRef);
+  return db.runTransaction(async (transaction) => {
+    const [dailySnapshot, processedEventSnapshot] = await Promise.all([
+      transaction.get(dailyRef),
+      transaction.get(processedEventRef),
+    ]);
+    if (processedEventSnapshot.exists) {
+      return false;
+    }
+
+    transaction.set(processedEventRef, {
+      eventType: normalizedEventType,
+      processedAt: new Date(),
+    });
     transaction.set(
       dailyRef,
       buildNextAdminDailyMetrics({
@@ -612,6 +630,7 @@ const recordBillingMetricEvent = async (eventType) => {
       }),
       { merge: true }
     );
+    return true;
   });
 };
 

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -58,7 +58,6 @@ const STORAGE_COLLECTIONS = [
   'userMetrics',
   'adminDailyMetrics',
   'adminMetricDedupes',
-  'processedBillingWebhookEvents',
 ];
 const STORAGE_CACHE_TTL_MS = 5 * 60 * 1000;
 let storageBytesCache = {
@@ -592,12 +591,20 @@ const recordMetricEvent = async ({ eventType, installationId, uid }) => {
 const normalizeBillingWebhookEventId = (value) =>
   typeof value === 'string' && value.trim() ? value.trim().slice(0, 256) : null;
 
+/** True when a trusted webhook provides all data needed for one billable metric write. */
+const hasBillingMetricWriteInput = ({ db, eventType, webhookEventId }) =>
+  Boolean(db && eventType && webhookEventId);
+
 /** Records admin-only billing metric events once per trusted Stripe webhook delivery id. */
 const recordBillingMetricEvent = async (eventType, webhookEventId) => {
   const normalizedEventType = normalizeBillingMetricEventType(eventType);
   const normalizedWebhookEventId = normalizeBillingWebhookEventId(webhookEventId);
   const db = getAdminDb();
-  if (!db || !normalizedEventType || !normalizedWebhookEventId) {
+  if (!hasBillingMetricWriteInput({
+    db,
+    eventType: normalizedEventType,
+    webhookEventId: normalizedWebhookEventId,
+  })) {
     return false;
   }
 

--- a/server/metrics.test.js
+++ b/server/metrics.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { after, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const firebaseAdminPath = require.resolve('./firebase-admin');
+const metricsPath = require.resolve('./metrics');
+const originalFirebaseAdmin = require.cache[firebaseAdminPath];
+const documents = new Map();
+
+const createRef = (collection, id) => ({ collection, id, key: `${collection}/${id}` });
+const getSnapshot = (ref) => {
+  const data = documents.get(ref.key);
+  return { exists: Boolean(data), data: () => data || {} };
+};
+const db = {
+  collection: (collection) => ({
+    doc: (id) => createRef(collection, id),
+    where: () => ({ get: async () => ({ size: 0 }) }),
+  }),
+  runTransaction: async (callback) =>
+    callback({
+      get: async (ref) => getSnapshot(ref),
+      set: (ref, data, options) => {
+        documents.set(ref.key, options?.merge ? { ...(documents.get(ref.key) || {}), ...data } : data);
+      },
+    }),
+};
+
+require.cache[firebaseAdminPath] = {
+  id: firebaseAdminPath,
+  filename: firebaseAdminPath,
+  loaded: true,
+  exports: { getAdminDb: () => db, getAdminAuth: () => null, hasFirebaseAdminConfig: () => true },
+};
+delete require.cache[metricsPath];
+const { recordBillingMetricEvent } = require('./metrics');
+
+after(() => {
+  documents.clear();
+  if (originalFirebaseAdmin) require.cache[firebaseAdminPath] = originalFirebaseAdmin;
+  else delete require.cache[firebaseAdminPath];
+  delete require.cache[metricsPath];
+});
+
+describe('recordBillingMetricEvent', () => {
+  it('records each Stripe webhook event id only once', async () => {
+    const first = await recordBillingMetricEvent('premium_upgrade', 'evt_checkout_123');
+    const replay = await recordBillingMetricEvent('premium_upgrade', 'evt_checkout_123');
+    const dailyMetrics = [...documents.entries()].find(([key]) => key.startsWith('adminDailyMetrics/'))?.[1];
+
+    assert.equal(first, true);
+    assert.equal(replay, false);
+    assert.equal(dailyMetrics.upgrades, 1);
+    assert.equal(documents.get('processedBillingWebhookEvents/evt_checkout_123').eventType, 'premium_upgrade');
+  });
+
+  it('counts distinct cancellation events and rejects missing event ids', async () => {
+    const accepted = await recordBillingMetricEvent('premium_cancellation', 'evt_cancel_456');
+    const missingId = await recordBillingMetricEvent('premium_cancellation', '');
+    const dailyMetrics = [...documents.entries()].find(([key]) => key.startsWith('adminDailyMetrics/'))?.[1];
+
+    assert.equal(accepted, true);
+    assert.equal(missingId, false);
+    assert.equal(dailyMetrics.cancellations, 1);
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "main": "analytics.js",
   "scripts": {
     "start": "node analytics.js",
-    "test": "node --test billing-stripe-period.test.js qs-dos.test.js lib/serverTarget.test.js lib/featureCapabilities.test.js server-stack.test.js tstm.test.js tstm-ingestion.test.js testing/featureExposureHarness.test.js testing/autoTstm.exposure.test.js lib/capabilityStatus.test.js"
+    "test": "node --test billing-stripe-period.test.js metrics.test.js qs-dos.test.js lib/serverTarget.test.js lib/featureCapabilities.test.js server-stack.test.js tstm.test.js tstm-ingestion.test.js testing/featureExposureHarness.test.js testing/autoTstm.exposure.test.js lib/capabilityStatus.test.js"
   },
   "dependencies": {
     "@sentry/node": "^10.65.0",


### PR DESCRIPTION
## Summary

Closes #600.

Stripe billing metric side effects now persist each trusted Stripe webhook event ID in `processedBillingWebhookEvents` in the same Firestore transaction as the daily metric update. A repeated delivery of the same event returns successfully but does not increment the upgrade or cancellation counter.

The entitlement writes are intentionally unchanged. This scope corrects metric accuracy without changing subscription state processing.

## Verification

- `node --test server/metrics.test.js`
- `server/npm test` (96 tests)
- `pnpm run build`
- `pnpm test --silent` (804 tests)

The new focused test proves the first delivery increments the metric, an identical event-ID replay does not, distinct cancellations count normally, and a missing event ID cannot increment billing metrics.
