### PR TITLE
fix: harden billing error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Security
+- **Billing API error boundary:** Return stable checkout and portal failure codes with correlation IDs while keeping bounded provider diagnostics in server logs.
 - **Hosted authorization boundaries:** Add source-controlled Firestore rules, hostile-client emulator coverage, reserved profile-field protection, trusted premium enforcement for cloud writes, and bounded cloud-cycle documents while retaining owner export/delete access after downgrade.
 - **CI shell injection:** Pass PR branch refs through `env` in `ci.yml` and `pr-governance.yml` `git fetch` steps so branch names cannot break out of the shell command.
 - **Dependabot changelog workflow:** Require Dependabot PR provenance before checking out PR head code with `GH_PAT`; pass base ref through env in shell steps; pin `actions/checkout` to an immutable SHA.

--- a/server/billing-error-boundary.test.js
+++ b/server/billing-error-boundary.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { describe, it, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const { wrapBillingJsonRoute } = require('./billing');
+
+/** Creates the small Express response surface used by billing route failures. */
+const createResponse = () => {
+  const response = {
+    headers: {},
+    statusCode: null,
+    body: null,
+    set(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(value) {
+      this.statusCode = value;
+      return this;
+    },
+    json(value) {
+      this.body = value;
+      return this;
+    },
+  };
+  return response;
+};
+
+describe('billing route error boundary', () => {
+  it('returns a stable public error without leaking provider exception text', async () => {
+    const providerMessage = 'Stripe request failed for secret customer details';
+    const providerError = Object.assign(new Error(providerMessage), { code: 'provider_internal' });
+    const handler = wrapBillingJsonRoute({
+      handler: async () => {
+        throw providerError;
+      },
+      fallbackMessage: 'Unable to create checkout session.',
+      failureCode: 'billing_checkout_failed',
+    });
+    const response = createResponse();
+    const errorLog = mock.method(console, 'error', () => {});
+
+    try {
+      await handler({ method: 'POST', path: '/api/billing/checkout' }, response);
+    } finally {
+      errorLog.mock.restore();
+    }
+
+    assert.equal(response.statusCode, 500);
+    assert.equal(response.body.error, 'Unable to create checkout session.');
+    assert.equal(response.body.code, 'billing_checkout_failed');
+    assert.match(response.body.requestId, /^[0-9a-f-]{36}$/i);
+    assert.equal(response.headers['X-Request-ID'], response.body.requestId);
+    assert.equal(JSON.stringify(response.body).includes(providerMessage), false);
+  });
+
+  it('logs bounded diagnostics under the same request id', async () => {
+    const providerError = Object.assign(new Error(`line one\n${'x'.repeat(700)}`), {
+      code: 'provider_timeout',
+    });
+    const handler = wrapBillingJsonRoute({
+      handler: async () => {
+        throw providerError;
+      },
+      fallbackMessage: 'Unable to open the billing portal.',
+      failureCode: 'billing_portal_failed',
+    });
+    const response = createResponse();
+    const errorLog = mock.method(console, 'error', () => {});
+
+    try {
+      await handler({ method: 'POST', path: '/api/billing/portal' }, response);
+      const [, diagnostic] = errorLog.mock.calls[0].arguments;
+      assert.equal(diagnostic.requestId, response.body.requestId);
+      assert.equal(diagnostic.failureCode, 'billing_portal_failed');
+      assert.equal(diagnostic.path, '/api/billing/portal');
+      assert.equal(diagnostic.errorMessage.includes('\n'), false);
+      assert.equal(diagnostic.errorMessage.length, 500);
+      assert.equal(diagnostic.providerCode, 'provider_timeout');
+    } finally {
+      errorLog.mock.restore();
+    }
+  });
+
+  it('does not interfere with handlers that intentionally send a response', async () => {
+    const response = createResponse();
+    const handler = wrapBillingJsonRoute({
+      handler: async (_req, res) => res.status(400).json({ error: 'Invalid billing plan selected.' }),
+      fallbackMessage: 'Unable to create checkout session.',
+      failureCode: 'billing_checkout_failed',
+    });
+
+    await handler({ method: 'POST', path: '/api/billing/checkout' }, response);
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.body, { error: 'Invalid billing plan selected.' });
+    assert.deepEqual(response.headers, {});
+  });
+});

--- a/server/billing.js
+++ b/server/billing.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { randomUUID } = require('node:crypto');
 const Stripe = require('stripe');
 const rateLimit = require('express-rate-limit');
 const { getSubscriptionPeriodEndUnix } = require('./billing-stripe-period');
@@ -479,12 +480,40 @@ const handleBillingWebhook = async (req, res) => {
   await processWebhookRequest(req, res, stripe, webhookSecret);
 };
 
-/** Generic wrapper for billing JSON routes with shared error handling. */
-const wrapBillingJsonRoute = ({ handler, fallbackMessage }) => async (req, res) => {
+/** Bounds diagnostic strings before they are written to operational logs. */
+const normalizeBillingDiagnostic = (value, fallback) =>
+  typeof value === 'string' && value.trim()
+    ? value.replace(/[\r\n\t]+/g, ' ').trim().slice(0, 500)
+    : fallback;
+
+/** Logs an unexpected billing route failure without request bodies or credentials. */
+const logBillingRouteError = ({ error, req, requestId, failureCode }) => {
+  console.error('[billing] route:error', {
+    requestId,
+    failureCode,
+    method: req.method || null,
+    path: req.path || null,
+    errorName: error instanceof Error ? normalizeBillingDiagnostic(error.name, 'Error') : 'UnknownError',
+    errorMessage: error instanceof Error
+      ? normalizeBillingDiagnostic(error.message, 'Unknown billing failure')
+      : 'Unknown billing failure',
+    providerCode: normalizeBillingDiagnostic(error?.code, null),
+  });
+};
+
+/** Generic wrapper for billing JSON routes with shared, non-sensitive error handling. */
+const wrapBillingJsonRoute = ({ handler, fallbackMessage, failureCode }) => async (req, res) => {
   try {
     await handler(req, res);
   } catch (error) {
-    res.status(500).json({ error: error instanceof Error ? error.message : fallbackMessage });
+    const requestId = randomUUID();
+    logBillingRouteError({ error, req, requestId, failureCode });
+    res.set('X-Request-ID', requestId);
+    res.status(500).json({
+      error: fallbackMessage,
+      code: failureCode,
+      requestId,
+    });
   }
 };
 
@@ -504,6 +533,7 @@ const registerBillingRoutes = (app, express) => {
     wrapBillingJsonRoute({
       handler: handleCheckout,
       fallbackMessage: 'Unable to create checkout session.',
+      failureCode: 'billing_checkout_failed',
     })
   );
   app.post(
@@ -513,10 +543,12 @@ const registerBillingRoutes = (app, express) => {
     wrapBillingJsonRoute({
       handler: handleBillingPortal,
       fallbackMessage: 'Unable to open the billing portal.',
+      failureCode: 'billing_portal_failed',
     })
   );
 };
 
 module.exports = {
   registerBillingRoutes,
+  wrapBillingJsonRoute,
 };

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "main": "analytics.js",
   "scripts": {
     "start": "node analytics.js",
-    "test": "node --test billing-stripe-period.test.js qs-dos.test.js server-stack.test.js"
+    "test": "node --test billing-error-boundary.test.js billing-stripe-period.test.js qs-dos.test.js server-stack.test.js"
   },
   "dependencies": {
     "@sentry/node": "^10.56.0",


### PR DESCRIPTION
## What changed

- return stable checkout and portal failure messages and machine-readable codes
- attach a correlation ID to the response body and `X-Request-ID` header
- keep bounded provider diagnostics in server logs without logging request bodies or credentials
- preserve intentional authentication, availability, and validation responses

## Why

Unexpected provider failures should be diagnosable without exposing provider-specific implementation details through the public API.

## Impact

Successful billing behavior and intentional 4xx/503 responses are unchanged. Unexpected checkout or portal failures now provide a stable support identifier.

## Verification

- `npm --prefix server test` — 11 passed
- `pnpm test -- --runInBand` — 126 suites / 488 tests passed
- `pnpm run build` — passed; existing non-fatal Sentry upload permission warning remains
