### PR TITLE
[codex] Resolve current Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
       "@tootallnate/once": "3.0.1",
       "@ungap/structured-clone": "1.3.1",
       "ws": "^8.21.0",
-      "esbuild": "^0.28.1"
+      "esbuild": "^0.28.1",
+      "gaxios>uuid": "11.1.1",
+      "websocket-driver": "0.7.5"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,8 @@ overrides:
   '@ungap/structured-clone': 1.3.1
   ws: ^8.21.0
   esbuild: ^0.28.1
+  gaxios>uuid: 11.1.1
+  websocket-driver: 0.7.5
 
 importers:
 
@@ -6501,13 +6503,12 @@ packages:
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -6594,8 +6595,8 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -11702,7 +11703,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fb-watchman@2.0.2:
     dependencies:
@@ -11958,7 +11959,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14505,9 +14506,9 @@ snapshots:
     dependencies:
       base64-arraybuffer: 1.0.2
 
-  uuid@14.0.1: {}
+  uuid@11.1.1: {}
 
-  uuid@9.0.1: {}
+  uuid@14.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -14558,7 +14559,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
## Summary

Resolves the three open Dependabot alerts detected in `pnpm-lock.yaml` without upgrading Firebase or the Firebase CLI.

## Root cause and fix

`firebase` resolved `faye-websocket` to the vulnerable `websocket-driver@0.7.4`, which is affected by two advisories. `firebase-tools` resolved `gaxios` to the vulnerable `uuid@9.0.1`.

This PR adds narrow pnpm overrides:

- `websocket-driver` is constrained to `0.7.5`, which patches both runtime advisories.
- `gaxios > uuid` is constrained to `11.1.1`, which patches the development-only UUID advisory while retaining the application's direct `uuid@14.0.1`.

## Verification

- `pnpm why websocket-driver` resolves `0.7.5` through Firebase.
- `pnpm why uuid` resolves `11.1.1` only through gaxios and retains direct `14.0.1`.
- `pnpm audit --prod --json` reports zero vulnerabilities.
- `pnpm run build` passed.
- `pnpm test -- --runInBand` passed: 126 suites, 488 tests.

The local full development audit still reports the separate OpenTelemetry advisory through `firebase-tools`; it is not an open Dependabot alert and is intentionally outside this narrowly scoped PR.
