### PR TITLE
CUS-01: define custom layer and product schemas

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #742
+
+- Define versioned one-off custom layer, reusable hosted product, embedded snapshot, and expiration/read-only contracts with strict validation and local-only exposure.
+
 ### PR #740
 
 - Require protected reviewer approval and pre-promotion build/test validation for the legacy direct beta-to-main emergency workflow.

--- a/docs/custom-products.md
+++ b/docs/custom-products.md
@@ -1,0 +1,21 @@
+# Custom layers and reusable products
+
+Custom content uses a snapshot-first contract. A one-off layer contains every category style and polygon needed to render it; it never depends on a hosted template. Loading a premium reusable product into a map copies its current version into an embedded snapshot. Later product edits, archival, deletion, or subscription expiration therefore cannot change an existing map.
+
+## Exposure
+
+The `customProducts` registry key is enabled only for the `local` build target while the feature is implemented and reviewed. Beta, staging, and production must not render custom-product routes, navigation, toolbar controls, unavailable-state messages, or start custom-product side effects. Broader exposure requires separate owner authorization.
+
+## Schema rules
+
+- A reusable product has a stable ID and a monotonically increasing positive version.
+- A product or one-off layer contains 1–12 ordered categories.
+- Product and category labels are 1–64 trimmed characters.
+- Colors use six-digit hex values; opacity is in the inclusive 0–1 interval.
+- Supported hatches are none, diagonal, reverse diagonal, and crosshatch.
+- Custom geometry is GeoJSON Polygon or MultiPolygon with closed linear rings.
+- Embedded snapshots contain no entitlement dependency and remain renderable read-only.
+- Archived or premium-expired products are read-only and cannot seed new maps; historical layer snapshots remain usable.
+
+The TypeScript contracts live in `src/types/customProducts.ts`; strict runtime validators and snapshot/version helpers live in `src/lib/customProducts.ts`.
+

--- a/src/config/featureExposure.acknowledgements.json
+++ b/src/config/featureExposure.acknowledgements.json
@@ -23,7 +23,8 @@
     "trackingIssue": 530
   },
   "customProducts": {
-    "reason": "Registry-only until custom product surfaces merge; adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",
-    "trackingIssue": 530
+    "reason": "Local-only implementation and review under #431; beta, staging, and production remain disabled until separate owner authorization. Adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",
+    "trackingIssue": 530,
+    "localDevelopmentApproved": true
   }
 }

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -112,7 +112,7 @@ describe('featureExposure registry', () => {
     }
   });
 
-  test('keeps unreleased v1.7 workstream keys disabled while local and beta expose forecast workflow v2', () => {
+  test('keeps unreleased v1.7 workstreams disabled outside their explicitly approved targets', () => {
     const workstreamKeys = [
       'forecastWorkflowV2',
       'verificationRelaunch',
@@ -121,7 +121,7 @@ describe('featureExposure registry', () => {
       'collaborationRoom',
     ] as const;
 
-    for (const feature of workstreamKeys.filter((feature) => feature !== 'forecastWorkflowV2')) {
+    for (const feature of workstreamKeys.filter((feature) => !['forecastWorkflowV2', 'customProducts'].includes(feature))) {
       for (const target of ['local', 'beta', 'staging', 'production'] as const) {
         expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
       }
@@ -131,6 +131,11 @@ describe('featureExposure registry', () => {
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'beta')).toBe(true);
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'staging')).toBe(false);
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'production')).toBe(false);
+
+    expect(isFeatureExposedOnTarget('customProducts', 'local')).toBe(true);
+    for (const target of ['beta', 'staging', 'production'] as const) {
+      expect(isFeatureExposedOnTarget('customProducts', target)).toBe(false);
+    }
 
     for (const target of ['local', 'staging', 'production'] as const) {
       expect(isFeatureExposedOnTarget('autoTstm', target)).toBe(false);

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -133,7 +133,7 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 430,
   },
   customProducts: {
-    exposure: { ...ALL_TARGETS_OFF },
+    exposure: { ...ALL_TARGETS_OFF, local: true },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,

--- a/src/config/v17WorkstreamAdoption.exposure.test.ts
+++ b/src/config/v17WorkstreamAdoption.exposure.test.ts
@@ -28,7 +28,7 @@ describe('v1.7 workstream adoption contract', () => {
   });
 
   test.each(
-    V17_WORKSTREAM_KEYS.filter((feature) => !['autoTstm', 'forecastWorkflowV2'].includes(feature))
+    V17_WORKSTREAM_KEYS.filter((feature) => !['autoTstm', 'forecastWorkflowV2', 'customProducts'].includes(feature))
   )(
     '%s stays disabled on every build target',
     (feature) => {
@@ -38,6 +38,14 @@ describe('v1.7 workstream adoption contract', () => {
       }
     }
   );
+
+  test('customProducts is enabled only for local implementation and review', () => {
+    for (const target of BUILD_TARGETS) {
+      const expected = target === 'local';
+      expect(isFeatureExposedOnTarget('customProducts', target)).toBe(expected);
+      expect(FEATURE_EXPOSURE_REGISTRY.customProducts.exposure[target]).toBe(expected);
+    }
+  });
 
   test('autoTstm is enabled only on beta', () => {
     for (const target of BUILD_TARGETS) {

--- a/src/lib/customCategoryValidation.ts
+++ b/src/lib/customCategoryValidation.ts
@@ -1,0 +1,64 @@
+import {
+  CUSTOM_PRODUCT_LIMITS,
+  type CustomCategoryStyle,
+  type CustomCategoryTemplate,
+} from '../types/customProducts';
+
+const HEX_COLOR = /^#[0-9a-f]{6}$/i;
+const HATCH_PATTERNS = new Set(['none', 'diagonal', 'reverse-diagonal', 'crosshatch']);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean =>
+  Object.keys(value).every((key) => keys.includes(key));
+
+const isBoundedText = (value: unknown): value is string =>
+  typeof value === 'string'
+  && value.trim() === value
+  && value.length > 0
+  && value.length <= CUSTOM_PRODUCT_LIMITS.labelLength;
+
+const isUnitInterval = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+
+const isHexColor = (value: unknown): value is string =>
+  typeof value === 'string' && HEX_COLOR.test(value);
+
+const isStrokeWidth = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 8;
+
+const isHatchPattern = (value: unknown): boolean =>
+  typeof value === 'string' && HATCH_PATTERNS.has(value);
+
+/** Validates a complete category style without accepting unknown fields. */
+export const isCustomCategoryStyle = (value: unknown): value is CustomCategoryStyle => {
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, ['fillColor', 'fillOpacity', 'strokeColor', 'strokeOpacity', 'strokeWidth', 'hatch'])) return false;
+  return isHexColor(value.fillColor)
+    && isUnitInterval(value.fillOpacity)
+    && isHexColor(value.strokeColor)
+    && isUnitInterval(value.strokeOpacity)
+    && isStrokeWidth(value.strokeWidth)
+    && isHatchPattern(value.hatch);
+};
+
+/** Validates one bounded ordered category definition. */
+export const isCustomCategoryTemplate = (value: unknown): value is CustomCategoryTemplate => {
+  if (!isRecord(value) || !hasOnlyKeys(value, ['id', 'label', 'order', 'style'])) return false;
+  return isBoundedText(value.id)
+    && isBoundedText(value.label)
+    && isNonNegativeInteger(value.order)
+    && isCustomCategoryStyle(value.style);
+};
+
+/** Validates category limits, unique identifiers, and contiguous ordering. */
+export const isCustomCategoryList = (value: unknown): value is CustomCategoryTemplate[] => {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  if (value.length > CUSTOM_PRODUCT_LIMITS.categoriesPerProduct || !value.every(isCustomCategoryTemplate)) return false;
+  const ids = new Set(value.map((category) => category.id));
+  return ids.size === value.length && value.every((category, index) => category.order === index);
+};

--- a/src/lib/customFeatureShape.ts
+++ b/src/lib/customFeatureShape.ts
@@ -1,0 +1,26 @@
+import { getCustomGeometryDimension, isCustomPolygonGeometry } from './customGeometry';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean =>
+  Object.keys(value).every((key) => keys.includes(key));
+
+const isBoundingBox = (value: unknown, dimension: number): boolean => {
+  if (!Array.isArray(value) || value.length !== dimension * 2) return false;
+  if (!value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate))) return false;
+  return value.slice(0, dimension).every((minimum, index) => minimum <= value[index + dimension]);
+};
+
+const isOptionalFeatureId = (value: unknown): boolean => {
+  if (value === undefined || typeof value === 'string') return true;
+  return typeof value === 'number' && Number.isFinite(value);
+};
+
+export const hasValidCustomFeatureShape = (value: Record<string, unknown>): boolean => {
+  if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
+  if (value.type !== 'Feature' || !isCustomPolygonGeometry(value.geometry)) return false;
+  if (!isRecord(value.properties) || !isOptionalFeatureId(value.id)) return false;
+  if (value.bbox === undefined) return true;
+  return isBoundingBox(value.bbox, getCustomGeometryDimension(value.geometry));
+};

--- a/src/lib/customFeatureValidation.ts
+++ b/src/lib/customFeatureValidation.ts
@@ -1,6 +1,6 @@
 import type { CustomPolygonFeature } from '../types/customProducts';
 import { CUSTOM_PRODUCT_LIMITS } from '../types/customProducts';
-import { getCustomGeometryDimension, isCustomPolygonGeometry } from './customGeometry';
+import { hasValidCustomFeatureShape } from './customFeatureShape';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -11,29 +11,6 @@ const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): b
 const isBoundedText = (value: unknown): value is string => {
   if (typeof value !== 'string' || value.trim() !== value) return false;
   return value.length > 0 && value.length <= CUSTOM_PRODUCT_LIMITS.labelLength;
-};
-
-const isBoundingBox = (value: unknown, dimension: number): boolean => {
-  if (!Array.isArray(value) || value.length !== dimension * 2) return false;
-  if (!value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate))) return false;
-  return value.slice(0, dimension).every((minimum, index) => minimum <= value[index + dimension]);
-};
-
-const isOptionalFeatureId = (value: unknown): boolean => {
-  if (value === undefined || typeof value === 'string') return true;
-  return typeof value === 'number' && Number.isFinite(value);
-};
-
-const isFeatureType = (value: Record<string, unknown>): boolean => value.type === 'Feature';
-
-const hasFeatureProperties = (value: Record<string, unknown>): boolean => isRecord(value.properties);
-
-const hasValidShape = (value: Record<string, unknown>): boolean => {
-  if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
-  if (!isFeatureType(value) || !isCustomPolygonGeometry(value.geometry)) return false;
-  if (!hasFeatureProperties(value) || !isOptionalFeatureId(value.id)) return false;
-  if (value.bbox === undefined) return true;
-  return isBoundingBox(value.bbox, getCustomGeometryDimension(value.geometry));
 };
 
 const hasValidProperties = (properties: Record<string, unknown>): boolean => {
@@ -59,7 +36,7 @@ export const isCustomPolygonFeature = (
   layerId?: string,
   categoryIds?: ReadonlySet<string>,
 ): value is CustomPolygonFeature => {
-  if (!isRecord(value) || !hasValidShape(value)) return false;
+  if (!isRecord(value) || !hasValidCustomFeatureShape(value)) return false;
   const properties = value.properties as Record<string, unknown>;
   return hasValidProperties(properties) && matchesOwner(properties, layerId, categoryIds);
 };

--- a/src/lib/customFeatureValidation.ts
+++ b/src/lib/customFeatureValidation.ts
@@ -24,10 +24,14 @@ const isOptionalFeatureId = (value: unknown): boolean => {
   return typeof value === 'number' && Number.isFinite(value);
 };
 
+const isFeatureType = (value: Record<string, unknown>): boolean => value.type === 'Feature';
+
+const hasFeatureProperties = (value: Record<string, unknown>): boolean => isRecord(value.properties);
+
 const hasValidShape = (value: Record<string, unknown>): boolean => {
   if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
-  if (value.type !== 'Feature' || !isCustomPolygonGeometry(value.geometry)) return false;
-  if (!isRecord(value.properties) || !isOptionalFeatureId(value.id)) return false;
+  if (!isFeatureType(value) || !isCustomPolygonGeometry(value.geometry)) return false;
+  if (!hasFeatureProperties(value) || !isOptionalFeatureId(value.id)) return false;
   if (value.bbox === undefined) return true;
   return isBoundingBox(value.bbox, getCustomGeometryDimension(value.geometry));
 };

--- a/src/lib/customFeatureValidation.ts
+++ b/src/lib/customFeatureValidation.ts
@@ -1,0 +1,61 @@
+import type { CustomPolygonFeature } from '../types/customProducts';
+import { CUSTOM_PRODUCT_LIMITS } from '../types/customProducts';
+import { getCustomGeometryDimension, isCustomPolygonGeometry } from './customGeometry';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean =>
+  Object.keys(value).every((key) => keys.includes(key));
+
+const isBoundedText = (value: unknown): value is string => {
+  if (typeof value !== 'string' || value.trim() !== value) return false;
+  return value.length > 0 && value.length <= CUSTOM_PRODUCT_LIMITS.labelLength;
+};
+
+const isBoundingBox = (value: unknown, dimension: number): boolean => {
+  if (!Array.isArray(value) || value.length !== dimension * 2) return false;
+  if (!value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate))) return false;
+  return value.slice(0, dimension).every((minimum, index) => minimum <= value[index + dimension]);
+};
+
+const isOptionalFeatureId = (value: unknown): boolean => {
+  if (value === undefined || typeof value === 'string') return true;
+  return typeof value === 'number' && Number.isFinite(value);
+};
+
+const hasValidShape = (value: Record<string, unknown>): boolean => {
+  if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
+  if (value.type !== 'Feature' || !isCustomPolygonGeometry(value.geometry)) return false;
+  if (!isRecord(value.properties) || !isOptionalFeatureId(value.id)) return false;
+  if (value.bbox === undefined) return true;
+  return isBoundingBox(value.bbox, getCustomGeometryDimension(value.geometry));
+};
+
+const hasValidProperties = (properties: Record<string, unknown>): boolean => {
+  if (!hasOnlyKeys(properties, ['customLayerId', 'categoryId', 'title'])) return false;
+  return isBoundedText(properties.customLayerId)
+    && isBoundedText(properties.categoryId)
+    && isBoundedText(properties.title);
+};
+
+const matchesOwner = (
+  properties: Record<string, unknown>,
+  layerId?: string,
+  categoryIds?: ReadonlySet<string>,
+): boolean => {
+  if (layerId !== undefined && properties.customLayerId !== layerId) return false;
+  if (categoryIds === undefined) return true;
+  return typeof properties.categoryId === 'string' && categoryIds.has(properties.categoryId);
+};
+
+/** Validates bounded custom GeoJSON polygons and their layer/category identities. */
+export const isCustomPolygonFeature = (
+  value: unknown,
+  layerId?: string,
+  categoryIds?: ReadonlySet<string>,
+): value is CustomPolygonFeature => {
+  if (!isRecord(value) || !hasValidShape(value)) return false;
+  const properties = value.properties as Record<string, unknown>;
+  return hasValidProperties(properties) && matchesOwner(properties, layerId, categoryIds);
+};

--- a/src/lib/customGeometry.ts
+++ b/src/lib/customGeometry.ts
@@ -1,7 +1,6 @@
 import type { Geometry, Position } from 'geojson';
 import {
   CUSTOM_PRODUCT_LIMITS,
-  type CustomPolygonFeature,
 } from '../types/customProducts';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -10,16 +9,11 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean =>
   Object.keys(value).every((key) => keys.includes(key));
 
-const isBoundedText = (value: unknown): value is string =>
-  typeof value === 'string'
-  && value.trim() === value
-  && value.length > 0
-  && value.length <= CUSTOM_PRODUCT_LIMITS.labelLength;
-
-const isPosition = (value: unknown): value is Position =>
-  Array.isArray(value)
-  && [2, 3].includes(value.length)
-  && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
+const isPosition = (value: unknown): value is Position => {
+  if (!Array.isArray(value)) return false;
+  if (![2, 3].includes(value.length)) return false;
+  return value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
+};
 
 const isLinearRing = (value: unknown): value is Position[] => {
   if (!Array.isArray(value)) return false;
@@ -31,11 +25,11 @@ const isLinearRing = (value: unknown): value is Position[] => {
   return first.every((coordinate, index) => coordinate === last[index]);
 };
 
-const isPolygonCoordinates = (value: unknown): value is Position[][] =>
-  Array.isArray(value)
-  && value.length > 0
-  && value.length <= CUSTOM_PRODUCT_LIMITS.ringsPerPolygon
-  && value.every(isLinearRing);
+const isPolygonCoordinates = (value: unknown): value is Position[][] => {
+  if (!Array.isArray(value)) return false;
+  if (value.length === 0 || value.length > CUSTOM_PRODUCT_LIMITS.ringsPerPolygon) return false;
+  return value.every(isLinearRing);
+};
 
 const getGeometryPositions = (value: Record<string, unknown>): Position[] => {
   if (!Array.isArray(value.coordinates)) return [];
@@ -49,70 +43,24 @@ const hasValidGeometryDimensions = (value: Record<string, unknown>): boolean => 
   return positions.every((position) => position.length === positions[0].length);
 };
 
-const hasValidPolygonGeometry = (value: Record<string, unknown>): boolean =>
-  value.type === 'Polygon'
-  && isPolygonCoordinates(value.coordinates)
-  && hasValidGeometryDimensions(value);
+const hasValidPolygonGeometry = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'Polygon') return false;
+  if (!isPolygonCoordinates(value.coordinates)) return false;
+  return hasValidGeometryDimensions(value);
+};
 
