### PR TITLE
fix: restore native Umami page views

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -6,7 +6,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ### PR #760
 
-- Restore native Umami page views for accurate traffic metrics and clarify GFC's cookie-free pseudonymous telemetry disclosure.
+- Restore native Umami page views for accurate traffic metrics, make non-essential telemetry an explicit opt-in, and clarify GFC's cookie-free pseudonymous telemetry disclosure.
 
 ### PR #759
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -6,7 +6,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ### PR #760
 
-- Restore native Umami page views for accurate traffic metrics, make non-essential telemetry an explicit opt-in, and clarify GFC's cookie-free pseudonymous telemetry disclosure.
+- Restore native Umami page views for accurate traffic metrics, make non-essential telemetry an explicit opt-in, minimize tracker URL data, and clarify GFC's cookie-free pseudonymous telemetry disclosure.
 
 ### PR #759
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #760
+
+- Restore native Umami page views for accurate traffic metrics and clarify GFC's cookie-free pseudonymous telemetry disclosure.
+
 ### PR #759
 
 - Replace GA4 and the legacy collector with privacy-gated, self-hosted Umami telemetry that keeps beta and production reporting separate.

--- a/docs/operations/umami-telemetry-privacy-operations.md
+++ b/docs/operations/umami-telemetry-privacy-operations.md
@@ -1,0 +1,68 @@
+# Umami Telemetry: Privacy Operations
+
+Last reviewed: July 21, 2026
+
+This is an engineering and operational record, not a legal certification. GFC uses this configuration as a conservative baseline for privacy principles commonly reflected in GDPR/UK GDPR, PECR, CCPA/CPRA, and similar regimes. Obtain qualified legal advice before representing the service as compliant in every jurisdiction.
+
+## Purpose and data boundary
+
+GFC uses self-hosted, cookie-free **pseudonymous product analytics** only to understand aggregate product use and prioritize improvements. It is not used for advertising, sale, cross-site tracking, or profiling tied to a Firebase account.
+
+| Category | Current handling |
+| --- | --- |
+| Route/page activity | Manual native Umami page views use a normalized path only; query strings and hashes are excluded. |
+| Product events | A small allowlist of workflow, export, cloud-save, and custom-layer milestones. Properties are coarse and allowlisted. |
+| Technical metadata | Browser, operating system, device type, timestamps, and the Umami pseudonymous visitor/session grouping. |
+| Location | Umami can derive location from an IP address, but the Nginx telemetry proxy now substitutes a loopback address. New GFC analytics records should not contain visitor country, region, or city. |
+| Excluded | Firebase UID, email, account identity, auth token, forecast contents, coordinates, layer text, filenames, export contents, user-created event properties, session replay, heatmaps, and content capture. |
+
+There is no `umami.identify()` call in GFC. The visitor/session grouping is not linked to Firebase account records.
+
+## Consent and application behavior
+
+- Product analytics are non-essential and disabled by default.
+- Privacy Policy acceptance does not enable analytics.
+- A separate optional control appears at the top of the policy in both acceptance and view-only flows.
+- Enabling is an affirmative local choice; declining does not block GFC.
+- Withdrawal removes the tracker and clears queued page views/events.
+- The tracker is configured for manual SPA page views, `Do Not Track`, search exclusion, and hash exclusion.
+- Production and beta are separate Umami websites/zones.
+
+## Infrastructure and access path
+
+| Component | Role / control |
+| --- | --- |
+| GFC web app | Loads Umami only after local opt-in and only on the matching production or beta hostname. |
+| Nginx | TLS terminates `telemetry.gfc.weatherboysuper.com`; HTTP redirects to HTTPS. The telemetry vhost disables access logging and substitutes `127.0.0.1` for forwarded client-IP headers before proxying to Umami. |
+| Umami | Dockerized, self-hosted dashboard/service on the GFC VPS. `PRIVATE_MODE=1`, `DISABLE_TELEMETRY=1`, `FORCE_SSL=1`, and trailing-slash normalization are enabled. |
+| PostgreSQL | Umami’s private Docker volume. It is bound inside the Docker network; the database is not publicly exposed. |
+| Hostinger/VPS | Infrastructure provider and host for Nginx, Docker, Umami, and PostgreSQL. |
+
+As of this review, the Umami instance has one admin user, the service is behind valid HTTPS, the PostgreSQL volume is local to Docker, and no Umami-specific backup artifact was found. Docker JSON logs are capped at three 10 MB files. Nginx’s general logrotate policy retains 14 daily rotations, but the telemetry vhost now has `access_log off`; old global access-log entries age out under that policy.
+
+## Retention and deletion
+
+**Unresolved business decision:** a fixed event-level Umami retention period and automated deletion job have not yet been adopted. Do not describe a fixed telemetry deletion window publicly until the decision and mechanism both exist.
+
+Before enabling general production collection beyond the current opt-in baseline, decide and implement:
+
+1. Event/session retention period (recommended engineering target: 90 days or less unless a documented product need requires more).
+2. A tested, scheduled deletion job that removes expired `website_event`, `event_data`, `session`, and any enabled replay/heatmap data in dependency-safe order.
+3. Encrypted database backup cadence, backup retention, restore testing, and the matching deletion behavior for backups.
+
+If region-level product insight becomes necessary, do not restore raw client-IP forwarding to Umami. First deploy and test a trusted country/region-only GeoIP resolver or proxy that never forwards city or raw IP to Umami, then update the policy and this record before enabling it.
+
+Firebase account deletion cannot automatically remove Umami data because no account identifier is sent to Umami. For access/deletion requests, the operator should ask for approximate date/time, browser/device, route/event details, and consent state; explain the limits of locating a pseudonymous record, perform the scoped Umami deletion where feasible, and record the request/response outside the analytics system.
+
+## Operational ownership and incident response
+
+- Privacy questions and access/deletion requests: `alex@weatherboysuper.com`.
+- VPS/Umami/Nginx/backup operator: GFC operator.
+- On a suspected telemetry or VPS breach: preserve minimum necessary evidence, rotate impacted access credentials/secrets, assess affected systems and records, consult counsel on notification duties, notify affected people/regulators where required, and document remediation.
+- Restrict Umami admin access to named operators, use unique strong credentials and HTTPS, and review access after any role or infrastructure change.
+
+## Verification checklist
+
+- Unit tests cover default-off, explicit opt-in, tracker removal/queue clearing on withdrawal, normalized native page views, and tracker privacy attributes.
+- Browser checks cover acceptance and view-only policy flows, top-of-document choice, disabled default, explicit opt-in, and withdrawal.
+- VPS checks cover Nginx syntax/health, TLS, Docker runtime flags, database exposure, logs, and replay/heatmap row counts.

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.css
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.css
@@ -150,6 +150,27 @@
   cursor: pointer;
 }
 
