### PR TITLE
Fix custom picker popover layering

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #757
+
+- Keep custom layer and category picker popovers above forecast safety and status overlays.
+
 ### PR #751
 
 - Refine the local-only Saved products experience with a responsive library layout, a respectful free-user Premium path, and a simple local-preview tester checklist.

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,10 +4,6 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### PR #757
-
-- Keep custom layer and category picker popovers above forecast safety and status overlays.
-
 ### PR #751
 
 - Refine the local-only Saved products experience with a responsive library layout, a respectful free-user Premium path, and a simple local-preview tester checklist.
@@ -19,6 +15,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 ### PR #744
 
 - Add reusable custom product creation, editing, lifecycle management, and snapshot-based use in local forecasts.
+
+### PR #757
+
+- Keep custom layer and category picker popovers above forecast safety and status overlays.
 
 ### PR #743
 

--- a/src/components/ui/popover.test.tsx
+++ b/src/components/ui/popover.test.tsx
@@ -52,10 +52,11 @@ describe('Popover components', () => {
   });
 
   it('allows custom alignment, offset, and classes', () => {
-    render(<PopoverContent align="start" sideOffset={12} className="extra">Menu</PopoverContent>);
+    render(<PopoverContent align="start" sideOffset={12} className="extra" style={{ width: 300, zIndex: 1 }}>Menu</PopoverContent>);
 
     expect(screen.getByText('Menu')).toHaveAttribute('data-align', 'start');
     expect(screen.getByText('Menu')).toHaveAttribute('data-side-offset', '12');
     expect(screen.getByText('Menu')).toHaveClass('extra');
+    expect(screen.getByText('Menu')).toHaveStyle({ width: '300px', zIndex: String(POPOVER_Z_INDEX) });
   });
 });

--- a/src/components/ui/popover.test.tsx
+++ b/src/components/ui/popover.test.tsx
@@ -6,7 +6,7 @@ import {
   type ReactNode,
 } from 'react';
 import { render, screen } from '@testing-library/react';
-import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from './popover';
+import { POPOVER_Z_INDEX, Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from './popover';
 
 jest.mock('@radix-ui/react-popover', () => {
   return {
@@ -46,6 +46,8 @@ describe('Popover components', () => {
     expect(screen.getByText('Content')).toHaveAttribute('data-align', 'center');
     expect(screen.getByText('Content')).toHaveAttribute('data-side-offset', '4');
     expect(screen.getByText('Content')).toHaveClass('z-dropdown', 'w-72');
+    expect(screen.getByText('Content')).toHaveStyle({ zIndex: String(POPOVER_Z_INDEX) });
+    expect(POPOVER_Z_INDEX).toBeGreaterThan(1400);
     expect(ref.current).toBe(screen.getByText('Content'));
   });
 

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -14,18 +14,18 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+>(({ className, align = 'center', sideOffset = 4, style, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      style={{ zIndex: POPOVER_Z_INDEX, ...props.style }}
+      {...props}
+      style={{ ...style, zIndex: POPOVER_Z_INDEX }}
       className={cn(
         'z-dropdown w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
         className
       )}
-      {...props}
     />
   </PopoverPrimitive.Portal>
 ));

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { cn } from '../../lib/utils';
 
+// Map status notices occupy 1300 and 1400; popovers must remain interactive above them.
+export const POPOVER_Z_INDEX = 1401;
+
 const Popover = PopoverPrimitive.Root;
 
 const PopoverTrigger = PopoverPrimitive.Trigger;
@@ -17,6 +20,7 @@ const PopoverContent = React.forwardRef<
       ref={ref}
       align={align}
       sideOffset={sideOffset}
+      style={{ zIndex: POPOVER_Z_INDEX, ...props.style }}
       className={cn(
         'z-dropdown w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
         className


### PR DESCRIPTION
## Summary

- Raise shared popover content above map status and Unofficial Forecast overlays.
- Preserve caller-provided inline z-index overrides.
- Add regression coverage that keeps the popover level above the 1400 status overlay.

## Root cause

Custom picker popovers inherited the shared z-dropdown level of 200, below the map's 1300 and 1400 safety/status overlays.

## Validation

- pnpm test -- --runTestsByPath src/components/ui/popover.test.tsx
- pnpm run build (succeeds; Sentry source-map upload reports expected non-blocking HTTP 403)