-const hasValidMultiPolygonGeometry = (value: Record<string, unknown>): boolean =>
-  value.type === 'MultiPolygon'
-  && Array.isArray(value.coordinates)
-  && value.coordinates.length > 0
-  && value.coordinates.length <= CUSTOM_PRODUCT_LIMITS.polygonsPerFeature
-  && value.coordinates.every(isPolygonCoordinates)
-  && hasValidGeometryDimensions(value);
+const hasValidMultiPolygonGeometry = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'MultiPolygon' || !Array.isArray(value.coordinates)) return false;
+  if (value.coordinates.length === 0) return false;
+  if (value.coordinates.length > CUSTOM_PRODUCT_LIMITS.polygonsPerFeature) return false;
+  if (!value.coordinates.every(isPolygonCoordinates)) return false;
+  return hasValidGeometryDimensions(value);
+};
 
-const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
+export const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
   if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'coordinates'])) return false;
   return hasValidPolygonGeometry(value) || hasValidMultiPolygonGeometry(value);
 };
 
-const isBoundingBox = (value: unknown, dimension: number): boolean => {
-  if (!Array.isArray(value) || value.length !== dimension * 2) return false;
-  if (!value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate))) return false;
-  return value.slice(0, dimension).every((minimum, index) => minimum <= value[index + dimension]);
-};
-
-const isOptionalFeatureId = (value: unknown): boolean =>
-  value === undefined
-  || typeof value === 'string'
-  || (typeof value === 'number' && Number.isFinite(value));
-
-const hasValidCustomFeatureShape = (value: Record<string, unknown>): boolean => {
-  if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
-  if (value.type !== 'Feature') return false;
-  if (!isCustomPolygonGeometry(value.geometry)) return false;
-  if (!isRecord(value.properties)) return false;
-  if (!isOptionalFeatureId(value.id)) return false;
-  const dimension = getGeometryPositions(value.geometry as Record<string, unknown>)[0]?.length;
-  if (value.bbox === undefined) return true;
-  return isBoundingBox(value.bbox, dimension);
-};
-
-const hasValidCustomFeatureProperties = (properties: Record<string, unknown>): boolean =>
-  hasOnlyKeys(properties, ['customLayerId', 'categoryId', 'title'])
-  && isBoundedText(properties.customLayerId)
-  && isBoundedText(properties.categoryId)
-  && isBoundedText(properties.title);
-
-const matchesCustomFeatureOwner = (
-  properties: Record<string, unknown>,
-  layerId?: string,
-  categoryIds?: ReadonlySet<string>,
-): boolean => {
-  if (layerId !== undefined && properties.customLayerId !== layerId) return false;
-  if (categoryIds === undefined) return true;
-  return typeof properties.categoryId === 'string' && categoryIds.has(properties.categoryId);
-};
-
-/** Validates bounded custom GeoJSON polygons and their layer/category identities. */
-export const isCustomPolygonFeature = (
-  value: unknown,
-  layerId?: string,
-  categoryIds?: ReadonlySet<string>,
-): value is CustomPolygonFeature => {
-  if (!isRecord(value) || !hasValidCustomFeatureShape(value)) return false;
-  const properties = value.properties as Record<string, unknown>;
-  return hasValidCustomFeatureProperties(properties)
-    && matchesCustomFeatureOwner(properties, layerId, categoryIds);
-};
+export const getCustomGeometryDimension = (value: Geometry): number =>
+  getGeometryPositions(value as Record<string, unknown>)[0]?.length ?? 0;

--- a/src/lib/customGeometry.ts
+++ b/src/lib/customGeometry.ts
@@ -22,11 +22,13 @@ const isPosition = (value: unknown): value is Position =>
   && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
 
 const isLinearRing = (value: unknown): value is Position[] => {
-  if (!Array.isArray(value) || value.length < 4 || !value.every(isPosition)) return false;
+  if (!Array.isArray(value)) return false;
+  if (value.length < 4) return false;
+  if (!value.every(isPosition)) return false;
   const first = value[0];
   const last = value[value.length - 1];
-  return first.length === last.length
-    && first.every((coordinate, index) => coordinate === last[index]);
+  if (first.length !== last.length) return false;
+  return first.every((coordinate, index) => coordinate === last[index]);
 };
 
 const isPolygonCoordinates = (value: unknown): value is Position[][] =>

--- a/src/lib/customGeometry.ts
+++ b/src/lib/customGeometry.ts
@@ -80,10 +80,13 @@ const isOptionalFeatureId = (value: unknown): boolean =>
 
 const hasValidCustomFeatureShape = (value: Record<string, unknown>): boolean => {
   if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
-  if (value.type !== 'Feature' || !isCustomPolygonGeometry(value.geometry) || !isRecord(value.properties)) return false;
+  if (value.type !== 'Feature') return false;
+  if (!isCustomPolygonGeometry(value.geometry)) return false;
+  if (!isRecord(value.properties)) return false;
   if (!isOptionalFeatureId(value.id)) return false;
   const dimension = getGeometryPositions(value.geometry as Record<string, unknown>)[0]?.length;
-  return value.bbox === undefined || isBoundingBox(value.bbox, dimension);
+  if (value.bbox === undefined) return true;
+  return isBoundingBox(value.bbox, dimension);
 };
 
 const hasValidCustomFeatureProperties = (properties: Record<string, unknown>): boolean =>

--- a/src/lib/customGeometry.ts
+++ b/src/lib/customGeometry.ts
@@ -1,0 +1,113 @@
+import type { Geometry, Position } from 'geojson';
+import {
+  CUSTOM_PRODUCT_LIMITS,
+  type CustomPolygonFeature,
+} from '../types/customProducts';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean =>
+  Object.keys(value).every((key) => keys.includes(key));
+
+const isBoundedText = (value: unknown): value is string =>
+  typeof value === 'string'
+  && value.trim() === value
+  && value.length > 0
+  && value.length <= CUSTOM_PRODUCT_LIMITS.labelLength;
+
+const isPosition = (value: unknown): value is Position =>
+  Array.isArray(value)
+  && [2, 3].includes(value.length)
+  && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
+
+const isLinearRing = (value: unknown): value is Position[] => {
+  if (!Array.isArray(value) || value.length < 4 || !value.every(isPosition)) return false;
+  const first = value[0];
+  const last = value[value.length - 1];
+  return first.length === last.length
+    && first.every((coordinate, index) => coordinate === last[index]);
+};
+
+const isPolygonCoordinates = (value: unknown): value is Position[][] =>
+  Array.isArray(value)
+  && value.length > 0
+  && value.length <= CUSTOM_PRODUCT_LIMITS.ringsPerPolygon
+  && value.every(isLinearRing);
+
+const getGeometryPositions = (value: Record<string, unknown>): Position[] => {
+  if (!Array.isArray(value.coordinates)) return [];
+  const polygons = value.type === 'Polygon' ? [value.coordinates] : value.coordinates;
+  return (polygons as Position[][][]).flat(2);
+};
+
+const hasValidGeometryDimensions = (value: Record<string, unknown>): boolean => {
+  const positions = getGeometryPositions(value);
+  if (positions.length === 0 || positions.length > CUSTOM_PRODUCT_LIMITS.coordinatesPerFeature) return false;
+  return positions.every((position) => position.length === positions[0].length);
+};
+
+const hasValidPolygonGeometry = (value: Record<string, unknown>): boolean =>
+  value.type === 'Polygon'
+  && isPolygonCoordinates(value.coordinates)
+  && hasValidGeometryDimensions(value);
+
+const hasValidMultiPolygonGeometry = (value: Record<string, unknown>): boolean =>
+  value.type === 'MultiPolygon'
+  && Array.isArray(value.coordinates)
+  && value.coordinates.length > 0
+  && value.coordinates.length <= CUSTOM_PRODUCT_LIMITS.polygonsPerFeature
+  && value.coordinates.every(isPolygonCoordinates)
+  && hasValidGeometryDimensions(value);
+
+const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
+  if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'coordinates'])) return false;
+  return hasValidPolygonGeometry(value) || hasValidMultiPolygonGeometry(value);
+};
+
+const isBoundingBox = (value: unknown, dimension: number): boolean => {
+  if (!Array.isArray(value) || value.length !== dimension * 2) return false;
+  if (!value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate))) return false;
+  return value.slice(0, dimension).every((minimum, index) => minimum <= value[index + dimension]);
+};
+
+const isOptionalFeatureId = (value: unknown): boolean =>
+  value === undefined
+  || typeof value === 'string'
+  || (typeof value === 'number' && Number.isFinite(value));
+
+const hasValidCustomFeatureShape = (value: Record<string, unknown>): boolean => {
+  if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
+  if (value.type !== 'Feature' || !isCustomPolygonGeometry(value.geometry) || !isRecord(value.properties)) return false;
+  if (!isOptionalFeatureId(value.id)) return false;
+  const dimension = getGeometryPositions(value.geometry as Record<string, unknown>)[0]?.length;
+  return value.bbox === undefined || isBoundingBox(value.bbox, dimension);
+};
+
+const hasValidCustomFeatureProperties = (properties: Record<string, unknown>): boolean =>
+  hasOnlyKeys(properties, ['customLayerId', 'categoryId', 'title'])
+  && isBoundedText(properties.customLayerId)
+  && isBoundedText(properties.categoryId)
+  && isBoundedText(properties.title);
+
+const matchesCustomFeatureOwner = (
+  properties: Record<string, unknown>,
+  layerId?: string,
+  categoryIds?: ReadonlySet<string>,
+): boolean => {
+  if (layerId !== undefined && properties.customLayerId !== layerId) return false;
+  if (categoryIds === undefined) return true;
+  return typeof properties.categoryId === 'string' && categoryIds.has(properties.categoryId);
+};
+
+/** Validates bounded custom GeoJSON polygons and their layer/category identities. */
+export const isCustomPolygonFeature = (
+  value: unknown,
+  layerId?: string,
+  categoryIds?: ReadonlySet<string>,
+): value is CustomPolygonFeature => {
+  if (!isRecord(value) || !hasValidCustomFeatureShape(value)) return false;
+  const properties = value.properties as Record<string, unknown>;
+  return hasValidCustomFeatureProperties(properties)
+    && matchesCustomFeatureOwner(properties, layerId, categoryIds);
+};

