### PR TITLE
Fix custom hatch seams

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,10 +4,6 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #755
-
-- Repair custom diagonal, reverse-diagonal, and crosshatch map fills so their repeated canvas tiles align cleanly.
-
 ### PR #751
 
 - Refine the local-only Saved products experience with a responsive library layout, a respectful free-user Premium path, and a simple local-preview tester checklist.
@@ -23,6 +19,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 ### PR #743
 
 - Add local-only custom forecast layers with category styling, polygon drawing, map legend support, and regression coverage while hosted environments remain unchanged.
+
+### PR #755
+
+- Repair custom diagonal, reverse-diagonal, and crosshatch map fills so their repeated canvas tiles align cleanly.
 
 ### PR #745
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #755
+
+- Repair custom diagonal, reverse-diagonal, and crosshatch map fills so their repeated canvas tiles align cleanly.
+
 ### PR #751
 
 - Refine the local-only Saved products experience with a responsive library layout, a respectful free-user Premium path, and a simple local-preview tester checklist.

--- a/src/components/Map/OpenLayersForecastMap.test.ts
+++ b/src/components/Map/OpenLayersForecastMap.test.ts
@@ -37,6 +37,7 @@ import {
   removeDrawInteraction,
   getCustomFeatureIdentity,
   toUpdatedCustomFeature,
+  createCustomFill,
   toCustomOlStyle,
 } from './OpenLayersForecastMap';
 
