### PR TITLE
feat: enable custom products for beta testing

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #752
+
+- Enable the approved Custom Products workspace for beta testers while keeping staging and production disabled.
+
 ### PR #751
 
 - Refine the local-only Saved products experience with a responsive library layout, a respectful free-user Premium path, and a simple local-preview tester checklist.

--- a/docs/operations/custom-products-beta-test-plan.md
+++ b/docs/operations/custom-products-beta-test-plan.md
@@ -1,12 +1,6 @@
-# Custom Products: local preview tester checklist
+# Custom Products: beta tester checklist
 
-This checklist is for the **local preview only**. Custom Products are intentionally unavailable on the hosted beta site until the feature is approved.
-
-## Open the preview
-
-1. Follow the one-time [local setup instructions](../../README.md#getting-started), then run `pnpm run dev` from the GFC folder.
-2. Open `http://localhost:3000/forecast?localTestAccount=premium` in your browser.
-3. Continue only when **Custom** appears in the Forecast page's **Draw** tab.
+Use the beta Forecast page. Continue only when **Custom** appears in the **Draw** tab.
 
 ## Before you start
 

--- a/docs/operations/custom-products-beta-test-plan.md
+++ b/docs/operations/custom-products-beta-test-plan.md
@@ -1,10 +1,11 @@
 # Custom Products: beta tester checklist
 
-Use the beta Forecast page. Continue only when **Custom** appears in the **Draw** tab.
-
 ## Before you start
 
-- Open the Forecast page on a desktop or phone.
+1. Open [the beta Forecast page](https://beta-gfc.weatherboysuper.com/forecast).
+2. Sign in with the Premium beta account provided for this test. Saved products require Premium.
+3. Continue only when **Custom** appears in the **Draw** tab.
+
 - Start with a new or disposable forecast. This test creates and edits layers.
 
 ## Quick test

--- a/e2e/custom-products.spec.ts
+++ b/e2e/custom-products.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { prepareAppState } from './testSetup';
 
 const buildTarget = process.env.VITE_BUILD_TARGET ?? 'local';
+const customProductsEnabledTarget = buildTarget === 'local' || buildTarget === 'beta';
 
 const createProduct = async (page: Page, name: string): Promise<void> => {
   await page.getByRole('button', { name: 'New product' }).click();
@@ -214,7 +215,7 @@ test.describe('Local reusable custom products', () => {
 });
 
 test.describe('Hosted custom-product absence', () => {
-  test.skip(buildTarget === 'local', 'Requires a beta, staging, or production-target dev server.');
+  test.skip(customProductsEnabledTarget, 'Requires a staging or production-target dev server.');
 
   test('keeps the route, account card, and Draw controls absent', async ({ page }) => {
     await prepareAppState(page);
@@ -230,5 +231,21 @@ test.describe('Hosted custom-product absence', () => {
     await expect(page.getByRole('button', { name: /wind/i })).toBeVisible();
     await expect(page.getByRole('radiogroup', { name: 'Drawing product' })).not.toBeVisible();
     await expect(page.getByRole('link', { name: /Products/i })).not.toBeVisible();
+  });
+});
+
+test.describe('Beta custom-product exposure', () => {
+  test.skip(buildTarget !== 'beta', 'Requires a beta-target dev server.');
+
+  test('registers the library route and exposes Custom drawing controls', async ({ page }) => {
+    await prepareAppState(page);
+    await page.goto('/custom-products');
+    await expect(page.getByRole('heading', { name: 'Sign in to manage reusable products' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open Account' })).toHaveAttribute('href', '/account');
+
+    await page.goto('/forecast');
+    await expect(page.getByRole('radio', { name: 'Custom' })).toBeVisible();
+    await page.getByRole('radio', { name: 'Custom' }).click();
+    await expect(page.getByRole('button', { name: 'Saved products' })).toBeVisible();
   });
 });

--- a/src/config/featureExposure.acknowledgements.json
+++ b/src/config/featureExposure.acknowledgements.json
@@ -23,8 +23,9 @@
     "trackingIssue": 530
   },
   "customProducts": {
-    "reason": "Local-only implementation and review under #431; beta, staging, and production remain disabled until separate owner authorization. Adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",
-    "trackingIssue": 530,
-    "localDevelopmentApproved": true
+    "reason": "Custom Products completed local implementation, UI review, and regression/E2E coverage under #431. Owner approval enables the beta tester rollout; staging and production remain disabled. Adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts and end-to-end coverage is in e2e/custom-products.spec.ts.",
+    "trackingIssue": 431,
+    "localDevelopmentApproved": true,
+    "betaEnablementApproved": true
   }
 }

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -133,7 +133,8 @@ describe('featureExposure registry', () => {
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'production')).toBe(false);
 
     expect(isFeatureExposedOnTarget('customProducts', 'local')).toBe(true);
-    for (const target of ['beta', 'staging', 'production'] as const) {
+    expect(isFeatureExposedOnTarget('customProducts', 'beta')).toBe(true);
+    for (const target of ['staging', 'production'] as const) {
       expect(isFeatureExposedOnTarget('customProducts', target)).toBe(false);
     }
 

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -133,11 +133,11 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 430,
   },
   customProducts: {
-    exposure: { ...ALL_TARGETS_OFF, local: true },
+    exposure: { ...ALL_TARGETS_OFF, local: true, beta: true },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,
-    removalCondition: 'Remove after custom layers and premium forecast products ship (#431).',
+    removalCondition: 'Remove after custom layers and premium forecast products complete their production rollout (#431).',
     serverBacked: false,
     trackingIssue: 431,
   },

--- a/src/config/v17WorkstreamAdoption.exposure.test.ts
+++ b/src/config/v17WorkstreamAdoption.exposure.test.ts
@@ -39,9 +39,9 @@ describe('v1.7 workstream adoption contract', () => {
     }
   );
 
-  test('customProducts is enabled only for local implementation and review', () => {
+  test('customProducts is enabled for local development and beta testing only', () => {
     for (const target of BUILD_TARGETS) {
-      const expected = target === 'local';
+      const expected = target === 'local' || target === 'beta';
       expect(isFeatureExposedOnTarget('customProducts', target)).toBe(expected);
       expect(FEATURE_EXPOSURE_REGISTRY.customProducts.exposure[target]).toBe(expected);
     }

--- a/src/routing/buildFeatureGatedRoutes.test.tsx
+++ b/src/routing/buildFeatureGatedRoutes.test.tsx
@@ -28,22 +28,20 @@ describe('buildFeatureGatedRoutes', () => {
     jest.restoreAllMocks();
   });
 
-  test('does not register gated routes while every feature remains disabled', () => {
+  test('registers only the beta-enabled custom products route while other gated routes remain disabled', () => {
     runWithBuildTarget('beta', () => {
       assertGatedRoutesAbsent('tropicalWorkspace', ['beta']);
       assertGatedRoutesAbsent('collaborationRoom', ['beta']);
-      expect(getExposedGatedRoutePaths('beta')).toEqual([]);
-      expect(buildFeatureGatedRoutes('beta')).toEqual([]);
+      expect(getExposedGatedRoutePaths('beta')).toEqual(['/custom-products']);
     });
   });
 
-  test('registers custom products only on the local target', async () => {
-    expect(getExposedGatedRoutePaths('local')).toContain('/custom-products');
-    expect(getExposedGatedRoutePaths('beta')).not.toContain('/custom-products');
+  test.each(['local', 'beta'] as const)('registers custom products on the %s target', async (target) => {
+    expect(getExposedGatedRoutePaths(target)).toContain('/custom-products');
 
     render(
       <MemoryRouter initialEntries={['/custom-products']}>
-        <Routes>{buildFeatureGatedRoutes('local')}</Routes>
+        <Routes>{buildFeatureGatedRoutes(target)}</Routes>
       </MemoryRouter>
     );
 

--- a/src/testing/featureExposure/exemplar.exposure.test.tsx
+++ b/src/testing/featureExposure/exemplar.exposure.test.tsx
@@ -43,7 +43,7 @@ describe('feature exposure exemplar contract', () => {
       runWithBuildTarget('beta', () => {
         expect(
           require('../../routing/buildFeatureGatedRoutes').getExposedGatedRoutePaths('beta')
-        ).toEqual(['/tropical']);
+        ).toEqual(['/tropical', '/custom-products']);
       });
 
       exposureSpy.mockRestore();


### PR DESCRIPTION
## Summary

- Enable the approved Custom Products feature on beta only.
- Keep staging and production disabled.
- Update the tester checklist for the hosted beta Forecast page.

## Verification

- pnpm test -- --runTestsByPath src/config/featureExposure.test.ts
- pnpm run build

## Exposure

Custom Products is enabled for local and beta. Staging and production remain disabled.