--- a/src/lib/customProductSnapshots.ts
+++ b/src/lib/customProductSnapshots.ts
@@ -42,14 +42,21 @@ export const createEmbeddedCustomProductSnapshot = (
   capturedAt,
 });
 
+const hasValidSnapshotReferences = (value: Record<string, unknown>): boolean => {
+  if (value.sourceProductId !== undefined && !isBoundedText(value.sourceProductId)) return false;
+  if (value.sourceProductVersion !== undefined && !isPositiveInteger(value.sourceProductVersion)) return false;
+  return true;
+};
+
+const hasValidSnapshotContent = (value: Record<string, unknown>): boolean =>
+  isBoundedText(value.label)
+  && isCustomCategoryList(value.categories)
+  && isIsoTimestamp(value.capturedAt);
+
 /** Validates an immutable-by-contract embedded product snapshot. */
 export const isEmbeddedCustomProductSnapshot = (value: unknown): value is EmbeddedCustomProductSnapshot => {
   if (!isRecord(value)) return false;
   if (!hasOnlyKeys(value, ['schemaVersion', 'sourceProductId', 'sourceProductVersion', 'label', 'categories', 'capturedAt'])) return false;
   if (value.schemaVersion !== CUSTOM_PRODUCTS_SCHEMA_VERSION) return false;
-  if (value.sourceProductId !== undefined && !isBoundedText(value.sourceProductId)) return false;
-  if (value.sourceProductVersion !== undefined && !isPositiveInteger(value.sourceProductVersion)) return false;
-  return isBoundedText(value.label)
-    && isCustomCategoryList(value.categories)
-    && isIsoTimestamp(value.capturedAt);
+  return hasValidSnapshotReferences(value) && hasValidSnapshotContent(value);
 };

--- a/src/lib/customProductSnapshots.ts
+++ b/src/lib/customProductSnapshots.ts
@@ -1,0 +1,55 @@
+import {
+  CUSTOM_PRODUCT_LIMITS,
+  CUSTOM_PRODUCTS_SCHEMA_VERSION,
+  type EmbeddedCustomProductSnapshot,
+  type HostedCustomProduct,
+} from '../types/customProducts';
+import { isCustomCategoryList } from './customCategoryValidation';
+
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean =>
+  Object.keys(value).every((key) => keys.includes(key));
+
+const isBoundedText = (value: unknown): value is string =>
+  typeof value === 'string'
+  && value.trim() === value
+  && value.length > 0
+  && value.length <= CUSTOM_PRODUCT_LIMITS.labelLength;
+
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 1;
+
+const isIsoTimestamp = (value: unknown): value is string =>
+  typeof value === 'string'
+  && ISO_TIMESTAMP.test(value)
+  && !Number.isNaN(Date.parse(value))
+  && new Date(value).toISOString() === value;
+
+/** Creates a detached snapshot so future product edits cannot alter old maps. */
+export const createEmbeddedCustomProductSnapshot = (
+  product: HostedCustomProduct,
+  capturedAt = new Date().toISOString(),
+): EmbeddedCustomProductSnapshot => ({
+  schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+  sourceProductId: product.id,
+  sourceProductVersion: product.version,
+  label: product.label,
+  categories: product.categories.map((category) => ({ ...category, style: { ...category.style } })),
+  capturedAt,
+});
+
+/** Validates an immutable-by-contract embedded product snapshot. */
+export const isEmbeddedCustomProductSnapshot = (value: unknown): value is EmbeddedCustomProductSnapshot => {
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, ['schemaVersion', 'sourceProductId', 'sourceProductVersion', 'label', 'categories', 'capturedAt'])) return false;
+  if (value.schemaVersion !== CUSTOM_PRODUCTS_SCHEMA_VERSION) return false;
+  if (value.sourceProductId !== undefined && !isBoundedText(value.sourceProductId)) return false;
+  if (value.sourceProductVersion !== undefined && !isPositiveInteger(value.sourceProductVersion)) return false;
+  return isBoundedText(value.label)
+    && isCustomCategoryList(value.categories)
+    && isIsoTimestamp(value.capturedAt);
+};

--- a/src/lib/customProducts.test.ts
+++ b/src/lib/customProducts.test.ts
@@ -1,0 +1,173 @@
+import type { HostedCustomProduct, CustomCategoryTemplate, OneOffCustomLayer } from '../types/customProducts';
+import { CUSTOM_PRODUCT_LIMITS, CUSTOM_PRODUCTS_SCHEMA_VERSION } from '../types/customProducts';
+import {
+  asCustomLayerId,
+  asCustomProductId,
+  createEmbeddedCustomProductSnapshot,
+  createLayerFromHostedProduct,
+  getCustomProductAccessState,
+  isCustomCategoryList,
+  isCustomCategoryStyle,
+  isCustomPolygonFeature,
+  isEmbeddedCustomProductSnapshot,
+  isHostedCustomProduct,
+  isOneOffCustomLayer,
+  reviseHostedCustomProduct,
+} from './customProducts';
+
+const category = (overrides: Partial<CustomCategoryTemplate> = {}): CustomCategoryTemplate => ({
+  id: 'cat-1' as CustomCategoryTemplate['id'],
+  label: 'Elevated hail risk',
+  order: 0,
+  style: {
+    fillColor: '#8a3ffc',
+    fillOpacity: 0.35,
+    strokeColor: '#4f1f8f',
+    strokeOpacity: 1,
+    strokeWidth: 2,
+    hatch: 'diagonal',
+  },
+  ...overrides,
+});
+
+const product = (overrides: Partial<HostedCustomProduct> = {}): HostedCustomProduct => ({
+  schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+  id: asCustomProductId('product-1'),
+  userId: 'user-1',
+  label: 'Local hail desk',
+  description: 'Reusable local categories',
+  version: 3,
+  status: 'active',
+  categories: [category()],
+  createdAt: '2026-07-17T12:00:00.000Z',
+  updatedAt: '2026-07-17T12:00:00.000Z',
+  ...overrides,
+});
+
+describe('custom product schema', () => {
+  test('accepts a bounded complete category style', () => {
+    expect(isCustomCategoryStyle(category().style)).toBe(true);
+  });
+
+  test.each([
+    { fillColor: 'red' },
+    { fillOpacity: 1.1 },
+    { strokeOpacity: -0.1 },
+    { strokeWidth: 9 },
+    { hatch: 'dots' },
+    { unknown: true },
+  ])('rejects malformed category style %p', (change) => {
+    expect(isCustomCategoryStyle({ ...category().style, ...change })).toBe(false);
+  });
+
+  test('enforces category count and unique ids/order values', () => {
+    expect(isCustomCategoryList([category()])).toBe(true);
+    expect(isCustomCategoryList([])).toBe(false);
+    expect(isCustomCategoryList([category(), category()])).toBe(false);
+    expect(isCustomCategoryList(Array.from(
+      { length: CUSTOM_PRODUCT_LIMITS.categoriesPerProduct + 1 },
+      (_, index) => category({ id: `cat-${index}` as CustomCategoryTemplate['id'], order: index }),
+    ))).toBe(false);
+  });
+
+  test('validates closed polygon and multipolygon GeoJSON only', () => {
+    const base = {
+      type: 'Feature',
+      properties: { customLayerId: 'layer-1', categoryId: 'cat-1', title: 'Elevated hail risk' },
+    } as const;
+    expect(isCustomPolygonFeature({
+      ...base,
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+    }, 'layer-1', new Set(['cat-1']))).toBe(true);
+    expect(isCustomPolygonFeature({
+      ...base,
+      geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] },
+    })).toBe(false);
+    expect(isCustomPolygonFeature({
+      ...base,
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [2, 2]]] },
+    })).toBe(false);
+  });
+
+  test('validates hosted product identity, owner, version, limits, and unknown fields', () => {
+    expect(isHostedCustomProduct(product())).toBe(true);
+    expect(isHostedCustomProduct({ ...product(), userId: '' })).toBe(false);
+    expect(isHostedCustomProduct({ ...product(), version: 0 })).toBe(false);
+    expect(isHostedCustomProduct({ ...product(), label: 'x'.repeat(65) })).toBe(false);
+    expect(isHostedCustomProduct({ ...product(), internalRole: 'admin' })).toBe(false);
+  });
+
+  test('creates a detached immutable-by-value package snapshot', () => {
+    const source = product();
+    const snapshot = createEmbeddedCustomProductSnapshot(source, '2026-07-17T13:00:00.000Z');
+    source.categories[0].label = 'Edited later';
+    source.categories[0].style.fillColor = '#000000';
+
+    expect(snapshot.sourceProductVersion).toBe(3);
+    expect(snapshot.categories[0].label).toBe('Elevated hail risk');
+    expect(snapshot.categories[0].style.fillColor).toBe('#8a3ffc');
+    expect(isEmbeddedCustomProductSnapshot(snapshot)).toBe(true);
+  });
+
+  test('creates a self-contained empty layer from a product', () => {
+    const layer = createLayerFromHostedProduct({
+      product: product(),
+      layerId: asCustomLayerId('layer-1'),
+      order: 2,
+      createdAt: '2026-07-17T13:00:00.000Z',
+    });
+    expect(layer.categories).toEqual(layer.productSnapshot?.categories);
+    expect(layer.categories).not.toBe(layer.productSnapshot?.categories);
+    expect(layer.features).toEqual([]);
+    expect(isOneOffCustomLayer(layer)).toBe(true);
+  });
+
+  test('one-off layers need no hosted snapshot and reject mismatched feature identity', () => {
+    const layer: OneOffCustomLayer = {
+      schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+      id: asCustomLayerId('layer-1'),
+      label: 'One-off local layer',
+      order: 0,
+      categories: [category()],
+      features: [{
+        type: 'Feature',
+        geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+        properties: { customLayerId: asCustomLayerId('layer-1'), categoryId: category().id, title: category().label },
+      }],
+      createdAt: '2026-07-17T13:00:00.000Z',
+      updatedAt: '2026-07-17T13:00:00.000Z',
+    };
+    expect(isOneOffCustomLayer(layer)).toBe(true);
+    expect(isOneOffCustomLayer({
+      ...layer,
+      features: [{ ...layer.features[0], properties: { ...layer.features[0].properties, customLayerId: asCustomLayerId('other') } }],
+    })).toBe(false);
+  });
+
+  test('derives active, expired, and archived access without changing snapshots', () => {
+    expect(getCustomProductAccessState({ premiumActive: true, status: 'active' })).toEqual({ mode: 'editable' });
+    expect(getCustomProductAccessState({ premiumActive: false, status: 'active' })).toEqual({
+      mode: 'read-only', reason: 'premium-expired',
+    });
+    expect(getCustomProductAccessState({ premiumActive: true, status: 'archived' })).toEqual({
+      mode: 'read-only', reason: 'archived',
+    });
+  });
+
+  test('revisions increment stable versions without mutating the old product', () => {
+    const original = product();
+    const revised = reviseHostedCustomProduct(original, {
+      label: 'Revised desk',
+      description: undefined,
+      categories: [category({ label: 'New category label' })],
+      status: 'active',
+    }, '2026-07-17T14:00:00.000Z');
+    revised.categories[0].style.fillColor = '#ffffff';
+
+    expect(revised.version).toBe(4);
+    expect(revised.id).toBe(original.id);
+    expect(revised.createdAt).toBe(original.createdAt);
+    expect(original.categories[0].style.fillColor).toBe('#8a3ffc');
+  });
+});
+

--- a/src/lib/customProducts.test.ts
+++ b/src/lib/customProducts.test.ts
@@ -181,4 +181,13 @@ describe('custom product schema', () => {
     expect(revised.createdAt).toBe(original.createdAt);
     expect(original.categories[0].style.fillColor).toBe('#8a3ffc');
   });
+
+  test('rejects a revision that would exceed the safe integer range', () => {
+    expect(() => reviseHostedCustomProduct(product({ version: Number.MAX_SAFE_INTEGER }), {
+      label: 'Cannot revise',
+      description: undefined,
+      categories: [category()],
+      status: 'active',
+    })).toThrow(RangeError);
+  });
 });

