### PR TITLE
Fix JPEG export bounds

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,10 +4,6 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #756
-
-- Match exported forecast JPEG bounds to the OpenLayers viewport to remove unused white space below the map.
-
 ### PR #751
 
 - Refine the local-only Saved products experience with a responsive library layout, a respectful free-user Premium path, and a simple local-preview tester checklist.
@@ -27,6 +23,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 ### PR #745
 
 - Secure reusable custom products with owner-scoped Firestore rules, premium enforcement, and hostile-client coverage.
+
+### PR #756
+
+- Match exported forecast JPEG bounds to the OpenLayers viewport to remove unused white space below the map.
 
 ### PR #750
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #756
+
+- Match exported forecast JPEG bounds to the OpenLayers viewport to remove unused white space below the map.
+
 ### PR #751
 
 - Refine the local-only Saved products experience with a responsive library layout, a respectful free-user Premium path, and a simple local-preview tester checklist.

--- a/src/utils/exportUtils.extra.test.ts
+++ b/src/utils/exportUtils.extra.test.ts
@@ -110,8 +110,8 @@ describe('exportUtils additional unit tests', () => {
     document.body.appendChild(outer);
 
     // jsdom doesn't compute layout; fake clientWidth/Height
-    Object.defineProperty(outer, 'clientWidth', { value: 200, configurable: true });
-    Object.defineProperty(outer, 'clientHeight', { value: 150, configurable: true });
+    Object.defineProperty(mapContainer, 'clientWidth', { value: 200, configurable: true });
+    Object.defineProperty(mapContainer, 'clientHeight', { value: 150, configurable: true });
 
     const mapLike = { getContainer: () => mapContainer };
     const res = getExportRootAndSize(mapLike as never);

--- a/src/utils/exportUtils.test.ts
+++ b/src/utils/exportUtils.test.ts
@@ -45,6 +45,28 @@ describe('exportUtils', () => {
     expect(() => getExportRootAndSize({} as never)).toThrow('Map container not available for export.');
   });
 
+  test('getExportRootAndSize uses the OpenLayers viewport dimensions within the map export root', () => {
+    const exportRoot = document.createElement('div');
+    exportRoot.className = 'map-container';
+    const mapContainer = document.createElement('div');
+    const viewport = document.createElement('div');
+    viewport.className = 'ol-viewport';
+    Object.defineProperties(mapContainer, { clientWidth: { value: 960 }, clientHeight: { value: 680 } });
+    Object.defineProperties(viewport, { clientWidth: { value: 960 }, clientHeight: { value: 640 } });
+    mapContainer.appendChild(viewport);
+    exportRoot.appendChild(mapContainer);
+    document.body.appendChild(exportRoot);
+
+    expect(getExportRootAndSize({ getTargetElement: () => mapContainer })).toMatchObject({
+      mapContainer,
+      exportRoot,
+      width: 960,
+      height: 640,
+    });
+
+    exportRoot.remove();
+  });
+
   test('createTempContainer appends and sets size', () => {
     const temp = createTempContainer(120, 80);
     expect(document.body.contains(temp)).toBe(true);

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -713,8 +713,12 @@ export function getExportRootAndSize(map: ExportMapLike) {
   }
 
   const exportRoot = (mapContainer.closest('.map-container, .forecast-map-container') as HTMLElement | null) || mapContainer;
-  const width = exportRoot.clientWidth;
-  const height = exportRoot.clientHeight;
+  // OpenLayers renders into this viewport, while the export root also contains
+  // map controls and status overlays. Capture using the viewport dimensions so
+  // html2canvas does not extend the JPEG into unused wrapper space below the map.
+  const viewport = mapContainer.querySelector<HTMLElement>('.ol-viewport');
+  const width = viewport?.clientWidth || mapContainer.clientWidth;
+  const height = viewport?.clientHeight || mapContainer.clientHeight;
   return { mapContainer, exportRoot, width, height };
 }
 


### PR DESCRIPTION
## Summary

- Size live map captures from the OpenLayers viewport rather than the outer map wrapper.
- Retain the wrapper as the capture root so status and legend overlays remain available.
- Add regression coverage for a viewport that is shorter than its wrapper.

## Root cause

The export capture root and its dimensions came from different surfaces. html2canvas therefore included unused wrapper space below the OpenLayers viewport in JPEGs.

## Validation

- pnpm test -- --runTestsByPath src/utils/exportUtils.test.ts src/utils/exportUtils.clone.test.ts src/utils/exportUtils.render.test.ts
- pnpm run build (succeeds; Sentry source-map upload reports expected non-blocking HTTP 403)