+.privacy-analytics-choice {
+  margin: 14px 0 18px;
+  padding: 14px;
+  border: 1px solid var(--accent-color);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface-secondary) 82%, var(--accent-color) 18%);
+}
+
+.privacy-analytics-choice h3 {
+  margin: 0 0 4px;
+}
+
+.privacy-analytics-choice p {
+  margin-bottom: 0;
+}
+
+.privacy-analytics-choice .privacy-analytics-preference {
+  margin: 12px 0 0;
+  background: var(--bg-primary);
+}
+
 .privacy-analytics-preference span {
   color: var(--text-secondary);
   font-size: 0.85rem;

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
@@ -19,7 +19,7 @@ describe('PrivacyPolicyModal Utils', () => {
   });
 
   test('hasAcceptedPrivacyPolicy returns true when accepted current version', () => {
-    localStorage.setItem('gfc-privacy-policy-accepted', '1.6.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.7.0');
     expect(hasAcceptedPrivacyPolicy()).toBe(true);
   });
 
@@ -45,7 +45,7 @@ describe('PrivacyPolicyModal Utils', () => {
   });
 
   test('isPrivacyPolicyUpgrade returns false when current version was accepted', () => {
-    localStorage.setItem('gfc-privacy-policy-accepted', '1.6.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.7.0');
     expect(isPrivacyPolicyUpgrade()).toBe(false);
   });
 });