--- a/src/lib/customProducts.test.ts
+++ b/src/lib/customProducts.test.ts
@@ -8,6 +8,7 @@ import {
   getCustomProductAccessState,
   isCustomCategoryList,
   isCustomCategoryStyle,
+  isCustomLayerCollection,
   isCustomPolygonFeature,
   isEmbeddedCustomProductSnapshot,
   isHostedCustomProduct,
@@ -91,6 +92,21 @@ describe('custom product schema', () => {
     })).toBe(false);
     expect(isCustomPolygonFeature({
       ...base,
+      id: Number.POSITIVE_INFINITY,
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+    })).toBe(false);
+    expect(isCustomPolygonFeature({
+      ...base,
+      bbox: [10, 10, -10, -10],
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+    })).toBe(false);
+    expect(isCustomPolygonFeature({
+      ...base,
+      bbox: [0, 0, 1, 1],
+      geometry: { type: 'Polygon', coordinates: [[[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 0, 0]]] },
+    })).toBe(false);
+    expect(isCustomPolygonFeature({
+      ...base,
       geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] },
     })).toBe(false);
     expect(isCustomPolygonFeature({
@@ -107,6 +123,7 @@ describe('custom product schema', () => {
     expect(isHostedCustomProduct({ ...product(), label: 'x'.repeat(65) })).toBe(false);
     expect(isHostedCustomProduct({ ...product(), internalRole: 'admin' })).toBe(false);
     expect(isHostedCustomProduct({ ...product(), updatedAt: '2026-02-31T12:00:00.000Z' })).toBe(false);
+    expect(isHostedCustomProduct({ ...product(), updatedAt: '2026-07-17T11:59:59.999Z' })).toBe(false);
   });
 
   test('creates a detached immutable-by-value package snapshot', () => {
@@ -154,6 +171,12 @@ describe('custom product schema', () => {
       ...layer,
       features: [{ ...layer.features[0], properties: { ...layer.features[0].properties, customLayerId: asCustomLayerId('other') } }],
     })).toBe(false);
+    expect(isOneOffCustomLayer({ ...layer, updatedAt: '2026-07-17T12:59:59.999Z' })).toBe(false);
+    expect(isCustomLayerCollection({ schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION, layers: [layer] })).toBe(true);
+    expect(isCustomLayerCollection({
+      schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+      layers: [layer, { ...layer, id: asCustomLayerId('layer-2'), order: 2 }],
+    })).toBe(false);
   });
 
   test('derives active, expired, and archived access without changing snapshots', () => {
@@ -180,6 +203,7 @@ describe('custom product schema', () => {
     expect(revised.id).toBe(original.id);
     expect(revised.createdAt).toBe(original.createdAt);
     expect(original.categories[0].style.fillColor).toBe('#8a3ffc');
+    expect(isHostedCustomProduct(revised)).toBe(true);
   });
 
   test('rejects a revision that would exceed the safe integer range', () => {
@@ -189,5 +213,22 @@ describe('custom product schema', () => {
       categories: [category()],
       status: 'active',
     })).toThrow(RangeError);
+    expect(() => reviseHostedCustomProduct(product(), {
+      label: '',
+      description: undefined,
+      categories: [category()],
+      status: 'active',
+    })).toThrow(TypeError);
+    expect(() => reviseHostedCustomProduct(product(), {
+      label: 'Moves backward',
+      description: undefined,
+      categories: [category()],
+      status: 'active',
+    }, '2026-07-17T11:59:59.999Z')).toThrow(TypeError);
+    expect(() => createLayerFromHostedProduct({
+      product: product({ label: '' }),
+      layerId: asCustomLayerId('layer-invalid'),
+      order: 0,
+    })).toThrow(TypeError);
   });
 });

--- a/src/lib/customProducts.test.ts
+++ b/src/lib/customProducts.test.ts
@@ -64,6 +64,10 @@ describe('custom product schema', () => {
     expect(isCustomCategoryList([category()])).toBe(true);
     expect(isCustomCategoryList([])).toBe(false);
     expect(isCustomCategoryList([category(), category()])).toBe(false);
+    expect(isCustomCategoryList([
+      category(),
+      category({ id: 'cat-2' as CustomCategoryTemplate['id'], order: 2 }),
+    ])).toBe(false);
     expect(isCustomCategoryList(Array.from(
       { length: CUSTOM_PRODUCT_LIMITS.categoriesPerProduct + 1 },
       (_, index) => category({ id: `cat-${index}` as CustomCategoryTemplate['id'], order: index }),
@@ -77,8 +81,14 @@ describe('custom product schema', () => {
     } as const;
     expect(isCustomPolygonFeature({
       ...base,
+      bbox: [0, 0, 1, 1],
       geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
     }, 'layer-1', new Set(['cat-1']))).toBe(true);
+    expect(isCustomPolygonFeature({
+      ...base,
+      bbox: [0, 0, Number.POSITIVE_INFINITY, 1],
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+    })).toBe(false);
     expect(isCustomPolygonFeature({
       ...base,
       geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] },
@@ -93,8 +103,10 @@ describe('custom product schema', () => {
     expect(isHostedCustomProduct(product())).toBe(true);
     expect(isHostedCustomProduct({ ...product(), userId: '' })).toBe(false);
     expect(isHostedCustomProduct({ ...product(), version: 0 })).toBe(false);
+    expect(isHostedCustomProduct({ ...product(), version: Number.MAX_SAFE_INTEGER + 1 })).toBe(false);
     expect(isHostedCustomProduct({ ...product(), label: 'x'.repeat(65) })).toBe(false);
     expect(isHostedCustomProduct({ ...product(), internalRole: 'admin' })).toBe(false);
+    expect(isHostedCustomProduct({ ...product(), updatedAt: '2026-02-31T12:00:00.000Z' })).toBe(false);
   });
 
   test('creates a detached immutable-by-value package snapshot', () => {
@@ -170,4 +182,3 @@ describe('custom product schema', () => {
     expect(original.categories[0].style.fillColor).toBe('#8a3ffc');
   });
 });
-

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -9,14 +9,14 @@ import {
   type HostedCustomProductStatus,
   type OneOffCustomLayer,
 } from '../types/customProducts';
-import { isCustomPolygonFeature } from './customGeometry';
+import { isCustomPolygonFeature } from './customFeatureValidation';
 import { isCustomCategoryList } from './customCategoryValidation';
 import {
   createEmbeddedCustomProductSnapshot,
   isEmbeddedCustomProductSnapshot,
 } from './customProductSnapshots';
 
-export { isCustomPolygonFeature } from './customGeometry';
+export { isCustomPolygonFeature } from './customFeatureValidation';
 export {
   isCustomCategoryList,
   isCustomCategoryStyle,

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -18,24 +18,31 @@ const HEX_COLOR = /^#[0-9a-f]{6}$/i;
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const HATCH_PATTERNS = new Set(['none', 'diagonal', 'reverse-diagonal', 'crosshatch']);
 
+/** Returns true only for non-array object records. */
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
 
+/** Rejects persistence fields outside a contract's explicit allowlist. */
 const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean =>
   Object.keys(value).every((key) => keys.includes(key));
 
+/** Validates trimmed non-empty text against a bounded length. */
 const isBoundedText = (value: unknown, max = CUSTOM_PRODUCT_LIMITS.labelLength): value is string =>
   typeof value === 'string' && value.trim() === value && value.length > 0 && value.length <= max;
 
+/** Validates a canonical UTC ISO timestamp. */
 const isIsoTimestamp = (value: unknown): value is string =>
   typeof value === 'string' && ISO_TIMESTAMP.test(value) && !Number.isNaN(Date.parse(value));
 
+/** Validates an opacity-like value in the inclusive zero-to-one interval. */
 const isUnitInterval = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
 
+/** Validates a whole number that may be zero. */
 const isNonNegativeInteger = (value: unknown): value is number =>
   typeof value === 'number' && Number.isInteger(value) && value >= 0;
 
+/** Validates a whole number that starts at one. */
 const isPositiveInteger = (value: unknown): value is number =>
   typeof value === 'number' && Number.isInteger(value) && value >= 1;
 
@@ -79,11 +86,13 @@ export const isCustomCategoryList = (value: unknown): value is CustomCategoryTem
   return ids.size === value.length && orders.size === value.length;
 };
 
+/** Validates one finite GeoJSON coordinate position. */
 const isPosition = (value: unknown): value is Position =>
   Array.isArray(value)
   && value.length >= 2
   && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
 
+/** Validates a closed GeoJSON linear ring with enough positions. */
 const isLinearRing = (value: unknown): value is Position[] => {
   if (!Array.isArray(value) || value.length < 4 || !value.every(isPosition)) return false;
   const first = value[0];
@@ -91,9 +100,11 @@ const isLinearRing = (value: unknown): value is Position[] => {
   return first.length === last.length && first.every((coordinate, index) => coordinate === last[index]);
 };
 
+/** Validates the ring collection used by one GeoJSON polygon. */
 const isPolygonCoordinates = (value: unknown): value is Position[][] =>
   Array.isArray(value) && value.length > 0 && value.every(isLinearRing);
 
+/** Accepts only Polygon or MultiPolygon geometry for custom forecast content. */
 const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
   if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'coordinates'])) return false;
   if (value.type === 'Polygon') return isPolygonCoordinates(value.coordinates);
@@ -134,6 +145,7 @@ export const createEmbeddedCustomProductSnapshot = (
   capturedAt,
 });
 
+/** Validates an immutable-by-contract embedded product snapshot. */
 export const isEmbeddedCustomProductSnapshot = (value: unknown): value is EmbeddedCustomProductSnapshot => {
   if (!isRecord(value) || !hasOnlyKeys(value, [
     'schemaVersion', 'sourceProductId', 'sourceProductVersion', 'label', 'categories', 'capturedAt',
@@ -235,6 +247,8 @@ export const createLayerFromHostedProduct = ({
   };
 };
 
+/** Brands a validated opaque string as a custom layer identifier. */
 export const asCustomLayerId = (value: string): CustomLayerId => value as CustomLayerId;
-export const asCustomProductId = (value: string): CustomProductId => value as CustomProductId;
 
+/** Brands a validated opaque string as a hosted custom product identifier. */
+export const asCustomProductId = (value: string): CustomProductId => value as CustomProductId;

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -295,6 +295,15 @@ export const getCustomProductAccessState = ({
   return { mode: 'editable' };
 };
 
+/** Returns the next safe revision number or rejects an exhausted counter. */
+const getNextProductVersion = (version: number): number => {
+  const nextVersion = version + 1;
+  if (!Number.isSafeInteger(nextVersion)) {
+    throw new RangeError('Custom product version has reached the safe integer limit');
+  }
+  return nextVersion;
+};
+
 /** Produces the next stable product revision while preserving identity and creation time. */
 export const reviseHostedCustomProduct = (
   product: HostedCustomProduct,
@@ -304,7 +313,7 @@ export const reviseHostedCustomProduct = (
   ...product,
   ...changes,
   categories: changes.categories.map((category) => ({ ...category, style: { ...category.style } })),
-  version: product.version + 1,
+  version: getNextProductVersion(product.version),
   updatedAt,
 });
 

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -158,18 +158,26 @@ const hasValidGeometryDimensions = (value: Record<string, unknown>): boolean => 
   return positions.every((position) => position.length === positions[0].length);
 };
 
+/** Validates one Polygon coordinate collection and its shared dimension. */
+const hasValidPolygonGeometry = (value: Record<string, unknown>): boolean =>
+  value.type === 'Polygon'
+  && isPolygonCoordinates(value.coordinates)
+  && hasValidGeometryDimensions(value);
+
+/** Validates one bounded MultiPolygon coordinate collection. */
+const hasValidMultiPolygonGeometry = (value: Record<string, unknown>): boolean =>
+  value.type === 'MultiPolygon'
+  && Array.isArray(value.coordinates)
+  && value.coordinates.length > 0
+  && value.coordinates.length <= CUSTOM_PRODUCT_LIMITS.polygonsPerFeature
+  && value.coordinates.every(isPolygonCoordinates)
+  && hasValidGeometryDimensions(value);
+
 /** Accepts only Polygon or MultiPolygon geometry for custom forecast content. */
 const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
   if (!isRecord(value)) return false;
   if (!hasOnlyKeys(value, ['type', 'coordinates'])) return false;
-  if (value.type === 'Polygon') {
-    return isPolygonCoordinates(value.coordinates) && hasValidGeometryDimensions(value);
-  }
-  if (value.type !== 'MultiPolygon') return false;
-  if (!Array.isArray(value.coordinates)) return false;
-  if (value.coordinates.length === 0) return false;
-  if (value.coordinates.length > CUSTOM_PRODUCT_LIMITS.polygonsPerFeature) return false;
-  return value.coordinates.every(isPolygonCoordinates) && hasValidGeometryDimensions(value);
+  return hasValidPolygonGeometry(value) || hasValidMultiPolygonGeometry(value);
 };
 
 /** Validates a finite, ordered GeoJSON bbox matching the geometry dimension. */

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -5,13 +5,16 @@ import {
   type CustomLayerCollection,
   type CustomProductAccessState,
   type CustomProductId,
-  type EmbeddedCustomProductSnapshot,
   type HostedCustomProduct,
   type HostedCustomProductStatus,
   type OneOffCustomLayer,
 } from '../types/customProducts';
 import { isCustomPolygonFeature } from './customGeometry';
 import { isCustomCategoryList } from './customCategoryValidation';
+import {
+  createEmbeddedCustomProductSnapshot,
+  isEmbeddedCustomProductSnapshot,
+} from './customProductSnapshots';
 
 export { isCustomPolygonFeature } from './customGeometry';
 export {
@@ -19,6 +22,10 @@ export {
   isCustomCategoryStyle,
   isCustomCategoryTemplate,
 } from './customCategoryValidation';
+export {
+  createEmbeddedCustomProductSnapshot,
+  isEmbeddedCustomProductSnapshot,
+} from './customProductSnapshots';
 
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
@@ -57,38 +64,6 @@ const hasValidChronology = (createdAt: unknown, updatedAt: unknown): boolean =>
 
 /** Combines field-level checks without a compound validator conditional. */
 const areAllValid = (checks: readonly boolean[]): boolean => checks.every(Boolean);
-
-/** Creates a detached snapshot so future product edits cannot alter old maps. */
-export const createEmbeddedCustomProductSnapshot = (
-  product: HostedCustomProduct,
-  capturedAt = new Date().toISOString(),
-): EmbeddedCustomProductSnapshot => ({
-  schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
-  sourceProductId: product.id,
-  sourceProductVersion: product.version,
-  label: product.label,
-  categories: product.categories.map((category) => ({
-    ...category,
-    style: { ...category.style },
-  })),
-  capturedAt,
-});
-
-/** Validates an immutable-by-contract embedded product snapshot. */
-export const isEmbeddedCustomProductSnapshot = (value: unknown): value is EmbeddedCustomProductSnapshot => {
-  if (!isRecord(value)) return false;
-  if (!hasOnlyKeys(value, [
-    'schemaVersion', 'sourceProductId', 'sourceProductVersion', 'label', 'categories', 'capturedAt',
-  ])) return false;
-  return areAllValid([
-    value.schemaVersion === CUSTOM_PRODUCTS_SCHEMA_VERSION,
-    value.sourceProductId === undefined || isBoundedText(value.sourceProductId),
-    value.sourceProductVersion === undefined || isPositiveInteger(value.sourceProductVersion),
-    isBoundedText(value.label),
-    isCustomCategoryList(value.categories),
-    isIsoTimestamp(value.capturedAt),
-  ]);
-};
 
 /** Validates the scalar, category, snapshot, and timestamp fields on a one-off layer. */
 const hasValidOneOffLayerFields = (value: Record<string, unknown>): boolean => areAllValid([

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -1,4 +1,3 @@
-import type { Geometry, Position } from 'geojson';
 import {
   CUSTOM_PRODUCT_LIMITS,
   CUSTOM_PRODUCTS_SCHEMA_VERSION,
@@ -6,7 +5,6 @@ import {
   type CustomCategoryTemplate,
   type CustomLayerId,
   type CustomLayerCollection,
-  type CustomPolygonFeature,
   type CustomProductAccessState,
   type CustomProductId,
   type EmbeddedCustomProductSnapshot,
@@ -14,6 +12,9 @@ import {
   type HostedCustomProductStatus,
   type OneOffCustomLayer,
 } from '../types/customProducts';
+import { isCustomPolygonFeature } from './customGeometry';
+
+export { isCustomPolygonFeature } from './customGeometry';
 
 const HEX_COLOR = /^#[0-9a-f]{6}$/i;
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
@@ -114,128 +115,6 @@ export const isCustomCategoryList = (value: unknown): value is CustomCategoryTem
   const ids = new Set(value.map((category) => category.id));
   if (ids.size !== value.length) return false;
   return value.every((category, index) => category.order === index);
-};
-
-/** Validates one finite GeoJSON coordinate position. */
-const isPosition = (value: unknown): value is Position =>
-  Array.isArray(value) && areAllValid([
-    [2, 3].includes(value.length),
-    value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate)),
-  ]);
-
-/** Validates a closed GeoJSON linear ring with enough positions. */
-const isLinearRing = (value: unknown): value is Position[] => {
-  if (!Array.isArray(value)) return false;
-  if (value.length < 4) return false;
-  if (!value.every(isPosition)) return false;
-  const first = value[0];
-  const last = value[value.length - 1];
-  return areAllValid([
-    first.length === last.length,
-    first.every((coordinate, index) => coordinate === last[index]),
-  ]);
-};
-
-/** Validates the ring collection used by one GeoJSON polygon. */
-const isPolygonCoordinates = (value: unknown): value is Position[][] =>
-  Array.isArray(value) && areAllValid([
-    value.length > 0,
-    value.length <= CUSTOM_PRODUCT_LIMITS.ringsPerPolygon,
-    value.every(isLinearRing),
-  ]);
-
-/** Flattens one supported polygon geometry into positions for bounded validation. */
-const getGeometryPositions = (value: Record<string, unknown>): Position[] => {
-  if (!Array.isArray(value.coordinates)) return [];
-  const polygons = value.type === 'Polygon' ? [value.coordinates] : value.coordinates;
-  return (polygons as Position[][][]).flat(2);
-};
-
-/** Ensures every coordinate in a geometry uses one consistent dimension. */
-const hasValidGeometryDimensions = (value: Record<string, unknown>): boolean => {
-  const positions = getGeometryPositions(value);
-  if (positions.length === 0 || positions.length > CUSTOM_PRODUCT_LIMITS.coordinatesPerFeature) return false;
-  return positions.every((position) => position.length === positions[0].length);
-};
-
-/** Validates one Polygon coordinate collection and its shared dimension. */
-const hasValidPolygonGeometry = (value: Record<string, unknown>): boolean =>
-  value.type === 'Polygon'
-  && isPolygonCoordinates(value.coordinates)
-  && hasValidGeometryDimensions(value);
-
-/** Validates one bounded MultiPolygon coordinate collection. */
-const hasValidMultiPolygonGeometry = (value: Record<string, unknown>): boolean =>
-  value.type === 'MultiPolygon'
-  && Array.isArray(value.coordinates)
-  && value.coordinates.length > 0
-  && value.coordinates.length <= CUSTOM_PRODUCT_LIMITS.polygonsPerFeature
-  && value.coordinates.every(isPolygonCoordinates)
-  && hasValidGeometryDimensions(value);
-
-/** Accepts only Polygon or MultiPolygon geometry for custom forecast content. */
-const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
-  if (!isRecord(value)) return false;
-  if (!hasOnlyKeys(value, ['type', 'coordinates'])) return false;
-  return hasValidPolygonGeometry(value) || hasValidMultiPolygonGeometry(value);
-};
-
-/** Validates a finite, ordered GeoJSON bbox matching the geometry dimension. */
-const isBoundingBox = (value: unknown, dimension: number): boolean => {
-  if (!Array.isArray(value) || value.length !== dimension * 2) return false;
-  if (!value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate))) return false;
-  return value.slice(0, dimension).every((minimum, index) => minimum <= value[index + dimension]);
-};
-
-/** Accepts the GeoJSON string or finite numeric feature identifier contract. */
-const isOptionalFeatureId = (value: unknown): boolean =>
-  value === undefined
-  || typeof value === 'string'
-  || (typeof value === 'number' && Number.isFinite(value));
-
-/** Validates the persistence shell shared by all custom GeoJSON features. */
-const hasValidCustomFeatureShape = (value: Record<string, unknown>): boolean => {
-  if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
-  if (value.type !== 'Feature') return false;
-  if (!isCustomPolygonGeometry(value.geometry)) return false;
-  if (!isRecord(value.properties)) return false;
-  if (!isOptionalFeatureId(value.id)) return false;
-  const dimension = getGeometryPositions(value.geometry as Record<string, unknown>)[0]?.length;
-  return value.bbox === undefined || isBoundingBox(value.bbox, dimension);
-};
-
-/** Validates the category identity and display title stored on a custom feature. */
-const hasValidCustomFeatureProperties = (properties: Record<string, unknown>): boolean => {
-  if (!hasOnlyKeys(properties, ['customLayerId', 'categoryId', 'title'])) return false;
-  return areAllValid([
-    isBoundedText(properties.customLayerId),
-    isBoundedText(properties.categoryId),
-    isBoundedText(properties.title),
-  ]);
-};
-
-/** Checks optional owning-layer and category constraints for one feature. */
-const matchesCustomFeatureOwner = (
-  properties: Record<string, unknown>,
-  layerId?: string,
-  categoryIds?: ReadonlySet<string>,
-): boolean => {
-  if (layerId !== undefined && properties.customLayerId !== layerId) return false;
-  if (categoryIds === undefined) return true;
-  return typeof properties.categoryId === 'string' && categoryIds.has(properties.categoryId);
-};
-
-/** Validates a custom GeoJSON polygon against its owning layer/category identities. */
-export const isCustomPolygonFeature = (
-  value: unknown,
-  layerId?: string,
-  categoryIds?: ReadonlySet<string>,
-): value is CustomPolygonFeature => {
-  if (!isRecord(value)) return false;
-  if (!hasValidCustomFeatureShape(value)) return false;
-  const properties = value.properties as Record<string, unknown>;
-  if (!hasValidCustomFeatureProperties(properties)) return false;
-  return matchesCustomFeatureOwner(properties, layerId, categoryIds);
 };
 
 /** Creates a detached snapshot so future product edits cannot alter old maps. */

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -15,7 +15,7 @@ import {
 } from '../types/customProducts';
 
 const HEX_COLOR = /^#[0-9a-f]{6}$/i;
-const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const HATCH_PATTERNS = new Set(['none', 'diagonal', 'reverse-diagonal', 'crosshatch']);
 
 /** Returns true only for non-array object records. */
@@ -32,7 +32,10 @@ const isBoundedText = (value: unknown, max = CUSTOM_PRODUCT_LIMITS.labelLength):
 
 /** Validates a canonical UTC ISO timestamp. */
 const isIsoTimestamp = (value: unknown): value is string =>
-  typeof value === 'string' && ISO_TIMESTAMP.test(value) && !Number.isNaN(Date.parse(value));
+  typeof value === 'string'
+  && ISO_TIMESTAMP.test(value)
+  && !Number.isNaN(Date.parse(value))
+  && new Date(value).toISOString() === value;
 
 /** Validates an opacity-like value in the inclusive zero-to-one interval. */
 const isUnitInterval = (value: unknown): value is number =>
@@ -40,11 +43,11 @@ const isUnitInterval = (value: unknown): value is number =>
 
 /** Validates a whole number that may be zero. */
 const isNonNegativeInteger = (value: unknown): value is number =>
-  typeof value === 'number' && Number.isInteger(value) && value >= 0;
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
 
 /** Validates a whole number that starts at one. */
 const isPositiveInteger = (value: unknown): value is number =>
-  typeof value === 'number' && Number.isInteger(value) && value >= 1;
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 1;
 
 /** Validates a complete category style without accepting unknown persistence fields. */
 export const isCustomCategoryStyle = (value: unknown): value is CustomCategoryStyle => {
@@ -82,8 +85,8 @@ export const isCustomCategoryList = (value: unknown): value is CustomCategoryTem
   }
   if (!value.every(isCustomCategoryTemplate)) return false;
   const ids = new Set(value.map((category) => category.id));
-  const orders = new Set(value.map((category) => category.order));
-  return ids.size === value.length && orders.size === value.length;
+  return ids.size === value.length
+    && value.every((category, index) => category.order === index);
 };
 
 /** Validates one finite GeoJSON coordinate position. */
@@ -114,14 +117,21 @@ const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
     && value.coordinates.every(isPolygonCoordinates);
 };
 
+/** Validates the finite four- or six-number GeoJSON bounding-box shape. */
+const isBoundingBox = (value: unknown): boolean =>
+  Array.isArray(value)
+  && (value.length === 4 || value.length === 6)
+  && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
+
 /** Validates a custom GeoJSON polygon against its owning layer/category identities. */
 export const isCustomPolygonFeature = (
   value: unknown,
   layerId?: string,
   categoryIds?: ReadonlySet<string>,
 ): value is CustomPolygonFeature => {
-  if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties'])) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
   if (value.type !== 'Feature' || !isCustomPolygonGeometry(value.geometry) || !isRecord(value.properties)) return false;
+  if (value.bbox !== undefined && !isBoundingBox(value.bbox)) return false;
   if (!hasOnlyKeys(value.properties, ['customLayerId', 'categoryId', 'title'])) return false;
   if (!isBoundedText(value.properties.customLayerId) || !isBoundedText(value.properties.categoryId)) return false;
   if (!isBoundedText(value.properties.title)) return false;

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -1,8 +1,6 @@
 import {
   CUSTOM_PRODUCT_LIMITS,
   CUSTOM_PRODUCTS_SCHEMA_VERSION,
-  type CustomCategoryStyle,
-  type CustomCategoryTemplate,
   type CustomLayerId,
   type CustomLayerCollection,
   type CustomProductAccessState,
@@ -13,12 +11,16 @@ import {
   type OneOffCustomLayer,
 } from '../types/customProducts';
 import { isCustomPolygonFeature } from './customGeometry';
+import { isCustomCategoryList } from './customCategoryValidation';
 
 export { isCustomPolygonFeature } from './customGeometry';
+export {
+  isCustomCategoryList,
+  isCustomCategoryStyle,
+  isCustomCategoryTemplate,
+} from './customCategoryValidation';
 
-const HEX_COLOR = /^#[0-9a-f]{6}$/i;
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
-const HATCH_PATTERNS = new Set(['none', 'diagonal', 'reverse-diagonal', 'crosshatch']);
 
 /** Returns true only for non-array object records. */
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -39,10 +41,6 @@ const isIsoTimestamp = (value: unknown): value is string =>
   && !Number.isNaN(Date.parse(value))
   && new Date(value).toISOString() === value;
 
-/** Validates an opacity-like value in the inclusive zero-to-one interval. */
-const isUnitInterval = (value: unknown): value is number =>
-  typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
-
 /** Validates a whole number that may be zero. */
 const isNonNegativeInteger = (value: unknown): value is number =>
   typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
@@ -57,65 +55,8 @@ const hasValidChronology = (createdAt: unknown, updatedAt: unknown): boolean =>
   && isIsoTimestamp(updatedAt)
   && Date.parse(updatedAt) >= Date.parse(createdAt);
 
-/** Validates one six-digit hexadecimal color. */
-const isHexColor = (value: unknown): value is string =>
-  typeof value === 'string' && HEX_COLOR.test(value);
-
-/** Validates a bounded map stroke width. */
-const isStrokeWidth = (value: unknown): value is number =>
-  typeof value === 'number'
-  && Number.isFinite(value)
-  && value >= 0
-  && value <= 8;
-
-/** Validates one supported custom hatch identifier. */
-const isHatchPattern = (value: unknown): boolean =>
-  typeof value === 'string' && HATCH_PATTERNS.has(value);
-
 /** Combines field-level checks without a compound validator conditional. */
 const areAllValid = (checks: readonly boolean[]): boolean => checks.every(Boolean);
-
-/** Validates the primitive fields of a category style record. */
-const hasValidCategoryStyleFields = (value: Record<string, unknown>): boolean => areAllValid([
-  isHexColor(value.fillColor),
-  isUnitInterval(value.fillOpacity),
-  isHexColor(value.strokeColor),
-  isUnitInterval(value.strokeOpacity),
-  isStrokeWidth(value.strokeWidth),
-  isHatchPattern(value.hatch),
-]);
-
-/** Validates a complete category style without accepting unknown persistence fields. */
-export const isCustomCategoryStyle = (value: unknown): value is CustomCategoryStyle => {
-  if (!isRecord(value)) return false;
-  if (!hasOnlyKeys(value, [
-    'fillColor', 'fillOpacity', 'strokeColor', 'strokeOpacity', 'strokeWidth', 'hatch',
-  ])) return false;
-  return hasValidCategoryStyleFields(value);
-};
-
-/** Validates one bounded ordered category definition. */
-export const isCustomCategoryTemplate = (value: unknown): value is CustomCategoryTemplate => {
-  if (!isRecord(value)) return false;
-  if (!hasOnlyKeys(value, ['id', 'label', 'order', 'style'])) return false;
-  return areAllValid([
-    isBoundedText(value.id),
-    isBoundedText(value.label),
-    isNonNegativeInteger(value.order),
-    isCustomCategoryStyle(value.style),
-  ]);
-};
-
-/** Validates category limits, unique identifiers, and stable ordering. */
-export const isCustomCategoryList = (value: unknown): value is CustomCategoryTemplate[] => {
-  if (!Array.isArray(value)) return false;
-  if (value.length === 0) return false;
-  if (value.length > CUSTOM_PRODUCT_LIMITS.categoriesPerProduct) return false;
-  if (!value.every(isCustomCategoryTemplate)) return false;
-  const ids = new Set(value.map((category) => category.id));
-  if (ids.size !== value.length) return false;
-  return value.every((category, index) => category.order === index);
-};
 
 /** Creates a detached snapshot so future product edits cannot alter old maps. */
 export const createEmbeddedCustomProductSnapshot = (

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -5,6 +5,7 @@ import {
   type CustomCategoryStyle,
   type CustomCategoryTemplate,
   type CustomLayerId,
+  type CustomLayerCollection,
   type CustomPolygonFeature,
   type CustomProductAccessState,
   type CustomProductId,
@@ -48,6 +49,12 @@ const isNonNegativeInteger = (value: unknown): value is number =>
 /** Validates a whole number that starts at one. */
 const isPositiveInteger = (value: unknown): value is number =>
   typeof value === 'number' && Number.isSafeInteger(value) && value >= 1;
+
+/** Validates a timestamp pair whose update cannot precede creation. */
+const hasValidChronology = (createdAt: unknown, updatedAt: unknown): boolean =>
+  isIsoTimestamp(createdAt)
+  && isIsoTimestamp(updatedAt)
+  && Date.parse(updatedAt) >= Date.parse(createdAt);
 
 /** Validates one six-digit hexadecimal color. */
 const isHexColor = (value: unknown): value is string =>
@@ -112,7 +119,7 @@ export const isCustomCategoryList = (value: unknown): value is CustomCategoryTem
 /** Validates one finite GeoJSON coordinate position. */
 const isPosition = (value: unknown): value is Position =>
   Array.isArray(value) && areAllValid([
-    value.length >= 2,
+    [2, 3].includes(value.length),
     value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate)),
   ]);
 
@@ -131,25 +138,52 @@ const isLinearRing = (value: unknown): value is Position[] => {
 
 /** Validates the ring collection used by one GeoJSON polygon. */
 const isPolygonCoordinates = (value: unknown): value is Position[][] =>
-  Array.isArray(value) && areAllValid([value.length > 0, value.every(isLinearRing)]);
+  Array.isArray(value) && areAllValid([
+    value.length > 0,
+    value.length <= CUSTOM_PRODUCT_LIMITS.ringsPerPolygon,
+    value.every(isLinearRing),
+  ]);
+
+/** Flattens one supported polygon geometry into positions for bounded validation. */
+const getGeometryPositions = (value: Record<string, unknown>): Position[] => {
+  if (!Array.isArray(value.coordinates)) return [];
+  const polygons = value.type === 'Polygon' ? [value.coordinates] : value.coordinates;
+  return (polygons as Position[][][]).flat(2);
+};
+
+/** Ensures every coordinate in a geometry uses one consistent dimension. */
+const hasValidGeometryDimensions = (value: Record<string, unknown>): boolean => {
+  const positions = getGeometryPositions(value);
+  if (positions.length === 0 || positions.length > CUSTOM_PRODUCT_LIMITS.coordinatesPerFeature) return false;
+  return positions.every((position) => position.length === positions[0].length);
+};
 
 /** Accepts only Polygon or MultiPolygon geometry for custom forecast content. */
 const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
   if (!isRecord(value)) return false;
   if (!hasOnlyKeys(value, ['type', 'coordinates'])) return false;
-  if (value.type === 'Polygon') return isPolygonCoordinates(value.coordinates);
+  if (value.type === 'Polygon') {
+    return isPolygonCoordinates(value.coordinates) && hasValidGeometryDimensions(value);
+  }
   if (value.type !== 'MultiPolygon') return false;
   if (!Array.isArray(value.coordinates)) return false;
   if (value.coordinates.length === 0) return false;
-  return value.coordinates.every(isPolygonCoordinates);
+  if (value.coordinates.length > CUSTOM_PRODUCT_LIMITS.polygonsPerFeature) return false;
+  return value.coordinates.every(isPolygonCoordinates) && hasValidGeometryDimensions(value);
 };
 
-/** Validates the finite four- or six-number GeoJSON bounding-box shape. */
-const isBoundingBox = (value: unknown): boolean =>
-  Array.isArray(value) && areAllValid([
-    [4, 6].includes(value.length),
-    value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate)),
-  ]);
+/** Validates a finite, ordered GeoJSON bbox matching the geometry dimension. */
+const isBoundingBox = (value: unknown, dimension: number): boolean => {
+  if (!Array.isArray(value) || value.length !== dimension * 2) return false;
+  if (!value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate))) return false;
+  return value.slice(0, dimension).every((minimum, index) => minimum <= value[index + dimension]);
+};
+
+/** Accepts the GeoJSON string or finite numeric feature identifier contract. */
+const isOptionalFeatureId = (value: unknown): boolean =>
+  value === undefined
+  || typeof value === 'string'
+  || (typeof value === 'number' && Number.isFinite(value));
 
 /** Validates the persistence shell shared by all custom GeoJSON features. */
 const hasValidCustomFeatureShape = (value: Record<string, unknown>): boolean => {
@@ -157,7 +191,9 @@ const hasValidCustomFeatureShape = (value: Record<string, unknown>): boolean => 
   if (value.type !== 'Feature') return false;
   if (!isCustomPolygonGeometry(value.geometry)) return false;
   if (!isRecord(value.properties)) return false;
-  return value.bbox === undefined || isBoundingBox(value.bbox);
+  if (!isOptionalFeatureId(value.id)) return false;
+  const dimension = getGeometryPositions(value.geometry as Record<string, unknown>)[0]?.length;
+  return value.bbox === undefined || isBoundingBox(value.bbox, dimension);
 };
 
 /** Validates the category identity and display title stored on a custom feature. */
@@ -234,8 +270,8 @@ const hasValidOneOffLayerFields = (value: Record<string, unknown>): boolean => a
   isNonNegativeInteger(value.order),
   isCustomCategoryList(value.categories),
   Array.isArray(value.features),
-  isIsoTimestamp(value.createdAt),
-  isIsoTimestamp(value.updatedAt),
+  value.features.length <= CUSTOM_PRODUCT_LIMITS.featuresPerLayer,
+  hasValidChronology(value.createdAt, value.updatedAt),
   value.productSnapshot === undefined || isEmbeddedCustomProductSnapshot(value.productSnapshot),
 ]);
 
@@ -249,6 +285,18 @@ export const isOneOffCustomLayer = (value: unknown): value is OneOffCustomLayer 
   const layer = value as unknown as OneOffCustomLayer;
   const categoryIds = new Set(layer.categories.map((category) => category.id));
   return layer.features.every((feature) => isCustomPolygonFeature(feature, layer.id, categoryIds));
+};
+
+/** Validates a bounded, uniquely identified, contiguously ordered layer collection. */
+export const isCustomLayerCollection = (value: unknown): value is CustomLayerCollection => {
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, ['schemaVersion', 'layers'])) return false;
+  if (value.schemaVersion !== CUSTOM_PRODUCTS_SCHEMA_VERSION || !Array.isArray(value.layers)) return false;
+  if (value.layers.length > CUSTOM_PRODUCT_LIMITS.layersPerCollection) return false;
+  if (!value.layers.every(isOneOffCustomLayer)) return false;
+  const ids = new Set(value.layers.map((layer) => layer.id));
+  return ids.size === value.layers.length
+    && value.layers.every((layer, index) => layer.order === index);
 };
 
 /** Validates an optional bounded product description. */
