### PR TITLE
refine(custom-products): align saved products dialog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         if: github.base_ref == 'main' && github.head_ref == 'beta'
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: 9
+          version: 10.30.3
 
       - name: Install dependencies for promotion exposure report
         if: github.base_ref == 'main' && github.head_ref == 'beta'
@@ -121,7 +121,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: 9
+          version: 10.30.3
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -157,7 +157,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: 9
+          version: 10.30.3
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -191,7 +191,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: 9
+          version: 10.30.3
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #751
+
+- Refine the local-only Saved products experience with a responsive library layout, a respectful free-user Premium path, and a simple local-preview tester checklist.
+
 ### PR #746
 
 - Integrate local custom layers with forecast workflows, exports, imports, map legends, and workflow disclosures.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Use this page as the starting point for repo docs. Operational docs are grouped 
 - [Auto-TSTM operations](./operations/auto-tstm-operations.md) - cached Auto-TSTM API behavior, cache health, and operational limits.
 - [Auto-TSTM beta test plans](./operations/auto-tstm-beta-test-plans.md) - beta smoke plans for Auto-TSTM.
 - [Auto-TSTM beta tester post](./operations/auto-tstm-beta-tester-post.md) - concise tester instructions.
+- [Custom products beta tester checklist](./operations/custom-products-beta-test-plan.md) - a short Forecast-editor test for custom layers and saved products.
 
 ## Product
 

--- a/docs/operations/custom-products-beta-test-plan.md
+++ b/docs/operations/custom-products-beta-test-plan.md
@@ -1,6 +1,12 @@
 # Custom Products: local preview tester checklist
 
