### PR TITLE
CUS-02: add local-only custom forecast layers

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #743
+
+- Add local-only custom forecast layers with category styling, polygon drawing, map legend support, and regression coverage while hosted environments remain unchanged.
+
 ### PR #742
 
 - Define versioned one-off custom layer, reusable hosted product, embedded snapshot, and expiration/read-only contracts with strict validation and local-only exposure.

--- a/docs/custom-products.md
+++ b/docs/custom-products.md
@@ -19,3 +19,17 @@ The `customProducts` registry key is enabled only for the `local` build target w
 
 The TypeScript contracts live in `src/types/customProducts.ts`; strict runtime validators and snapshot/version helpers live in `src/lib/customProducts.ts`.
 
+## Local one-off layer workflow
+
+On a local build, the Draw tab starts in the existing Severe mode and exposes a
+leftmost Severe/Custom switch. Custom mode replaces the severe controls with
+layer and category controls while leaving the severe forecast data untouched.
+Each forecast day owns its custom layers independently. Layer/category order,
+labels, fill and stroke appearance, hatching, and polygon geometry are included
+in normal forecast JSON saves and restored only after strict schema validation.
+
+Custom edits participate in the existing day-scoped undo/redo history. The map,
+popup, legend, and image capture use the embedded style values, so a saved file
+needs no separate template. Signed-out local users receive the same one-off
+layer workflow. Hosted builds take the unchanged Severe-only rendering path.
+

--- a/e2e/custom-layers.spec.ts
+++ b/e2e/custom-layers.spec.ts
@@ -8,8 +8,21 @@ const openForecast = async (page: import('@playwright/test').Page) => {
   await expect(page.locator('.map-container')).toBeVisible({ timeout: 10_000 });
 };
 