@@ -269,8 +317,7 @@ const hasValidHostedProductFields = (value: Record<string, unknown>): boolean =>
   isPositiveInteger(value.version),
   isHostedProductStatus(value.status),
   isCustomCategoryList(value.categories),
-  isIsoTimestamp(value.createdAt),
-  isIsoTimestamp(value.updatedAt),
+  hasValidChronology(value.createdAt, value.updatedAt),
 ]);
 
 /** Validates the owner-scoped reusable product persistence shape. */
@@ -309,13 +356,20 @@ export const reviseHostedCustomProduct = (
   product: HostedCustomProduct,
   changes: Pick<HostedCustomProduct, 'label' | 'description' | 'categories' | 'status'>,
   updatedAt = new Date().toISOString(),
-): HostedCustomProduct => ({
-  ...product,
-  ...changes,
-  categories: changes.categories.map((category) => ({ ...category, style: { ...category.style } })),
-  version: getNextProductVersion(product.version),
-  updatedAt,
-});
+): HostedCustomProduct => {
+  if (!isHostedCustomProduct(product)) throw new TypeError('Cannot revise an invalid custom product');
+  const revised: HostedCustomProduct = {
+    ...product,
+    ...changes,
+    categories: changes.categories.map((category) => ({ ...category, style: { ...category.style } })),
+    version: getNextProductVersion(product.version),
+    updatedAt,
+  };
+  if (!isHostedCustomProduct(revised) || Date.parse(updatedAt) < Date.parse(product.updatedAt)) {
+    throw new TypeError('Custom product revision is invalid');
+  }
+  return revised;
+};
 
 /** Seeds a self-contained empty layer from a reusable product snapshot. */
 export const createLayerFromHostedProduct = ({
@@ -329,8 +383,9 @@ export const createLayerFromHostedProduct = ({
   order: number;
   createdAt?: string;
 }): OneOffCustomLayer => {
+  if (!isHostedCustomProduct(product)) throw new TypeError('Cannot create a layer from an invalid custom product');
   const productSnapshot = createEmbeddedCustomProductSnapshot(product, createdAt);
-  return {
+  const layer: OneOffCustomLayer = {
     schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
     id: layerId,
     label: product.label,
@@ -341,6 +396,8 @@ export const createLayerFromHostedProduct = ({
     createdAt,
     updatedAt: createdAt,
   };
+  if (!isOneOffCustomLayer(layer)) throw new TypeError('Custom layer seed is invalid');
+  return layer;
 };
 
 /** Brands a validated opaque string as a custom layer identifier. */

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -1,0 +1,240 @@
+import type { Geometry, Position } from 'geojson';
+import {
+  CUSTOM_PRODUCT_LIMITS,
+  CUSTOM_PRODUCTS_SCHEMA_VERSION,
+  type CustomCategoryStyle,
+  type CustomCategoryTemplate,
+  type CustomLayerId,
+  type CustomPolygonFeature,
+  type CustomProductAccessState,
+  type CustomProductId,
+  type EmbeddedCustomProductSnapshot,
+  type HostedCustomProduct,
+  type HostedCustomProductStatus,
+  type OneOffCustomLayer,
+} from '../types/customProducts';
+
+const HEX_COLOR = /^#[0-9a-f]{6}$/i;
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const HATCH_PATTERNS = new Set(['none', 'diagonal', 'reverse-diagonal', 'crosshatch']);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const hasOnlyKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean =>
+  Object.keys(value).every((key) => keys.includes(key));
+
+const isBoundedText = (value: unknown, max = CUSTOM_PRODUCT_LIMITS.labelLength): value is string =>
+  typeof value === 'string' && value.trim() === value && value.length > 0 && value.length <= max;
+
+const isIsoTimestamp = (value: unknown): value is string =>
+  typeof value === 'string' && ISO_TIMESTAMP.test(value) && !Number.isNaN(Date.parse(value));
+
+const isUnitInterval = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value >= 0;
+
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value >= 1;
+
+/** Validates a complete category style without accepting unknown persistence fields. */
+export const isCustomCategoryStyle = (value: unknown): value is CustomCategoryStyle => {
+  if (!isRecord(value) || !hasOnlyKeys(value, [
+    'fillColor', 'fillOpacity', 'strokeColor', 'strokeOpacity', 'strokeWidth', 'hatch',
+  ])) return false;
+
+  return typeof value.fillColor === 'string'
+    && HEX_COLOR.test(value.fillColor)
+    && isUnitInterval(value.fillOpacity)
+    && typeof value.strokeColor === 'string'
+    && HEX_COLOR.test(value.strokeColor)
+    && isUnitInterval(value.strokeOpacity)
+    && typeof value.strokeWidth === 'number'
+    && Number.isFinite(value.strokeWidth)
+    && value.strokeWidth >= 0
+    && value.strokeWidth <= 8
+    && typeof value.hatch === 'string'
+    && HATCH_PATTERNS.has(value.hatch);
+};
+
+/** Validates one bounded ordered category definition. */
+export const isCustomCategoryTemplate = (value: unknown): value is CustomCategoryTemplate => {
+  if (!isRecord(value) || !hasOnlyKeys(value, ['id', 'label', 'order', 'style'])) return false;
+  return isBoundedText(value.id)
+    && isBoundedText(value.label)
+    && isNonNegativeInteger(value.order)
+    && isCustomCategoryStyle(value.style);
+};
+
+/** Validates category limits, unique identifiers, and stable ordering. */
+export const isCustomCategoryList = (value: unknown): value is CustomCategoryTemplate[] => {
+  if (!Array.isArray(value) || value.length === 0 || value.length > CUSTOM_PRODUCT_LIMITS.categoriesPerProduct) {
+    return false;
+  }
+  if (!value.every(isCustomCategoryTemplate)) return false;
+  const ids = new Set(value.map((category) => category.id));
+  const orders = new Set(value.map((category) => category.order));
+  return ids.size === value.length && orders.size === value.length;
+};
+
+const isPosition = (value: unknown): value is Position =>
+  Array.isArray(value)
+  && value.length >= 2
+  && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
+
+const isLinearRing = (value: unknown): value is Position[] => {
+  if (!Array.isArray(value) || value.length < 4 || !value.every(isPosition)) return false;
+  const first = value[0];
+  const last = value[value.length - 1];
+  return first.length === last.length && first.every((coordinate, index) => coordinate === last[index]);
+};
+
+const isPolygonCoordinates = (value: unknown): value is Position[][] =>
+  Array.isArray(value) && value.length > 0 && value.every(isLinearRing);
+
+const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
+  if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'coordinates'])) return false;
+  if (value.type === 'Polygon') return isPolygonCoordinates(value.coordinates);
+  return value.type === 'MultiPolygon'
+    && Array.isArray(value.coordinates)
+    && value.coordinates.length > 0
+    && value.coordinates.every(isPolygonCoordinates);
+};
+
+/** Validates a custom GeoJSON polygon against its owning layer/category identities. */
+export const isCustomPolygonFeature = (
+  value: unknown,
+  layerId?: string,
+  categoryIds?: ReadonlySet<string>,
+): value is CustomPolygonFeature => {
+  if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties'])) return false;
+  if (value.type !== 'Feature' || !isCustomPolygonGeometry(value.geometry) || !isRecord(value.properties)) return false;
+  if (!hasOnlyKeys(value.properties, ['customLayerId', 'categoryId', 'title'])) return false;
+  if (!isBoundedText(value.properties.customLayerId) || !isBoundedText(value.properties.categoryId)) return false;
+  if (!isBoundedText(value.properties.title)) return false;
+  if (layerId && value.properties.customLayerId !== layerId) return false;
+  return !categoryIds || categoryIds.has(value.properties.categoryId);
+};
+
+/** Creates a detached snapshot so future product edits cannot alter old maps. */
+export const createEmbeddedCustomProductSnapshot = (
+  product: HostedCustomProduct,
+  capturedAt = new Date().toISOString(),
+): EmbeddedCustomProductSnapshot => ({
+  schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+  sourceProductId: product.id,
+  sourceProductVersion: product.version,
+  label: product.label,
+  categories: product.categories.map((category) => ({
+    ...category,
+    style: { ...category.style },
+  })),
+  capturedAt,
+});
+
+export const isEmbeddedCustomProductSnapshot = (value: unknown): value is EmbeddedCustomProductSnapshot => {
+  if (!isRecord(value) || !hasOnlyKeys(value, [
+    'schemaVersion', 'sourceProductId', 'sourceProductVersion', 'label', 'categories', 'capturedAt',
+  ])) return false;
+  return value.schemaVersion === CUSTOM_PRODUCTS_SCHEMA_VERSION
+    && (value.sourceProductId === undefined || isBoundedText(value.sourceProductId))
+    && (value.sourceProductVersion === undefined || isPositiveInteger(value.sourceProductVersion))
+    && isBoundedText(value.label)
+    && isCustomCategoryList(value.categories)
+    && isIsoTimestamp(value.capturedAt);
+};
+
+/** Validates a complete self-contained one-off layer. */
+export const isOneOffCustomLayer = (value: unknown): value is OneOffCustomLayer => {
+  if (!isRecord(value) || !hasOnlyKeys(value, [
+    'schemaVersion', 'id', 'label', 'order', 'categories', 'features', 'productSnapshot', 'createdAt', 'updatedAt',
+  ])) return false;
+  if (value.schemaVersion !== CUSTOM_PRODUCTS_SCHEMA_VERSION
+    || !isBoundedText(value.id)
+    || !isBoundedText(value.label)
+    || !isNonNegativeInteger(value.order)
+    || !isCustomCategoryList(value.categories)
+    || !Array.isArray(value.features)
+    || !isIsoTimestamp(value.createdAt)
+    || !isIsoTimestamp(value.updatedAt)
+    || (value.productSnapshot !== undefined && !isEmbeddedCustomProductSnapshot(value.productSnapshot))) {
+    return false;
+  }
+  const categoryIds = new Set(value.categories.map((category) => category.id));
+  return value.features.every((feature) => isCustomPolygonFeature(feature, value.id as string, categoryIds));
+};
+
+/** Validates the owner-scoped reusable product persistence shape. */
+export const isHostedCustomProduct = (value: unknown): value is HostedCustomProduct => {
+  if (!isRecord(value) || !hasOnlyKeys(value, [
+    'schemaVersion', 'id', 'userId', 'label', 'description', 'version', 'status', 'categories', 'createdAt', 'updatedAt',
+  ])) return false;
+  return value.schemaVersion === CUSTOM_PRODUCTS_SCHEMA_VERSION
+    && isBoundedText(value.id)
+    && isBoundedText(value.userId, 128)
+    && isBoundedText(value.label)
+    && (value.description === undefined || (typeof value.description === 'string' && value.description.length <= 500))
+    && isPositiveInteger(value.version)
+    && (value.status === 'active' || value.status === 'archived')
+    && isCustomCategoryList(value.categories)
+    && isIsoTimestamp(value.createdAt)
+    && isIsoTimestamp(value.updatedAt);
+};
+
+/** Derives editability without mutating persisted product or embedded snapshot data. */
+export const getCustomProductAccessState = ({
+  premiumActive,
+  status,
+}: {
+  premiumActive: boolean;
+  status: HostedCustomProductStatus;
+}): CustomProductAccessState => {
+  if (status === 'archived') return { mode: 'read-only', reason: 'archived' };
+  if (!premiumActive) return { mode: 'read-only', reason: 'premium-expired' };
+  return { mode: 'editable' };
+};
+
+/** Produces the next stable product revision while preserving identity and creation time. */
+export const reviseHostedCustomProduct = (
+  product: HostedCustomProduct,
+  changes: Pick<HostedCustomProduct, 'label' | 'description' | 'categories' | 'status'>,
+  updatedAt = new Date().toISOString(),
+): HostedCustomProduct => ({
+  ...product,
+  ...changes,
+  categories: changes.categories.map((category) => ({ ...category, style: { ...category.style } })),
+  version: product.version + 1,
+  updatedAt,
+});
+
+/** Seeds a self-contained empty layer from a reusable product snapshot. */
+export const createLayerFromHostedProduct = ({
+  product,
+  layerId,
+  order,
+  createdAt = new Date().toISOString(),
+}: {
+  product: HostedCustomProduct;
+  layerId: CustomLayerId;
+  order: number;
+  createdAt?: string;
+}): OneOffCustomLayer => {
+  const productSnapshot = createEmbeddedCustomProductSnapshot(product, createdAt);
+  return {
+    schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+    id: layerId,
+    label: product.label,
+    order,
+    categories: productSnapshot.categories.map((category) => ({ ...category, style: { ...category.style } })),
+    features: [],
+    productSnapshot,
+    createdAt,
+    updatedAt: createdAt,
+  };
+};
+
+export const asCustomLayerId = (value: string): CustomLayerId => value as CustomLayerId;
+export const asCustomProductId = (value: string): CustomProductId => value as CustomProductId;
+

--- a/src/lib/customProducts.ts
+++ b/src/lib/customProducts.ts
@@ -49,79 +49,137 @@ const isNonNegativeInteger = (value: unknown): value is number =>
 const isPositiveInteger = (value: unknown): value is number =>
   typeof value === 'number' && Number.isSafeInteger(value) && value >= 1;
 
+/** Validates one six-digit hexadecimal color. */
+const isHexColor = (value: unknown): value is string =>
+  typeof value === 'string' && HEX_COLOR.test(value);
+
+/** Validates a bounded map stroke width. */
+const isStrokeWidth = (value: unknown): value is number =>
+  typeof value === 'number'
+  && Number.isFinite(value)
+  && value >= 0
+  && value <= 8;
+
+/** Validates one supported custom hatch identifier. */
+const isHatchPattern = (value: unknown): boolean =>
+  typeof value === 'string' && HATCH_PATTERNS.has(value);
+
+/** Combines field-level checks without a compound validator conditional. */
+const areAllValid = (checks: readonly boolean[]): boolean => checks.every(Boolean);
+
+/** Validates the primitive fields of a category style record. */
+const hasValidCategoryStyleFields = (value: Record<string, unknown>): boolean => areAllValid([
+  isHexColor(value.fillColor),
+  isUnitInterval(value.fillOpacity),
+  isHexColor(value.strokeColor),
+  isUnitInterval(value.strokeOpacity),
+  isStrokeWidth(value.strokeWidth),
+  isHatchPattern(value.hatch),
+]);
+
 /** Validates a complete category style without accepting unknown persistence fields. */
 export const isCustomCategoryStyle = (value: unknown): value is CustomCategoryStyle => {
-  if (!isRecord(value) || !hasOnlyKeys(value, [
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, [
     'fillColor', 'fillOpacity', 'strokeColor', 'strokeOpacity', 'strokeWidth', 'hatch',
   ])) return false;
-
-  return typeof value.fillColor === 'string'
-    && HEX_COLOR.test(value.fillColor)
-    && isUnitInterval(value.fillOpacity)
-    && typeof value.strokeColor === 'string'
-    && HEX_COLOR.test(value.strokeColor)
-    && isUnitInterval(value.strokeOpacity)
-    && typeof value.strokeWidth === 'number'
-    && Number.isFinite(value.strokeWidth)
-    && value.strokeWidth >= 0
-    && value.strokeWidth <= 8
-    && typeof value.hatch === 'string'
-    && HATCH_PATTERNS.has(value.hatch);
+  return hasValidCategoryStyleFields(value);
 };
 
 /** Validates one bounded ordered category definition. */
 export const isCustomCategoryTemplate = (value: unknown): value is CustomCategoryTemplate => {
-  if (!isRecord(value) || !hasOnlyKeys(value, ['id', 'label', 'order', 'style'])) return false;
-  return isBoundedText(value.id)
-    && isBoundedText(value.label)
-    && isNonNegativeInteger(value.order)
-    && isCustomCategoryStyle(value.style);
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, ['id', 'label', 'order', 'style'])) return false;
+  return areAllValid([
+    isBoundedText(value.id),
+    isBoundedText(value.label),
+    isNonNegativeInteger(value.order),
+    isCustomCategoryStyle(value.style),
+  ]);
 };
 
 /** Validates category limits, unique identifiers, and stable ordering. */
 export const isCustomCategoryList = (value: unknown): value is CustomCategoryTemplate[] => {
-  if (!Array.isArray(value) || value.length === 0 || value.length > CUSTOM_PRODUCT_LIMITS.categoriesPerProduct) {
-    return false;
-  }
+  if (!Array.isArray(value)) return false;
+  if (value.length === 0) return false;
+  if (value.length > CUSTOM_PRODUCT_LIMITS.categoriesPerProduct) return false;
   if (!value.every(isCustomCategoryTemplate)) return false;
   const ids = new Set(value.map((category) => category.id));
-  return ids.size === value.length
-    && value.every((category, index) => category.order === index);
+  if (ids.size !== value.length) return false;
+  return value.every((category, index) => category.order === index);
 };
 
 /** Validates one finite GeoJSON coordinate position. */
 const isPosition = (value: unknown): value is Position =>