@@ -75,7 +75,7 @@ describe('PrivacyPolicyModal component', () => {
     expect(screen.getByText(/Last updated July 21, 2026/u)).toBeInTheDocument();
     const note = screen.getByRole('note');
     expect(note).toBeInTheDocument();
-    expect(within(note).getByText(/What's new in version 1\.6\.0/u)).toBeInTheDocument();
+    expect(within(note).getByText(/What's new in version 1\.7\.0/u)).toBeInTheDocument();
     expect(within(note).getByText(/hosted error monitoring \(Sentry\)/u)).toBeInTheDocument();
     expect(within(note).getByText(/Google Analytics \(GA4\)/u)).toBeInTheDocument();
   });
@@ -98,7 +98,7 @@ describe('PrivacyPolicyModal component', () => {
 
   test('hides whats new in view-only mode but shows version date', () => {
     render(<PrivacyPolicyModal onAccept={onAcceptMock} viewOnly onClose={onCloseMock} />);
-    expect(screen.getByText(/Version 1\.6\.0 — Last updated July 21, 2026/u)).toBeInTheDocument();
+    expect(screen.getByText(/Version 1\.7\.0 — Last updated July 21, 2026/u)).toBeInTheDocument();
     expect(screen.queryByRole('note')).not.toBeInTheDocument();
     expect(screen.queryByText(/What's new in version/i)).not.toBeInTheDocument();
   });
@@ -115,7 +115,13 @@ describe('PrivacyPolicyModal component', () => {
     const choice = screen.getByRole('region', { name: 'Optional product analytics' });
     expect(choice).toBeInTheDocument();
     expect(choice).toHaveTextContent(/disabled by default/u);
+    expect(choice).toHaveTextContent(/separate choice from accepting this Privacy Policy/u);
     expect(choice).toHaveTextContent(/never affects access to GFC/u);
+  });
+
+  test('keeps the optional analytics choice available in view-only mode', () => {
+    render(<PrivacyPolicyModal onAccept={onAcceptMock} viewOnly onClose={onCloseMock} />);
+    expect(screen.getByRole('region', { name: 'Optional product analytics' })).toBeInTheDocument();
   });
 
   test('calls onAccept and updates localStorage when accepted', () => {
@@ -126,7 +132,7 @@ describe('PrivacyPolicyModal component', () => {
     fireEvent.click(acceptButton);
 
     expect(onAcceptMock).toHaveBeenCalled();
-    expect(localStorage.getItem('gfc-privacy-policy-accepted')).toBe('1.6.0');
+    expect(localStorage.getItem('gfc-privacy-policy-accepted')).toBe('1.7.0');
   });
 
   test('renders view-only mode when specified', () => {

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
@@ -110,6 +110,14 @@ describe('PrivacyPolicyModal component', () => {
     expect(screen.getByText('Accept & Continue')).toBeEnabled();
   });
 
+  test('shows the optional analytics choice before the policy sections', () => {
+    render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
+    const choice = screen.getByRole('region', { name: 'Optional product analytics' });
+    expect(choice).toBeInTheDocument();
+    expect(choice).toHaveTextContent(/disabled by default/u);
+    expect(choice).toHaveTextContent(/never affects access to GFC/u);
+  });
+
   test('calls onAccept and updates localStorage when accepted', () => {
     render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
     const checkbox = screen.getByRole('checkbox');

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
@@ -155,7 +155,29 @@ describe('PrivacyPolicyModal component', () => {
     expect(onCloseMock).toHaveBeenCalled();
   });
 
-  test('handles localStorage.setItem throwing in handleAccept', () => {
+  test('reflects storage failure when enabling analytics — UI stays disabled', () => {
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('Storage error'); });
+
+  render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
+  const toggle = screen.getByRole('switch');
+  expect(toggle).toHaveAttribute('aria-checked', 'false');
+  fireEvent.click(toggle);
+  expect(toggle).toHaveAttribute('aria-checked', 'false');
+});
+
+test('reflects storage failure when disabling analytics — UI shows disabled after teardown', () => {
+  localStorage.setItem('gfc-analytics-enabled', 'true');
+  render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
+
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('Storage error'); });
+
+  const toggle = screen.getByRole('switch');
+  expect(toggle).toHaveAttribute('aria-checked', 'true');
+  fireEvent.click(toggle);
+  expect(toggle).toHaveAttribute('aria-checked', 'false');
+});
+
+test('handles localStorage.setItem throwing in handleAccept', () => {
     jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('Storage error');
     });

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
@@ -19,7 +19,7 @@ describe('PrivacyPolicyModal Utils', () => {
   });
 
   test('hasAcceptedPrivacyPolicy returns true when accepted current version', () => {
-    localStorage.setItem('gfc-privacy-policy-accepted', '1.5.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.6.0');
     expect(hasAcceptedPrivacyPolicy()).toBe(true);
   });
 
@@ -45,7 +45,7 @@ describe('PrivacyPolicyModal Utils', () => {
   });
 
   test('isPrivacyPolicyUpgrade returns false when current version was accepted', () => {
-    localStorage.setItem('gfc-privacy-policy-accepted', '1.5.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.6.0');
     expect(isPrivacyPolicyUpgrade()).toBe(false);
   });
 });
@@ -75,7 +75,7 @@ describe('PrivacyPolicyModal component', () => {
     expect(screen.getByText(/Last updated July 21, 2026/u)).toBeInTheDocument();
     const note = screen.getByRole('note');
     expect(note).toBeInTheDocument();
-    expect(within(note).getByText(/What's new in version 1\.5\.0/u)).toBeInTheDocument();
+    expect(within(note).getByText(/What's new in version 1\.6\.0/u)).toBeInTheDocument();
     expect(within(note).getByText(/hosted error monitoring \(Sentry\)/u)).toBeInTheDocument();
     expect(within(note).getByText(/Google Analytics \(GA4\)/u)).toBeInTheDocument();
   });
@@ -98,7 +98,7 @@ describe('PrivacyPolicyModal component', () => {
 
   test('hides whats new in view-only mode but shows version date', () => {
     render(<PrivacyPolicyModal onAccept={onAcceptMock} viewOnly onClose={onCloseMock} />);
-    expect(screen.getByText(/Version 1\.5\.0 — Last updated July 21, 2026/u)).toBeInTheDocument();
+    expect(screen.getByText(/Version 1\.6\.0 — Last updated July 21, 2026/u)).toBeInTheDocument();
     expect(screen.queryByRole('note')).not.toBeInTheDocument();
     expect(screen.queryByText(/What's new in version/i)).not.toBeInTheDocument();
   });
@@ -118,7 +118,7 @@ describe('PrivacyPolicyModal component', () => {
     fireEvent.click(acceptButton);
 
     expect(onAcceptMock).toHaveBeenCalled();
-    expect(localStorage.getItem('gfc-privacy-policy-accepted')).toBe('1.5.0');
+    expect(localStorage.getItem('gfc-privacy-policy-accepted')).toBe('1.6.0');
   });
 
   test('renders view-only mode when specified', () => {

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.test.tsx
@@ -19,7 +19,7 @@ describe('PrivacyPolicyModal Utils', () => {
   });
 
   test('hasAcceptedPrivacyPolicy returns true when accepted current version', () => {
-    localStorage.setItem('gfc-privacy-policy-accepted', '1.4.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.5.0');
     expect(hasAcceptedPrivacyPolicy()).toBe(true);
   });
 
@@ -45,7 +45,7 @@ describe('PrivacyPolicyModal Utils', () => {
   });
 
   test('isPrivacyPolicyUpgrade returns false when current version was accepted', () => {
-    localStorage.setItem('gfc-privacy-policy-accepted', '1.4.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.5.0');
     expect(isPrivacyPolicyUpgrade()).toBe(false);
   });
 });
@@ -72,10 +72,10 @@ describe('PrivacyPolicyModal component', () => {
   test('shows last updated date and whats new when upgrading from an older policy', () => {
     localStorage.setItem('gfc-privacy-policy-accepted', '1.0.0');
     render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
-    expect(screen.getByText(/Last updated July 20, 2026/u)).toBeInTheDocument();
+    expect(screen.getByText(/Last updated July 21, 2026/u)).toBeInTheDocument();
     const note = screen.getByRole('note');
     expect(note).toBeInTheDocument();
-    expect(within(note).getByText(/What's new in version 1\.4\.0/u)).toBeInTheDocument();
+    expect(within(note).getByText(/What's new in version 1\.5\.0/u)).toBeInTheDocument();
     expect(within(note).getByText(/hosted error monitoring \(Sentry\)/u)).toBeInTheDocument();
     expect(within(note).getByText(/Google Analytics \(GA4\)/u)).toBeInTheDocument();
   });
@@ -91,14 +91,14 @@ describe('PrivacyPolicyModal component', () => {
 
   test('hides whats new for first-time users in acceptance mode', () => {
     render(<PrivacyPolicyModal onAccept={onAcceptMock} />);
-    expect(screen.getByText(/Last updated July 20, 2026/u)).toBeInTheDocument();
+    expect(screen.getByText(/Last updated July 21, 2026/u)).toBeInTheDocument();
     expect(screen.queryByRole('note')).not.toBeInTheDocument();
     expect(screen.queryByText(/What's new in version/u)).not.toBeInTheDocument();
   });
 
   test('hides whats new in view-only mode but shows version date', () => {
     render(<PrivacyPolicyModal onAccept={onAcceptMock} viewOnly onClose={onCloseMock} />);
-    expect(screen.getByText(/Version 1\.4\.0 — Last updated July 20, 2026/u)).toBeInTheDocument();
+    expect(screen.getByText(/Version 1\.5\.0 — Last updated July 21, 2026/u)).toBeInTheDocument();
     expect(screen.queryByRole('note')).not.toBeInTheDocument();
     expect(screen.queryByText(/What's new in version/i)).not.toBeInTheDocument();
   });
@@ -118,7 +118,7 @@ describe('PrivacyPolicyModal component', () => {
     fireEvent.click(acceptButton);
 
     expect(onAcceptMock).toHaveBeenCalled();
-    expect(localStorage.getItem('gfc-privacy-policy-accepted')).toBe('1.4.0');
+    expect(localStorage.getItem('gfc-privacy-policy-accepted')).toBe('1.5.0');
   });
 
   test('renders view-only mode when specified', () => {

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -4,7 +4,7 @@ import { isProductAnalyticsEnabled, setProductAnalyticsEnabled } from '../../lib
 
 // Bump this version string whenever the Privacy Policy changes materially.
 // Users who accepted an older version will be asked to re-accept.
-const PRIVACY_POLICY_VERSION = '1.5.0';
+const PRIVACY_POLICY_VERSION = '1.6.0';
 const PRIVACY_POLICY_LAST_UPDATED = 'July 21, 2026';
 const STORAGE_KEY = 'gfc-privacy-policy-accepted';
 
@@ -27,6 +27,10 @@ const PRIVACY_POLICY_CHANGELOG: Record<string, string[]> = {
   '1.5.0': [
     'We clarified that cookie-free product analytics use a pseudonymous visitor/session identifier, not account identity.',
     'We added a clearer description of the coarse technical and IP-derived location information visible in our self-hosted analytics.',
+  ],
+  '1.6.0': [
+    'Non-essential product analytics are now disabled by default and require a separate, optional opt-in.',
+    'You can withdraw that telemetry permission at any time without affecting access to GFC.',
   ],
 };
 
@@ -108,7 +112,7 @@ const ProductAnalyticsPreference: React.FC = () => {
   return (
     <button type="button" role="switch" aria-checked={enabled} className="privacy-analytics-preference" onClick={handleChange}>
       <strong>Non-essential product analytics: {enabled ? 'Enabled' : 'Disabled'}</strong>
-      <span>{enabled ? 'Disable local pseudonymous telemetry' : 'Enable local pseudonymous telemetry'}</span>
+      <span>{enabled ? 'Withdraw telemetry permission' : 'Enable optional pseudonymous telemetry'}</span>
     </button>
   );
 };
@@ -173,10 +177,12 @@ const PrivacyPolicyContent: React.FC<{ whatsNewItems?: string[] }> = ({ whatsNew
       your account view.
     </p>
     <p>
-      You can disable non-essential product analytics from your local telemetry preference. When disabled, GFC does
-      not load the Umami tracker or send product-analytics events. Analytics are hosted by GFC on our VPS and are not
-      used for advertising, cross-site tracking, or sale of personal data. Event-level telemetry is retained only for
-      product operations and may be deleted during routine maintenance; aggregate metrics may be retained longer.
+      Non-essential product analytics are disabled by default. You may optionally enable them using the local telemetry
+      preference below; choosing not to enable them does not affect access to GFC. You can withdraw that permission at
+      any time from the same control. When disabled, GFC does not load the Umami tracker or send product-analytics
+      events. Analytics are hosted by GFC on our VPS and are not used for advertising, cross-site tracking, or sale of
+      personal data. Event-level telemetry is retained only for product operations and may be deleted during routine
+      maintenance; aggregate metrics may be retained longer.
     </p>
     <ProductAnalyticsPreference />
     <p>

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -109,11 +109,11 @@ const ProductAnalyticsPreference: React.FC = () => {
   const [enabled, setEnabled] = useState(() => isProductAnalyticsEnabled());
   const handleChange = () => {
     const nextEnabled = !enabled;
-    setProductAnalyticsEnabled(nextEnabled);
+    const effectiveEnabled = setProductAnalyticsEnabled(nextEnabled);
     // A consent action is the earliest permitted point to initialize analytics.
     // Record the page the person explicitly chose from; nothing is injected or queued beforehand.
-    if (nextEnabled) trackProductPageView();
-    setEnabled(nextEnabled);
+    if (effectiveEnabled) trackProductPageView();
+    setEnabled(effectiveEnabled);
   };
 
   return (

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -126,6 +126,17 @@ const PrivacyPolicyContent: React.FC<{ whatsNewItems?: string[] }> = ({ whatsNew
       collect what is strictly necessary to sync your work and securely manage your subscription.
     </p>
 
+    <section className="privacy-analytics-choice" aria-labelledby="privacy-analytics-choice-title">
+      <div>
+        <h3 id="privacy-analytics-choice-title">Optional product analytics</h3>
+        <p>
+          Help us understand which parts of GFC are useful. This is disabled by default, never affects access to GFC,
+          and can be changed here at any time.
+        </p>
+      </div>
+      <ProductAnalyticsPreference />
+    </section>
+
     <h3>1. Local-First by Default</h3>
     <p>
       If you use Graphical Forecast Creator (GFC) without creating an account, all of your forecast data, preferences,
@@ -178,13 +189,12 @@ const PrivacyPolicyContent: React.FC<{ whatsNewItems?: string[] }> = ({ whatsNew
     </p>
     <p>
       Non-essential product analytics are disabled by default. You may optionally enable them using the local telemetry
-      preference below; choosing not to enable them does not affect access to GFC. You can withdraw that permission at
+      preference at the top of this policy; choosing not to enable them does not affect access to GFC. You can withdraw that permission at
       any time from the same control. When disabled, GFC does not load the Umami tracker or send product-analytics
       events. Analytics are hosted by GFC on our VPS and are not used for advertising, cross-site tracking, or sale of
       personal data. Event-level telemetry is retained only for product operations and may be deleted during routine
       maintenance; aggregate metrics may be retained longer.
     </p>
-    <ProductAnalyticsPreference />
     <p>
       On production and beta hosted deployments, we use Sentry (a third-party error monitoring service) to capture
       application errors and limited performance data so we can fix bugs quickly. This is separate from product analytics

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import './PrivacyPolicyModal.css';
-import { isProductAnalyticsEnabled, setProductAnalyticsEnabled } from '../../lib/productAnalytics';
+import { isProductAnalyticsEnabled, setProductAnalyticsEnabled, trackProductPageView } from '../../lib/productAnalytics';
 
 // Bump this version string whenever the Privacy Policy changes materially.
 // Users who accepted an older version will be asked to re-accept.
@@ -110,6 +110,9 @@ const ProductAnalyticsPreference: React.FC = () => {
   const handleChange = () => {
     const nextEnabled = !enabled;
     setProductAnalyticsEnabled(nextEnabled);
+    // A consent action is the earliest permitted point to initialize analytics.
+    // Record the page the person explicitly chose from; nothing is injected or queued beforehand.
+    if (nextEnabled) trackProductPageView();
     setEnabled(nextEnabled);
   };
 

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -4,7 +4,7 @@ import { isProductAnalyticsEnabled, setProductAnalyticsEnabled } from '../../lib
 
 // Bump this version string whenever the Privacy Policy changes materially.
 // Users who accepted an older version will be asked to re-accept.
-const PRIVACY_POLICY_VERSION = '1.6.0';
+const PRIVACY_POLICY_VERSION = '1.7.0';
 const PRIVACY_POLICY_LAST_UPDATED = 'July 21, 2026';
 const STORAGE_KEY = 'gfc-privacy-policy-accepted';
 
@@ -31,6 +31,10 @@ const PRIVACY_POLICY_CHANGELOG: Record<string, string[]> = {
   '1.6.0': [
     'Non-essential product analytics are now disabled by default and require a separate, optional opt-in.',
     'You can withdraw that telemetry permission at any time without affecting access to GFC.',
+  ],
+  '1.7.0': [
+    'We minimized new product-analytics location collection and documented how to request access or deletion help for pseudonymous telemetry.',
+    'We clarified that a fixed event-level telemetry retention period is still an unresolved operational decision.',
   ],
 };
 
@@ -130,8 +134,8 @@ const PrivacyPolicyContent: React.FC<{ whatsNewItems?: string[] }> = ({ whatsNew
       <div>
         <h3 id="privacy-analytics-choice-title">Optional product analytics</h3>
         <p>
-          Help us understand which parts of GFC are useful. This is disabled by default, never affects access to GFC,
-          and can be changed here at any time.
+          Help us understand which parts of GFC are useful. This is disabled by default and is a separate choice from
+          accepting this Privacy Policy. It never affects access to GFC and can be changed here at any time.
         </p>
       </div>
       <ProductAnalyticsPreference />
@@ -176,8 +180,10 @@ const PrivacyPolicyContent: React.FC<{ whatsNewItems?: string[] }> = ({ whatsNew
       analytics on the production and beta deployments in separate reporting zones. It uses a pseudonymous
       visitor/session identifier to group activity from the same browser without attaching it to your GFC account. We
       collect page views, selected milestone events such as completed exports, cloud-save outcomes, workflow outcomes,
-      and custom-layer creation, plus coarse technical information (browser, operating system, device type, and time)
-      and IP-derived approximate location (country, region, and city). <strong>We do not use account identity,
+      and custom-layer creation, plus route/page activity, timestamps, and coarse technical information (browser,
+      operating system, and device type). The Umami service can derive approximate location from an IP address, but GFC
+      currently removes visitor IP addresses before they reach Umami, so new GFC telemetry does not include country,
+      region, or city. <strong>We do not use account identity,
       Firebase UID, email address, forecast contents, coordinates, layer text, filenames, or export contents for
       product analytics.</strong>
     </p>
@@ -192,8 +198,11 @@ const PrivacyPolicyContent: React.FC<{ whatsNewItems?: string[] }> = ({ whatsNew
       preference at the top of this policy; choosing not to enable them does not affect access to GFC. You can withdraw that permission at
       any time from the same control. When disabled, GFC does not load the Umami tracker or send product-analytics
       events. Analytics are hosted by GFC on our VPS and are not used for advertising, cross-site tracking, or sale of
-      personal data. Event-level telemetry is retained only for product operations and may be deleted during routine
-      maintenance; aggregate metrics may be retained longer.
+      personal data. Beta and production are separate analytics zones. Because this telemetry is not linked to a
+      Firebase account, Firebase account deletion does not identify a matching telemetry record. A fixed event-level
+      telemetry retention period has not yet been adopted; we will publish and implement one before representing a
+      fixed deletion schedule. For a telemetry access or deletion request, or any privacy question, contact us at the
+      address in section 9 with the approximate date, browser/device, and route or event details you want us to locate.
     </p>
     <p>
       On production and beta hosted deployments, we use Sentry (a third-party error monitoring service) to capture

--- a/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -4,8 +4,8 @@ import { isProductAnalyticsEnabled, setProductAnalyticsEnabled } from '../../lib
 
 // Bump this version string whenever the Privacy Policy changes materially.
 // Users who accepted an older version will be asked to re-accept.
-const PRIVACY_POLICY_VERSION = '1.4.0';
-const PRIVACY_POLICY_LAST_UPDATED = 'July 20, 2026';
+const PRIVACY_POLICY_VERSION = '1.5.0';
+const PRIVACY_POLICY_LAST_UPDATED = 'July 21, 2026';
 const STORAGE_KEY = 'gfc-privacy-policy-accepted';
 
 // Changelog of material privacy-policy changes, keyed by the version that introduced them.
@@ -23,6 +23,10 @@ const PRIVACY_POLICY_CHANGELOG: Record<string, string[]> = {
   '1.4.0': [
     'We replaced Google Analytics and the previous hosted metrics collector with self-hosted Umami product analytics.',
     'Production and beta analytics are kept in separate reporting zones, and the same local preference can disable non-essential analytics for both.',
+  ],
+  '1.5.0': [
+    'We clarified that cookie-free product analytics use a pseudonymous visitor/session identifier, not account identity.',
+    'We added a clearer description of the coarse technical and IP-derived location information visible in our self-hosted analytics.',
   ],
 };
 
@@ -104,7 +108,7 @@ const ProductAnalyticsPreference: React.FC = () => {
   return (
     <button type="button" role="switch" aria-checked={enabled} className="privacy-analytics-preference" onClick={handleChange}>
       <strong>Non-essential product analytics: {enabled ? 'Enabled' : 'Disabled'}</strong>
-      <span>{enabled ? 'Disable local anonymous telemetry' : 'Enable local anonymous telemetry'}</span>
+      <span>{enabled ? 'Disable local pseudonymous telemetry' : 'Enable local pseudonymous telemetry'}</span>
     </button>
   );
 };
@@ -153,11 +157,14 @@ const PrivacyPolicyContent: React.FC<{ whatsNewItems?: string[] }> = ({ whatsNew
 
     <h3>5. Product Analytics &amp; Progress Metrics</h3>
     <p>
-      To understand which hosted GFC workflows need improvement, we use self-hosted Umami product analytics on the
-      production and beta deployments in separate reporting zones. We collect page views, coarse browser/device
-      information, and selected milestone events such as completed exports, cloud-save outcomes, workflow outcomes,
-      and custom-layer creation. <strong>We do not use account identity, Firebase UID, email address, forecast
-      contents, coordinates, layer text, filenames, or export contents for product analytics.</strong>
+      To understand which hosted GFC workflows need improvement, we use self-hosted, cookie-free Umami product
+      analytics on the production and beta deployments in separate reporting zones. It uses a pseudonymous
+      visitor/session identifier to group activity from the same browser without attaching it to your GFC account. We
+      collect page views, selected milestone events such as completed exports, cloud-save outcomes, workflow outcomes,
+      and custom-layer creation, plus coarse technical information (browser, operating system, device type, and time)
+      and IP-derived approximate location (country, region, and city). <strong>We do not use account identity,
+      Firebase UID, email address, forecast contents, coordinates, layer text, filenames, or export contents for
+      product analytics.</strong>
     </p>
     <p>
       If you are signed in, we also store limited progress metrics tied to your account so we can show you your own
@@ -168,7 +175,8 @@ const PrivacyPolicyContent: React.FC<{ whatsNewItems?: string[] }> = ({ whatsNew
     <p>
       You can disable non-essential product analytics from your local telemetry preference. When disabled, GFC does
       not load the Umami tracker or send product-analytics events. Analytics are hosted by GFC on our VPS and are not
-      used for advertising, cross-site tracking, or sale of personal data.
+      used for advertising, cross-site tracking, or sale of personal data. Event-level telemetry is retained only for
+      product operations and may be deleted during routine maintenance; aggregate metrics may be retained longer.
     </p>
     <ProductAnalyticsPreference />
     <p>

--- a/src/lib/productAnalytics.test.ts
+++ b/src/lib/productAnalytics.test.ts
@@ -45,7 +45,19 @@ test('loads the matching zone and normalizes page paths before tracking', () => 
   initProductAnalytics('gfc.weatherboysuper.com');
   expect(document.querySelector('script[data-website-id="prod-zone"]')).not.toBeNull();
   trackProductPageView('/forecast?name=not-for-analytics', 'gfc.weatherboysuper.com');
-  expect(track).toHaveBeenCalledWith('page_view', { path: '/forecast' });
+  expect(track).toHaveBeenCalledWith({ url: '/forecast' });
+});
+
+test('flushes a queued route as a native Umami page view after the tracker loads', () => {
+  initProductAnalytics('beta-gfc.weatherboysuper.com');
+  trackProductPageView('/cloud-library#private', 'beta-gfc.weatherboysuper.com');
+
+  const track = jest.fn();
+  window.umami = { track };
+  document.querySelector<HTMLScriptElement>('script[data-gfc-umami="true"]')?.dispatchEvent(new Event('load'));
+
+  expect(track).toHaveBeenCalledWith({ url: '/cloud-library' });
+  expect(track).not.toHaveBeenCalledWith('page_view', expect.anything());
 });
 
 test('discards queued events when analytics is explicitly disabled', () => {

--- a/src/lib/productAnalytics.test.ts
+++ b/src/lib/productAnalytics.test.ts
@@ -38,6 +38,18 @@ test('does not load a tracker until the visitor explicitly enables analytics', (
   expect(isProductAnalyticsEnabled()).toBe(false);
 });
 
+test('loads a privacy-minimized tracker only after explicit opt-in', () => {
+  setProductAnalyticsEnabled(true);
+  initProductAnalytics('gfc.weatherboysuper.com');
+
+  const script = document.querySelector<HTMLScriptElement>('script[data-gfc-umami="true"]');
+  expect(script).not.toBeNull();
+  expect(script?.dataset.autoTrack).toBe('false');
+  expect(script?.dataset.doNotTrack).toBe('true');
+  expect(script?.dataset.excludeSearch).toBe('true');
+  expect(script?.dataset.excludeHash).toBe('true');
+});
+
 test('preserves a prior explicit workflow opt-in until the unified preference is set', () => {
   localStorage.setItem('gfc-workflow-analytics-enabled', 'true');
   expect(isProductAnalyticsEnabled()).toBe(true);
@@ -68,7 +80,7 @@ test('flushes a queued route as a native Umami page view after the tracker loads
   expect(track).not.toHaveBeenCalledWith('page_view', expect.anything());
 });
 
-test('discards queued events when analytics is explicitly disabled', () => {
+test('withdrawal removes the tracker and discards queued telemetry', () => {
   setProductAnalyticsEnabled(true);
   initProductAnalytics('gfc.weatherboysuper.com');
   trackProductEvent('cloud_save_completed');

--- a/src/lib/productAnalytics.test.ts
+++ b/src/lib/productAnalytics.test.ts
@@ -32,9 +32,15 @@ test('does not load a tracker when the unified preference is disabled', () => {
   expect(isProductAnalyticsEnabled()).toBe(false);
 });
 
-test('preserves the prior workflow-only opt-out until the unified preference is set', () => {
-  localStorage.setItem('gfc-workflow-analytics-enabled', 'false');
+test('does not load a tracker until the visitor explicitly enables analytics', () => {
+  initProductAnalytics('gfc.weatherboysuper.com');
+  expect(document.querySelector('script[data-website-id]')).toBeNull();
   expect(isProductAnalyticsEnabled()).toBe(false);
+});
+
+test('preserves a prior explicit workflow opt-in until the unified preference is set', () => {
+  localStorage.setItem('gfc-workflow-analytics-enabled', 'true');
+  expect(isProductAnalyticsEnabled()).toBe(true);
   setProductAnalyticsEnabled(true);
   expect(isProductAnalyticsEnabled()).toBe(true);
 });
@@ -42,6 +48,7 @@ test('preserves the prior workflow-only opt-out until the unified preference is 
 test('loads the matching zone and normalizes page paths before tracking', () => {
   const track = jest.fn();
   window.umami = { track };
+  setProductAnalyticsEnabled(true);
   initProductAnalytics('gfc.weatherboysuper.com');
   expect(document.querySelector('script[data-website-id="prod-zone"]')).not.toBeNull();
   trackProductPageView('/forecast?name=not-for-analytics', 'gfc.weatherboysuper.com');
@@ -49,6 +56,7 @@ test('loads the matching zone and normalizes page paths before tracking', () => 
 });
 
 test('flushes a queued route as a native Umami page view after the tracker loads', () => {
+  setProductAnalyticsEnabled(true);
   initProductAnalytics('beta-gfc.weatherboysuper.com');
   trackProductPageView('/cloud-library#private', 'beta-gfc.weatherboysuper.com');
 
@@ -61,6 +69,7 @@ test('flushes a queued route as a native Umami page view after the tracker loads
 });
 
 test('discards queued events when analytics is explicitly disabled', () => {
+  setProductAnalyticsEnabled(true);
   initProductAnalytics('gfc.weatherboysuper.com');
   trackProductEvent('cloud_save_completed');
   setProductAnalyticsEnabled(false);

--- a/src/lib/productAnalytics.test.ts
+++ b/src/lib/productAnalytics.test.ts
@@ -80,6 +80,26 @@ test('flushes a queued route as a native Umami page view after the tracker loads
   expect(track).not.toHaveBeenCalledWith('page_view', expect.anything());
 });
 
+test('tears down tracker even when localStorage.setItem throws on disable', () => {
+  setProductAnalyticsEnabled(true);
+  initProductAnalytics('gfc.weatherboysuper.com');
+  expect(document.querySelector('script[data-gfc-umami="true"]')).not.toBeNull();
+
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('Storage full'); });
+
+  const effective = setProductAnalyticsEnabled(false);
+  expect(effective).toBe(false);
+  expect(document.querySelector('script[data-gfc-umami="true"]')).toBeNull();
+});
+
+test('returns false when enabling analytics but localStorage.setItem throws', () => {
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('Storage full'); });
+
+  const effective = setProductAnalyticsEnabled(true);
+  expect(effective).toBe(false);
+  expect(isProductAnalyticsEnabled()).toBe(false);
+});
+
 test('withdrawal removes the tracker and discards queued telemetry', () => {
   setProductAnalyticsEnabled(true);
   initProductAnalytics('gfc.weatherboysuper.com');

--- a/src/lib/productAnalytics.ts
+++ b/src/lib/productAnalytics.ts
@@ -137,6 +137,8 @@ const createTrackerScript = ({ host, websiteId }: TrackerConfiguration): HTMLScr
   script.dataset.hostUrl = host;
   script.dataset.autoTrack = 'false';
   script.dataset.doNotTrack = 'true';
+  script.dataset.excludeSearch = 'true';
+  script.dataset.excludeHash = 'true';
   script.dataset.gfcUmami = 'true';
   script.addEventListener('load', () => { if (isProductAnalyticsEnabled()) flushPendingTelemetry(); });
   script.addEventListener('error', () => { initializedZone = null; });

--- a/src/lib/productAnalytics.ts
+++ b/src/lib/productAnalytics.ts
@@ -62,14 +62,14 @@ export const getProductAnalyticsZone = (hostname?: string): AnalyticsZone | null
   return null;
 };
 
-/** False is an explicit opt-out; absence preserves the product default. */
+/** Analytics are non-essential and remain off until the visitor explicitly enables them. */
 export const isProductAnalyticsEnabled = (): boolean => {
   try {
-    if (typeof localStorage === 'undefined') return true;
+    if (typeof localStorage === 'undefined') return false;
     const preference = localStorage.getItem(PRODUCT_ANALYTICS_PREFERENCE_KEY);
-    if (preference !== null) return preference !== 'false';
-    // Preserve an existing workflow-only opt-out when moving to the unified preference.
-    return localStorage.getItem(LEGACY_WORKFLOW_ANALYTICS_PREFERENCE_KEY) !== 'false';
+    if (preference !== null) return preference === 'true';
+    // A prior explicit workflow opt-in remains valid; absence never enables new telemetry.
+    return localStorage.getItem(LEGACY_WORKFLOW_ANALYTICS_PREFERENCE_KEY) === 'true';
   } catch {
     return false;
   }

--- a/src/lib/productAnalytics.ts
+++ b/src/lib/productAnalytics.ts
@@ -76,11 +76,13 @@ export const isProductAnalyticsEnabled = (): boolean => {
 };
 
 /** Stores the local opt-out and removes the injected tracker immediately when it is disabled. */
-export const setProductAnalyticsEnabled = (enabled: boolean): void => {
+export const setProductAnalyticsEnabled = (enabled: boolean): boolean => {
+  let persisted = false;
   try {
     localStorage.setItem(PRODUCT_ANALYTICS_PREFERENCE_KEY, String(enabled));
+    persisted = true;
   } catch {
-    return;
+    // localStorage unavailable — effective state cannot match the requested value
   }
   if (!enabled && typeof document !== 'undefined') {
     document.querySelector('script[data-gfc-umami="true"]')?.remove();
@@ -88,6 +90,8 @@ export const setProductAnalyticsEnabled = (enabled: boolean): void => {
     pendingPagePath = null;
     pendingEvents = [];
   }
+  // Disable always succeeds (teardown happened); enable requires persistence.
+  return enabled ? persisted : false;
 };
 
 const getWebsiteId = (zone: AnalyticsZone): string => {

--- a/src/lib/productAnalytics.ts
+++ b/src/lib/productAnalytics.ts
@@ -14,10 +14,11 @@ export type ProductAnalyticsEvent = (typeof PRODUCT_ANALYTICS_EVENTS)[number];
 export type ProductAnalyticsProperties = Record<string, string | number | boolean>;
 type AnalyticsZone = 'production' | 'beta';
 type TrackerConfiguration = { zone: AnalyticsZone; host: string; websiteId: string };
+type UmamiPageView = { url: string };
 
 declare global {
   interface Window {
-    umami?: { track: (event: string, data?: ProductAnalyticsProperties) => void };
+    umami?: { track: (event: string | UmamiPageView, data?: ProductAnalyticsProperties) => void };
   }
 }
 
@@ -107,8 +108,17 @@ const trackSafely = ({ event, properties }: { event: string; properties?: Produc
   } catch { return false; }
 };
 
+/** Sends a native Umami page view, keeping user-provided query/hash data out of the URL. */
+const trackPageViewSafely = (path: string): boolean => {
+  try {
+    if (!window.umami) return false;
+    window.umami.track({ url: path });
+    return true;
+  } catch { return false; }
+};
+
 const flushPendingTelemetry = (): void => {
-  if (pendingPagePath) trackSafely({ event: 'page_view', properties: { path: pendingPagePath } });
+  if (pendingPagePath) trackPageViewSafely(pendingPagePath);
   pendingPagePath = null;
   const queuedEvents = pendingEvents;
   pendingEvents = [];
@@ -161,7 +171,7 @@ export const trackProductPageView = (pathname?: string, hostname?: string): void
   if (!getProductAnalyticsZone(hostname)) return;
   const path = (pathname ?? window.location.pathname).split(/[?#]/, 1)[0];
   initProductAnalytics(hostname);
-  if (!trackSafely({ event: 'page_view', properties: { path } })) pendingPagePath = path;
+  if (!trackPageViewSafely(path)) pendingPagePath = path;
 };
 
 /** Sends only registry-backed, coarse event properties. */


### PR DESCRIPTION
## Summary

- send manual SPA routes through Umami's native page-view API, restoring Overview and native page metrics
- retain allowlisted custom milestone events for Umami event metrics, funnels, journeys, and tables
- make product analytics a separate, optional opt-in and clarify the self-hosted telemetry privacy disclosure
- minimize new telemetry location data at the VPS edge, disable the Umami vhost access log, and document retention, access/deletion, backup, and incident-response decisions

## Verification

- `pnpm test` (870 passed)
- `server/npm test` (96 passed)
- `pnpm run build` (successful artifact; known non-blocking Sentry sourcemap-upload 403)
- local browser smoke checks of the top-of-policy analytics choice, default-off state, explicit opt-in, and withdrawal
- read-only Umami/VPS audit followed by a tested Nginx vhost privacy change (no service restart or data deletion)

## Notes

- Production and beta remain separate Umami website zones.
- No Firebase UID, account identity, or forecast content is sent to Umami.
- This is conservative engineering/privacy hardening, not a claim of worldwide legal certification. The event-level retention and backup-retention decision remains explicitly unresolved in `docs/operations/umami-telemetry-privacy-operations.md`.