@@ -200,6 +201,31 @@ describe('OpenLayersForecastMap helpers', () => {
     expect(style.getFill()?.getColor()).toBe('rgba(59, 130, 246, 0.45)');
     expect(style.getStroke()?.getColor()).toBe('rgba(255, 255, 255, 0.9)');
     expect(style.getZIndex()).toBe(704);
+  });
+
+  test.each([
+    ['diagonal', [[-12, 12, 0, 0], [0, 12, 12, 0], [12, 12, 24, 0]]],
+    ['reverse-diagonal', [[-12, 0, 0, 12], [0, 0, 12, 12], [12, 0, 24, 12]]],
+    ['crosshatch', [[-12, 12, 0, 0], [0, 12, 12, 0], [12, 12, 24, 0], [-12, 0, 0, 12], [0, 0, 12, 12], [12, 0, 24, 12]]],
+  ] as const)('custom %s hatch lines continue at every repeated tile edge', (hatch, expectedLines) => {
+    const calls: number[][] = [];
+    document.createElement = ((tag: string) => {
+      if (tag !== 'canvas') return originalCreateElement.call(document, tag);
+      const context = {
+        fillStyle: '', strokeStyle: '', lineWidth: 0,
+        fillRect: jest.fn(),
+        beginPath: jest.fn(),
+        moveTo: jest.fn((x: number, y: number) => calls.push([x, y])),
+        lineTo: jest.fn((x: number, y: number) => calls[calls.length - 1].push(x, y)),
+        stroke: jest.fn(),
+        createPattern: jest.fn(() => 'custom-pattern'),
+      };
+      return { width: 0, height: 0, getContext: () => context } as unknown as HTMLElement;
+    }) as typeof document.createElement;
+
+    createCustomFill({ fillColor: '#3b82f6', fillOpacity: .45, strokeColor: '#ffffff', strokeOpacity: .9, strokeWidth: 2, hatch });
+
+    expect(calls).toEqual(expectedLines);
   });
 
   test('toOlStyle transparencyScale reduces fill and stroke alpha', () => {

--- a/src/components/Map/OpenLayersForecastMap.test.ts
+++ b/src/components/Map/OpenLayersForecastMap.test.ts
@@ -204,12 +204,12 @@ describe('OpenLayersForecastMap helpers', () => {
   });
 
   test.each([
-    ['diagonal', [[-12, 12, 0, 0], [0, 12, 12, 0], [12, 12, 24, 0]]],
-    ['reverse-diagonal', [[-12, 0, 0, 12], [0, 0, 12, 12], [12, 0, 24, 12]]],
-    ['crosshatch', [[-12, 12, 0, 0], [0, 12, 12, 0], [12, 12, 24, 0], [-12, 0, 0, 12], [0, 0, 12, 12], [12, 0, 24, 12]]],
+    ['diagonal', [[-12, 12, 12, -12], [-12, 24, 24, -12], [0, 24, 24, 0]]],
+    ['reverse-diagonal', [[-12, 0, 12, 24], [-12, -12, 24, 24], [0, -12, 24, 12]]],
+    ['crosshatch', [[-12, 12, 12, -12], [-12, 24, 24, -12], [0, 24, 24, 0], [-12, 0, 12, 24], [-12, -12, 24, 24], [0, -12, 24, 12]]],
   ] as const)('custom %s hatch lines continue at every repeated tile edge', (hatch, expectedLines) => {
     const calls: number[][] = [];
-    document.createElement = ((tag: string) => {
+    const createElementSpy = jest.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
       if (tag !== 'canvas') return originalCreateElement.call(document, tag);
       const context = {
         fillStyle: '', strokeStyle: '', lineWidth: 0,
@@ -221,11 +221,14 @@ describe('OpenLayersForecastMap helpers', () => {
         createPattern: jest.fn(() => 'custom-pattern'),
       };
       return { width: 0, height: 0, getContext: () => context } as unknown as HTMLElement;
-    }) as typeof document.createElement;
+    }) as typeof document.createElement);
 
-    createCustomFill({ fillColor: '#3b82f6', fillOpacity: .45, strokeColor: '#ffffff', strokeOpacity: .9, strokeWidth: 2, hatch });
-
-    expect(calls).toEqual(expectedLines);
+    try {
+      createCustomFill({ fillColor: '#3b82f6', fillOpacity: .45, strokeColor: '#ffffff', strokeOpacity: .9, strokeWidth: 2, hatch });
+      expect(calls).toEqual(expectedLines);
+    } finally {
+      createElementSpy.mockRestore();
+    }
   });
 
   test('toOlStyle transparencyScale reduces fill and stroke alpha', () => {

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -435,11 +435,14 @@ export const createCustomFill = (style: CustomCategoryStyle): Fill => {
   const line = (x1: number, y1: number, x2: number, y2: number) => {
     context.beginPath(); context.moveTo(x1, y1); context.lineTo(x2, y2); context.stroke();
   };
+  // Each line continues exactly at the opposite edge of the 12px tile. Keeping
+  // the adjacent off-tile segments prevents gaps where a repeated CanvasPattern
+  // joins, including when both directions are combined for crosshatch.
   if (style.hatch === "diagonal" || style.hatch === "crosshatch") {
-    line(-2, 10, 10, -2); line(2, 14, 14, 2);
+    line(-12, 12, 0, 0); line(0, 12, 12, 0); line(12, 12, 24, 0);
   }
   if (style.hatch === "reverse-diagonal" || style.hatch === "crosshatch") {
-    line(-2, 2, 10, 14); line(2, -2, 14, 10);
+    line(-12, 0, 0, 12); line(0, 0, 12, 12); line(12, 0, 24, 12);
   }
   const pattern = context.createPattern(canvas, "repeat");
   return new Fill({ color: pattern ?? toRgbaColor({ color: style.fillColor, alpha: style.fillOpacity }) });

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -435,14 +435,13 @@ export const createCustomFill = (style: CustomCategoryStyle): Fill => {
   const line = (x1: number, y1: number, x2: number, y2: number) => {
     context.beginPath(); context.moveTo(x1, y1); context.lineTo(x2, y2); context.stroke();
   };
-  // Each line continues exactly at the opposite edge of the 12px tile. Keeping
-  // the adjacent off-tile segments prevents gaps where a repeated CanvasPattern
-  // joins, including when both directions are combined for crosshatch.
+  // Extend strokes beyond the 12px tile boundaries so canvas clipping produces
+  // continuous joins without anti-aliasing seams in the repeated pattern.
   if (style.hatch === "diagonal" || style.hatch === "crosshatch") {
-    line(-12, 12, 0, 0); line(0, 12, 12, 0); line(12, 12, 24, 0);
+    line(-12, 12, 12, -12); line(-12, 24, 24, -12); line(0, 24, 24, 0);
   }
   if (style.hatch === "reverse-diagonal" || style.hatch === "crosshatch") {
-    line(-12, 0, 0, 12); line(0, 0, 12, 12); line(12, 0, 24, 12);
+    line(-12, 0, 12, 24); line(-12, -12, 24, 24); line(0, -12, 24, 12);
   }
   const pattern = context.createPattern(canvas, "repeat");
   return new Fill({ color: pattern ?? toRgbaColor({ color: style.fillColor, alpha: style.fillOpacity }) });


### PR DESCRIPTION
## Summary

- Make custom diagonal and reverse-diagonal canvas tiles continuous at every repeat boundary.
- Compose crosshatch from the two continuous directions.
- Add focused regression coverage for all custom hatch variants.

## Root cause

The previous line endpoints did not meet at opposing 12px tile edges, leaving visible seams and misaligned repeats.

## Validation

- pnpm test -- --runTestsByPath src/components/Map/OpenLayersForecastMap.test.ts
- pnpm run build (succeeds; Sentry source-map upload reports expected non-blocking HTTP 403)