-  Array.isArray(value)
-  && value.length >= 2
-  && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
+  Array.isArray(value) && areAllValid([
+    value.length >= 2,
+    value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate)),
+  ]);
 
 /** Validates a closed GeoJSON linear ring with enough positions. */
 const isLinearRing = (value: unknown): value is Position[] => {
-  if (!Array.isArray(value) || value.length < 4 || !value.every(isPosition)) return false;
+  if (!Array.isArray(value)) return false;
+  if (value.length < 4) return false;
+  if (!value.every(isPosition)) return false;
   const first = value[0];
   const last = value[value.length - 1];
-  return first.length === last.length && first.every((coordinate, index) => coordinate === last[index]);
+  return areAllValid([
+    first.length === last.length,
+    first.every((coordinate, index) => coordinate === last[index]),
+  ]);
 };
 
 /** Validates the ring collection used by one GeoJSON polygon. */
 const isPolygonCoordinates = (value: unknown): value is Position[][] =>
-  Array.isArray(value) && value.length > 0 && value.every(isLinearRing);
+  Array.isArray(value) && areAllValid([value.length > 0, value.every(isLinearRing)]);
 
 /** Accepts only Polygon or MultiPolygon geometry for custom forecast content. */
 const isCustomPolygonGeometry = (value: unknown): value is Geometry => {
-  if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'coordinates'])) return false;
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, ['type', 'coordinates'])) return false;
   if (value.type === 'Polygon') return isPolygonCoordinates(value.coordinates);