-This checklist is for the **local preview only**. Custom Products are intentionally unavailable on the hosted beta site until the feature is approved. Open the local preview provided to you and continue only when **Custom** appears in the Forecast page's **Draw** tab.
+This checklist is for the **local preview only**. Custom Products are intentionally unavailable on the hosted beta site until the feature is approved.
+
+## Open the preview
+
+1. Follow the one-time [local setup instructions](../../README.md#getting-started), then run `pnpm run dev` from the GFC folder.
+2. Open `http://localhost:3000/forecast?localTestAccount=premium` in your browser.
+3. Continue only when **Custom** appears in the Forecast page's **Draw** tab.
 
 ## Before you start
 

--- a/docs/operations/custom-products-beta-test-plan.md
+++ b/docs/operations/custom-products-beta-test-plan.md
@@ -1,0 +1,39 @@
+# Custom Products: beta tester checklist
+
+Use this only when **Custom** is available in the Forecast page's **Draw** tab.
+
+## Before you start
+
+- Open the Forecast page on a desktop or phone.
+- Start with a new or disposable forecast. This test creates and edits layers.
+
+## Quick test
+
+1. Open **Draw** and switch from **Severe** to **Custom**.
+2. Click **+** to add a custom layer.
+3. Rename the layer and its category to anything you like.
+4. Pick a fill color, adjust opacity, and choose a hatch if you want one.
+5. Use the map's **Draw** tool to make a polygon. Double-click to finish it.
+6. Switch back to **Severe**, then back to **Custom**. Your layer and polygon should still be there.
+
+## Saved products
+
+1. In Custom mode, select **Saved products**.
+2. Choose **New product**.
+3. Give it a name, add or edit a category, then save it.
+4. Select **Use in Forecast** on the saved product.
+5. Confirm that a new custom layer appears with the product's name and category settings.
+
+## One extra check
+
+Try the same steps on your phone, if possible. The map should stay usable and the controls should not overlap or disappear.
+
+## What to report
+
+Please include:
+
+- What you clicked or drew.
+- What you expected to happen.
+- What happened instead.
+- A screenshot or screen recording, if you can.
+

--- a/docs/operations/custom-products-beta-test-plan.md
+++ b/docs/operations/custom-products-beta-test-plan.md
@@ -1,6 +1,6 @@
-# Custom Products: beta tester checklist
+# Custom Products: local preview tester checklist
 
-Use this only when **Custom** is available in the Forecast page's **Draw** tab.
+This checklist is for the **local preview only**. Custom Products are intentionally unavailable on the hosted beta site until the feature is approved. Open the local preview provided to you and continue only when **Custom** appears in the Forecast page's **Draw** tab.
 
 ## Before you start
 
@@ -36,4 +36,3 @@ Please include:
 - What you expected to happen.
 - What happened instead.
 - A screenshot or screen recording, if you can.
-

--- a/e2e/custom-products.spec.ts
+++ b/e2e/custom-products.spec.ts
@@ -197,6 +197,20 @@ test.describe('Local reusable custom products', () => {
     await page.getByRole('button', { name: 'Delete' }).click();
     await expect(page.getByRole('heading', { name: 'Expired fire product' })).toHaveCount(0);
   });
+
+  test('shows free users a respectful Premium path from the saved-products panel', async ({ page }) => {
+    await prepareAppState(page);
+    await page.goto('/forecast?localTestAccount=free');
+    await page.getByRole('radio', { name: 'Custom' }).click();
+    await page.getByRole('button', { name: 'Saved products' }).click();
+
+    const savedProductsDialog = page.getByRole('dialog', { name: 'Saved products' });
+    await expect(savedProductsDialog.getByText('Premium feature', { exact: true })).toBeVisible();
+    await expect(savedProductsDialog.getByRole('heading', { name: 'Save a product, use it whenever.' })).toBeVisible();
+    await expect(savedProductsDialog.getByText('Build custom layers now, then save reusable category sets with Premium.')).toBeVisible();
+    await expect(savedProductsDialog.getByRole('link', { name: 'View Premium' })).toHaveAttribute('href', '/account');
+    await expect(savedProductsDialog.getByRole('button', { name: 'New product' })).not.toBeVisible();
+  });
 });
 
 test.describe('Hosted custom-product absence', () => {

--- a/e2e/custom-products.spec.ts
+++ b/e2e/custom-products.spec.ts
@@ -41,6 +41,8 @@ test.describe('Local reusable custom products', () => {
     await page.getByRole('radio', { name: 'Custom' }).click();
     await page.getByRole('button', { name: 'Saved products' }).click();
     const savedProductsDialog = page.getByRole('dialog', { name: 'Saved products' });
+    await expect(savedProductsDialog.getByText('Custom library', { exact: true })).toBeVisible();
+    await expect(savedProductsDialog.getByText('Apply a reusable category set to this forecast without leaving your workspace.')).toBeVisible();
     await savedProductsDialog.getByRole('button', { name: 'Use in Forecast' }).click();
     await expect(savedProductsDialog).not.toBeVisible();
     await expect(page).toHaveURL(/\/forecast(?:\?localTestAccount=premium)?$/);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "graphical-forecast-creator",
   "version": "1.7.0-beta.74",
   "private": true,
+  "packageManager": "pnpm@10.30.3",
   "engines": {
     "node": ">=22.12.0 <23 || >=24 <26"
   },

--- a/src/components/IntegratedToolbar/CustomProductsDialog.css
+++ b/src/components/IntegratedToolbar/CustomProductsDialog.css
@@ -1,0 +1,25 @@
+/* The Saved products dialog is shared by desktop and phone forecast workspaces. */
+.custom-products-dialog-content .custom-products-page--dialog .custom-products-hero__actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  column-gap: 18px;
+}
+
+@media (max-width: 768px) {
+  .custom-products-dialog-content .custom-products-page--dialog .custom-products-hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+    row-gap: 16px;
+  }
+
+  .custom-products-dialog-content .custom-products-page--dialog .custom-products-hero__actions span {
+    align-self: flex-start;
+  }
+
+  .custom-products-dialog-content .custom-products-page--dialog .custom-products-hero__actions button {
+    width: 100%;
+    min-height: 42px;
+  }
+}

--- a/src/components/IntegratedToolbar/CustomProductsDialog.tsx
+++ b/src/components/IntegratedToolbar/CustomProductsDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { LibraryBig } from 'lucide-react';
+import { ArrowUpRight, Check, LibraryBig, Sparkles } from 'lucide-react';
 import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { Button } from '../ui/button';
 import {
   Dialog,
@@ -16,12 +17,37 @@ import type { RootState } from '../../store';
 import type { OneOffCustomLayer } from '../../types/customProducts';
 import { CUSTOM_PRODUCT_LIMITS } from '../../types/customProducts';
 import CustomProductsWorkspace from '../../pages/gated/CustomProductsWorkspace';
+import { useAuth } from '../../auth/AuthProvider';
+import { useEntitlement } from '../../billing/EntitlementProvider';
+
+/** A light-touch upgrade prompt shown only to signed-in free users in the forecast workspace. */
+const CustomProductsUpgradePrompt = ({ onViewPremium }: { onViewPremium(): void }) => (
+  <section className="custom-products-upgrade-prompt" aria-labelledby="custom-products-upgrade-title">
+    <span className="custom-products-upgrade-prompt__icon" aria-hidden="true"><Sparkles /></span>
+    <div className="custom-products-upgrade-prompt__copy">
+      <span>Premium feature</span>
+      <h3 id="custom-products-upgrade-title">Save a product, use it whenever.</h3>
+      <p>Premium lets you keep a category set ready for the next forecast, without rebuilding it each time.</p>
+    </div>
+    <ul>
+      <li><Check aria-hidden="true" /> Save reusable category sets</li>
+      <li><Check aria-hidden="true" /> Add them to a forecast in one click</li>
+    </ul>
+    <Button asChild className="custom-products-upgrade-prompt__action">
+      <Link to="/account" onClick={onViewPremium}>View Premium <ArrowUpRight aria-hidden="true" /></Link>
+    </Button>
+    <p className="custom-products-upgrade-prompt__note">You can keep drawing custom layers without Premium.</p>
+  </section>
+);
 
 /** Keeps reusable custom products in the forecast workspace rather than navigating away from in-progress work. */
 const CustomProductsDialog = () => {
   const dispatch = useDispatch();
+  const { user } = useAuth();
+  const { premiumActive } = useEntitlement();
   const [open, setOpen] = useState(false);
   const layerCount = useSelector((state: RootState) => state.forecast.forecastCycle.days[state.forecast.forecastCycle.currentDay]?.customLayers?.layers.length ?? 0);
+  const showUpgradePrompt = Boolean(user && !premiumActive);
 
   if (!isFeatureExposed('customProducts')) return null;
 
@@ -40,7 +66,7 @@ const CustomProductsDialog = () => {
           <LibraryBig className="h-4 w-4" /> Saved products
         </Button>
       </DialogTrigger>
-      <DialogContent className="custom-products-dialog-content">
+      <DialogContent className={`custom-products-dialog-content${showUpgradePrompt ? ' custom-products-dialog-content--upgrade' : ''}`}>
         <DialogHeader className="custom-products-dialog-header">
           <div className="custom-products-dialog-header__identity">
             <span className="custom-products-dialog-header__icon" aria-hidden="true"><LibraryBig /></span>
@@ -49,9 +75,13 @@ const CustomProductsDialog = () => {
               <DialogTitle>Saved products</DialogTitle>
             </div>
           </div>
-          <DialogDescription>Apply a reusable category set to this forecast without leaving your workspace.</DialogDescription>
+          <DialogDescription>{showUpgradePrompt
+            ? 'Build custom layers now, then save reusable category sets with Premium.'
+            : 'Apply a reusable category set to this forecast without leaving your workspace.'}</DialogDescription>
         </DialogHeader>
-        <CustomProductsWorkspace embedded onProductUse={useProduct} />
+        {showUpgradePrompt
+          ? <CustomProductsUpgradePrompt onViewPremium={() => setOpen(false)} />
+          : <CustomProductsWorkspace embedded onProductUse={useProduct} />}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/IntegratedToolbar/CustomProductsDialog.tsx
+++ b/src/components/IntegratedToolbar/CustomProductsDialog.tsx
@@ -19,6 +19,7 @@ import { CUSTOM_PRODUCT_LIMITS } from '../../types/customProducts';
 import CustomProductsWorkspace from '../../pages/gated/CustomProductsWorkspace';
 import { useAuth } from '../../auth/AuthProvider';
 import { useEntitlement } from '../../billing/EntitlementProvider';
+import './CustomProductsDialog.css';
 
 /** A light-touch upgrade prompt shown only to signed-in free users in the forecast workspace. */
 const CustomProductsUpgradePrompt = ({ onViewPremium }: { onViewPremium(): void }) => (

--- a/src/components/IntegratedToolbar/CustomProductsDialog.tsx
+++ b/src/components/IntegratedToolbar/CustomProductsDialog.tsx
@@ -42,8 +42,14 @@ const CustomProductsDialog = () => {
       </DialogTrigger>
       <DialogContent className="custom-products-dialog-content">
         <DialogHeader className="custom-products-dialog-header">
-          <DialogTitle>Saved products</DialogTitle>
-          <DialogDescription>Apply a reusable category set without leaving this forecast.</DialogDescription>
+          <div className="custom-products-dialog-header__identity">
+            <span className="custom-products-dialog-header__icon" aria-hidden="true"><LibraryBig /></span>
+            <div>
+              <span className="custom-products-dialog-header__eyebrow">Custom library</span>
+              <DialogTitle>Saved products</DialogTitle>
+            </div>
+          </div>
+          <DialogDescription>Apply a reusable category set to this forecast without leaving your workspace.</DialogDescription>
         </DialogHeader>
         <CustomProductsWorkspace embedded onProductUse={useProduct} />
       </DialogContent>

--- a/src/components/IntegratedToolbar/IntegratedToolbar.css
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.css
@@ -1065,10 +1065,10 @@
   .custom-products-dialog-content { width: calc(100vw - 1rem); }
   .custom-products-dialog-header { padding: 16px 50px 14px 16px; }
   .custom-products-dialog-content .custom-products-page--dialog { padding: 12px 14px 16px; }
-  .custom-products-page--dialog .custom-products-hero { align-items: stretch; flex-direction: column; }
-  .custom-products-page--dialog .custom-products-hero__actions { flex-direction: column; align-items: stretch; justify-content: flex-start; gap: 8px; }
+  .custom-products-page--dialog .custom-products-hero { align-items: stretch; flex-direction: column; padding: 14px; }
+  .custom-products-page--dialog .custom-products-hero__actions { flex-direction: column; align-items: stretch; justify-content: flex-start; gap: 12px; }
   .custom-products-page--dialog .custom-products-hero__actions span { align-self: flex-start; }
-  .custom-products-page--dialog .custom-products-hero__actions button { width: 100%; }
+  .custom-products-page--dialog .custom-products-hero__actions button { width: 100%; min-height: 42px; }
 }
 
 @media (max-height: 500px) and (orientation: landscape) {

--- a/src/components/IntegratedToolbar/IntegratedToolbar.css
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.css
@@ -1081,8 +1081,9 @@
   .custom-products-dialog-header { padding: 16px 50px 14px 16px; }
   .custom-products-dialog-content .custom-products-page--dialog { padding: 12px 14px 16px; }
   .custom-products-page--dialog .custom-products-hero { align-items: stretch; flex-direction: column; padding: 14px; }
-  .custom-products-page--dialog .custom-products-hero__actions { flex-direction: column; align-items: stretch; justify-content: flex-start; gap: 12px; }
+  .custom-products-page--dialog .custom-products-hero__actions { flex-direction: column; align-items: stretch; justify-content: flex-start; gap: 0; }
   .custom-products-page--dialog .custom-products-hero__actions span { align-self: flex-start; }
+  .custom-products-page--dialog .custom-products-hero__actions button { margin-top: 16px; }
   .custom-products-page--dialog .custom-products-hero__actions button { width: 100%; min-height: 42px; }
   .custom-products-upgrade-prompt { grid-template-columns: auto minmax(0, 1fr); gap: 12px; padding: 18px 16px 20px; }
   .custom-products-upgrade-prompt ul,

--- a/src/components/IntegratedToolbar/IntegratedToolbar.css
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.css
@@ -203,20 +203,33 @@
 .custom-draw-panel__empty { min-width: 220px; display: flex; align-items: center; padding: 10px 14px; color: var(--text-secondary); font-size: 12px; }
 .custom-products-dialog-trigger { display: inline-flex; height: 34px; gap: 7px; border-color: color-mix(in srgb, var(--button-bg) 45%, var(--border-color)); color: var(--button-bg); font-size: 12px; font-weight: 750; }
 .custom-products-dialog-trigger:hover { border-color: var(--button-bg); background: color-mix(in srgb, var(--button-bg) 9%, transparent); }
-.custom-products-dialog-content { width: min(960px, calc(100vw - 2rem)); max-width: 960px; padding: 0; border-color: var(--border-color); background: var(--bg-primary); color: var(--text-primary); box-shadow: 0 24px 70px rgba(15, 23, 42, .30); }
+.custom-products-dialog-content { width: min(960px, calc(100vw - 2rem)); max-width: 960px; padding: 0; border: 1px solid color-mix(in srgb, var(--border-color) 88%, var(--button-bg)); border-radius: 18px; background: var(--bg-secondary); color: var(--text-primary); box-shadow: 0 30px 88px rgba(15, 23, 42, .38), 0 0 0 1px rgba(255,255,255,.22) inset; }
 .custom-products-dialog-content > div:first-child { gap: 0; padding: 0; }
-.custom-products-dialog-header { padding: 22px 24px 0; text-align: left; }
-.custom-products-dialog-header h2 { color: var(--text-primary); }
-.custom-products-dialog-header p { color: var(--text-secondary); }
+.custom-products-dialog-header { display: grid; gap: 7px; padding: 20px 58px 18px 22px; border-bottom: 1px solid var(--border-color); background: linear-gradient(112deg, color-mix(in srgb, var(--button-bg) 17%, var(--bg-tertiary)), var(--bg-tertiary)); text-align: left; }
+.custom-products-dialog-header__identity { display: flex; align-items: center; gap: 11px; }
+.custom-products-dialog-header__icon { display: grid; width: 36px; height: 36px; place-items: center; border: 1px solid color-mix(in srgb, var(--button-bg) 55%, var(--border-color)); border-radius: 10px; background: var(--button-bg); color: #fff; box-shadow: 0 7px 18px -10px color-mix(in srgb, var(--button-bg) 92%, transparent); }
+.custom-products-dialog-header__icon svg { width: 18px; height: 18px; }
+.custom-products-dialog-header__eyebrow { display: block; margin-bottom: 2px; color: var(--text-secondary); font-size: 10px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.custom-products-dialog-header h2 { color: var(--text-primary); font-size: 20px; line-height: 1.1; }
+.custom-products-dialog-header p { max-width: 620px; color: var(--text-secondary); font-size: 13px; line-height: 1.45; }
 .custom-products-dialog-content [data-radix-dialog-content] { color: var(--text-primary); }
-.custom-products-dialog-content > button { top: 18px !important; right: 18px !important; left: auto !important; color: var(--text-secondary); }
-.custom-products-dialog-content .custom-products-page--dialog { height: auto; min-height: 0; overflow: visible; padding: 20px 24px 24px; background: transparent; }
-.custom-products-page--dialog .custom-products-hero { margin-bottom: 1rem; align-items: center; }
+.custom-products-dialog-content > button { top: 18px !important; right: 18px !important; left: auto !important; display: grid; width: 30px; height: 30px; place-items: center; border: 1px solid var(--border-color); border-radius: 8px; background: color-mix(in srgb, var(--bg-primary) 78%, transparent); color: var(--text-secondary); opacity: 1; }
+.custom-products-dialog-content > button:hover { background: var(--bg-primary); color: var(--text-primary); }
+.custom-products-dialog-content .custom-products-page--dialog { height: auto; min-height: 0; overflow: visible; padding: 16px 22px 22px; background: transparent; }
+.custom-products-page--dialog .custom-products-hero { margin-bottom: 16px; align-items: center; padding: 10px 12px; border: 1px solid var(--border-color); border-radius: 12px; background: var(--bg-primary); }
 .custom-products-page--dialog .custom-products-hero h1 { display: none; }
 .custom-products-page--dialog .custom-product-eyebrow { display: none; }
 .custom-products-page--dialog .custom-products-hero p { display: none; }
-.custom-products-page--dialog .custom-products-hero__actions { align-items: flex-end; }
+.custom-products-page--dialog .custom-products-hero > div:first-child { display: none; }
+.custom-products-page--dialog .custom-products-hero__actions { flex-direction: row; align-items: center; justify-content: flex-start; gap: 10px; }
+.custom-products-page--dialog .custom-products-hero__actions span { flex: 0 0 auto; padding: 6px 9px; border: 1px solid var(--border-color); border-radius: 999px; background: var(--bg-tertiary); color: var(--text-secondary); font-size: 11px; font-weight: 700; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.custom-products-page--dialog .custom-products-hero__actions button { min-height: 34px; border-radius: 9px; box-shadow: 0 7px 15px -11px color-mix(in srgb, var(--button-bg) 95%, transparent); }
 .custom-products-page--dialog .custom-products-grid { grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr)); }
+.custom-products-page--dialog .custom-products-empty { display: flex; width: 100%; min-height: 174px; flex-direction: column; align-items: center; justify-content: center; gap: .5rem; border: 1px dashed color-mix(in srgb, var(--border-color) 78%, var(--button-bg)); border-radius: 12px; background: linear-gradient(135deg, color-mix(in srgb, var(--button-bg) 5%, transparent), transparent); }
+.custom-products-page--dialog .custom-products-empty > * { text-align: center; }
+.dark-mode .custom-products-dialog-content { border-color: rgba(255,255,255,.13); background: #191b20; box-shadow: 0 34px 96px rgba(0,0,0,.62), 0 0 0 1px rgba(255,255,255,.035) inset; }
+.dark-mode .custom-products-dialog-header { border-bottom-color: rgba(255,255,255,.1); background: linear-gradient(112deg, color-mix(in srgb, var(--button-bg) 25%, #20242c), #20242c); }
+.dark-mode .custom-products-page--dialog .custom-products-hero { border-color: rgba(255,255,255,.1); background: #202228; }
 
 @keyframes custom-product-panel-enter {
   from { opacity: 0; transform: translateX(10px); }
@@ -1050,7 +1063,12 @@
   .tabbed-integrated-toolbar__section--product-mode { flex: 0 0 218px; }
   .custom-product-toggle { width: 120px; }
   .custom-products-dialog-content { width: calc(100vw - 1rem); }
-  .custom-products-dialog-content .custom-products-page--dialog { padding-inline: 14px; }
+  .custom-products-dialog-header { padding: 16px 50px 14px 16px; }
+  .custom-products-dialog-content .custom-products-page--dialog { padding: 12px 14px 16px; }
+  .custom-products-page--dialog .custom-products-hero { align-items: stretch; flex-direction: column; }
+  .custom-products-page--dialog .custom-products-hero__actions { flex-direction: column; align-items: stretch; justify-content: flex-start; gap: 8px; }
+  .custom-products-page--dialog .custom-products-hero__actions span { align-self: flex-start; }
+  .custom-products-page--dialog .custom-products-hero__actions button { width: 100%; }
 }
 
 @media (max-height: 500px) and (orientation: landscape) {

--- a/src/components/IntegratedToolbar/IntegratedToolbar.css
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.css
@@ -204,6 +204,7 @@
 .custom-products-dialog-trigger { display: inline-flex; height: 34px; gap: 7px; border-color: color-mix(in srgb, var(--button-bg) 45%, var(--border-color)); color: var(--button-bg); font-size: 12px; font-weight: 750; }
 .custom-products-dialog-trigger:hover { border-color: var(--button-bg); background: color-mix(in srgb, var(--button-bg) 9%, transparent); }
 .custom-products-dialog-content { width: min(960px, calc(100vw - 2rem)); max-width: 960px; padding: 0; border: 1px solid color-mix(in srgb, var(--border-color) 88%, var(--button-bg)); border-radius: 18px; background: var(--bg-secondary); color: var(--text-primary); box-shadow: 0 30px 88px rgba(15, 23, 42, .38), 0 0 0 1px rgba(255,255,255,.22) inset; }
+.custom-products-dialog-content--upgrade { width: min(720px, calc(100vw - 2rem)); max-width: 720px; }
 .custom-products-dialog-content > div:first-child { gap: 0; padding: 0; }
 .custom-products-dialog-header { display: grid; gap: 7px; padding: 20px 58px 18px 22px; border-bottom: 1px solid var(--border-color); background: linear-gradient(112deg, color-mix(in srgb, var(--button-bg) 17%, var(--bg-tertiary)), var(--bg-tertiary)); text-align: left; }
 .custom-products-dialog-header__identity { display: flex; align-items: center; gap: 11px; }
@@ -227,9 +228,23 @@
 .custom-products-page--dialog .custom-products-grid { grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr)); }
 .custom-products-page--dialog .custom-products-empty { display: flex; width: 100%; min-height: 174px; flex-direction: column; align-items: center; justify-content: center; gap: .5rem; border: 1px dashed color-mix(in srgb, var(--border-color) 78%, var(--button-bg)); border-radius: 12px; background: linear-gradient(135deg, color-mix(in srgb, var(--button-bg) 5%, transparent), transparent); }
 .custom-products-page--dialog .custom-products-empty > * { text-align: center; }
+.custom-products-upgrade-prompt { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 14px; padding: 22px; background: linear-gradient(135deg, color-mix(in srgb, var(--button-bg) 12%, var(--bg-primary)), var(--bg-primary)); }
+.custom-products-upgrade-prompt__icon { display: grid; width: 42px; height: 42px; place-items: center; border: 1px solid color-mix(in srgb, var(--button-bg) 50%, var(--border-color)); border-radius: 12px; background: color-mix(in srgb, var(--button-bg) 15%, transparent); color: var(--button-bg); }
+.custom-products-upgrade-prompt__icon svg { width: 20px; height: 20px; }
+.custom-products-upgrade-prompt__copy > span { color: var(--button-bg); font-size: 10px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.custom-products-upgrade-prompt__copy h3 { margin: 3px 0 4px; color: var(--text-primary); font-size: 17px; line-height: 1.2; }
+.custom-products-upgrade-prompt__copy p { max-width: 490px; color: var(--text-secondary); font-size: 13px; line-height: 1.5; }
+.custom-products-upgrade-prompt ul { display: grid; grid-column: 2 / -1; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px 16px; margin: 0; padding: 2px 0 0; list-style: none; color: var(--text-secondary); font-size: 12px; }
+.custom-products-upgrade-prompt li { display: flex; align-items: center; gap: 6px; }
+.custom-products-upgrade-prompt li svg { width: 14px; height: 14px; color: var(--button-bg); }
+.custom-products-upgrade-prompt__action { grid-column: 2 / -1; justify-self: start; min-height: 38px; border-radius: 9px; }
+.custom-products-upgrade-prompt__action a { display: inline-flex; align-items: center; gap: 7px; }
+.custom-products-upgrade-prompt__action svg { width: 15px; height: 15px; }
+.custom-products-upgrade-prompt__note { grid-column: 2 / -1; margin: -6px 0 0; color: var(--text-secondary); font-size: 11px; }
 .dark-mode .custom-products-dialog-content { border-color: rgba(255,255,255,.13); background: #191b20; box-shadow: 0 34px 96px rgba(0,0,0,.62), 0 0 0 1px rgba(255,255,255,.035) inset; }
 .dark-mode .custom-products-dialog-header { border-bottom-color: rgba(255,255,255,.1); background: linear-gradient(112deg, color-mix(in srgb, var(--button-bg) 25%, #20242c), #20242c); }
 .dark-mode .custom-products-page--dialog .custom-products-hero { border-color: rgba(255,255,255,.1); background: #202228; }
+.dark-mode .custom-products-upgrade-prompt { background: linear-gradient(135deg, color-mix(in srgb, var(--button-bg) 16%, #1d2027), #1d2027); }
 
 @keyframes custom-product-panel-enter {
   from { opacity: 0; transform: translateX(10px); }
@@ -1069,6 +1084,13 @@
   .custom-products-page--dialog .custom-products-hero__actions { flex-direction: column; align-items: stretch; justify-content: flex-start; gap: 12px; }
   .custom-products-page--dialog .custom-products-hero__actions span { align-self: flex-start; }
   .custom-products-page--dialog .custom-products-hero__actions button { width: 100%; min-height: 42px; }
+  .custom-products-upgrade-prompt { grid-template-columns: auto minmax(0, 1fr); gap: 12px; padding: 18px 16px 20px; }
+  .custom-products-upgrade-prompt ul,
+  .custom-products-upgrade-prompt__action,
+  .custom-products-upgrade-prompt__note { grid-column: 1 / -1; }
+  .custom-products-upgrade-prompt ul { grid-template-columns: 1fr; gap: 7px; padding-top: 4px; }
+  .custom-products-upgrade-prompt__action { width: 100%; min-height: 42px; }
+  .custom-products-upgrade-prompt__note { margin-top: -2px; text-align: center; }
 }
 
 @media (max-height: 500px) and (orientation: landscape) {

--- a/src/components/IntegratedToolbar/IntegratedToolbar.test.tsx
+++ b/src/components/IntegratedToolbar/IntegratedToolbar.test.tsx
@@ -39,6 +39,12 @@ jest.mock('../DrawingTools/useExportMap', () => ({
     cancelExport: jest.fn(),
   }),
 }));
+jest.mock('../../auth/AuthProvider', () => ({
+  useAuth: () => ({ user: null }),
+}));
+jest.mock('../../billing/EntitlementProvider', () => ({
+  useEntitlement: () => ({ premiumActive: false }),
+}));
 
 const mockAddToast = jest.fn();
 


### PR DESCRIPTION
## Summary

- Restyle the Forecast editor's Saved products modal as a compact custom-library surface that matches the toolbar in light and dark modes.
- Make the phone action layout intentional and keep the empty state centered.
- Give signed-in free users a compact, respectful Premium path from that modal while preserving custom drawing access.
- Add a simple non-technical beta tester checklist for custom layers and saved products.
- Extend reusable-product E2E coverage for the modal identity, free-user path, and in-forecast guidance.
- Repair the CI validation jobs by updating their pnpm runtime to the project-compatible version.

## Changelog

- Polish the local-only Saved products modal, add a free-user Premium path, and provide a concise beta tester checklist for custom layers and saved products.
- Keep the CI validation jobs compatible with the project package manager.

## Verification

- `pnpm exec playwright test e2e/custom-layers.spec.ts e2e/custom-products.spec.ts e2e/workflows.spec.ts`
- `pnpm test -- --runTestsByPath src/lib/customProductsRepository.test.ts src/lib/customProducts.test.ts src/lib/cloudCyclesService.custom.test.ts src/hooks/useCustomProducts.test.tsx src/store/forecastSlice.custom.test.ts src/utils/customLayerPersistence.test.ts src/pages/gated/CustomProductsPage.test.tsx src/components/IntegratedToolbar/IntegratedToolbar.test.tsx src/config/featureExposure.test.ts`
- `pnpm run build`

## Exposure

`customProducts` remains local-only. This PR does not enable beta, staging, or production exposure.