+const downloadForecast = async (page: import('@playwright/test').Page) => {
+  await page.getByRole('tab', { name: 'Tools' }).click();
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Save' }).first().click();
+  const download = await downloadPromise;
+  const savedPath = await download.path();
+  if (!savedPath) throw new Error('Custom forecast download has no readable path');
+  const saved = JSON.parse(await readFile(savedPath, 'utf8'));
+  await page.getByRole('tab', { name: 'Draw' }).click();
+  return saved;
+};
+
 test.describe('local-only custom layers', () => {
   test('switches cleanly, draws, identifies, deletes, and undoes a custom polygon', async ({ page }) => {
+    test.setTimeout(60_000);
     await openForecast(page);
     await expect(page.getByRole('radiogroup', { name: 'Drawing product' })).toBeVisible();
     await page.getByRole('radio', { name: 'Custom' }).click();
@@ -35,22 +48,26 @@ test.describe('local-only custom layers', () => {
     await page.mouse.dblclick(...points[2]);
 
     await page.getByRole('button', { name: 'Pan map' }).click();
+    const edgeMidpoint = [
+      (points[0][0] + points[1][0]) / 2,
+      (points[0][1] + points[1][1]) / 2,
+    ] as const;
+    await page.mouse.move(...edgeMidpoint);
+    await page.mouse.down();
+    await page.mouse.move(edgeMidpoint[0], edgeMidpoint[1] - 28, { steps: 8 });
+    await page.mouse.up();
     await page.mouse.click(box.x + box.width * .51, box.y + box.height * .46);
     await expect(page.locator('.ol-popup')).toContainText('Heavy snow');
+
+    const saved = await downloadForecast(page);
+    expect(saved.forecastCycle.days['1'].customLayers.layers[0].features[0].geometry.coordinates[0]).toHaveLength(5);
+    expect(saved.forecastCycle.days['1'].customLayers.layers[0].categories[0].style.hatch).toBe('crosshatch');
 
     await page.getByRole('button', { name: 'Delete polygons' }).click();
     await page.mouse.click(box.x + box.width * .51, box.y + box.height * .46);
     await page.getByRole('tab', { name: 'Tools' }).click();
     await page.getByRole('button', { name: 'Undo' }).first().click();
     await expect(page.getByRole('button', { name: 'Redo' }).first()).toBeEnabled();
-    const downloadPromise = page.waitForEvent('download');
-    await page.getByRole('button', { name: 'Save' }).first().click();
-    const download = await downloadPromise;
-    const savedPath = await download.path();
-    if (!savedPath) throw new Error('Custom forecast download has no readable path');
-    const saved = JSON.parse(await readFile(savedPath, 'utf8'));
-    expect(saved.forecastCycle.days['1'].customLayers.layers[0].features).toHaveLength(1);
-    expect(saved.forecastCycle.days['1'].customLayers.layers[0].categories[0].style.hatch).toBe('crosshatch');
   });
 
   for (const viewport of [

--- a/e2e/custom-layers.spec.ts
+++ b/e2e/custom-layers.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { prepareAppState } from './testSetup';
+
+const openForecast = async (page: import('@playwright/test').Page) => {
+  await prepareAppState(page);
+  await page.goto('/forecast?localBetaBypass=true');
+  await expect(page.locator('.map-container')).toBeVisible({ timeout: 10_000 });
+};
+
+test.describe('local-only custom layers', () => {
+  test('switches cleanly, draws, identifies, deletes, and undoes a custom polygon', async ({ page }) => {
+    await openForecast(page);
+    await expect(page.getByRole('radiogroup', { name: 'Drawing product' })).toBeVisible();
+    await page.getByRole('radio', { name: 'Custom' }).click();
+    await page.getByRole('button', { name: 'Add custom layer' }).click();
+    await page.getByLabel('Layer title').fill('Winter impacts');
+    await page.getByLabel('Layer title').blur();
+    await page.getByLabel('Category label').fill('Heavy snow');
+    await page.getByLabel('Category label').blur();
+    await page.getByLabel('Category hatch').selectOption('crosshatch');
+    await expect(page.getByRole('complementary', { name: 'Map Legend' })).toContainText('Heavy snow');
+
+    await page.getByRole('button', { name: 'Draw polygons' }).click();
+    const viewport = page.locator('.map-container .ol-viewport');
+    const box = await viewport.boundingBox();
+    if (!box) throw new Error('Map viewport has no measurable bounds');
+    const points = [
+      [box.x + box.width * .42, box.y + box.height * .38],
+      [box.x + box.width * .58, box.y + box.height * .38],
+      [box.x + box.width * .52, box.y + box.height * .58],
+    ] as const;
+    await page.mouse.click(...points[0]);
+    await page.mouse.click(...points[1]);
+    await page.mouse.dblclick(...points[2]);
+
+    await page.getByRole('button', { name: 'Pan map' }).click();
+    await page.mouse.click(box.x + box.width * .51, box.y + box.height * .46);
+    await expect(page.locator('.ol-popup')).toContainText('Heavy snow');
+
+    await page.getByRole('button', { name: 'Delete polygons' }).click();
+    await page.mouse.click(box.x + box.width * .51, box.y + box.height * .46);
+    await page.getByRole('tab', { name: 'Tools' }).click();
+    await page.getByRole('button', { name: 'Undo' }).first().click();
+    await expect(page.getByRole('button', { name: 'Redo' }).first()).toBeEnabled();
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Save' }).first().click();
+    const download = await downloadPromise;
+    const savedPath = await download.path();
+    if (!savedPath) throw new Error('Custom forecast download has no readable path');
+    const saved = JSON.parse(await readFile(savedPath, 'utf8'));
+    expect(saved.forecastCycle.days['1'].customLayers.layers[0].features).toHaveLength(1);
+    expect(saved.forecastCycle.days['1'].customLayers.layers[0].categories[0].style.hatch).toBe('crosshatch');
+  });
+
+  for (const viewport of [
+    { name: 'portrait phone', width: 390, height: 844 },
+    { name: 'landscape phone', width: 932, height: 430 },
+  ]) {
+    test(`keeps the toggle and map usable on ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await openForecast(page);
+      await expect(page.getByRole('radio', { name: 'Severe' })).toBeVisible();
+      await page.getByRole('radio', { name: 'Custom' }).click();
+      await expect(page.getByRole('button', { name: 'Add custom layer' })).toBeVisible();
+      await expect(page.locator('.map-container')).toBeVisible();
+      const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+      expect(overflow).toBeLessThanOrEqual(1);
+    });
+  }
+});

--- a/src/components/IntegratedToolbar/CustomDrawPanel.tsx
+++ b/src/components/IntegratedToolbar/CustomDrawPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { ArrowDown, ArrowUp, Plus, Trash2 } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
@@ -61,6 +61,11 @@ const CustomDrawPanel: React.FC = () => {
   const activeLayer = layers.find(({ id }) => id === editor.activeLayerId) ?? layers[0];
   const categories = activeLayer ? [...activeLayer.categories].sort((a, b) => a.order - b.order) : [];
   const activeCategory = categories.find(({ id }) => id === editor.activeCategoryId) ?? categories[0];
+  const [layerLabelDraft, setLayerLabelDraft] = useState(activeLayer?.label ?? '');
+  const [categoryLabelDraft, setCategoryLabelDraft] = useState(activeCategory?.label ?? '');
+
+  useEffect(() => setLayerLabelDraft(activeLayer?.label ?? ''), [activeLayer?.id, activeLayer?.label]);
+  useEffect(() => setCategoryLabelDraft(activeCategory?.label ?? ''), [activeCategory?.id, activeCategory?.label]);
 
   const updateCategory = (changes: Partial<CustomCategoryTemplate> & { style?: Partial<CustomCategoryTemplate['style']> }) => {
     if (!activeLayer || !activeCategory) return;
@@ -97,9 +102,13 @@ const CustomDrawPanel: React.FC = () => {
           <input
             aria-label="Layer title"
             maxLength={64}
-            defaultValue={activeLayer.label}
-            key={activeLayer.id}
-            onBlur={(event) => dispatch(updateCustomLayerLabel({ layerId: activeLayer.id, label: event.target.value }))}
+            value={layerLabelDraft}
+            onChange={(event) => setLayerLabelDraft(event.target.value)}
+            onBlur={() => {
+              const label = layerLabelDraft.trim();
+              if (label) dispatch(updateCustomLayerLabel({ layerId: activeLayer.id, label }));
+              setLayerLabelDraft(label || activeLayer.label);
+            }}
           />
         ) : null}
       </section>
@@ -121,7 +130,11 @@ const CustomDrawPanel: React.FC = () => {
 
           <section className="custom-draw-panel__group custom-draw-panel__appearance" aria-label="Category appearance">
             <span className="custom-draw-panel__label">Appearance</span>
-            <input aria-label="Category label" data-testid="custom-label-input" maxLength={64} defaultValue={activeCategory.label} key={activeCategory.id} onBlur={(event) => updateCategory({ label: event.target.value.trim() || 'Category' })} />
+            <input aria-label="Category label" data-testid="custom-label-input" maxLength={64} value={categoryLabelDraft} onChange={(event) => setCategoryLabelDraft(event.target.value)} onBlur={() => {
+              const label = categoryLabelDraft.trim() || 'Category';
+              updateCategory({ label });
+              setCategoryLabelDraft(label);
+            }} />
             <label>Color <input aria-label="Category color" data-testid="custom-color-input" type="color" value={activeCategory.style.fillColor} onChange={(event) => updateCategory({ style: { fillColor: event.target.value } })} /></label>
             <label>Opacity <input aria-label="Category opacity" data-testid="custom-opacity-input" type="range" min="0" max="1" step="0.05" value={activeCategory.style.fillOpacity} onChange={(event) => updateCategory({ style: { fillOpacity: Number(event.target.value) } })} /></label>
             <select aria-label="Category hatch" data-testid="custom-hatch-select" value={activeCategory.style.hatch} onChange={(event) => updateCategory({ style: { hatch: event.target.value as CustomHatchPattern } })}>

--- a/src/components/IntegratedToolbar/CustomDrawPanel.tsx
+++ b/src/components/IntegratedToolbar/CustomDrawPanel.tsx
@@ -53,32 +53,43 @@ const IconButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & { lab
   <button type="button" aria-label={label} title={label} className="custom-draw-panel__icon-button" {...props}>{children}</button>
 );
 
-const CustomLayerSection: React.FC<{
+const CustomLayerTitleInput: React.FC<{ layer: OneOffCustomLayer }> = ({ layer }) => {
+  const dispatch = useDispatch();
+  const [draft, setDraft] = useState(layer.label);
+  useEffect(() => setDraft(layer.label), [layer.id, layer.label]);
+  return <input aria-label="Layer title" maxLength={64} value={draft} onChange={(event) => setDraft(event.target.value)} onBlur={() => {
+    const label = draft.trim();
+    if (label) dispatch(updateCustomLayerLabel({ layerId: layer.id, label }));
+    setDraft(label || layer.label);
+  }} />;
+};
+
+const CustomLayerActionRow: React.FC<{
   layers: OneOffCustomLayer[];
   activeLayer?: OneOffCustomLayer;
 }> = ({ layers, activeLayer }) => {
   const dispatch = useDispatch();
-  const [layerLabelDraft, setLayerLabelDraft] = useState(activeLayer?.label ?? '');
-  useEffect(() => setLayerLabelDraft(activeLayer?.label ?? ''), [activeLayer?.id, activeLayer?.label]);
+  return <div className="custom-draw-panel__row">
+    <select aria-label="Custom layer" data-testid="custom-layer-picker" value={activeLayer?.id ?? ''} onChange={(event) => dispatch(selectCustomLayer(event.target.value))}>
+      {!activeLayer ? <option value="">Create a layer</option> : null}
+      {layers.map((layer) => <option key={layer.id} value={layer.id}>{layer.label}</option>)}
+    </select>
+    <IconButton label="Add custom layer" disabled={layers.length >= CUSTOM_PRODUCT_LIMITS.layersPerCollection} onClick={() => dispatch(addCustomLayer(makeLayer(layers.length)))}><Plus /></IconButton>
+    <IconButton label="Move layer up" disabled={!activeLayer || activeLayer.order === 0} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: -1 }))}><ArrowUp /></IconButton>
+    <IconButton label="Move layer down" disabled={!activeLayer || activeLayer.order === layers.length - 1} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: 1 }))}><ArrowDown /></IconButton>
+    <IconButton label="Delete custom layer" disabled={!activeLayer} onClick={() => activeLayer && dispatch(removeCustomLayer(activeLayer.id))}><Trash2 /></IconButton>
+  </div>;
+};
 
+const CustomLayerSection: React.FC<{
+  layers: OneOffCustomLayer[];
+  activeLayer?: OneOffCustomLayer;
+}> = ({ layers, activeLayer }) => {
   return (
     <section className="custom-draw-panel__group" aria-label="Custom layers">
       <span className="custom-draw-panel__label">Layer</span>
-      <div className="custom-draw-panel__row">
-        <select aria-label="Custom layer" data-testid="custom-layer-picker" value={activeLayer?.id ?? ''} onChange={(event) => dispatch(selectCustomLayer(event.target.value))}>
-          {!activeLayer ? <option value="">Create a layer</option> : null}
-          {layers.map((layer) => <option key={layer.id} value={layer.id}>{layer.label}</option>)}
-        </select>
-        <IconButton label="Add custom layer" disabled={layers.length >= CUSTOM_PRODUCT_LIMITS.layersPerCollection} onClick={() => dispatch(addCustomLayer(makeLayer(layers.length)))}><Plus /></IconButton>
-        <IconButton label="Move layer up" disabled={!activeLayer || activeLayer.order === 0} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: -1 }))}><ArrowUp /></IconButton>
-        <IconButton label="Move layer down" disabled={!activeLayer || activeLayer.order === layers.length - 1} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: 1 }))}><ArrowDown /></IconButton>
-        <IconButton label="Delete custom layer" disabled={!activeLayer} onClick={() => activeLayer && dispatch(removeCustomLayer(activeLayer.id))}><Trash2 /></IconButton>
-      </div>
-      {activeLayer ? <input aria-label="Layer title" maxLength={64} value={layerLabelDraft} onChange={(event) => setLayerLabelDraft(event.target.value)} onBlur={() => {
-        const label = layerLabelDraft.trim();
-        if (label) dispatch(updateCustomLayerLabel({ layerId: activeLayer.id, label }));
-        setLayerLabelDraft(label || activeLayer.label);
-      }} /> : null}
+      <CustomLayerActionRow layers={layers} activeLayer={activeLayer} />
+      {activeLayer ? <CustomLayerTitleInput layer={activeLayer} /> : null}
     </section>
   );
 };

--- a/src/components/IntegratedToolbar/CustomDrawPanel.tsx
+++ b/src/components/IntegratedToolbar/CustomDrawPanel.tsx
@@ -53,104 +53,90 @@ const IconButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & { lab
   <button type="button" aria-label={label} title={label} className="custom-draw-panel__icon-button" {...props}>{children}</button>
 );
 
-const CustomDrawPanel: React.FC = () => {
+const CustomLayerSection: React.FC<{
+  layers: OneOffCustomLayer[];
+  activeLayer?: OneOffCustomLayer;
+}> = ({ layers, activeLayer }) => {
   const dispatch = useDispatch();
+  const [layerLabelDraft, setLayerLabelDraft] = useState(activeLayer?.label ?? '');
+  useEffect(() => setLayerLabelDraft(activeLayer?.label ?? ''), [activeLayer?.id, activeLayer?.label]);
+
+  return (
+    <section className="custom-draw-panel__group" aria-label="Custom layers">
+      <span className="custom-draw-panel__label">Layer</span>
+      <div className="custom-draw-panel__row">
+        <select aria-label="Custom layer" data-testid="custom-layer-picker" value={activeLayer?.id ?? ''} onChange={(event) => dispatch(selectCustomLayer(event.target.value))}>
+          {!activeLayer ? <option value="">Create a layer</option> : null}
+          {layers.map((layer) => <option key={layer.id} value={layer.id}>{layer.label}</option>)}
+        </select>
+        <IconButton label="Add custom layer" disabled={layers.length >= CUSTOM_PRODUCT_LIMITS.layersPerCollection} onClick={() => dispatch(addCustomLayer(makeLayer(layers.length)))}><Plus /></IconButton>
+        <IconButton label="Move layer up" disabled={!activeLayer || activeLayer.order === 0} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: -1 }))}><ArrowUp /></IconButton>
+        <IconButton label="Move layer down" disabled={!activeLayer || activeLayer.order === layers.length - 1} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: 1 }))}><ArrowDown /></IconButton>
+        <IconButton label="Delete custom layer" disabled={!activeLayer} onClick={() => activeLayer && dispatch(removeCustomLayer(activeLayer.id))}><Trash2 /></IconButton>
+      </div>
+      {activeLayer ? <input aria-label="Layer title" maxLength={64} value={layerLabelDraft} onChange={(event) => setLayerLabelDraft(event.target.value)} onBlur={() => {
+        const label = layerLabelDraft.trim();
+        if (label) dispatch(updateCustomLayerLabel({ layerId: activeLayer.id, label }));
+        setLayerLabelDraft(label || activeLayer.label);
+      }} /> : null}
+    </section>
+  );
+};
+
+const CustomCategorySections: React.FC<{
+  layer: OneOffCustomLayer;
+  categories: CustomCategoryTemplate[];
+  activeCategory: CustomCategoryTemplate;
+}> = ({ layer, categories, activeCategory }) => {
+  const dispatch = useDispatch();
+  const [labelDraft, setLabelDraft] = useState(activeCategory.label);
+  useEffect(() => setLabelDraft(activeCategory.label), [activeCategory.id, activeCategory.label]);
+  const updateCategory = (changes: Partial<CustomCategoryTemplate> & { style?: Partial<CustomCategoryTemplate['style']> }) => dispatch(updateCustomCategory({
+    layerId: layer.id,
+    category: { ...activeCategory, ...changes, style: { ...activeCategory.style, ...changes.style } },
+  }));
+
+  return <>
+    <section className="custom-draw-panel__group" aria-label="Custom categories">
+      <span className="custom-draw-panel__label">Category</span>
+      <div className="custom-draw-panel__row">
+        <select aria-label="Custom category" data-testid="custom-category-list" value={activeCategory.id} onChange={(event) => dispatch(selectCustomCategory(event.target.value))}>
+          {categories.map((category) => <option key={category.id} value={category.id}>{category.label}</option>)}
+        </select>
+        <IconButton label="Add custom category" disabled={categories.length >= CUSTOM_PRODUCT_LIMITS.categoriesPerProduct} onClick={() => dispatch(addCustomCategory({ layerId: layer.id, category: makeCategory(categories.length) }))}><Plus /></IconButton>
+        <IconButton label="Move category up" disabled={activeCategory.order === 0} onClick={() => dispatch(moveCustomCategory({ layerId: layer.id, categoryId: activeCategory.id, direction: -1 }))}><ArrowUp /></IconButton>
+        <IconButton label="Move category down" disabled={activeCategory.order === categories.length - 1} onClick={() => dispatch(moveCustomCategory({ layerId: layer.id, categoryId: activeCategory.id, direction: 1 }))}><ArrowDown /></IconButton>
+        <IconButton label="Delete custom category" disabled={categories.length === 1} onClick={() => dispatch(removeCustomCategory({ layerId: layer.id, categoryId: activeCategory.id }))}><Trash2 /></IconButton>
+      </div>
+    </section>
+    <section className="custom-draw-panel__group custom-draw-panel__appearance" aria-label="Category appearance">
+      <span className="custom-draw-panel__label">Appearance</span>
+      <input aria-label="Category label" data-testid="custom-label-input" maxLength={64} value={labelDraft} onChange={(event) => setLabelDraft(event.target.value)} onBlur={() => {
+        const label = labelDraft.trim() || 'Category'; updateCategory({ label }); setLabelDraft(label);
+      }} />
+      <label>Color <input aria-label="Category color" data-testid="custom-color-input" type="color" value={activeCategory.style.fillColor} onChange={(event) => updateCategory({ style: { fillColor: event.target.value } })} /></label>
+      <label>Opacity <input aria-label="Category opacity" data-testid="custom-opacity-input" type="range" min="0" max="1" step="0.05" value={activeCategory.style.fillOpacity} onChange={(event) => updateCategory({ style: { fillOpacity: Number(event.target.value) } })} /></label>
+      <select aria-label="Category hatch" data-testid="custom-hatch-select" value={activeCategory.style.hatch} onChange={(event) => updateCategory({ style: { hatch: event.target.value as CustomHatchPattern } })}>
+        <option value="none">No hatch</option><option value="diagonal">Diagonal</option><option value="reverse-diagonal">Reverse diagonal</option><option value="crosshatch">Crosshatch</option>
+      </select>
+      <span className={`custom-style-swatch hatch-${activeCategory.style.hatch}`} style={{ '--custom-fill': activeCategory.style.fillColor, '--custom-opacity': activeCategory.style.fillOpacity } as React.CSSProperties} aria-label={`${activeCategory.label} preview`} />
+    </section>
+  </>;
+};
+
+const CustomDrawPanel: React.FC = () => {
   const collection = useSelector(selectCurrentCustomLayers);
   const editor = useSelector((state: RootState) => state.forecast.customEditor);
   const layers = [...collection.layers].sort((a, b) => a.order - b.order);
   const activeLayer = layers.find(({ id }) => id === editor.activeLayerId) ?? layers[0];
   const categories = activeLayer ? [...activeLayer.categories].sort((a, b) => a.order - b.order) : [];
   const activeCategory = categories.find(({ id }) => id === editor.activeCategoryId) ?? categories[0];
-  const [layerLabelDraft, setLayerLabelDraft] = useState(activeLayer?.label ?? '');
-  const [categoryLabelDraft, setCategoryLabelDraft] = useState(activeCategory?.label ?? '');
-
-  useEffect(() => setLayerLabelDraft(activeLayer?.label ?? ''), [activeLayer?.id, activeLayer?.label]);
-  useEffect(() => setCategoryLabelDraft(activeCategory?.label ?? ''), [activeCategory?.id, activeCategory?.label]);
-
-  const updateCategory = (changes: Partial<CustomCategoryTemplate> & { style?: Partial<CustomCategoryTemplate['style']> }) => {
-    if (!activeLayer || !activeCategory) return;
-    dispatch(updateCustomCategory({
-      layerId: activeLayer.id,
-      category: {
-        ...activeCategory,
-        ...changes,
-        style: { ...activeCategory.style, ...changes.style },
-      },
-    }));
-  };
-
-  return (
-    <div className="custom-draw-panel" data-testid="custom-draw-panel">
-      <section className="custom-draw-panel__group" aria-label="Custom layers">
-        <span className="custom-draw-panel__label">Layer</span>
-        <div className="custom-draw-panel__row">
-          <select
-            aria-label="Custom layer"
-            data-testid="custom-layer-picker"
-            value={activeLayer?.id ?? ''}
-            onChange={(event) => dispatch(selectCustomLayer(event.target.value))}
-          >
-            {!activeLayer ? <option value="">Create a layer</option> : null}
-            {layers.map((layer) => <option key={layer.id} value={layer.id}>{layer.label}</option>)}
-          </select>
-          <IconButton label="Add custom layer" disabled={layers.length >= CUSTOM_PRODUCT_LIMITS.layersPerCollection} onClick={() => dispatch(addCustomLayer(makeLayer(layers.length)))}><Plus /></IconButton>
-          <IconButton label="Move layer up" disabled={!activeLayer || activeLayer.order === 0} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: -1 }))}><ArrowUp /></IconButton>
-          <IconButton label="Move layer down" disabled={!activeLayer || activeLayer.order === layers.length - 1} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: 1 }))}><ArrowDown /></IconButton>
-          <IconButton label="Delete custom layer" disabled={!activeLayer} onClick={() => activeLayer && dispatch(removeCustomLayer(activeLayer.id))}><Trash2 /></IconButton>
-        </div>
-        {activeLayer ? (
-          <input
-            aria-label="Layer title"
-            maxLength={64}
-            value={layerLabelDraft}
-            onChange={(event) => setLayerLabelDraft(event.target.value)}
-            onBlur={() => {
-              const label = layerLabelDraft.trim();
-              if (label) dispatch(updateCustomLayerLabel({ layerId: activeLayer.id, label }));
-              setLayerLabelDraft(label || activeLayer.label);
-            }}
-          />
-        ) : null}
-      </section>
-
-      {activeLayer && activeCategory ? (
-        <>
-          <section className="custom-draw-panel__group" aria-label="Custom categories">
-            <span className="custom-draw-panel__label">Category</span>
-            <div className="custom-draw-panel__row">
-              <select aria-label="Custom category" data-testid="custom-category-list" value={activeCategory.id} onChange={(event) => dispatch(selectCustomCategory(event.target.value))}>
-                {categories.map((category) => <option key={category.id} value={category.id}>{category.label}</option>)}
-              </select>
-              <IconButton label="Add custom category" disabled={categories.length >= CUSTOM_PRODUCT_LIMITS.categoriesPerProduct} onClick={() => dispatch(addCustomCategory({ layerId: activeLayer.id, category: makeCategory(categories.length) }))}><Plus /></IconButton>
-              <IconButton label="Move category up" disabled={activeCategory.order === 0} onClick={() => dispatch(moveCustomCategory({ layerId: activeLayer.id, categoryId: activeCategory.id, direction: -1 }))}><ArrowUp /></IconButton>
-              <IconButton label="Move category down" disabled={activeCategory.order === categories.length - 1} onClick={() => dispatch(moveCustomCategory({ layerId: activeLayer.id, categoryId: activeCategory.id, direction: 1 }))}><ArrowDown /></IconButton>
-              <IconButton label="Delete custom category" disabled={categories.length === 1} onClick={() => dispatch(removeCustomCategory({ layerId: activeLayer.id, categoryId: activeCategory.id }))}><Trash2 /></IconButton>
-            </div>
-          </section>
-
-          <section className="custom-draw-panel__group custom-draw-panel__appearance" aria-label="Category appearance">
-            <span className="custom-draw-panel__label">Appearance</span>
-            <input aria-label="Category label" data-testid="custom-label-input" maxLength={64} value={categoryLabelDraft} onChange={(event) => setCategoryLabelDraft(event.target.value)} onBlur={() => {
-              const label = categoryLabelDraft.trim() || 'Category';
-              updateCategory({ label });
-              setCategoryLabelDraft(label);
-            }} />
-            <label>Color <input aria-label="Category color" data-testid="custom-color-input" type="color" value={activeCategory.style.fillColor} onChange={(event) => updateCategory({ style: { fillColor: event.target.value } })} /></label>
-            <label>Opacity <input aria-label="Category opacity" data-testid="custom-opacity-input" type="range" min="0" max="1" step="0.05" value={activeCategory.style.fillOpacity} onChange={(event) => updateCategory({ style: { fillOpacity: Number(event.target.value) } })} /></label>
-            <select aria-label="Category hatch" data-testid="custom-hatch-select" value={activeCategory.style.hatch} onChange={(event) => updateCategory({ style: { hatch: event.target.value as CustomHatchPattern } })}>
-              <option value="none">No hatch</option>
-              <option value="diagonal">Diagonal</option>
-              <option value="reverse-diagonal">Reverse diagonal</option>
-              <option value="crosshatch">Crosshatch</option>
-            </select>
-            <span className={`custom-style-swatch hatch-${activeCategory.style.hatch}`} style={{ '--custom-fill': activeCategory.style.fillColor, '--custom-opacity': activeCategory.style.fillOpacity } as React.CSSProperties} aria-label={`${activeCategory.label} preview`} />
-          </section>
-        </>
-      ) : (
-        <div className="custom-draw-panel__empty">Create a layer to start drawing custom polygons.</div>
-      )}
-    </div>
-  );
+  return <div className="custom-draw-panel" data-testid="custom-draw-panel">
+    <CustomLayerSection layers={layers} activeLayer={activeLayer} />
+    {activeLayer && activeCategory
+      ? <CustomCategorySections layer={activeLayer} categories={categories} activeCategory={activeCategory} />
+      : <div className="custom-draw-panel__empty">Create a layer to start drawing custom polygons.</div>}
+  </div>;
 };
 
 export default CustomDrawPanel;

--- a/src/components/IntegratedToolbar/CustomDrawPanel.tsx
+++ b/src/components/IntegratedToolbar/CustomDrawPanel.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { ArrowDown, ArrowUp, Plus, Trash2 } from 'lucide-react';
+import { v4 as uuidv4 } from 'uuid';
+import type { RootState } from '../../store';
+import {
+  addCustomCategory,
+  addCustomLayer,
+  moveCustomCategory,
+  moveCustomLayer,
+  removeCustomCategory,
+  removeCustomLayer,
+  selectCurrentCustomLayers,
+  selectCustomCategory,
+  selectCustomLayer,
+  updateCustomCategory,
+  updateCustomLayerLabel,
+} from '../../store/forecastSlice';
+import { CUSTOM_PRODUCT_LIMITS, CUSTOM_PRODUCTS_SCHEMA_VERSION, type CustomCategoryTemplate, type CustomHatchPattern, type OneOffCustomLayer } from '../../types/customProducts';
+import { asCustomLayerId } from '../../lib/customProducts';
+
+const colors = ['#22c55e', '#eab308', '#f97316', '#ef4444', '#a855f7', '#3b82f6'];
+
+const makeCategory = (order: number): CustomCategoryTemplate => ({
+  id: `category-${uuidv4()}` as CustomCategoryTemplate['id'],
+  label: `Category ${order + 1}`,
+  order,
+  style: {
+    fillColor: colors[order % colors.length],
+    fillOpacity: 0.55,
+    strokeColor: '#111827',
+    strokeOpacity: 1,
+    strokeWidth: 2,
+    hatch: 'none',
+  },
+});
+
+const makeLayer = (order: number): OneOffCustomLayer => {
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+    id: asCustomLayerId(`layer-${uuidv4()}`),
+    label: `Custom Layer ${order + 1}`,
+    order,
+    categories: [makeCategory(0)],
+    features: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+const IconButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & { label: string }> = ({ label, children, ...props }) => (
+  <button type="button" aria-label={label} title={label} className="custom-draw-panel__icon-button" {...props}>{children}</button>
+);
+
+const CustomDrawPanel: React.FC = () => {
+  const dispatch = useDispatch();
+  const collection = useSelector(selectCurrentCustomLayers);
+  const editor = useSelector((state: RootState) => state.forecast.customEditor);
+  const layers = [...collection.layers].sort((a, b) => a.order - b.order);
+  const activeLayer = layers.find(({ id }) => id === editor.activeLayerId) ?? layers[0];
+  const categories = activeLayer ? [...activeLayer.categories].sort((a, b) => a.order - b.order) : [];
+  const activeCategory = categories.find(({ id }) => id === editor.activeCategoryId) ?? categories[0];
+
+  const updateCategory = (changes: Partial<CustomCategoryTemplate> & { style?: Partial<CustomCategoryTemplate['style']> }) => {
+    if (!activeLayer || !activeCategory) return;
+    dispatch(updateCustomCategory({
+      layerId: activeLayer.id,
+      category: {
+        ...activeCategory,
+        ...changes,
+        style: { ...activeCategory.style, ...changes.style },
+      },
+    }));
+  };
+
+  return (
+    <div className="custom-draw-panel" data-testid="custom-draw-panel">
+      <section className="custom-draw-panel__group" aria-label="Custom layers">
+        <span className="custom-draw-panel__label">Layer</span>
+        <div className="custom-draw-panel__row">
+          <select
+            aria-label="Custom layer"
+            data-testid="custom-layer-picker"
+            value={activeLayer?.id ?? ''}
+            onChange={(event) => dispatch(selectCustomLayer(event.target.value))}
+          >
+            {!activeLayer ? <option value="">Create a layer</option> : null}
+            {layers.map((layer) => <option key={layer.id} value={layer.id}>{layer.label}</option>)}
+          </select>
+          <IconButton label="Add custom layer" disabled={layers.length >= CUSTOM_PRODUCT_LIMITS.layersPerCollection} onClick={() => dispatch(addCustomLayer(makeLayer(layers.length)))}><Plus /></IconButton>
+          <IconButton label="Move layer up" disabled={!activeLayer || activeLayer.order === 0} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: -1 }))}><ArrowUp /></IconButton>
+          <IconButton label="Move layer down" disabled={!activeLayer || activeLayer.order === layers.length - 1} onClick={() => activeLayer && dispatch(moveCustomLayer({ layerId: activeLayer.id, direction: 1 }))}><ArrowDown /></IconButton>
+          <IconButton label="Delete custom layer" disabled={!activeLayer} onClick={() => activeLayer && dispatch(removeCustomLayer(activeLayer.id))}><Trash2 /></IconButton>
+        </div>
+        {activeLayer ? (
+          <input
+            aria-label="Layer title"
+            maxLength={64}
+            defaultValue={activeLayer.label}
+            key={activeLayer.id}
+            onBlur={(event) => dispatch(updateCustomLayerLabel({ layerId: activeLayer.id, label: event.target.value }))}
+          />
+        ) : null}
+      </section>
+
+      {activeLayer && activeCategory ? (
+        <>
+          <section className="custom-draw-panel__group" aria-label="Custom categories">
+            <span className="custom-draw-panel__label">Category</span>
+            <div className="custom-draw-panel__row">
+              <select aria-label="Custom category" data-testid="custom-category-list" value={activeCategory.id} onChange={(event) => dispatch(selectCustomCategory(event.target.value))}>
+                {categories.map((category) => <option key={category.id} value={category.id}>{category.label}</option>)}
+              </select>
+              <IconButton label="Add custom category" disabled={categories.length >= CUSTOM_PRODUCT_LIMITS.categoriesPerProduct} onClick={() => dispatch(addCustomCategory({ layerId: activeLayer.id, category: makeCategory(categories.length) }))}><Plus /></IconButton>
+              <IconButton label="Move category up" disabled={activeCategory.order === 0} onClick={() => dispatch(moveCustomCategory({ layerId: activeLayer.id, categoryId: activeCategory.id, direction: -1 }))}><ArrowUp /></IconButton>
+              <IconButton label="Move category down" disabled={activeCategory.order === categories.length - 1} onClick={() => dispatch(moveCustomCategory({ layerId: activeLayer.id, categoryId: activeCategory.id, direction: 1 }))}><ArrowDown /></IconButton>
+              <IconButton label="Delete custom category" disabled={categories.length === 1} onClick={() => dispatch(removeCustomCategory({ layerId: activeLayer.id, categoryId: activeCategory.id }))}><Trash2 /></IconButton>
+            </div>
+          </section>
+
+          <section className="custom-draw-panel__group custom-draw-panel__appearance" aria-label="Category appearance">
+            <span className="custom-draw-panel__label">Appearance</span>
+            <input aria-label="Category label" data-testid="custom-label-input" maxLength={64} defaultValue={activeCategory.label} key={activeCategory.id} onBlur={(event) => updateCategory({ label: event.target.value.trim() || 'Category' })} />
+            <label>Color <input aria-label="Category color" data-testid="custom-color-input" type="color" value={activeCategory.style.fillColor} onChange={(event) => updateCategory({ style: { fillColor: event.target.value } })} /></label>
+            <label>Opacity <input aria-label="Category opacity" data-testid="custom-opacity-input" type="range" min="0" max="1" step="0.05" value={activeCategory.style.fillOpacity} onChange={(event) => updateCategory({ style: { fillOpacity: Number(event.target.value) } })} /></label>
+            <select aria-label="Category hatch" data-testid="custom-hatch-select" value={activeCategory.style.hatch} onChange={(event) => updateCategory({ style: { hatch: event.target.value as CustomHatchPattern } })}>
+              <option value="none">No hatch</option>
+              <option value="diagonal">Diagonal</option>
+              <option value="reverse-diagonal">Reverse diagonal</option>
+              <option value="crosshatch">Crosshatch</option>
+            </select>
+            <span className={`custom-style-swatch hatch-${activeCategory.style.hatch}`} style={{ '--custom-fill': activeCategory.style.fillColor, '--custom-opacity': activeCategory.style.fillOpacity } as React.CSSProperties} aria-label={`${activeCategory.label} preview`} />
+          </section>
+        </>
+      ) : (
+        <div className="custom-draw-panel__empty">Create a layer to start drawing custom polygons.</div>
+      )}
+    </div>
+  );
+};
+
+export default CustomDrawPanel;

--- a/src/components/IntegratedToolbar/IntegratedToolbar.css
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.css
@@ -140,6 +140,40 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.32), 0 10px 24px -18px rgba(15, 23, 42, 0.55);
 }
 
+.custom-product-mode-panel,
+.custom-draw-panel { display: flex; height: 100%; align-items: stretch; gap: 8px; }
+.custom-product-mode-panel { animation: custom-product-panel-enter 190ms ease-out; }
+.custom-product-toggle { display: grid; grid-template-columns: 1fr; width: 132px; gap: 6px; }
+.custom-product-toggle__button,
+.custom-draw-panel button,
+.custom-draw-panel input,
+.custom-draw-panel select { min-height: 34px; border: 1px solid hsl(var(--border)); border-radius: 10px; background: hsl(var(--background)); color: hsl(var(--foreground)); }
+.custom-product-toggle__button { padding: 6px 12px; font-size: 12px; font-weight: 800; transition: background-color 160ms ease, color 160ms ease, transform 160ms ease; }
+.custom-product-toggle__button.is-active { background: hsl(var(--primary)); color: hsl(var(--primary-foreground)); transform: translateX(3px); }
+.custom-draw-panel__group { display: flex; min-width: 250px; flex-direction: column; justify-content: center; gap: 6px; border-right: 1px solid hsl(var(--border)); padding: 0 12px 0 4px; }
+.custom-draw-panel__group > input,
+.custom-draw-panel__group select { min-width: 0; padding: 5px 8px; }
+.custom-draw-panel__row { display: flex; align-items: center; gap: 5px; }
+.custom-draw-panel__row select { width: 142px; }
+.custom-draw-panel__icon-button { display: inline-flex; width: 34px; align-items: center; justify-content: center; padding: 7px; }
+.custom-draw-panel__icon-button svg { width: 15px; height: 15px; }
+.custom-draw-panel__label { font-size: 10px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; color: hsl(var(--muted-foreground)); }
+.custom-draw-panel__appearance { min-width: 520px; display: grid; grid-template-columns: 120px 132px 155px 145px 34px; grid-template-rows: 20px 38px; align-content: center; align-items: center; }
+.custom-draw-panel__appearance .custom-draw-panel__label { grid-column: 1 / -1; }
+.custom-draw-panel__appearance label { display: flex; align-items: center; gap: 5px; font-size: 11px; white-space: nowrap; }
+.custom-draw-panel__appearance input[type='color'] { width: 38px; padding: 2px; }
+.custom-draw-panel__appearance input[type='range'] { width: 90px; }
+.custom-style-swatch { width: 34px; height: 34px; border: 2px solid #111827; border-radius: 8px; background-color: var(--custom-fill); opacity: var(--custom-opacity); }
+.custom-style-swatch.hatch-diagonal { background-image: repeating-linear-gradient(45deg, transparent 0 6px, #111 6px 8px); }
+.custom-style-swatch.hatch-reverse-diagonal { background-image: repeating-linear-gradient(-45deg, transparent 0 6px, #111 6px 8px); }
+.custom-style-swatch.hatch-crosshatch { background-image: repeating-linear-gradient(45deg, transparent 0 6px, #111 6px 8px), repeating-linear-gradient(-45deg, transparent 0 6px, #111 6px 8px); }
+.custom-draw-panel__empty { min-width: 330px; display: flex; align-items: center; padding: 12px; color: hsl(var(--muted-foreground)); }
+
+@keyframes custom-product-panel-enter {
+  from { opacity: 0; transform: translateX(10px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
 .tabbed-integrated-toolbar__row {
   box-sizing: border-box;
   scroll-behavior: smooth;
@@ -214,6 +248,8 @@
     transition: none !important;
     transform: none !important;
   }
+  .custom-product-mode-panel,
+  .custom-product-toggle__button { animation: none !important; transition: none !important; transform: none !important; }
 }
 
 .dark-mode .tabbed-integrated-toolbar {
@@ -959,4 +995,19 @@
   .tabbed-integrated-toolbar__section--workspace-actions .tabbed-integrated-toolbar__section-content > div {
     width: max-content;
   }
+}
+
+@media (max-width: 768px) {
+  .tabbed-integrated-toolbar__section--product-mode { flex: 0 0 132px; }
+  .custom-product-toggle { width: 120px; }
+  .custom-draw-panel__group { min-width: 238px; }
+  .custom-draw-panel__appearance { min-width: 500px; }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+  .tabbed-integrated-toolbar__section--product-mode { flex-basis: 230px; }
+  .custom-product-toggle { width: 220px; grid-template-columns: 1fr 1fr; }
+  .custom-draw-panel__group { min-width: 300px; flex-direction: row; align-items: center; padding-block: 0; }
+  .custom-draw-panel__label { display: none; }
+  .custom-draw-panel__appearance { display: flex; min-width: 760px; }
 }

--- a/src/components/IntegratedToolbar/IntegratedToolbar.test.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.test.tsx
@@ -147,3 +147,32 @@ describe('TabbedIntegratedToolbar completion validation exposure', () => {
     }
   );
 });
+
+describe('local-only custom Draw mode', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test('keeps hosted Draw UI unchanged with no custom toggle or placeholder', () => {
+    jest.spyOn(require('../../config/featureExposure'), 'isFeatureExposed').mockImplementation((feature: string) => feature !== 'customProducts');
+    renderToolbar('tabbed');
+    expect(screen.queryByRole('radiogroup', { name: 'Drawing product' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /wind/i })).toBeInTheDocument();
+    expect(screen.queryByText(/not available/i)).not.toBeInTheDocument();
+  });
+
+  test('animates a clean Severe/Custom swap and creates signed-out layers', async () => {
+    jest.spyOn(require('../../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
+    const user = userEvent.setup();
+    renderToolbar('tabbed');
+    expect(screen.getByRole('radio', { name: 'Severe' })).toHaveAttribute('aria-checked', 'true');
+
+    await user.click(screen.getByRole('radio', { name: 'Custom' }));
+    expect(screen.queryByRole('button', { name: /wind/i })).not.toBeInTheDocument();
+    expect(screen.getByTestId('custom-draw-panel')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Add custom layer' }));
+    expect(screen.getByLabelText('Layer title')).toHaveValue('Custom Layer 1');
+
+    await user.click(screen.getByRole('radio', { name: 'Severe' }));
+    expect(screen.getByRole('button', { name: /wind/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-draw-panel')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/IntegratedToolbar/IntegratedToolbar.test.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.test.tsx
@@ -1,11 +1,11 @@
 import React, { useRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { IntegratedToolbar, TabbedIntegratedToolbar } from './IntegratedToolbar';
 import { useForecastWorkspaceController } from '../ForecastWorkspace/useForecastWorkspaceController';
-import forecastReducer, { addFeature } from '../../store/forecastSlice';
+import forecastReducer, { addFeature, undoLastEdit } from '../../store/forecastSlice';
 import overlaysReducer from '../../store/overlaysSlice';
 import type { ForecastMapHandle } from '../Map/ForecastMap';
 
@@ -162,7 +162,8 @@ describe('local-only custom Draw mode', () => {
   test('animates a clean Severe/Custom swap and creates signed-out layers', async () => {
     jest.spyOn(require('../../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
     const user = userEvent.setup();
-    renderToolbar('tabbed');
+    const store = createStore();
+    renderToolbar('tabbed', store);
     expect(screen.getByRole('radio', { name: 'Severe' })).toHaveAttribute('aria-checked', 'true');
 
     await user.click(screen.getByRole('radio', { name: 'Custom' }));
@@ -170,6 +171,12 @@ describe('local-only custom Draw mode', () => {
     expect(screen.getByTestId('custom-draw-panel')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Add custom layer' }));
     expect(screen.getByLabelText('Layer title')).toHaveValue('Custom Layer 1');
+    await user.clear(screen.getByLabelText('Layer title'));
+    await user.type(screen.getByLabelText('Layer title'), 'Winter impacts');
+    await user.tab();
+    expect(screen.getByLabelText('Layer title')).toHaveValue('Winter impacts');
+    act(() => { store.dispatch(undoLastEdit()); });
+    await waitFor(() => expect(screen.getByLabelText('Layer title')).toHaveValue('Custom Layer 1'));
 
     await user.click(screen.getByRole('radio', { name: 'Severe' }));
     expect(screen.getByRole('button', { name: /wind/i })).toBeInTheDocument();

--- a/src/components/IntegratedToolbar/IntegratedToolbar.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Archive,
   CalendarDays,
@@ -43,6 +44,9 @@ import {
   outlookShortcuts,
 } from '../ForecastWorkspace/workspaceMeta';
 import TabbedToolbarSelectionStrip from './TabbedToolbarSelectionStrip';
+import CustomDrawPanel from './CustomDrawPanel';
+import type { RootState } from '../../store';
+import { setCustomEditorMode } from '../../store/forecastSlice';
 import './IntegratedToolbar.css';
 
 interface IntegratedToolbarProps {
@@ -543,9 +547,9 @@ const TabbedToolbarStatPill: React.FC<{ label: string; value: string }> = ({ lab
   </div>
 );
 
-/** Draw tab containing outlook type and probability controls. */
-const TabbedToolbarDrawTab: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
-  <TabbedToolbarTabRow>
+/** Existing severe-weather controls, unchanged when custom products are unavailable. */
+const SevereDrawControls: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => (
+  <>
     <TabbedToolbarStripSection label="Outlook Type" hint="T / W / H / C" className="tabbed-integrated-toolbar__section--type w-[316px]">
       <div className="flex flex-wrap items-center gap-1.5">
         {controller.availableTypes.map((type) => (
@@ -573,8 +577,43 @@ const TabbedToolbarDrawTab: React.FC<{ controller: ForecastWorkspaceController }
     <TabbedToolbarStripSection label="Current Selection" className="tabbed-integrated-toolbar__section--selection w-[360px]">
       <TabbedToolbarSelectionStrip controller={controller} showShortcuts={false} />
     </TabbedToolbarStripSection>
-  </TabbedToolbarTabRow>
+  </>
 );
+
+/** Draw tab with a local-only animated switch between severe and custom layers. */
+const TabbedToolbarDrawTab: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => {
+  const dispatch = useDispatch();
+  const storedMode = useSelector((state: RootState) => state.forecast.customEditor.mode);
+  const customExposed = isFeatureExposed('customProducts');
+
+  if (!customExposed) {
+    return <TabbedToolbarTabRow><SevereDrawControls controller={controller} /></TabbedToolbarTabRow>;
+  }
+
+  return (
+    <TabbedToolbarTabRow>
+      <TabbedToolbarStripSection label="Product" className="tabbed-integrated-toolbar__section--product-mode w-[150px]">
+        <div className="custom-product-toggle" role="radiogroup" aria-label="Drawing product" data-testid="custom-product-toggle">
+          {(['severe', 'custom'] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              role="radio"
+              aria-checked={storedMode === mode}
+              className={cn('custom-product-toggle__button', storedMode === mode && 'is-active')}
+              onClick={() => dispatch(setCustomEditorMode(mode))}
+            >
+              {mode === 'severe' ? 'Severe' : 'Custom'}
+            </button>
+          ))}
+        </div>
+      </TabbedToolbarStripSection>
+      <div key={storedMode} className="custom-product-mode-panel">
+        {storedMode === 'severe' ? <SevereDrawControls controller={controller} /> : <CustomDrawPanel />}
+      </div>
+    </TabbedToolbarTabRow>
+  );
+};
 
 /** Control for cycle date selection/editor used in the Days tab. */
 const CycleDateControl: React.FC<{ controller: ForecastWorkspaceController }> = ({ controller }) => {

--- a/src/components/Map/Legend.test.tsx
+++ b/src/components/Map/Legend.test.tsx
@@ -17,6 +17,18 @@ const createMockStore = (preloadedState = {}) =>
     preloadedState,
   });
 
+const renderSevereLegend = (
+  activeOutlookType: 'categorical' | 'tornado' | 'wind' | 'hail' | 'totalSevere' | 'day4-8',
+  props: Partial<React.ComponentProps<typeof Legend>> = {},
+  darkMode = false,
+) => {
+  const store = createMockStore({
+    forecast: { drawingState: { activeOutlookType }, uiVariant: 'standard' },
+    theme: { darkMode },
+  });
+  return render(<Provider store={store}><Legend activeOutlookType={activeOutlookType} {...props} /></Provider>);
+};
+
 describe('Legend', () => {
   it('renders ordered custom labels and exact hatch appearance in local custom mode', () => {
     const store = createMockStore();
@@ -37,74 +49,24 @@ describe('Legend', () => {
   });
 
   it('renders the legend component without crashing', () => {
-    const store = createMockStore({
-      forecast: {
-        drawingState: { activeOutlookType: 'categorical' },
-        uiVariant: 'standard',
-      },
-      theme: { darkMode: false },
-    });
-    
-    render(
-      <Provider store={store}>
-        <Legend />
-      </Provider>
-    );
-    
+    renderSevereLegend('categorical');
     // Legend should render its title
     expect(screen.getByText(/categorical risk levels/i)).toBeInTheDocument();
   });
 
   it('renders tornado outlook type', () => {
-    const store = createMockStore({
-      forecast: {
-        drawingState: { activeOutlookType: 'tornado' },
-        uiVariant: 'standard',
-      },
-      theme: { darkMode: false },
-    });
-    
-    render(
-      <Provider store={store}>
-        <Legend activeOutlookType="tornado" />
-      </Provider>
-    );
-    
+    renderSevereLegend('tornado');
     expect(screen.getByText(/tornado/i)).toBeInTheDocument();
   });
 
   it('marks the legend as open for the mobile popout state', () => {
-    const store = createMockStore({
-      forecast: {
-        drawingState: { activeOutlookType: 'tornado' },
-        uiVariant: 'standard',
-      },
-      theme: { darkMode: false },
-    });
-
-    render(
-      <Provider store={store}>
-        <Legend activeOutlookType="tornado" mobileOpen />
-      </Provider>
-    );
+    renderSevereLegend('tornado', { mobileOpen: true });
 
     expect(screen.getByRole('complementary', { name: /map legend/i })).toHaveClass('map-legend--mobile-open');
   });
 
   it('marks the legend as hidden when the desktop key is toggled off', () => {
-    const store = createMockStore({
-      forecast: {
-        drawingState: { activeOutlookType: 'tornado' },
-        uiVariant: 'standard',
-      },
-      theme: { darkMode: false },
-    });
-
-    render(
-      <Provider store={store}>
-        <Legend activeOutlookType="tornado" desktopOpen={false} />
-      </Provider>
-    );
+    renderSevereLegend('tornado', { desktopOpen: false });
 
     expect(screen.getByRole('complementary', { name: /map legend/i })).toHaveClass('map-legend--desktop-hidden');
   });
@@ -115,19 +77,7 @@ describe('Legend', () => {
     ['totalSevere', /totalsevere probabilities/i, /45%/i, /CIG1 \(Hatching\)/i],
     ['day4-8', /day4-8 probabilities/i, /15%/i, /30%/i],
   ] as const)('renders %s probability entries', (activeOutlookType, title, firstEntry, secondEntry) => {
-    const store = createMockStore({
-      forecast: {
-        drawingState: { activeOutlookType },
-        uiVariant: 'standard',
-      },
-      theme: { darkMode: false },
-    });
-
-    render(
-      <Provider store={store}>
-        <Legend activeOutlookType={activeOutlookType} />
-      </Provider>
-    );
+    renderSevereLegend(activeOutlookType);
 
     expect(screen.getByText(title)).toBeInTheDocument();
     expect(screen.getByText(firstEntry)).toBeInTheDocument();
@@ -135,19 +85,7 @@ describe('Legend', () => {
   });
 
   it('uses dark-mode styling for hatch swatches', () => {
-    const store = createMockStore({
-      forecast: {
-        drawingState: { activeOutlookType: 'tornado' },
-        uiVariant: 'standard',
-      },
-      theme: { darkMode: true },
-    });
-
-    render(
-      <Provider store={store}>
-        <Legend activeOutlookType="tornado" />
-      </Provider>
-    );
+    renderSevereLegend('tornado', {}, true);
 
     expect(screen.getByRole('img', { name: /Legend for CIG1/i })).toHaveStyle({
       border: '1px solid rgba(255,255,255,0.55)',

--- a/src/components/Map/Legend.test.tsx
+++ b/src/components/Map/Legend.test.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
-import forecastReducer from '../../store/forecastSlice';
+import forecastReducer, { addCustomLayer, setCustomEditorMode } from '../../store/forecastSlice';
+import { CUSTOM_PRODUCTS_SCHEMA_VERSION } from '../../types/customProducts';
+import { asCustomLayerId } from '../../lib/customProducts';
 import themeReducer from '../../store/themeSlice';
 import Legend from './Legend';
 
@@ -16,6 +18,24 @@ const createMockStore = (preloadedState = {}) =>
   });
 
 describe('Legend', () => {
+  it('renders ordered custom labels and exact hatch appearance in local custom mode', () => {
+    const store = createMockStore();
+    store.dispatch(addCustomLayer({
+      schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+      id: asCustomLayerId('winter'), label: 'Winter impacts', order: 0,
+      categories: [
+        { id: 'major' as never, label: 'Major', order: 1, style: { fillColor: '#ef4444', fillOpacity: .7, strokeColor: '#111827', strokeOpacity: 1, strokeWidth: 2, hatch: 'crosshatch' } },
+        { id: 'minor' as never, label: 'Minor', order: 0, style: { fillColor: '#22c55e', fillOpacity: .5, strokeColor: '#111827', strokeOpacity: 1, strokeWidth: 2, hatch: 'none' } },
+      ], features: [], createdAt: '2026-07-17T12:00:00.000Z', updatedAt: '2026-07-17T12:00:00.000Z',
+    }));
+    store.dispatch(setCustomEditorMode('custom'));
+    render(<Provider store={store}><Legend /></Provider>);
+    expect(screen.getByText('Winter impacts')).toBeInTheDocument();
+    const items = screen.getAllByRole('listitem');
+    expect(items.map((item) => item.textContent)).toEqual(['Minor', 'Major']);
+    expect(screen.getByRole('img', { name: 'Major custom style' })).toHaveStyle({ backgroundColor: '#ef4444', opacity: '0.7' });
+  });
+
   it('renders the legend component without crashing', () => {
     const store = createMockStore({
       forecast: {

--- a/src/components/Map/Legend.tsx
+++ b/src/components/Map/Legend.tsx
@@ -5,6 +5,9 @@ import { RootState } from '../../store';
 import { colorMappings, getCategoricalRiskDisplayName } from '../../utils/outlookUtils';
 import { CategoricalRiskLevel } from '../../types/outlooks';
 import './Legend.css';
+import { isFeatureExposed } from '../../config/featureExposure';
+import { selectCurrentCustomLayers } from '../../store/forecastSlice';
+import type { CustomCategoryTemplate } from '../../types/customProducts';
 
 type LegendOutlookType = 'categorical' | 'tornado' | 'wind' | 'hail' | 'totalSevere' | 'day4-8';
 
@@ -23,7 +26,38 @@ const Legend: React.FC<LegendProps> = React.memo(({
   // Optimized: Select only activeOutlookType to avoid re-rendering on other drawing state changes (like activeProbability)
   const storeActiveOutlookType = useSelector((state: RootState) => state.forecast.drawingState.activeOutlookType);
   const darkMode = useSelector((state: RootState) => state.theme.darkMode);
+  const customEditor = useSelector((state: RootState) => state.forecast.customEditor) ?? { mode: 'severe' as const, activeLayerId: null, activeCategoryId: null };
+  const customLayers = useSelector(selectCurrentCustomLayers);
   const activeOutlookType = activeOutlookTypeOverride || storeActiveOutlookType;
+  const customMode = !activeOutlookTypeOverride && isFeatureExposed('customProducts') && customEditor.mode === 'custom';
+  const activeCustomLayer = customLayers.layers.find(({ id }) => id === customEditor.activeLayerId) ?? customLayers.layers[0];
+
+  const customSwatchBackground = (category: CustomCategoryTemplate): React.CSSProperties => {
+    const angle = category.style.hatch === 'reverse-diagonal' ? '-45deg' : '45deg';
+    const diagonal = `repeating-linear-gradient(${angle}, transparent 0 6px, ${category.style.strokeColor} 6px 8px)`;
+    const reverse = `repeating-linear-gradient(-45deg, transparent 0 6px, ${category.style.strokeColor} 6px 8px)`;
+    return {
+      backgroundColor: category.style.fillColor,
+      opacity: category.style.fillOpacity,
+      backgroundImage: category.style.hatch === 'none' ? undefined : category.style.hatch === 'crosshatch' ? `${diagonal}, ${reverse}` : diagonal,
+      borderColor: category.style.strokeColor,
+      borderWidth: category.style.strokeWidth,
+    };
+  };
+
+  const renderCustomLegend = () => (
+    <>
+      <h4 id="legend-title">{activeCustomLayer?.label ?? 'Custom Layers'}</h4>
+      <div className="legend-items" role="list" aria-labelledby="legend-title">
+        {activeCustomLayer ? [...activeCustomLayer.categories].sort((a, b) => a.order - b.order).map((category) => (
+          <div key={category.id} className="legend-item" role="listitem">
+            <div className="legend-color" style={customSwatchBackground(category)} role="img" aria-label={`${category.label} custom style`} />
+            <span>{category.label}</span>
+          </div>
+        )) : <span>No custom layer selected</span>}
+      </div>
+    </>
+  );
 
   /** Renders the categorical legend swatches using the released opaque map treatment. */
   const renderCategoricalLegend = () => (
@@ -143,7 +177,7 @@ const Legend: React.FC<LegendProps> = React.memo(({
       aria-label="Map Legend"
       translate="no"
     >
-      {activeOutlookType === 'categorical' ? renderCategoricalLegend() : renderProbabilisticLegend()}
+      {customMode ? renderCustomLegend() : activeOutlookType === 'categorical' ? renderCategoricalLegend() : renderProbabilisticLegend()}
     </div>
   );
 });

--- a/src/components/Map/OpenLayersForecastMap.test.ts
+++ b/src/components/Map/OpenLayersForecastMap.test.ts
@@ -35,6 +35,9 @@ import {
   toOlStyle,
   toGhostOlStyle,
   removeDrawInteraction,
+  getCustomFeatureIdentity,
+  toUpdatedCustomFeature,
+  toCustomOlStyle,
 } from './OpenLayersForecastMap';
 
 type FeatureStub = {
@@ -178,6 +181,25 @@ describe('OpenLayersForecastMap helpers', () => {
     const s2 = toGhostOlStyle({ outlookType: 'categorical', probability: 'P10', isCategorical: true });
     expect(s1).toBeTruthy();
     expect(s2).toBeTruthy();
+  });
+
+  test('custom feature identity and geometry round-trip stay separate from severe metadata', () => {
+    const values = { featureId: 'custom-1', customLayerId: 'layer-1', categoryId: 'cat-1', title: 'Heavy snow' };
+    const feature: FeatureStub = { get: (key) => values[key as keyof typeof values], getGeometry: () => ({ type: 'Polygon' }) };
+    expect(getCustomFeatureIdentity(feature)).toEqual(values);
+    const format: GeometryFormatStub = { writeGeometryObject: () => ({ type: 'Polygon', coordinates: [] }) };
+    expect(toUpdatedCustomFeature(feature, format as never)?.properties).toEqual({ customLayerId: 'layer-1', categoryId: 'cat-1', title: 'Heavy snow' });
+    expect(getFeatureIdentity(feature)).toBeNull();
+  });
+
+  test('custom solid style preserves color, opacity, stroke, and category order', () => {
+    const style = toCustomOlStyle({
+      id: 'cat-1' as never, label: 'Heavy snow', order: 4,
+      style: { fillColor: '#3b82f6', fillOpacity: .45, strokeColor: '#ffffff', strokeOpacity: .9, strokeWidth: 2, hatch: 'none' },
+    });
+    expect(style.getFill()?.getColor()).toBe('rgba(59, 130, 246, 0.45)');
+    expect(style.getStroke()?.getColor()).toBe('rgba(255, 255, 255, 0.9)');
+    expect(style.getZIndex()).toBe(704);
   });
 
   test('toOlStyle transparencyScale reduces fill and stroke alpha', () => {

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -57,7 +57,7 @@ import {
 } from "../../lib/openFreeMap";
 import "./ForecastMap.css";
 import { isFeatureExposed } from "../../config/featureExposure";
-import type { CustomCategoryStyle, CustomCategoryTemplate, CustomPolygonFeature } from "../../types/customProducts";
+import type { CustomCategoryStyle, CustomCategoryTemplate, CustomPolygonFeature, OneOffCustomLayer } from "../../types/customProducts";
 
 type OutlookMapLike = Record<string, globalThis.Map<string, GeoJsonFeature[]>>;
 type EditableOutlookType =
@@ -471,6 +471,26 @@ export const toUpdatedCustomFeature = (feature: FeatureLike, format: GeoJSON): C
     id: identity.featureId,
     geometry: format.writeGeometryObject(geometry as Geometry, { dataProjection: "EPSG:4326", featureProjection: "EPSG:3857" }) as Polygon,
     properties: { customLayerId: identity.customLayerId as CustomPolygonFeature['properties']['customLayerId'], categoryId: identity.categoryId as CustomPolygonFeature['properties']['categoryId'], title: identity.title },
+  };
+};
+
+/** Converts a completed draw geometry when an active custom draw target exists. */
+export const toDrawnCustomFeature = (
+  geometry: Geometry,
+  layer: OneOffCustomLayer | undefined,
+  category: CustomCategoryTemplate | undefined,
+  enabled: boolean,
+): CustomPolygonFeature | null => {
+  if (!enabled || !layer || !category) return null;
+  return {
+    type: "Feature",
+    id: uuidv4(),
+    geometry: geometry as Polygon,
+    properties: {
+      customLayerId: layer.id,
+      categoryId: category.id,
+      title: category.label,
+    },
   };
 };
 
@@ -1501,17 +1521,13 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
         });
         // Create a new feature object with the drawn geometry and current drawing state properties,
         // then dispatch an action to add it to the Redux store.
-        if (customMode && activeCustomLayer && activeCustomCategory) {
-          const customFeature: CustomPolygonFeature = {
-            type: "Feature",
-            id: uuidv4(),
-            geometry: geometry as Polygon,
-            properties: {
-              customLayerId: activeCustomLayer.id,
-              categoryId: activeCustomCategory.id,
-              title: activeCustomCategory.label,
-            },
-          };
+        const customFeature = toDrawnCustomFeature(
+          geometry as Geometry,
+          activeCustomLayer,
+          activeCustomCategory,
+          customMode,
+        );
+        if (customFeature) {
           dispatch(addCustomFeature(customFeature));
           return;
         }

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -29,10 +29,14 @@ import { v4 as uuidv4 } from "uuid";
 import { RootState } from "../../store";
 import {
   addFeature,
+  addCustomFeature,
   removeFeature,
+  removeCustomFeature,
+  selectCurrentCustomLayers,
   selectCurrentOutlooks,
   setMapView,
   updateFeature,
+  updateCustomFeature,
 } from "../../store/forecastSlice";
 
 import type { BaseMapStyle } from "../../store/overlaysSlice";
@@ -52,6 +56,8 @@ import {
   isOpenFreeMapStyle,
 } from "../../lib/openFreeMap";
 import "./ForecastMap.css";
+import { isFeatureExposed } from "../../config/featureExposure";
+import type { CustomCategoryStyle, CustomCategoryTemplate, CustomPolygonFeature } from "../../types/customProducts";
 
 type OutlookMapLike = Record<string, globalThis.Map<string, GeoJsonFeature[]>>;
 type EditableOutlookType =
@@ -66,6 +72,13 @@ interface FeatureIdentity {
   featureId: string;
   outlookType: string;
   probability: string;
+}
+
+interface CustomFeatureIdentity {
+  featureId: string;
+  customLayerId: string;
+  categoryId: string;
+  title: string;
 }
 
 interface BlankLayerConfig {
@@ -405,6 +418,62 @@ export const toOlStyle = (
   });
 };
 
+/** Builds an exact custom category fill, including all supported hatch directions. */
+export const createCustomFill = (style: CustomCategoryStyle): Fill => {
+  if (style.hatch === "none") {
+    return new Fill({ color: toRgbaColor({ color: style.fillColor, alpha: style.fillOpacity }) });
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = 12;
+  canvas.height = 12;
+  const context = canvas.getContext("2d");
+  if (!context) return new Fill({ color: toRgbaColor({ color: style.fillColor, alpha: style.fillOpacity }) });
+  context.fillStyle = toRgbaColor({ color: style.fillColor, alpha: style.fillOpacity });
+  context.fillRect(0, 0, 12, 12);
+  context.strokeStyle = toRgbaColor({ color: style.strokeColor, alpha: style.strokeOpacity });
+  context.lineWidth = Math.max(1, style.strokeWidth / 2);
+  const line = (x1: number, y1: number, x2: number, y2: number) => {
+    context.beginPath(); context.moveTo(x1, y1); context.lineTo(x2, y2); context.stroke();
+  };
+  if (style.hatch === "diagonal" || style.hatch === "crosshatch") {
+    line(-2, 10, 10, -2); line(2, 14, 14, 2);
+  }
+  if (style.hatch === "reverse-diagonal" || style.hatch === "crosshatch") {
+    line(-2, 2, 10, 14); line(2, -2, 14, 10);
+  }
+  const pattern = context.createPattern(canvas, "repeat");
+  return new Fill({ color: pattern ?? toRgbaColor({ color: style.fillColor, alpha: style.fillOpacity }) });
+};
+
+export const toCustomOlStyle = (category: CustomCategoryTemplate, isTopLayer = false, zIndex = 700 + category.order): Style => new Style({
+  fill: createCustomFill(category.style),
+  stroke: new Stroke({
+    color: toRgbaColor({ color: category.style.strokeColor, alpha: category.style.strokeOpacity }),
+    width: isTopLayer ? Math.max(3, category.style.strokeWidth) : category.style.strokeWidth,
+  }),
+  zIndex,
+});
+
+export const getCustomFeatureIdentity = (feature: FeatureLike): CustomFeatureIdentity | null => {
+  const featureId = feature.get("featureId") as string | undefined;
+  const customLayerId = feature.get("customLayerId") as string | undefined;
+  const categoryId = feature.get("categoryId") as string | undefined;
+  const title = feature.get("title") as string | undefined;
+  return featureId && customLayerId && categoryId && title ? { featureId, customLayerId, categoryId, title } : null;
+};
+
+export const toUpdatedCustomFeature = (feature: FeatureLike, format: GeoJSON): CustomPolygonFeature | null => {
+  const identity = getCustomFeatureIdentity(feature);
+  const geometry = feature.getGeometry();
+  if (!identity || !geometry) return null;
+  return {
+    type: "Feature",
+    id: identity.featureId,
+    geometry: format.writeGeometryObject(geometry as Geometry, { dataProjection: "EPSG:4326", featureProjection: "EPSG:3857" }) as Polygon,
+    properties: { customLayerId: identity.customLayerId as CustomPolygonFeature['properties']['customLayerId'], categoryId: identity.categoryId as CustomPolygonFeature['properties']['categoryId'], title: identity.title },
+  };
+};
+
 /** Creates a dashed preview style for uncommitted Auto-TSTM guidance. */
 export const toTstmPreviewOlStyle = () => {
   const style = getFeatureStyle("categorical", "TSTM");
@@ -641,6 +710,11 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
     const drawingState = useSelector(
       (state: RootState) => state.forecast.drawingState,
     );
+    const customEditor = useSelector((state: RootState) => state.forecast.customEditor);
+    const customLayers = useSelector(selectCurrentCustomLayers);
+    const customMode = isFeatureExposed("customProducts") && customEditor.mode === "custom";
+    const activeCustomLayer = customLayers.layers.find(({ id }) => id === customEditor.activeLayerId) ?? customLayers.layers[0];
+    const activeCustomCategory = activeCustomLayer?.categories.find(({ id }) => id === customEditor.activeCategoryId) ?? activeCustomLayer?.categories[0];
     const currentMapView = useSelector(
       (state: RootState) => state.forecast.currentMapView,
     );
@@ -656,10 +730,13 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
     const popupRef = useRef<HTMLDivElement>(null);
     const overlayRef = useRef<Overlay | null>(null);
     const interactionModeRef = useRef(interactionMode);
+    const customModeRef = useRef(customMode);
 
     useEffect(() => {
       interactionModeRef.current = interactionMode;
     }, [interactionMode]);
+
+    useEffect(() => { customModeRef.current = customMode; }, [customMode]);
 
     useEffect(() => {
       currentMapViewRef.current = currentMapView;
@@ -703,6 +780,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
         probability: string;
         feature: GeoJsonFeature;
       }> = [];
+      if (customMode) return items;
       Object.entries(outlooks).forEach(([outlookType, probs]) => {
         if (outlookType !== drawingState.activeOutlookType) {
           return;
@@ -716,7 +794,18 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
         });
       });
       return items;
-    }, [outlooks, drawingState.activeOutlookType]);
+    }, [outlooks, drawingState.activeOutlookType, customMode]);
+
+    const serializedCustomFeatures = useMemo(() => {
+      if (!customMode) return [];
+      return customLayers.layers.flatMap((layer) => {
+        const categories = new Map(layer.categories.map((category) => [category.id, category]));
+        return layer.features.flatMap((feature) => {
+          const category = categories.get(feature.properties.categoryId);
+          return category ? [{ feature, category, layer }] : [];
+        });
+      });
+    }, [customLayers.layers, customMode]);
 
     useImperativeHandle(
       ref,
@@ -928,8 +1017,11 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
             layer === vectorLayerRef.current || layer === catLayerRef.current,
         });
         if (feature && overlayRef.current) {
-          const outlookType = feature.get("outlookType") as string;
-          const probability = feature.get("probability") as string;
+          const customIdentity = getCustomFeatureIdentity(feature);
+          const outlookType = customIdentity
+            ? (feature.get("customLayerTitle") as string || "Custom layer")
+            : feature.get("outlookType") as string;
+          const probability = customIdentity?.title ?? feature.get("probability") as string;
           const isSignificant = feature.get("isSignificant") as boolean;
 
           setPopupInfo({ outlookType, probability, isSignificant });
@@ -945,6 +1037,11 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
       modify.on("modifyend", (event) => {
         const format = new GeoJSON();
         event.features.forEach((feature) => {
+          const customFeature = toUpdatedCustomFeature(feature, format);
+          if (customFeature) {
+            dispatch(updateCustomFeature(customFeature));
+            return;
+          }
           const updatedFeature = toUpdatedGeoJsonFeature(
             feature,
             format,
@@ -1012,6 +1109,13 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
         // Keep them read-only here; users should edit tornado/wind/hail/totalSevere
         // (or draw/delete TSTM manually) and let auto-categorical regenerate.
         if (outlookType === "categorical" && derivedFrom === "auto-generated") {
+          select.getFeatures().clear();
+          return;
+        }
+
+        const customIdentity = getCustomFeatureIdentity(selected);
+        if (customIdentity) {
+          dispatch(removeCustomFeature({ layerId: customIdentity.customLayerId, featureId: customIdentity.featureId }));
           select.getFeatures().clear();
           return;
         }
@@ -1371,10 +1475,12 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
       }
 
       if (
-        !isDrawableOutlookType({ outlookType: drawingState.activeOutlookType })
+        !customMode && !isDrawableOutlookType({ outlookType: drawingState.activeOutlookType })
       ) {
         return;
       }
+
+      if (customMode && (!activeCustomLayer || !activeCustomCategory)) return;
 
       const drawSource =
         drawingState.activeOutlookType === "categorical"
@@ -1395,6 +1501,21 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
         });
         // Create a new feature object with the drawn geometry and current drawing state properties,
         // then dispatch an action to add it to the Redux store.
+        if (customMode && activeCustomLayer && activeCustomCategory) {
+          const customFeature: CustomPolygonFeature = {
+            type: "Feature",
+            id: uuidv4(),
+            geometry: geometry as Polygon,
+            properties: {
+              customLayerId: activeCustomLayer.id,
+              categoryId: activeCustomCategory.id,
+              title: activeCustomCategory.label,
+            },
+          };
+          dispatch(addCustomFeature(customFeature));
+          return;
+        }
+
         const feature: GeoJsonFeature<Polygon, GeoJsonProperties> = {
           type: "Feature",
           id: uuidv4(),
@@ -1430,6 +1551,9 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
       drawingState.activeOutlookType,
       drawingState.activeProbability,
       drawingState.isSignificant,
+      customMode,
+      activeCustomLayer,
+      activeCustomCategory,
       interactionMode,
     ]);
 
@@ -1441,6 +1565,25 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
       catSource.clear();
       ghostSource.clear();
       const format = new GeoJSON();
+
+      if (customMode) {
+        const highestZIndex = Math.max(...serializedCustomFeatures.map(({ layer, category }) => 700 + layer.order * 20 + category.order), 700);
+        serializedCustomFeatures.forEach(({ feature, category, layer }) => {
+          const zIndex = 700 + layer.order * 20 + category.order;
+          const olFeature = format.readFeature(feature, { dataProjection: "EPSG:4326", featureProjection: "EPSG:3857" });
+          const applyCustomProps = (item: OLFeature<Geometry>) => {
+            item.setStyle(toCustomOlStyle(category, zIndex === highestZIndex, zIndex));
+            item.set("featureId", feature.id as string);
+            item.set("customLayerId", layer.id);
+            item.set("customLayerTitle", layer.label);
+            item.set("categoryId", category.id);
+            item.set("title", category.label);
+            source.addFeature(item);
+          };
+          if (Array.isArray(olFeature)) olFeature.forEach((item) => applyCustomProps(item as OLFeature<Geometry>));
+          else applyCustomProps(olFeature as OLFeature<Geometry>);
+        });
+      }
 
       // Find the maximum z-index for bold styling
       let maxZIndex = -Infinity;
@@ -1489,6 +1632,7 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
 
       Object.entries(outlooks).forEach(([outlookType, probs]) => {
         if (
+          customMode ||
           outlookType === drawingState.activeOutlookType ||
           !ghostOutlooks[outlookType as EditableOutlookType]
         ) {
@@ -1534,6 +1678,8 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
       });
     }, [
       serializedFeatures,
+      serializedCustomFeatures,
+      customMode,
       outlooks,
       drawingState.activeOutlookType,
       ghostOutlooks,

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -481,7 +481,9 @@ export const toDrawnCustomFeature = (
   category: CustomCategoryTemplate | undefined,
   enabled: boolean,
 ): CustomPolygonFeature | null => {
-  if (!enabled || !layer || !category) return null;
+  if (!enabled) return null;
+  if (!layer) return null;
+  if (!category) return null;
   return {
     type: "Feature",
     id: uuidv4(),

--- a/src/store/customCategoryReducers.ts
+++ b/src/store/customCategoryReducers.ts
@@ -1,0 +1,53 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { CUSTOM_PRODUCT_LIMITS, type CustomCategoryTemplate } from '../types/customProducts';
+import type { ForecastState } from './forecastSlice';
+import { cloneCustomValue, getCurrentCustomLayers, normalizeCustomOrder, touchCustomLayer } from './customLayerReducerUtils';
+
+/** Category reducers that share the parent forecast day's undo history. */
+export const createCustomCategoryReducers = (pushUndoSnapshot: (state: ForecastState) => void) => ({
+  addCustomCategory: (state: ForecastState, action: PayloadAction<{ layerId: string; category: CustomCategoryTemplate }>) => {
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+    if (!layer || layer.categories.length >= CUSTOM_PRODUCT_LIMITS.categoriesPerProduct) return;
+    pushUndoSnapshot(state);
+    layer.categories.push(cloneCustomValue(action.payload.category));
+    normalizeCustomOrder(layer.categories);
+    touchCustomLayer(layer);
+    state.customEditor.activeCategoryId = action.payload.category.id;
+    state.isSaved = false;
+  },
+  updateCustomCategory: (state: ForecastState, action: PayloadAction<{ layerId: string; category: CustomCategoryTemplate }>) => {
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+    const index = layer?.categories.findIndex(({ id }) => id === action.payload.category.id) ?? -1;
+    if (!layer || index < 0) return;
+    pushUndoSnapshot(state);
+    layer.categories[index] = { ...cloneCustomValue(action.payload.category), order: layer.categories[index].order };
+    layer.features.forEach((feature) => {
+      if (feature.properties.categoryId === action.payload.category.id) feature.properties.title = action.payload.category.label;
+    });
+    touchCustomLayer(layer);
+    state.isSaved = false;
+  },
+  removeCustomCategory: (state: ForecastState, action: PayloadAction<{ layerId: string; categoryId: string }>) => {
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+    const index = layer?.categories.findIndex(({ id }) => id === action.payload.categoryId) ?? -1;
+    if (!layer || index < 0 || layer.categories.length === 1) return;
+    pushUndoSnapshot(state);
+    layer.categories.splice(index, 1);
+    layer.features = layer.features.filter(({ properties }) => properties.categoryId !== action.payload.categoryId);
+    normalizeCustomOrder(layer.categories);
+    state.customEditor.activeCategoryId = layer.categories[Math.min(index, layer.categories.length - 1)]?.id ?? null;
+    touchCustomLayer(layer);
+    state.isSaved = false;
+  },
+  moveCustomCategory: (state: ForecastState, action: PayloadAction<{ layerId: string; categoryId: string; direction: -1 | 1 }>) => {
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+    const index = layer?.categories.findIndex(({ id }) => id === action.payload.categoryId) ?? -1;
+    const target = index + action.payload.direction;
+    if (!layer || index < 0 || target < 0 || target >= layer.categories.length) return;
+    pushUndoSnapshot(state);
+    [layer.categories[index], layer.categories[target]] = [layer.categories[target], layer.categories[index]];
+    normalizeCustomOrder(layer.categories);
+    touchCustomLayer(layer);
+    state.isSaved = false;
+  },
+});

--- a/src/store/customCategoryReducers.ts
+++ b/src/store/customCategoryReducers.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { CUSTOM_PRODUCT_LIMITS, type CustomCategoryTemplate } from '../types/customProducts';
 import type { ForecastState } from './forecastSlice';
-import { cloneCustomValue, getCurrentCustomLayers, normalizeCustomOrder, touchCustomLayer } from './customLayerReducerUtils';
+import { canMoveCustomItem, cloneCustomValue, getCurrentCustomLayers, normalizeCustomOrder, touchCustomLayer } from './customLayerReducerUtils';
 
 /** Category reducers that share the parent forecast day's undo history. */
 export const createCustomCategoryReducers = (pushUndoSnapshot: (state: ForecastState) => void) => ({
@@ -30,7 +30,8 @@ export const createCustomCategoryReducers = (pushUndoSnapshot: (state: ForecastS
   removeCustomCategory: (state: ForecastState, action: PayloadAction<{ layerId: string; categoryId: string }>) => {
     const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
     const index = layer?.categories.findIndex(({ id }) => id === action.payload.categoryId) ?? -1;
-    if (!layer || index < 0 || layer.categories.length === 1) return;
+    if (!layer || index < 0) return;
+    if (layer.categories.length === 1) return;
     pushUndoSnapshot(state);
     layer.categories.splice(index, 1);
     layer.features = layer.features.filter(({ properties }) => properties.categoryId !== action.payload.categoryId);
@@ -43,7 +44,8 @@ export const createCustomCategoryReducers = (pushUndoSnapshot: (state: ForecastS
     const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
     const index = layer?.categories.findIndex(({ id }) => id === action.payload.categoryId) ?? -1;
     const target = index + action.payload.direction;
-    if (!layer || index < 0 || target < 0 || target >= layer.categories.length) return;
+    if (!layer) return;
+    if (!canMoveCustomItem(index, target, layer.categories.length)) return;
     pushUndoSnapshot(state);
     [layer.categories[index], layer.categories[target]] = [layer.categories[target], layer.categories[index]];
     normalizeCustomOrder(layer.categories);

--- a/src/store/customFeatureReducers.ts
+++ b/src/store/customFeatureReducers.ts
@@ -1,0 +1,35 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { CUSTOM_PRODUCT_LIMITS, type CustomPolygonFeature } from '../types/customProducts';
+import type { ForecastState } from './forecastSlice';
+import { cloneCustomValue, getCurrentCustomLayers, touchCustomLayer } from './customLayerReducerUtils';
+
+/** Polygon reducers that share the parent forecast day's undo history. */
+export const createCustomFeatureReducers = (pushUndoSnapshot: (state: ForecastState) => void) => ({
+  addCustomFeature: (state: ForecastState, action: PayloadAction<CustomPolygonFeature>) => {
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.properties.customLayerId);
+    if (!layer || layer.features.length >= CUSTOM_PRODUCT_LIMITS.featuresPerLayer
+      || !layer.categories.some(({ id }) => id === action.payload.properties.categoryId)) return;
+    pushUndoSnapshot(state);
+    layer.features.push(cloneCustomValue(action.payload));
+    touchCustomLayer(layer);
+    state.isSaved = false;
+  },
+  updateCustomFeature: (state: ForecastState, action: PayloadAction<CustomPolygonFeature>) => {
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.properties.customLayerId);
+    const index = layer?.features.findIndex(({ id }) => id === action.payload.id) ?? -1;
+    if (!layer || index < 0) return;
+    pushUndoSnapshot(state);
+    layer.features[index] = cloneCustomValue(action.payload);
+    touchCustomLayer(layer);
+    state.isSaved = false;
+  },
+  removeCustomFeature: (state: ForecastState, action: PayloadAction<{ layerId: string; featureId: string }>) => {
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+    const index = layer?.features.findIndex(({ id }) => id === action.payload.featureId) ?? -1;
+    if (!layer || index < 0) return;
+    pushUndoSnapshot(state);
+    layer.features.splice(index, 1);
+    touchCustomLayer(layer);
+    state.isSaved = false;
+  },
+});

--- a/src/store/customFeatureReducers.ts
+++ b/src/store/customFeatureReducers.ts
@@ -7,8 +7,9 @@ import { cloneCustomValue, getCurrentCustomLayers, touchCustomLayer } from './cu
 export const createCustomFeatureReducers = (pushUndoSnapshot: (state: ForecastState) => void) => ({
   addCustomFeature: (state: ForecastState, action: PayloadAction<CustomPolygonFeature>) => {
     const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.properties.customLayerId);
-    if (!layer || layer.features.length >= CUSTOM_PRODUCT_LIMITS.featuresPerLayer
-      || !layer.categories.some(({ id }) => id === action.payload.properties.categoryId)) return;
+    if (!layer) return;
+    if (layer.features.length >= CUSTOM_PRODUCT_LIMITS.featuresPerLayer) return;
+    if (!layer.categories.some(({ id }) => id === action.payload.properties.categoryId)) return;
     pushUndoSnapshot(state);
     layer.features.push(cloneCustomValue(action.payload));
     touchCustomLayer(layer);

--- a/src/store/customLayerReducerUtils.ts
+++ b/src/store/customLayerReducerUtils.ts
@@ -13,3 +13,6 @@ export const touchCustomLayer = (layer: OneOffCustomLayer) => {
 export const normalizeCustomOrder = <T extends { order: number }>(items: T[]) => {
   items.forEach((item, order) => { item.order = order; });
 };
+
+export const canMoveCustomItem = (index: number, target: number, length: number): boolean =>
+  index >= 0 && target >= 0 && target < length;

--- a/src/store/customLayerReducerUtils.ts
+++ b/src/store/customLayerReducerUtils.ts
@@ -1,0 +1,15 @@
+import type { OneOffCustomLayer } from '../types/customProducts';
+import type { ForecastState } from './forecastSlice';
+
+export const cloneCustomValue = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+export const getCurrentCustomLayers = (state: ForecastState) =>
+  state.forecastCycle.days[state.forecastCycle.currentDay]?.customLayers;
+
+export const touchCustomLayer = (layer: OneOffCustomLayer) => {
+  layer.updatedAt = new Date().toISOString();
+};
+
+export const normalizeCustomOrder = <T extends { order: number }>(items: T[]) => {
+  items.forEach((item, order) => { item.order = order; });
+};

--- a/src/store/customLayerReducers.ts
+++ b/src/store/customLayerReducers.ts
@@ -4,7 +4,7 @@ import {
   type OneOffCustomLayer,
 } from '../types/customProducts';
 import type { ForecastState } from './forecastSlice';
-import { cloneCustomValue, getCurrentCustomLayers, normalizeCustomOrder, touchCustomLayer } from './customLayerReducerUtils';
+import { canMoveCustomItem, cloneCustomValue, getCurrentCustomLayers, normalizeCustomOrder, touchCustomLayer } from './customLayerReducerUtils';
 
 /** Builds the custom-layer reducer group while reusing forecast day history. */
 export const createCustomLayerReducers = (pushUndoSnapshot: (state: ForecastState) => void) => ({
@@ -58,9 +58,10 @@ export const createCustomLayerReducers = (pushUndoSnapshot: (state: ForecastStat
 
   moveCustomLayer: (state: ForecastState, action: PayloadAction<{ layerId: string; direction: -1 | 1 }>) => {
     const layers = getCurrentCustomLayers(state)?.layers;
+    if (!layers) return;
     const index = layers?.findIndex(({ id }) => id === action.payload.layerId) ?? -1;
     const target = index + action.payload.direction;
-    if (!layers || index < 0 || target < 0 || target >= layers.length) return;
+    if (!canMoveCustomItem(index, target, layers.length)) return;
     pushUndoSnapshot(state);
     [layers[index], layers[target]] = [layers[target], layers[index]];
     normalizeCustomOrder(layers);

--- a/src/store/customLayerReducers.ts
+++ b/src/store/customLayerReducers.ts
@@ -1,0 +1,70 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import {
+  CUSTOM_PRODUCT_LIMITS,
+  type OneOffCustomLayer,
+} from '../types/customProducts';
+import type { ForecastState } from './forecastSlice';
+import { cloneCustomValue, getCurrentCustomLayers, normalizeCustomOrder, touchCustomLayer } from './customLayerReducerUtils';
+
+/** Builds the custom-layer reducer group while reusing forecast day history. */
+export const createCustomLayerReducers = (pushUndoSnapshot: (state: ForecastState) => void) => ({
+  setCustomEditorMode: (state: ForecastState, action: PayloadAction<'severe' | 'custom'>) => {
+    state.customEditor.mode = action.payload;
+  },
+
+  selectCustomLayer: (state: ForecastState, action: PayloadAction<string | null>) => {
+    state.customEditor.activeLayerId = action.payload;
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload);
+    state.customEditor.activeCategoryId = layer?.categories[0]?.id ?? null;
+  },
+
+  selectCustomCategory: (state: ForecastState, action: PayloadAction<string | null>) => {
+    state.customEditor.activeCategoryId = action.payload;
+  },
+
+  addCustomLayer: (state: ForecastState, action: PayloadAction<OneOffCustomLayer>) => {
+    const day = state.forecastCycle.days[state.forecastCycle.currentDay];
+    if (!day || (day.customLayers?.layers.length ?? 0) >= CUSTOM_PRODUCT_LIMITS.layersPerCollection) return;
+    pushUndoSnapshot(state);
+    day.customLayers ??= { schemaVersion: action.payload.schemaVersion, layers: [] };
+    day.customLayers.layers.push(cloneCustomValue(action.payload));
+    normalizeCustomOrder(day.customLayers.layers);
+    state.customEditor.activeLayerId = action.payload.id;
+    state.customEditor.activeCategoryId = action.payload.categories[0]?.id ?? null;
+    state.isSaved = false;
+  },
+
+  updateCustomLayerLabel: (state: ForecastState, action: PayloadAction<{ layerId: string; label: string }>) => {
+    const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+    if (!layer || !action.payload.label.trim()) return;
+    pushUndoSnapshot(state);
+    layer.label = action.payload.label.trim().slice(0, 64);
+    touchCustomLayer(layer);
+    state.isSaved = false;
+  },
+
+  removeCustomLayer: (state: ForecastState, action: PayloadAction<string>) => {
+    const collection = getCurrentCustomLayers(state);
+    const index = collection?.layers.findIndex(({ id }) => id === action.payload) ?? -1;
+    if (!collection || index < 0) return;
+    pushUndoSnapshot(state);
+    collection.layers.splice(index, 1);
+    normalizeCustomOrder(collection.layers);
+    const next = collection.layers[Math.min(index, collection.layers.length - 1)];
+    state.customEditor.activeLayerId = next?.id ?? null;
+    state.customEditor.activeCategoryId = next?.categories[0]?.id ?? null;
+    state.isSaved = false;
+  },
+
+  moveCustomLayer: (state: ForecastState, action: PayloadAction<{ layerId: string; direction: -1 | 1 }>) => {
+    const layers = getCurrentCustomLayers(state)?.layers;
+    const index = layers?.findIndex(({ id }) => id === action.payload.layerId) ?? -1;
+    const target = index + action.payload.direction;
+    if (!layers || index < 0 || target < 0 || target >= layers.length) return;
+    pushUndoSnapshot(state);
+    [layers[index], layers[target]] = [layers[target], layers[index]];
+    normalizeCustomOrder(layers);
+    state.isSaved = false;
+  },
+
+});

--- a/src/store/forecastSlice.custom.test.ts
+++ b/src/store/forecastSlice.custom.test.ts
@@ -1,0 +1,61 @@
+import type { Polygon } from 'geojson';
+import type { OneOffCustomLayer, CustomPolygonFeature } from '../types/customProducts';
+import { CUSTOM_PRODUCTS_SCHEMA_VERSION } from '../types/customProducts';
+import { asCustomLayerId } from '../lib/customProducts';
+import reducer, {
+  addCustomFeature,
+  addCustomLayer,
+  moveCustomCategory,
+  removeCustomFeature,
+  redoLastEdit,
+  undoLastEdit,
+  updateCustomCategory,
+} from './forecastSlice';
+
+const layer = (): OneOffCustomLayer => ({
+  schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+  id: asCustomLayerId('layer-1'),
+  label: 'Winter impacts',
+  order: 0,
+  categories: [
+    { id: 'cat-1' as never, label: 'Minor', order: 0, style: { fillColor: '#22c55e', fillOpacity: .5, strokeColor: '#111827', strokeOpacity: 1, strokeWidth: 2, hatch: 'none' } },
+    { id: 'cat-2' as never, label: 'Major', order: 1, style: { fillColor: '#ef4444', fillOpacity: .7, strokeColor: '#111827', strokeOpacity: 1, strokeWidth: 2, hatch: 'crosshatch' } },
+  ],
+  features: [],
+  createdAt: '2026-07-17T12:00:00.000Z',
+  updatedAt: '2026-07-17T12:00:00.000Z',
+});
+
+const feature = (): CustomPolygonFeature => ({
+  type: 'Feature', id: 'custom-1',
+  geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] } as Polygon,
+  properties: { customLayerId: asCustomLayerId('layer-1'), categoryId: 'cat-1' as never, title: 'Minor' },
+});
+
+describe('custom layer forecast state', () => {
+  test('stores custom geometry outside severe outlook maps and supports undo/redo', () => {
+    let state = reducer(undefined, addCustomLayer(layer()));
+    state = reducer(state, addCustomFeature(feature()));
+    expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(1);
+    expect(state.forecastCycle.days[1]?.data.tornado?.size).toBe(0);
+
+    state = reducer(state, undoLastEdit());
+    expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(0);
+    state = reducer(state, redoLastEdit());
+    expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(1);
+
+    state = reducer(state, removeCustomFeature({ layerId: 'layer-1', featureId: 'custom-1' }));
+    expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(0);
+  });
+
+  test('reorders categories and propagates edited labels to existing polygon titles', () => {
+    let state = reducer(undefined, addCustomLayer(layer()));
+    state = reducer(state, addCustomFeature(feature()));
+    state = reducer(state, moveCustomCategory({ layerId: 'layer-1', categoryId: 'cat-2', direction: -1 }));
+    expect(state.forecastCycle.days[1]?.customLayers?.layers[0].categories.map(({ id, order }) => [id, order])).toEqual([['cat-2', 0], ['cat-1', 1]]);
+
+    const edited = { ...layer().categories[0], label: 'Elevated icing' };
+    state = reducer(state, updateCustomCategory({ layerId: 'layer-1', category: edited }));
+    expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features[0].properties.title).toBe('Elevated icing');
+  });
+});

--- a/src/store/forecastSlice.custom.test.ts
+++ b/src/store/forecastSlice.custom.test.ts
@@ -33,12 +33,16 @@ const feature = (): CustomPolygonFeature => ({
 });
 
 describe('custom layer forecast state', () => {
-  test('stores custom geometry outside severe outlook maps and supports undo/redo', () => {
+  test('stores custom geometry outside severe outlook maps', () => {
     let state = reducer(undefined, addCustomLayer(layer()));
     state = reducer(state, addCustomFeature(feature()));
     expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(1);
     expect(state.forecastCycle.days[1]?.data.tornado?.size).toBe(0);
+  });
 
+  test('includes custom geometry in day-scoped undo and redo history', () => {
+    let state = reducer(undefined, addCustomLayer(layer()));
+    state = reducer(state, addCustomFeature(feature()));
     state = reducer(state, undoLastEdit());
     expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(0);
     state = reducer(state, redoLastEdit());

--- a/src/store/forecastSlice.custom.test.ts
+++ b/src/store/forecastSlice.custom.test.ts
@@ -43,9 +43,14 @@ describe('custom layer forecast state', () => {
     expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(0);
     state = reducer(state, redoLastEdit());
     expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(1);
+  });
 
+  test('removes a custom feature without changing severe outlook maps', () => {
+    let state = reducer(undefined, addCustomLayer(layer()));
+    state = reducer(state, addCustomFeature(feature()));
     state = reducer(state, removeCustomFeature({ layerId: 'layer-1', featureId: 'custom-1' }));
     expect(state.forecastCycle.days[1]?.customLayers?.layers[0].features).toHaveLength(0);
+    expect(state.forecastCycle.days[1]?.data.tornado?.size).toBe(0);
   });
 
   test('reorders categories and propagates edited labels to existing polygon titles', () => {

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -4,11 +4,13 @@ import { OutlookData, OutlookType, DrawingState, ForecastCycle, DayType, Outlook
 import type { CycleMetadata, WorkflowMetadata, Package, CycleValidationResult, StandardGrouping } from '../types/workflow';
 import { normalizeForecastCycle } from '../utils/outlookMapCoercion';
 import type { Feature } from 'geojson';
-import type { CustomCategoryTemplate, CustomLayerCollection, CustomPolygonFeature, OneOffCustomLayer } from '../types/customProducts';
-import { CUSTOM_PRODUCT_LIMITS } from '../types/customProducts';
+import type { CustomLayerCollection } from '../types/customProducts';
 import { RootState } from './index'; // Need RootState for selectors
 import { cloneForecastCycle } from '../utils/fileUtils';
 import { countForecastMetrics } from '../utils/forecastMetrics';
+import { createCustomLayerReducers } from './customLayerReducers';
+import { createCustomCategoryReducers } from './customCategoryReducers';
+import { createCustomFeatureReducers } from './customFeatureReducers';
 import { getLocalCalendarDate } from '../utils/localDate';
 import { areTstmFeaturesEqual } from '../utils/tstmGeneration';
 import { validateCycleCompletion } from '../utils/completionValidation';
@@ -410,17 +412,6 @@ const cloneOutlookData = (data: OutlookData): OutlookData => {
   };
 };
 
-const getCurrentCustomLayers = (state: ForecastState): CustomLayerCollection | undefined =>
-  state.forecastCycle.days[state.forecastCycle.currentDay]?.customLayers;
-
-const touchCustomLayer = (layer: OneOffCustomLayer) => {
-  layer.updatedAt = new Date().toISOString();
-};
-
-const normalizeCustomOrder = <T extends { order: number }>(items: T[]) => {
-  items.forEach((item, order) => { item.order = order; });
-};
-
 const cloneCustomLayers = (customLayers?: CustomLayerCollection): CustomLayerCollection | undefined =>
   customLayers ? cloneJsonValue(customLayers) : undefined;
 
@@ -676,143 +667,9 @@ export const forecastSlice = createSlice({
       state.drawingState.isSignificant = false;
     },
 
-    setCustomEditorMode: (state, action: PayloadAction<'severe' | 'custom'>) => {
-      state.customEditor.mode = action.payload;
-    },
-
-    selectCustomLayer: (state, action: PayloadAction<string | null>) => {
-      state.customEditor.activeLayerId = action.payload;
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload);
-      state.customEditor.activeCategoryId = layer?.categories[0]?.id ?? null;
-    },
-
-    selectCustomCategory: (state, action: PayloadAction<string | null>) => {
-      state.customEditor.activeCategoryId = action.payload;
-    },
-
-    addCustomLayer: (state, action: PayloadAction<OneOffCustomLayer>) => {
-      const day = state.forecastCycle.days[state.forecastCycle.currentDay];
-      if (!day) return;
-      if ((day.customLayers?.layers.length ?? 0) >= CUSTOM_PRODUCT_LIMITS.layersPerCollection) return;
-      pushUndoSnapshot(state);
-      day.customLayers ??= { schemaVersion: action.payload.schemaVersion, layers: [] };
-      day.customLayers.layers.push(cloneJsonValue(action.payload));
-      normalizeCustomOrder(day.customLayers.layers);
-      state.customEditor.activeLayerId = action.payload.id;
-      state.customEditor.activeCategoryId = action.payload.categories[0]?.id ?? null;
-      state.isSaved = false;
-    },
-
-    updateCustomLayerLabel: (state, action: PayloadAction<{ layerId: string; label: string }>) => {
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
-      if (!layer || !action.payload.label.trim()) return;
-      pushUndoSnapshot(state);
-      layer.label = action.payload.label.trim().slice(0, 64);
-      touchCustomLayer(layer);
-      state.isSaved = false;
-    },
-
-    removeCustomLayer: (state, action: PayloadAction<string>) => {
-      const collection = getCurrentCustomLayers(state);
-      const index = collection?.layers.findIndex(({ id }) => id === action.payload) ?? -1;
-      if (!collection || index < 0) return;
-      pushUndoSnapshot(state);
-      collection.layers.splice(index, 1);
-      normalizeCustomOrder(collection.layers);
-      const next = collection.layers[Math.min(index, collection.layers.length - 1)];
-      state.customEditor.activeLayerId = next?.id ?? null;
-      state.customEditor.activeCategoryId = next?.categories[0]?.id ?? null;
-      state.isSaved = false;
-    },
-
-    moveCustomLayer: (state, action: PayloadAction<{ layerId: string; direction: -1 | 1 }>) => {
-      const layers = getCurrentCustomLayers(state)?.layers;
-      const index = layers?.findIndex(({ id }) => id === action.payload.layerId) ?? -1;
-      const target = index + action.payload.direction;
-      if (!layers || index < 0 || target < 0 || target >= layers.length) return;
-      pushUndoSnapshot(state);
-      [layers[index], layers[target]] = [layers[target], layers[index]];
-      normalizeCustomOrder(layers);
-      state.isSaved = false;
-    },
-
-    addCustomCategory: (state, action: PayloadAction<{ layerId: string; category: CustomCategoryTemplate }>) => {
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
-      if (!layer || layer.categories.length >= CUSTOM_PRODUCT_LIMITS.categoriesPerProduct) return;
-      pushUndoSnapshot(state);
-      layer.categories.push(cloneJsonValue(action.payload.category));
-      normalizeCustomOrder(layer.categories);
-      touchCustomLayer(layer);
-      state.customEditor.activeCategoryId = action.payload.category.id;
-      state.isSaved = false;
-    },
-
-    updateCustomCategory: (state, action: PayloadAction<{ layerId: string; category: CustomCategoryTemplate }>) => {
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
-      const index = layer?.categories.findIndex(({ id }) => id === action.payload.category.id) ?? -1;
-      if (!layer || index < 0) return;
-      pushUndoSnapshot(state);
-      layer.categories[index] = { ...cloneJsonValue(action.payload.category), order: layer.categories[index].order };
-      layer.features.forEach((feature) => {
-        if (feature.properties.categoryId === action.payload.category.id) feature.properties.title = action.payload.category.label;
-      });
-      touchCustomLayer(layer);
-      state.isSaved = false;
-    },
-
-    removeCustomCategory: (state, action: PayloadAction<{ layerId: string; categoryId: string }>) => {
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
-      const index = layer?.categories.findIndex(({ id }) => id === action.payload.categoryId) ?? -1;
-      if (!layer || index < 0 || layer.categories.length === 1) return;
-      pushUndoSnapshot(state);
-      layer.categories.splice(index, 1);
-      layer.features = layer.features.filter(({ properties }) => properties.categoryId !== action.payload.categoryId);
-      normalizeCustomOrder(layer.categories);
-      state.customEditor.activeCategoryId = layer.categories[Math.min(index, layer.categories.length - 1)]?.id ?? null;
-      touchCustomLayer(layer);
-      state.isSaved = false;
-    },
-
-    moveCustomCategory: (state, action: PayloadAction<{ layerId: string; categoryId: string; direction: -1 | 1 }>) => {
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
-      const index = layer?.categories.findIndex(({ id }) => id === action.payload.categoryId) ?? -1;
-      const target = index + action.payload.direction;
-      if (!layer || index < 0 || target < 0 || target >= layer.categories.length) return;
-      pushUndoSnapshot(state);
-      [layer.categories[index], layer.categories[target]] = [layer.categories[target], layer.categories[index]];
-      normalizeCustomOrder(layer.categories);
-      touchCustomLayer(layer);
-      state.isSaved = false;
-    },
-
-    addCustomFeature: (state, action: PayloadAction<CustomPolygonFeature>) => {
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.properties.customLayerId);
-      if (!layer || layer.features.length >= CUSTOM_PRODUCT_LIMITS.featuresPerLayer || !layer.categories.some(({ id }) => id === action.payload.properties.categoryId)) return;
-      pushUndoSnapshot(state);
-      layer.features.push(cloneJsonValue(action.payload));
-      touchCustomLayer(layer);
-      state.isSaved = false;
-    },
-
-    updateCustomFeature: (state, action: PayloadAction<CustomPolygonFeature>) => {
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.properties.customLayerId);
-      const index = layer?.features.findIndex(({ id }) => id === action.payload.id) ?? -1;
-      if (!layer || index < 0) return;
-      pushUndoSnapshot(state);
-      layer.features[index] = cloneJsonValue(action.payload);
-      touchCustomLayer(layer);
-      state.isSaved = false;
-    },
-
-    removeCustomFeature: (state, action: PayloadAction<{ layerId: string; featureId: string }>) => {
-      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
-      const index = layer?.features.findIndex(({ id }) => id === action.payload.featureId) ?? -1;
-      if (!layer || index < 0) return;
-      pushUndoSnapshot(state);
-      layer.features.splice(index, 1);
-      touchCustomLayer(layer);
-      state.isSaved = false;
-    },
+    ...createCustomLayerReducers(pushUndoSnapshot),
+    ...createCustomCategoryReducers(pushUndoSnapshot),
+    ...createCustomFeatureReducers(pushUndoSnapshot),
 
     addFeature: (state, action: PayloadAction<{ feature: Feature }>) => {
       const feature = action.payload.feature;

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -4,6 +4,8 @@ import { OutlookData, OutlookType, DrawingState, ForecastCycle, DayType, Outlook
 import type { CycleMetadata, WorkflowMetadata, Package, CycleValidationResult, StandardGrouping } from '../types/workflow';
 import { normalizeForecastCycle } from '../utils/outlookMapCoercion';
 import type { Feature } from 'geojson';
+import type { CustomCategoryTemplate, CustomLayerCollection, CustomPolygonFeature, OneOffCustomLayer } from '../types/customProducts';
+import { CUSTOM_PRODUCT_LIMITS } from '../types/customProducts';
 import { RootState } from './index'; // Need RootState for selectors
 import { cloneForecastCycle } from '../utils/fileUtils';
 import { countForecastMetrics } from '../utils/forecastMetrics';
@@ -33,6 +35,11 @@ export interface SavedCycle {
 export interface ForecastState {
   forecastCycle: ForecastCycle;
   drawingState: DrawingState;
+  customEditor: {
+    mode: 'severe' | 'custom';
+    activeLayerId: string | null;
+    activeCategoryId: string | null;
+  };
   currentMapView: {
     center: [number, number]; // [latitude, longitude]
     zoom: number;
@@ -62,6 +69,7 @@ interface ForecastDaySnapshot {
   day: DayType;
   data: OutlookData;
   lowProbabilityOutlooks: OutlookType[];
+  customLayers?: CustomLayerCollection;
 }
 
 interface ForecastHistoryEntry {
@@ -253,6 +261,11 @@ const initialState: ForecastState = {
     activeProbability: '2%',
     isSignificant: false
   },
+  customEditor: {
+    mode: 'severe',
+    activeLayerId: null,
+    activeCategoryId: null,
+  },
   currentMapView: {
     center: [39.8283, -98.5795],
     zoom: 4
@@ -397,6 +410,20 @@ const cloneOutlookData = (data: OutlookData): OutlookData => {
   };
 };
 
+const getCurrentCustomLayers = (state: ForecastState): CustomLayerCollection | undefined =>
+  state.forecastCycle.days[state.forecastCycle.currentDay]?.customLayers;
+
+const touchCustomLayer = (layer: OneOffCustomLayer) => {
+  layer.updatedAt = new Date().toISOString();
+};
+
+const normalizeCustomOrder = <T extends { order: number }>(items: T[]) => {
+  items.forEach((item, order) => { item.order = order; });
+};
+
+const cloneCustomLayers = (customLayers?: CustomLayerCollection): CustomLayerCollection | undefined =>
+  customLayers ? cloneJsonValue(customLayers) : undefined;
+
 /** Captures the current day's drawable outlook data and low-probability metadata for history. */
 const getCurrentDaySnapshot = (state: ForecastState): ForecastDaySnapshot | null => {
   const currentDay = state.forecastCycle.currentDay;
@@ -407,6 +434,7 @@ const getCurrentDaySnapshot = (state: ForecastState): ForecastDaySnapshot | null
     day: currentDay,
     data: cloneOutlookData(dayData.data),
     lowProbabilityOutlooks: [...(dayData.metadata.lowProbabilityOutlooks || [])],
+    customLayers: cloneCustomLayers(dayData.customLayers),
   };
 };
 
@@ -421,6 +449,7 @@ const applyDaySnapshot = (state: ForecastState, snapshot: ForecastDaySnapshot) =
   if (!targetDay) return;
 
   targetDay.data = cloneOutlookData(snapshot.data);
+  targetDay.customLayers = cloneCustomLayers(snapshot.customLayers);
   targetDay.metadata.lowProbabilityOutlooks = [...snapshot.lowProbabilityOutlooks];
   targetDay.metadata.lastModified = new Date().toISOString();
 };
@@ -645,6 +674,144 @@ export const forecastSlice = createSlice({
 
     toggleSignificant: (state) => {
       state.drawingState.isSignificant = false;
+    },
+
+    setCustomEditorMode: (state, action: PayloadAction<'severe' | 'custom'>) => {
+      state.customEditor.mode = action.payload;
+    },
+
+    selectCustomLayer: (state, action: PayloadAction<string | null>) => {
+      state.customEditor.activeLayerId = action.payload;
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload);
+      state.customEditor.activeCategoryId = layer?.categories[0]?.id ?? null;
+    },
+
+    selectCustomCategory: (state, action: PayloadAction<string | null>) => {
+      state.customEditor.activeCategoryId = action.payload;
+    },
+
+    addCustomLayer: (state, action: PayloadAction<OneOffCustomLayer>) => {
+      const day = state.forecastCycle.days[state.forecastCycle.currentDay];
+      if (!day) return;
+      if ((day.customLayers?.layers.length ?? 0) >= CUSTOM_PRODUCT_LIMITS.layersPerCollection) return;
+      pushUndoSnapshot(state);
+      day.customLayers ??= { schemaVersion: action.payload.schemaVersion, layers: [] };
+      day.customLayers.layers.push(cloneJsonValue(action.payload));
+      normalizeCustomOrder(day.customLayers.layers);
+      state.customEditor.activeLayerId = action.payload.id;
+      state.customEditor.activeCategoryId = action.payload.categories[0]?.id ?? null;
+      state.isSaved = false;
+    },
+
+    updateCustomLayerLabel: (state, action: PayloadAction<{ layerId: string; label: string }>) => {
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+      if (!layer || !action.payload.label.trim()) return;
+      pushUndoSnapshot(state);
+      layer.label = action.payload.label.trim().slice(0, 64);
+      touchCustomLayer(layer);
+      state.isSaved = false;
+    },
+
+    removeCustomLayer: (state, action: PayloadAction<string>) => {
+      const collection = getCurrentCustomLayers(state);
+      const index = collection?.layers.findIndex(({ id }) => id === action.payload) ?? -1;
+      if (!collection || index < 0) return;
+      pushUndoSnapshot(state);
+      collection.layers.splice(index, 1);
+      normalizeCustomOrder(collection.layers);
+      const next = collection.layers[Math.min(index, collection.layers.length - 1)];
+      state.customEditor.activeLayerId = next?.id ?? null;
+      state.customEditor.activeCategoryId = next?.categories[0]?.id ?? null;
+      state.isSaved = false;
+    },
+
+    moveCustomLayer: (state, action: PayloadAction<{ layerId: string; direction: -1 | 1 }>) => {
+      const layers = getCurrentCustomLayers(state)?.layers;
+      const index = layers?.findIndex(({ id }) => id === action.payload.layerId) ?? -1;
+      const target = index + action.payload.direction;
+      if (!layers || index < 0 || target < 0 || target >= layers.length) return;
+      pushUndoSnapshot(state);
+      [layers[index], layers[target]] = [layers[target], layers[index]];
+      normalizeCustomOrder(layers);
+      state.isSaved = false;
+    },
+
+    addCustomCategory: (state, action: PayloadAction<{ layerId: string; category: CustomCategoryTemplate }>) => {
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+      if (!layer || layer.categories.length >= CUSTOM_PRODUCT_LIMITS.categoriesPerProduct) return;
+      pushUndoSnapshot(state);
+      layer.categories.push(cloneJsonValue(action.payload.category));
+      normalizeCustomOrder(layer.categories);
+      touchCustomLayer(layer);
+      state.customEditor.activeCategoryId = action.payload.category.id;
+      state.isSaved = false;
+    },
+
+    updateCustomCategory: (state, action: PayloadAction<{ layerId: string; category: CustomCategoryTemplate }>) => {
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+      const index = layer?.categories.findIndex(({ id }) => id === action.payload.category.id) ?? -1;
+      if (!layer || index < 0) return;
+      pushUndoSnapshot(state);
+      layer.categories[index] = { ...cloneJsonValue(action.payload.category), order: layer.categories[index].order };
+      layer.features.forEach((feature) => {
+        if (feature.properties.categoryId === action.payload.category.id) feature.properties.title = action.payload.category.label;
+      });
+      touchCustomLayer(layer);
+      state.isSaved = false;
+    },
+
+    removeCustomCategory: (state, action: PayloadAction<{ layerId: string; categoryId: string }>) => {
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+      const index = layer?.categories.findIndex(({ id }) => id === action.payload.categoryId) ?? -1;
+      if (!layer || index < 0 || layer.categories.length === 1) return;
+      pushUndoSnapshot(state);
+      layer.categories.splice(index, 1);
+      layer.features = layer.features.filter(({ properties }) => properties.categoryId !== action.payload.categoryId);
+      normalizeCustomOrder(layer.categories);
+      state.customEditor.activeCategoryId = layer.categories[Math.min(index, layer.categories.length - 1)]?.id ?? null;
+      touchCustomLayer(layer);
+      state.isSaved = false;
+    },
+
+    moveCustomCategory: (state, action: PayloadAction<{ layerId: string; categoryId: string; direction: -1 | 1 }>) => {
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+      const index = layer?.categories.findIndex(({ id }) => id === action.payload.categoryId) ?? -1;
+      const target = index + action.payload.direction;
+      if (!layer || index < 0 || target < 0 || target >= layer.categories.length) return;
+      pushUndoSnapshot(state);
+      [layer.categories[index], layer.categories[target]] = [layer.categories[target], layer.categories[index]];
+      normalizeCustomOrder(layer.categories);
+      touchCustomLayer(layer);
+      state.isSaved = false;
+    },
+
+    addCustomFeature: (state, action: PayloadAction<CustomPolygonFeature>) => {
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.properties.customLayerId);
+      if (!layer || layer.features.length >= CUSTOM_PRODUCT_LIMITS.featuresPerLayer || !layer.categories.some(({ id }) => id === action.payload.properties.categoryId)) return;
+      pushUndoSnapshot(state);
+      layer.features.push(cloneJsonValue(action.payload));
+      touchCustomLayer(layer);
+      state.isSaved = false;
+    },
+
+    updateCustomFeature: (state, action: PayloadAction<CustomPolygonFeature>) => {
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.properties.customLayerId);
+      const index = layer?.features.findIndex(({ id }) => id === action.payload.id) ?? -1;
+      if (!layer || index < 0) return;
+      pushUndoSnapshot(state);
+      layer.features[index] = cloneJsonValue(action.payload);
+      touchCustomLayer(layer);
+      state.isSaved = false;
+    },
+
+    removeCustomFeature: (state, action: PayloadAction<{ layerId: string; featureId: string }>) => {
+      const layer = getCurrentCustomLayers(state)?.layers.find(({ id }) => id === action.payload.layerId);
+      const index = layer?.features.findIndex(({ id }) => id === action.payload.featureId) ?? -1;
+      if (!layer || index < 0) return;
+      pushUndoSnapshot(state);
+      layer.features.splice(index, 1);
+      touchCustomLayer(layer);
+      state.isSaved = false;
     },
 
     addFeature: (state, action: PayloadAction<{ feature: Feature }>) => {
@@ -1399,6 +1566,20 @@ export const {
   setActiveOutlookType,
   setActiveProbability,
   toggleSignificant,
+  setCustomEditorMode,
+  selectCustomLayer,
+  selectCustomCategory,
+  addCustomLayer,
+  updateCustomLayerLabel,
+  removeCustomLayer,
+  moveCustomLayer,
+  addCustomCategory,
+  updateCustomCategory,
+  removeCustomCategory,
+  moveCustomCategory,
+  addCustomFeature,
+  updateCustomFeature,
+  removeCustomFeature,
   addFeature,
   updateFeature,
   removeFeature,
@@ -1457,6 +1638,10 @@ export const selectDiscussionDraftForScope = (state: RootState, scopeId: string)
 export const selectCurrentOutlooks = (state: RootState) => {
   const cycle = state.forecast.forecastCycle;
   return cycle.days[cycle.currentDay]?.data || createEmptyOutlook(cycle.currentDay).data;
+};
+export const selectCurrentCustomLayers = (state: RootState): CustomLayerCollection => {
+  const cycle = state.forecast.forecastCycle;
+  return cycle?.days?.[cycle.currentDay]?.customLayers || { schemaVersion: '1.0.0', layers: [] };
 };
 /** Selects the outlook maps for a specific day, falling back to an empty day shape when absent. */
 export const selectOutlooksForDay = (state: RootState, day: DayType) => {

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1639,9 +1639,13 @@ export const selectCurrentOutlooks = (state: RootState) => {
   const cycle = state.forecast.forecastCycle;
   return cycle.days[cycle.currentDay]?.data || createEmptyOutlook(cycle.currentDay).data;
 };
+const EMPTY_CUSTOM_LAYERS: CustomLayerCollection = {
+  schemaVersion: '1.0.0',
+  layers: [],
+};
 export const selectCurrentCustomLayers = (state: RootState): CustomLayerCollection => {
   const cycle = state.forecast.forecastCycle;
-  return cycle?.days?.[cycle.currentDay]?.customLayers || { schemaVersion: '1.0.0', layers: [] };
+  return cycle?.days?.[cycle.currentDay]?.customLayers || EMPTY_CUSTOM_LAYERS;
 };
 /** Selects the outlook maps for a specific day, falling back to an empty day shape when absent. */
 export const selectOutlooksForDay = (state: RootState, day: DayType) => {

--- a/src/types/outlooks.ts
+++ b/src/types/outlooks.ts
@@ -181,6 +181,8 @@ export interface DiscussionGrouping {
 export interface OutlookDay {
   day: DayType;
   data: OutlookData; // The actual polygon data
+  /** Self-contained custom layers kept outside severe-weather outlook maps. */
+  customLayers?: import('./customProducts').CustomLayerCollection;
   metadata: {
     issueDate: string;
     validDate: string;
@@ -224,6 +226,7 @@ export interface GFCForecastSaveData {
     days: Partial<Record<DayType, {
       day: DayType;
       data: SerializedOutlookData;
+      customLayers?: import('./customProducts').CustomLayerCollection;
       metadata: {
         issueDate: string;
         validDate: string;

--- a/src/utils/customLayerPersistence.test.ts
+++ b/src/utils/customLayerPersistence.test.ts
@@ -1,0 +1,17 @@
+import { addCustomLayer } from '../store/forecastSlice';
+import forecastReducer from '../store/forecastSlice';
+import { CUSTOM_PRODUCTS_SCHEMA_VERSION } from '../types/customProducts';
+import { asCustomLayerId } from '../lib/customProducts';
+import { deserializeForecast, serializeForecast } from './fileUtils';
+
+test('signed-out JSON persistence round-trips self-contained custom layer appearance', () => {
+  const category = { id: 'cat-1' as never, label: 'Heavy snow', order: 0, style: { fillColor: '#3b82f6', fillOpacity: .45, strokeColor: '#ffffff', strokeOpacity: .9, strokeWidth: 3, hatch: 'diagonal' as const } };
+  const state = forecastReducer(undefined, addCustomLayer({
+    schemaVersion: CUSTOM_PRODUCTS_SCHEMA_VERSION,
+    id: asCustomLayerId('snow'), label: 'Snow bands', order: 0, categories: [category], features: [],
+    createdAt: '2026-07-17T12:00:00.000Z', updatedAt: '2026-07-17T12:00:00.000Z',
+  }));
+  const saved = serializeForecast(state.forecastCycle, { center: [40, -97], zoom: 5 });
+  const restored = deserializeForecast(JSON.parse(JSON.stringify(saved)));
+  expect(restored.days[1]?.customLayers?.layers[0].categories[0]).toEqual(category);
+});

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -67,6 +67,7 @@ type SerializedDay = {
     lastModified?: string;
   };
   data: SerializedOutlookData;
+  customLayers?: OutlookDay['customLayers'];
   discussion?: DiscussionData;
 };
 
@@ -83,6 +84,7 @@ const serializeOutlookDay = (outlookDay: OutlookDay): SerializedDay => {
     day: outlookDay.day,
     metadata: { ...outlookDay.metadata, lowProbabilityOutlooks: outlookDay.metadata.lowProbabilityOutlooks || [] },
     data: serializedData,
+    ...(outlookDay.customLayers ? { customLayers: JSON.parse(JSON.stringify(outlookDay.customLayers)) as OutlookDay['customLayers'] } : {}),
     discussion: outlookDay.discussion,
   };
 };

--- a/src/utils/forecastCycleDeserialize.ts
+++ b/src/utils/forecastCycleDeserialize.ts
@@ -9,6 +9,7 @@ import type {
   OutlookType,
 } from '../types/outlooks';
 import { coerceOutlookProbabilityMap } from './outlookMapCoercion';
+import { isCustomLayerCollection } from '../lib/customProducts';
 
 type SerializedDay = {
   day: DayType;
@@ -21,6 +22,7 @@ type SerializedDay = {
     lastModified?: string;
   };
   data: SerializedOutlookData;
+  customLayers?: OutlookDay['customLayers'];
   discussion?: DiscussionData;
 };
 
@@ -67,6 +69,9 @@ const deserializeSavedOutlookDay = (savedDay: SerializedDay): OutlookDay => {
       lastModified: meta.lastModified ?? new Date().toISOString(),
     },
     data: outlookData,
+    ...(isCustomLayerCollection(savedDay.customLayers)
+      ? { customLayers: JSON.parse(JSON.stringify(savedDay.customLayers)) as OutlookDay['customLayers'] }
+      : {}),
     discussion: (savedDay as Partial<{ discussion?: DiscussionData }>).discussion,
   };
 };


### PR DESCRIPTION
## Summary

- add the local-only Severe/Custom Draw-tab switch without changing hosted beta UI
- add one-off custom layer/category editing, exact styles and hatching, and map draw/modify/delete support
- persist custom layers independently from severe outlook data with undo/redo, validated save/load, legend, popup, and export support
- cover desktop, portrait-phone, and constrained-landscape flows with Playwright

## Exposure

`customProducts` remains enabled only for the `local` build target. Beta, staging, and production render the existing Severe controls only; no custom toggle, unavailable message, route, or custom-product side effect is exposed.

## Stack

- Depends on #742 (CUS-01 schemas)
- This PR is the CUS-02 implementation
- Merge order: #742, then this PR

## Verification

- `pnpm test` — 162 suites / 828 tests passed
- focused post-rebase Jest — 6 suites / 50 tests passed
- `pnpm run build` — passed with Sentry upload disabled
- `pnpm exec playwright test e2e/custom-layers.spec.ts` — 3/3 passed
- beta-target browser inspection — toggle/custom text absent; existing severe Wind control present
- `git diff --check`

## Changelog

- Add local-only one-off custom forecast layers with exact styles, map editing, persistence, undo/redo, legend, and export support while preserving the hosted Severe-only UI.

Closes #468