-  return value.type === 'MultiPolygon'
-    && Array.isArray(value.coordinates)
-    && value.coordinates.length > 0
-    && value.coordinates.every(isPolygonCoordinates);
+  if (value.type !== 'MultiPolygon') return false;
+  if (!Array.isArray(value.coordinates)) return false;
+  if (value.coordinates.length === 0) return false;
+  return value.coordinates.every(isPolygonCoordinates);
 };
 
 /** Validates the finite four- or six-number GeoJSON bounding-box shape. */
 const isBoundingBox = (value: unknown): boolean =>
-  Array.isArray(value)
-  && (value.length === 4 || value.length === 6)
-  && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
+  Array.isArray(value) && areAllValid([
+    [4, 6].includes(value.length),
+    value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate)),
+  ]);
+
+/** Validates the persistence shell shared by all custom GeoJSON features. */
+const hasValidCustomFeatureShape = (value: Record<string, unknown>): boolean => {
+  if (!hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
+  if (value.type !== 'Feature') return false;
+  if (!isCustomPolygonGeometry(value.geometry)) return false;
+  if (!isRecord(value.properties)) return false;
+  return value.bbox === undefined || isBoundingBox(value.bbox);
+};
+
+/** Validates the category identity and display title stored on a custom feature. */
+const hasValidCustomFeatureProperties = (properties: Record<string, unknown>): boolean => {
+  if (!hasOnlyKeys(properties, ['customLayerId', 'categoryId', 'title'])) return false;
+  return areAllValid([
+    isBoundedText(properties.customLayerId),
+    isBoundedText(properties.categoryId),
+    isBoundedText(properties.title),
+  ]);
+};
+
+/** Checks optional owning-layer and category constraints for one feature. */
+const matchesCustomFeatureOwner = (
+  properties: Record<string, unknown>,
+  layerId?: string,
+  categoryIds?: ReadonlySet<string>,
+): boolean => {
+  if (layerId !== undefined && properties.customLayerId !== layerId) return false;
+  if (categoryIds === undefined) return true;
+  return typeof properties.categoryId === 'string' && categoryIds.has(properties.categoryId);
+};
 
 /** Validates a custom GeoJSON polygon against its owning layer/category identities. */
 export const isCustomPolygonFeature = (
@@ -129,14 +187,11 @@ export const isCustomPolygonFeature = (
   layerId?: string,
   categoryIds?: ReadonlySet<string>,
 ): value is CustomPolygonFeature => {
-  if (!isRecord(value) || !hasOnlyKeys(value, ['type', 'id', 'geometry', 'properties', 'bbox'])) return false;
-  if (value.type !== 'Feature' || !isCustomPolygonGeometry(value.geometry) || !isRecord(value.properties)) return false;
-  if (value.bbox !== undefined && !isBoundingBox(value.bbox)) return false;
-  if (!hasOnlyKeys(value.properties, ['customLayerId', 'categoryId', 'title'])) return false;
-  if (!isBoundedText(value.properties.customLayerId) || !isBoundedText(value.properties.categoryId)) return false;
-  if (!isBoundedText(value.properties.title)) return false;
-  if (layerId && value.properties.customLayerId !== layerId) return false;
-  return !categoryIds || categoryIds.has(value.properties.categoryId);
+  if (!isRecord(value)) return false;
+  if (!hasValidCustomFeatureShape(value)) return false;
+  const properties = value.properties as Record<string, unknown>;
+  if (!hasValidCustomFeatureProperties(properties)) return false;
+  return matchesCustomFeatureOwner(properties, layerId, categoryIds);
 };
 
 /** Creates a detached snapshot so future product edits cannot alter old maps. */
@@ -157,52 +212,74 @@ export const createEmbeddedCustomProductSnapshot = (
 
 /** Validates an immutable-by-contract embedded product snapshot. */
 export const isEmbeddedCustomProductSnapshot = (value: unknown): value is EmbeddedCustomProductSnapshot => {
-  if (!isRecord(value) || !hasOnlyKeys(value, [
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, [
     'schemaVersion', 'sourceProductId', 'sourceProductVersion', 'label', 'categories', 'capturedAt',
   ])) return false;
-  return value.schemaVersion === CUSTOM_PRODUCTS_SCHEMA_VERSION
-    && (value.sourceProductId === undefined || isBoundedText(value.sourceProductId))
-    && (value.sourceProductVersion === undefined || isPositiveInteger(value.sourceProductVersion))
-    && isBoundedText(value.label)
-    && isCustomCategoryList(value.categories)
-    && isIsoTimestamp(value.capturedAt);
+  return areAllValid([
+    value.schemaVersion === CUSTOM_PRODUCTS_SCHEMA_VERSION,
+    value.sourceProductId === undefined || isBoundedText(value.sourceProductId),
+    value.sourceProductVersion === undefined || isPositiveInteger(value.sourceProductVersion),
+    isBoundedText(value.label),
+    isCustomCategoryList(value.categories),
+    isIsoTimestamp(value.capturedAt),
+  ]);
 };
+
+/** Validates the scalar, category, snapshot, and timestamp fields on a one-off layer. */
+const hasValidOneOffLayerFields = (value: Record<string, unknown>): boolean => areAllValid([
+  value.schemaVersion === CUSTOM_PRODUCTS_SCHEMA_VERSION,
+  isBoundedText(value.id),
+  isBoundedText(value.label),
+  isNonNegativeInteger(value.order),
+  isCustomCategoryList(value.categories),
+  Array.isArray(value.features),
+  isIsoTimestamp(value.createdAt),
+  isIsoTimestamp(value.updatedAt),
+  value.productSnapshot === undefined || isEmbeddedCustomProductSnapshot(value.productSnapshot),
+]);
 
 /** Validates a complete self-contained one-off layer. */
 export const isOneOffCustomLayer = (value: unknown): value is OneOffCustomLayer => {
-  if (!isRecord(value) || !hasOnlyKeys(value, [
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, [
     'schemaVersion', 'id', 'label', 'order', 'categories', 'features', 'productSnapshot', 'createdAt', 'updatedAt',
   ])) return false;
-  if (value.schemaVersion !== CUSTOM_PRODUCTS_SCHEMA_VERSION
-    || !isBoundedText(value.id)
-    || !isBoundedText(value.label)
-    || !isNonNegativeInteger(value.order)
-    || !isCustomCategoryList(value.categories)
-    || !Array.isArray(value.features)
-    || !isIsoTimestamp(value.createdAt)
-    || !isIsoTimestamp(value.updatedAt)
-    || (value.productSnapshot !== undefined && !isEmbeddedCustomProductSnapshot(value.productSnapshot))) {
-    return false;
-  }
-  const categoryIds = new Set(value.categories.map((category) => category.id));
-  return value.features.every((feature) => isCustomPolygonFeature(feature, value.id as string, categoryIds));
+  if (!hasValidOneOffLayerFields(value)) return false;
+  const layer = value as unknown as OneOffCustomLayer;
+  const categoryIds = new Set(layer.categories.map((category) => category.id));
+  return layer.features.every((feature) => isCustomPolygonFeature(feature, layer.id, categoryIds));
 };
+
+/** Validates an optional bounded product description. */
+const isOptionalDescription = (value: unknown): boolean =>
+  value === undefined || (typeof value === 'string' && value.length <= 500);
+
+/** Validates the active/archive lifecycle value. */
+const isHostedProductStatus = (value: unknown): value is HostedCustomProductStatus =>
+  value === 'active' || value === 'archived';
+
+/** Validates all fields after a hosted product's strict key check. */
+const hasValidHostedProductFields = (value: Record<string, unknown>): boolean => areAllValid([
+  value.schemaVersion === CUSTOM_PRODUCTS_SCHEMA_VERSION,
+  isBoundedText(value.id),
+  isBoundedText(value.userId, 128),
+  isBoundedText(value.label),
+  isOptionalDescription(value.description),
+  isPositiveInteger(value.version),
+  isHostedProductStatus(value.status),
+  isCustomCategoryList(value.categories),
+  isIsoTimestamp(value.createdAt),
+  isIsoTimestamp(value.updatedAt),
+]);
 
 /** Validates the owner-scoped reusable product persistence shape. */
 export const isHostedCustomProduct = (value: unknown): value is HostedCustomProduct => {
-  if (!isRecord(value) || !hasOnlyKeys(value, [
+  if (!isRecord(value)) return false;
+  if (!hasOnlyKeys(value, [
     'schemaVersion', 'id', 'userId', 'label', 'description', 'version', 'status', 'categories', 'createdAt', 'updatedAt',
   ])) return false;
-  return value.schemaVersion === CUSTOM_PRODUCTS_SCHEMA_VERSION
-    && isBoundedText(value.id)
-    && isBoundedText(value.userId, 128)
-    && isBoundedText(value.label)
-    && (value.description === undefined || (typeof value.description === 'string' && value.description.length <= 500))
-    && isPositiveInteger(value.version)
-    && (value.status === 'active' || value.status === 'archived')
-    && isCustomCategoryList(value.categories)
-    && isIsoTimestamp(value.createdAt)
-    && isIsoTimestamp(value.updatedAt);
+  return hasValidHostedProductFields(value);
 };
 
 /** Derives editability without mutating persisted product or embedded snapshot data. */

--- a/src/types/customProducts.ts
+++ b/src/types/customProducts.ts
@@ -6,7 +6,12 @@ export const CUSTOM_PRODUCTS_SCHEMA_VERSION = '1.0.0' as const;
 /** Product limits shared by client validation and hosted persistence. */
 export const CUSTOM_PRODUCT_LIMITS = {
   productsPerAccount: 20,
+  layersPerCollection: 12,
   categoriesPerProduct: 12,
+  featuresPerLayer: 500,
+  polygonsPerFeature: 32,
+  ringsPerPolygon: 64,
+  coordinatesPerFeature: 10_000,
   labelLength: 64,
 } as const;
 
@@ -95,4 +100,3 @@ export interface CustomLayerCollection {
   schemaVersion: typeof CUSTOM_PRODUCTS_SCHEMA_VERSION;
   layers: OneOffCustomLayer[];
 }
-

--- a/src/types/customProducts.ts
+++ b/src/types/customProducts.ts
@@ -1,0 +1,98 @@
+import type { Feature, MultiPolygon, Polygon } from 'geojson';
+
+/** Serialized schema version for custom layer/product data. */
+export const CUSTOM_PRODUCTS_SCHEMA_VERSION = '1.0.0' as const;
+
+/** Product limits shared by client validation and hosted persistence. */
+export const CUSTOM_PRODUCT_LIMITS = {
+  productsPerAccount: 20,
+  categoriesPerProduct: 12,
+  labelLength: 64,
+} as const;
+
+export type CustomLayerId = string & { readonly _brand: 'CustomLayerId' };
+export type CustomCategoryId = string & { readonly _brand: 'CustomCategoryId' };
+export type CustomProductId = string & { readonly _brand: 'CustomProductId' };
+
+export type CustomHatchPattern = 'none' | 'diagonal' | 'reverse-diagonal' | 'crosshatch';
+
+/** Complete visual treatment for one custom forecast category. */
+export interface CustomCategoryStyle {
+  fillColor: string;
+  fillOpacity: number;
+  strokeColor: string;
+  strokeOpacity: number;
+  strokeWidth: number;
+  hatch: CustomHatchPattern;
+}
+
+/** Ordered, reusable category definition embedded into layers and products. */
+export interface CustomCategoryTemplate {
+  id: CustomCategoryId;
+  label: string;
+  order: number;
+  style: CustomCategoryStyle;
+}
+
+export interface CustomFeatureProperties {
+  customLayerId: CustomLayerId;
+  categoryId: CustomCategoryId;
+  /** Copied label makes exported GeoJSON understandable without a template lookup. */
+  title: string;
+}
+
+export type CustomPolygonFeature = Feature<Polygon | MultiPolygon, CustomFeatureProperties>;
+
+/** Immutable record of the product/category version used to create a map. */
+export interface EmbeddedCustomProductSnapshot {
+  schemaVersion: typeof CUSTOM_PRODUCTS_SCHEMA_VERSION;
+  sourceProductId?: CustomProductId;
+  sourceProductVersion?: number;
+  label: string;
+  categories: CustomCategoryTemplate[];
+  capturedAt: string;
+}
+
+/** A self-contained custom layer; no hosted product is required to render it. */
+export interface OneOffCustomLayer {
+  schemaVersion: typeof CUSTOM_PRODUCTS_SCHEMA_VERSION;
+  id: CustomLayerId;
+  label: string;
+  order: number;
+  categories: CustomCategoryTemplate[];
+  features: CustomPolygonFeature[];
+  /** Present when the layer was seeded from a reusable hosted product. */
+  productSnapshot?: EmbeddedCustomProductSnapshot;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type HostedCustomProductStatus = 'active' | 'archived';
+
+/** Owner-scoped, versioned category template stored in Firestore. */
+export interface HostedCustomProduct {
+  schemaVersion: typeof CUSTOM_PRODUCTS_SCHEMA_VERSION;
+  id: CustomProductId;
+  userId: string;
+  label: string;
+  description?: string;
+  version: number;
+  status: HostedCustomProductStatus;
+  categories: CustomCategoryTemplate[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CustomProductReadOnlyReason = 'premium-expired' | 'archived';
+
+/** Runtime access state derived from entitlement and product lifecycle. */
+export type CustomProductAccessState =
+  | { mode: 'editable'; reason?: never }
+  | { mode: 'read-only'; reason: CustomProductReadOnlyReason };
+
+/** Custom content persisted with a cycle/package. */
+export interface CustomLayerCollection {
+  schemaVersion: typeof CUSTOM_PRODUCTS_SCHEMA_VERSION;
+  layers: OneOffCustomLayer[];
+}
+


### PR DESCRIPTION
## Summary

- define strict versioned contracts for one-off custom layers, reusable hosted products, embedded snapshots, and read-only states
- add runtime validation for bounded styles, ordered categories, GeoJSON polygons, product documents, and self-contained layers
- add snapshot, revision, and product-to-layer helpers so historical maps cannot change after template edits or entitlement expiration
- expose `customProducts` on the local build target only; beta, staging, and production remain disabled
- document the schema and local-only rollout boundary

## Why

Issue #467 is the foundation for the custom-products workstream. Downstream editor, hosted management, security, and workflow PRs need one stable contract that does not couple historical rendering to a live hosted template.

## Validation

- `pnpm test -- --runTestsByPath src/lib/customProducts.test.ts src/config/featureExposure.test.ts src/config/v17WorkstreamAdoption.exposure.test.ts --runInBand`
- `pnpm run validate:feature-exposure`
- `pnpm run build`

The build completed successfully. The optional local Sentry sourcemap upload reported a permission 403 after output generation.

## Stack

1. This PR — CUS-01 schemas (#467)
2. CUS-02 one-off custom layers (#468)
3. CUS-03 reusable custom products (#469)
4. CUS-04 Firestore security and expiration (#470)
5. CUS-05 workflow/package/cloud integration (#471)

Closes #467
