### PR TITLE
fix: harden billing webhook state transitions

### DIFF
--- a/server/billing-webhook-state.js
+++ b/server/billing-webhook-state.js
@@ -18,52 +18,80 @@ const isStaleStripeEvent = (existingData, event) => {
   );
 };
 
+/** True when the transaction has every verified input needed to write billing state. */
+const hasWebhookStateInput = ({ db, entitlementRef, event, buildNextPayload }) =>
+  [db, entitlementRef, event?.id, event?.type, typeof buildNextPayload === 'function'].every(Boolean);
+
+/** Reads the ledger and entitlement snapshots before any transaction writes occur. */
+const readWebhookState = async (transaction, eventRef, entitlementRef) => {
+  const [eventSnapshot, entitlementSnapshot] = await Promise.all([
+    transaction.get(eventRef),
+    transaction.get(entitlementRef),
+  ]);
+  return { eventSnapshot, entitlementSnapshot };
+};
+
+/** Returns the previously committed outcome for a repeated Stripe event id. */
+const createDuplicateResult = (eventSnapshot) => ({
+  applied: false,
+  reason: 'duplicate',
+  priorOutcome: eventSnapshot.data()?.outcome || 'unknown',
+});
+
+/** Builds the TTL-ready ledger record for one entitlement processing attempt. */
+const createEventLedgerPayload = ({ event, entitlementRef, stale }) => {
+  const processedAt = new Date();
+  return {
+    eventType: event.type,
+    eventCreated: Number(event.created) || 0,
+    entitlementId: entitlementRef.id,
+    outcome: stale ? 'stale' : 'applied',
+    processedAt,
+    expiresAt: new Date(processedAt.getTime() + EVENT_LEDGER_RETENTION_MS),
+  };
+};
+
+/** Builds the accepted entitlement payload with its Stripe ordering marker. */
+const createAcceptedEntitlementPayload = ({ existingData, event, buildNextPayload }) => ({
+  ...buildNextPayload(existingData),
+  lastStripeEventId: event.id,
+  lastStripeEventType: event.type,
+  lastStripeEventCreated: Number(event.created) || 0,
+});
+
+/** Performs one atomic ledger and entitlement update. */
+const applyEntitlementTransaction = async ({ transaction, eventRef, entitlementRef, event, buildNextPayload }) => {
+  const { eventSnapshot, entitlementSnapshot } = await readWebhookState(
+    transaction,
+    eventRef,
+    entitlementRef
+  );
+  if (eventSnapshot.exists) {
+    return createDuplicateResult(eventSnapshot);
+  }
+
+  const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
+  const stale = isStaleStripeEvent(existingData, event);
+  transaction.set(eventRef, createEventLedgerPayload({ event, entitlementRef, stale }));
+  if (stale) {
+    return { applied: false, reason: 'stale' };
+  }
+
+  const nextPayload = createAcceptedEntitlementPayload({ existingData, event, buildNextPayload });
+  transaction.set(entitlementRef, nextPayload, { merge: true });
+  return { applied: true, reason: 'applied', nextPayload };
+};
+
 /** Applies one verified Stripe event exactly once without allowing older state to win. */
 const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNextPayload }) => {
-  if (!db || !entitlementRef || !event?.id || !event?.type || typeof buildNextPayload !== 'function') {
+  if (!hasWebhookStateInput({ db, entitlementRef, event, buildNextPayload })) {
     throw new Error('A verified Stripe event and entitlement target are required.');
   }
 
   const eventRef = db.collection(EVENT_LEDGER_COLLECTION).doc(event.id);
-  return db.runTransaction(async (transaction) => {
-    const [eventSnapshot, entitlementSnapshot] = await Promise.all([
-      transaction.get(eventRef),
-      transaction.get(entitlementRef),
-    ]);
-
-    if (eventSnapshot.exists) {
-      return {
-        applied: false,
-        reason: 'duplicate',
-        priorOutcome: eventSnapshot.data()?.outcome || 'unknown',
-      };
-    }
-
-    const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
-    const stale = isStaleStripeEvent(existingData, event);
-    const processedAt = new Date();
-    transaction.set(eventRef, {
-      eventType: event.type,
-      eventCreated: Number(event.created) || 0,
-      entitlementId: entitlementRef.id,
-      outcome: stale ? 'stale' : 'applied',
-      processedAt,
-      expiresAt: new Date(processedAt.getTime() + EVENT_LEDGER_RETENTION_MS),
-    });
-
-    if (stale) {
-      return { applied: false, reason: 'stale' };
-    }
-
-    const nextPayload = {
-      ...buildNextPayload(existingData),
-      lastStripeEventId: event.id,
-      lastStripeEventType: event.type,
-      lastStripeEventCreated: Number(event.created) || 0,
-    };
-    transaction.set(entitlementRef, nextPayload, { merge: true });
-    return { applied: true, reason: 'applied', nextPayload };
-  });
+  return db.runTransaction((transaction) =>
+    applyEntitlementTransaction({ transaction, eventRef, entitlementRef, event, buildNextPayload })
+  );
 };
 
 module.exports = {

--- a/server/billing-webhook-state.js
+++ b/server/billing-webhook-state.js
@@ -32,7 +32,11 @@ const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNe
     ]);
 
     if (eventSnapshot.exists) {
-      return { applied: false, reason: 'duplicate' };
+      return {
+        applied: false,
+        reason: 'duplicate',
+        priorOutcome: eventSnapshot.data()?.outcome || 'unknown',
+      };
     }
 
     const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};

--- a/server/billing-webhook-state.js
+++ b/server/billing-webhook-state.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const EVENT_LEDGER_COLLECTION = 'processedStripeWebhookEvents';
+const EVENT_LEDGER_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Returns true when the incoming event would move entitlement state backward. */
+const isStaleStripeEvent = (existingData, event) => {
+  const lastCreated = Number(existingData.lastStripeEventCreated) || 0;
+  const eventCreated = Number(event.created) || 0;
+  if (eventCreated < lastCreated) {
+    return true;
+  }
+
+  return (
+    eventCreated === lastCreated &&
+    existingData.lastStripeEventType === 'customer.subscription.deleted' &&
+    event.type !== 'customer.subscription.deleted'
+  );
+};
+
+/** Applies one verified Stripe event exactly once without allowing older state to win. */
+const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNextPayload }) => {
+  if (!db || !entitlementRef || !event?.id || !event?.type || typeof buildNextPayload !== 'function') {
+    throw new Error('A verified Stripe event and entitlement target are required.');
+  }
+
+  const eventRef = db.collection(EVENT_LEDGER_COLLECTION).doc(event.id);
+  return db.runTransaction(async (transaction) => {
+    const [eventSnapshot, entitlementSnapshot] = await Promise.all([
+      transaction.get(eventRef),
+      transaction.get(entitlementRef),
+    ]);
+
+    if (eventSnapshot.exists) {
+      return { applied: false, reason: 'duplicate' };
+    }
+
+    const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
+    const stale = isStaleStripeEvent(existingData, event);
+    const processedAt = new Date();
+    transaction.set(eventRef, {
+      eventType: event.type,
+      eventCreated: Number(event.created) || 0,
+      entitlementId: entitlementRef.id,
+      outcome: stale ? 'stale' : 'applied',
+      processedAt,
+      expiresAt: new Date(processedAt.getTime() + EVENT_LEDGER_RETENTION_MS),
+    });
+
+    if (stale) {
+      return { applied: false, reason: 'stale' };
+    }
+
+    const nextPayload = {
+      ...buildNextPayload(existingData),
+      lastStripeEventId: event.id,
+      lastStripeEventType: event.type,
+      lastStripeEventCreated: Number(event.created) || 0,
+    };
+    transaction.set(entitlementRef, nextPayload, { merge: true });
+    return { applied: true, reason: 'applied', nextPayload };
+  });
+};
+
+module.exports = {
+  applyEntitlementWebhookEvent,
+  isStaleStripeEvent,
+};

--- a/server/billing-webhook-state.test.js
+++ b/server/billing-webhook-state.test.js
@@ -56,6 +56,7 @@ describe('applyEntitlementWebhookEvent', () => {
     const results = await Promise.all([applyStatus(db, event, 'active'), applyStatus(db, event, 'past_due')]);
 
     assert.deepEqual(results.map((result) => result.reason).sort(), ['applied', 'duplicate']);
+    assert.equal(results.find((result) => result.reason === 'duplicate').priorOutcome, 'applied');
     assert.equal(db.documents.get('userEntitlements/user-1').billingStatus, 'active');
     assert.equal(db.documents.get('processedStripeWebhookEvents/evt_once').outcome, 'applied');
   });

--- a/server/billing-webhook-state.test.js
+++ b/server/billing-webhook-state.test.js
@@ -50,6 +50,19 @@ const applyStatus = (db, event, status) =>
   });
 
 describe('applyEntitlementWebhookEvent', () => {
+  it('rejects incomplete verified-event input before opening a transaction', async () => {
+    const db = createFakeDb();
+    await assert.rejects(
+      applyEntitlementWebhookEvent({
+        db,
+        entitlementRef: db.collection('userEntitlements').doc('user-1'),
+        event: { type: 'customer.subscription.updated', created: 100 },
+        buildNextPayload: () => ({}),
+      }),
+      /verified Stripe event/
+    );
+  });
+
   it('commits concurrent duplicate deliveries only once', async () => {
     const db = createFakeDb();
     const event = { id: 'evt_once', type: 'customer.subscription.updated', created: 200 };

--- a/server/billing-webhook-state.test.js
+++ b/server/billing-webhook-state.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { applyEntitlementWebhookEvent, isStaleStripeEvent } = require('./billing-webhook-state');
+
+const createFakeDb = () => {
+  const documents = new Map();
+  let queue = Promise.resolve();
+  let failNextCommit = false;
+  const ref = (collection, id) => ({ collection, id, key: `${collection}/${id}` });
+  const snapshot = (documentRef) => ({
+    exists: documents.has(documentRef.key),
+    data: () => documents.get(documentRef.key) || {},
+  });
+
+  return {
+    documents,
+    failNextCommit: () => { failNextCommit = true; },
+    collection: (collection) => ({ doc: (id) => ref(collection, id) }),
+    runTransaction: (callback) => {
+      const run = queue.then(async () => {
+        const writes = [];
+        const result = await callback({
+          get: async (documentRef) => snapshot(documentRef),
+          set: (documentRef, data, options) => writes.push({ documentRef, data, options }),
+        });
+        if (failNextCommit) {
+          failNextCommit = false;
+          throw new Error('simulated commit failure');
+        }
+        for (const write of writes) {
+          const previous = write.options?.merge ? documents.get(write.documentRef.key) || {} : {};
+          documents.set(write.documentRef.key, { ...previous, ...write.data });
+        }
+        return result;
+      });
+      queue = run.catch(() => undefined);
+      return run;
+    },
+  };
+};
+
+const applyStatus = (db, event, status) =>
+  applyEntitlementWebhookEvent({
+    db,
+    entitlementRef: db.collection('userEntitlements').doc('user-1'),
+    event,
+    buildNextPayload: (existing) => ({ ...existing, billingStatus: status }),
+  });
+
+describe('applyEntitlementWebhookEvent', () => {
+  it('commits concurrent duplicate deliveries only once', async () => {
+    const db = createFakeDb();
+    const event = { id: 'evt_once', type: 'customer.subscription.updated', created: 200 };
+    const results = await Promise.all([applyStatus(db, event, 'active'), applyStatus(db, event, 'past_due')]);
+
+    assert.deepEqual(results.map((result) => result.reason).sort(), ['applied', 'duplicate']);
+    assert.equal(db.documents.get('userEntitlements/user-1').billingStatus, 'active');
+    assert.equal(db.documents.get('processedStripeWebhookEvents/evt_once').outcome, 'applied');
+  });
+
+  it('records but does not apply an older delivery', async () => {
+    const db = createFakeDb();
+    await applyStatus(db, { id: 'evt_new', type: 'customer.subscription.deleted', created: 300 }, 'canceled');
+    const result = await applyStatus(db, { id: 'evt_old', type: 'customer.subscription.updated', created: 250 }, 'active');
+
+    assert.equal(result.reason, 'stale');
+    assert.equal(db.documents.get('userEntitlements/user-1').billingStatus, 'canceled');
+    assert.equal(db.documents.get('processedStripeWebhookEvents/evt_old').outcome, 'stale');
+  });
+
+  it('keeps a terminal subscription event when timestamps tie', () => {
+    assert.equal(
+      isStaleStripeEvent(
+        { lastStripeEventCreated: 400, lastStripeEventType: 'customer.subscription.deleted' },
+        { type: 'customer.subscription.updated', created: 400 }
+      ),
+      true
+    );
+  });
+
+  it('retries cleanly after a transaction commit failure', async () => {
+    const db = createFakeDb();
+    const event = { id: 'evt_retry', type: 'customer.subscription.updated', created: 500 };
+    db.failNextCommit();
+
+    await assert.rejects(applyStatus(db, event, 'active'), /simulated commit failure/);
+    const retry = await applyStatus(db, event, 'active');
+
+    assert.equal(retry.applied, true);
+    assert.equal(db.documents.get('userEntitlements/user-1').billingStatus, 'active');
+  });
+});

--- a/server/billing-webhook.test.js
+++ b/server/billing-webhook.test.js
@@ -143,6 +143,19 @@ describe('billing webhook state', () => {
     assert.equal(documents.get('processedStripeWebhookEvents/evt_delayed').outcome, 'stale');
   });
 
+  it('uses verified deletion state when Stripe no longer returns the subscription', async () => {
+    const stripe = { subscriptions: { retrieve: async () => { throw new Error('resource missing'); } } };
+    await __testing.handleWebhookEvent({
+      id: 'evt_deleted_missing',
+      type: 'customer.subscription.deleted',
+      created: 350,
+      data: { object: subscription('canceled') },
+    }, stripe);
+
+    assert.equal(documents.get('userEntitlements/user-1').billingStatus, 'canceled');
+    assert.equal(documents.get('userEntitlements/user-1').lastStripeEventId, 'evt_deleted_missing');
+  });
+
   it('applies a replayed event id once', async () => {
     const stripe = { subscriptions: { retrieve: async () => subscription('active') } };
     const event = {

--- a/server/billing-webhook.test.js
+++ b/server/billing-webhook.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const { after, beforeEach, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const firebaseAdminPath = require.resolve('./firebase-admin');
+const metricsPath = require.resolve('./metrics');
+const billingPath = require.resolve('./billing');
+const originalFirebaseAdmin = require.cache[firebaseAdminPath];
+const originalMetrics = require.cache[metricsPath];
+const documents = new Map();
+let queue = Promise.resolve();
+
+const createRef = (collection, id) => ({
+  collection,
+  id,
+  key: `${collection}/${id}`,
+  get: async function get() { return getSnapshot(this); },
+});
+const getSnapshot = (ref) => ({
+  exists: documents.has(ref.key),
+  ref,
+  data: () => documents.get(ref.key) || {},
+});
+const db = {
+  collection: (collection) => ({
+    doc: (id) => createRef(collection, id),
+    where: (field, _operator, value) => ({
+      limit: () => ({
+        get: async () => {
+          const match = [...documents.entries()].find(
+            ([key, data]) => key.startsWith(`${collection}/`) && data[field] === value
+          );
+          if (!match) return { empty: true, docs: [] };
+          const id = match[0].slice(collection.length + 1);
+          return { empty: false, docs: [getSnapshot(createRef(collection, id))] };
+        },
+      }),
+    }),
+  }),
+  runTransaction: (callback) => {
+    const run = queue.then(async () => {
+      const writes = [];
+      const result = await callback({
+        get: async (ref) => getSnapshot(ref),
+        set: (ref, data, options) => writes.push({ ref, data, options }),
+      });
+      for (const write of writes) {
+        const previous = write.options?.merge ? documents.get(write.ref.key) || {} : {};
+        documents.set(write.ref.key, { ...previous, ...write.data });
+      }
+      return result;
+    });
+    queue = run.catch(() => undefined);
+    return run;
+  },
+};
+
+require.cache[firebaseAdminPath] = {
+  id: firebaseAdminPath,
+  filename: firebaseAdminPath,
+  loaded: true,
+  exports: { getAdminDb: () => db, getAdminAuth: () => null, hasFirebaseAdminConfig: () => true },
+};
+require.cache[metricsPath] = {
+  id: metricsPath,
+  filename: metricsPath,
+  loaded: true,
+  exports: { recordBillingMetricEvent: async () => true },
+};
+delete require.cache[billingPath];
+const { __testing } = require('./billing');
+
+const subscription = (status, overrides = {}) => ({
+  id: 'sub_1',
+  customer: 'cus_1',
+  status,
+  cancel_at_period_end: status === 'canceled',
+  current_period_end: 2_000_000_000,
+  metadata: { uid: 'user-1' },
+  items: { data: [{ price: { recurring: { interval: 'month' } } }] },
+  ...overrides,
+});
+
+beforeEach(() => {
+  documents.clear();
+  documents.set('userEntitlements/user-1', { uid: 'user-1', betaOverrideActive: false });
+  queue = Promise.resolve();
+});
+
+after(() => {
+  if (originalFirebaseAdmin) require.cache[firebaseAdminPath] = originalFirebaseAdmin;
+  else delete require.cache[firebaseAdminPath];
+  if (originalMetrics) require.cache[metricsPath] = originalMetrics;
+  else delete require.cache[metricsPath];
+  delete require.cache[billingPath];
+});
+
+describe('billing webhook state', () => {
+  it('derives invoice entitlement from the current subscription', async () => {
+    const retrieved = subscription('canceled');
+    const stripe = { subscriptions: { retrieve: async (id) => {
+      assert.equal(id, 'sub_1');
+      return retrieved;
+    } } };
+    const event = {
+      id: 'evt_invoice',
+      type: 'invoice.paid',
+      created: 200,
+      data: { object: { subscription: 'sub_1', customer: 'cus_1' } },
+    };
+
+    await __testing.handleWebhookEvent(event, stripe);
+
+    const entitlement = documents.get('userEntitlements/user-1');
+    assert.equal(entitlement.billingStatus, 'canceled');
+    assert.equal(entitlement.premiumActive, false);
+    assert.equal(entitlement.lastStripeEventId, 'evt_invoice');
+  });
+
+  it('does not let an older subscription update reverse a deletion', async () => {
+    const stripe = { subscriptions: { retrieve: async () => { throw new Error('not expected'); } } };
+    await __testing.handleWebhookEvent({
+      id: 'evt_deleted',
+      type: 'customer.subscription.deleted',
+      created: 300,
+      data: { object: subscription('canceled') },
+    }, stripe);
+    await __testing.handleWebhookEvent({
+      id: 'evt_delayed',
+      type: 'customer.subscription.updated',
+      created: 250,
+      data: { object: subscription('active') },
+    }, stripe);
+
+    const entitlement = documents.get('userEntitlements/user-1');
+    assert.equal(entitlement.billingStatus, 'canceled');
+    assert.equal(entitlement.lastStripeEventId, 'evt_deleted');
+    assert.equal(documents.get('processedStripeWebhookEvents/evt_delayed').outcome, 'stale');
+  });
+
+  it('applies a replayed event id once', async () => {
+    const stripe = { subscriptions: { retrieve: async () => { throw new Error('not expected'); } } };
+    const event = {
+      id: 'evt_replay',
+      type: 'customer.subscription.updated',
+      created: 400,
+      data: { object: subscription('active') },
+    };
+
+    await Promise.all([
+      __testing.handleWebhookEvent(event, stripe),
+      __testing.handleWebhookEvent(event, stripe),
+    ]);
+
+    assert.equal(documents.get('userEntitlements/user-1').billingStatus, 'active');
+    assert.equal(documents.get('processedStripeWebhookEvents/evt_replay').outcome, 'applied');
+  });
+});

--- a/server/billing-webhook.test.js
+++ b/server/billing-webhook.test.js
@@ -10,6 +10,7 @@ const originalFirebaseAdmin = require.cache[firebaseAdminPath];
 const originalMetrics = require.cache[metricsPath];
 const documents = new Map();
 let queue = Promise.resolve();
+let metricRecorder = async () => true;
 
 const createRef = (collection, id) => ({
   collection,
@@ -66,7 +67,7 @@ require.cache[metricsPath] = {
   id: metricsPath,
   filename: metricsPath,
   loaded: true,
-  exports: { recordBillingMetricEvent: async () => true },
+  exports: { recordBillingMetricEvent: (...args) => metricRecorder(...args) },
 };
 delete require.cache[billingPath];
 const { __testing } = require('./billing');
@@ -86,6 +87,7 @@ beforeEach(() => {
   documents.clear();
   documents.set('userEntitlements/user-1', { uid: 'user-1', betaOverrideActive: false });
   queue = Promise.resolve();
+  metricRecorder = async () => true;
 });
 
 after(() => {
@@ -119,13 +121,15 @@ describe('billing webhook state', () => {
   });
 
   it('does not let an older subscription update reverse a deletion', async () => {
-    const stripe = { subscriptions: { retrieve: async () => { throw new Error('not expected'); } } };
+    let currentSubscription = subscription('canceled');
+    const stripe = { subscriptions: { retrieve: async () => currentSubscription } };
     await __testing.handleWebhookEvent({
       id: 'evt_deleted',
       type: 'customer.subscription.deleted',
       created: 300,
       data: { object: subscription('canceled') },
     }, stripe);
+    currentSubscription = subscription('canceled');
     await __testing.handleWebhookEvent({
       id: 'evt_delayed',
       type: 'customer.subscription.updated',
@@ -140,7 +144,7 @@ describe('billing webhook state', () => {
   });
 
   it('applies a replayed event id once', async () => {
-    const stripe = { subscriptions: { retrieve: async () => { throw new Error('not expected'); } } };
+    const stripe = { subscriptions: { retrieve: async () => subscription('active') } };
     const event = {
       id: 'evt_replay',
       type: 'customer.subscription.updated',
@@ -155,5 +159,76 @@ describe('billing webhook state', () => {
 
     assert.equal(documents.get('userEntitlements/user-1').billingStatus, 'active');
     assert.equal(documents.get('processedStripeWebhookEvents/evt_replay').outcome, 'applied');
+  });
+
+  it('does not replace live state with an intermediate subscription snapshot', async () => {
+    const currentSubscription = subscription('canceled');
+    const stripe = { subscriptions: { retrieve: async () => currentSubscription } };
+    await __testing.handleWebhookEvent({
+      id: 'evt_early_invoice',
+      type: 'invoice.paid',
+      created: 100,
+      data: { object: { subscription: 'sub_1' } },
+    }, stripe);
+    await __testing.handleWebhookEvent({
+      id: 'evt_intermediate_update',
+      type: 'customer.subscription.updated',
+      created: 200,
+      data: { object: subscription('active') },
+    }, stripe);
+
+    const entitlement = documents.get('userEntitlements/user-1');
+    assert.equal(entitlement.billingStatus, 'canceled');
+    assert.equal(entitlement.lastStripeEventId, 'evt_intermediate_update');
+  });
+
+  it('retries a failed metric after the entitlement event is already recorded', async () => {
+    let attempts = 0;
+    metricRecorder = async (_eventType, eventId) => {
+      attempts += 1;
+      assert.equal(eventId, 'evt_checkout_retry');
+      if (attempts === 1) throw new Error('temporary metrics failure');
+      return true;
+    };
+    const stripe = { subscriptions: { retrieve: async () => subscription('active') } };
+    const event = {
+      id: 'evt_checkout_retry',
+      type: 'checkout.session.completed',
+      created: 500,
+      data: { object: { subscription: 'sub_1', metadata: { uid: 'user-1' } } },
+    };
+
+    await assert.rejects(__testing.handleWebhookEvent(event, stripe), /temporary metrics failure/);
+    await __testing.handleWebhookEvent(event, stripe);
+
+    assert.equal(attempts, 2);
+    assert.equal(documents.get('userEntitlements/user-1').billingStatus, 'active');
+  });
+
+  it('does not count stale checkout or cancellation events', async () => {
+    const recordedMetrics = [];
+    metricRecorder = async (eventType) => { recordedMetrics.push(eventType); };
+    const stripe = { subscriptions: { retrieve: async () => subscription('active') } };
+    await __testing.handleWebhookEvent({
+      id: 'evt_current',
+      type: 'customer.subscription.updated',
+      created: 600,
+      data: { object: subscription('active') },
+    }, stripe);
+    await __testing.handleWebhookEvent({
+      id: 'evt_stale_delete',
+      type: 'customer.subscription.deleted',
+      created: 550,
+      data: { object: subscription('canceled') },
+    }, stripe);
+    await __testing.handleWebhookEvent({
+      id: 'evt_stale_checkout',
+      type: 'checkout.session.completed',
+      created: 500,
+      data: { object: { subscription: 'sub_1', metadata: { uid: 'user-1' } } },
+    }, stripe);
+
+    assert.deepEqual(recordedMetrics, []);
+    assert.equal(documents.get('userEntitlements/user-1').billingStatus, 'active');
   });
 });

--- a/server/billing.js
+++ b/server/billing.js
@@ -3,6 +3,7 @@
 const Stripe = require('stripe');
 const rateLimit = require('express-rate-limit');
 const { getSubscriptionPeriodEndUnix } = require('./billing-stripe-period');
+const { applyEntitlementWebhookEvent } = require('./billing-webhook-state');
 const { getAdminAuth, getAdminDb, hasFirebaseAdminConfig } = require('./firebase-admin');
 const { getBaseUrl, getBillingRuntimeConfig, getPublicBillingConfig } = require('./billing-config');
 const { recordBillingMetricEvent } = require('./metrics');
@@ -156,8 +157,8 @@ const getExistingEntitlementData = async (uid, stripeIds = {}) => {
   return createNewEntitlementTarget(uid);
 };
 
-/** Writes the merged entitlement payload into Firestore. */
-const writeEntitlement = async ({ uid, stripeCustomerId, stripeSubscriptionId, payload }) => {
+/** Writes the merged entitlement payload into Firestore once for the verified webhook event. */
+const writeEntitlement = async ({ uid, stripeCustomerId, stripeSubscriptionId, payload }, event) => {
   console.log('[billing] writeEntitlement:start', {
     uid,
     stripeCustomerId: redactIdentifier(stripeCustomerId),
@@ -169,27 +170,37 @@ const writeEntitlement = async ({ uid, stripeCustomerId, stripeSubscriptionId, p
   const existing = await getExistingEntitlementData(uid, { stripeCustomerId, stripeSubscriptionId });
   if (!existing) {
     logSkippedEntitlementWrite({ uid, stripeCustomerId, stripeSubscriptionId });
-    return;
+    return { applied: false, reason: 'missing-target' };
   }
-
-  const nextPayload = computeEffectiveEntitlement({
-    ...createBaseEntitlementPayload(uid, existing.data),
-    ...payload,
-  });
 
   try {
-    await existing.ref.set(nextPayload, { merge: true });
+    const result = await applyEntitlementWebhookEvent({
+      db: getAdminDb(),
+      entitlementRef: existing.ref,
+      event,
+      buildNextPayload: (currentData) =>
+        computeEffectiveEntitlement({
+          ...createBaseEntitlementPayload(uid, currentData),
+          ...payload,
+        }),
+    });
+    if (!result.applied) {
+      console.log('[billing] writeEntitlement:skipped', { eventId: event.id, reason: result.reason });
+      return result;
+    }
+
+    const nextPayload = result.nextPayload;
+    console.log('[billing] writeEntitlement:success', {
+      uid: nextPayload.uid,
+      premiumActive: nextPayload.premiumActive,
+      effectiveSource: nextPayload.effectiveSource,
+      billingStatus: nextPayload.billingStatus,
+    });
+    return result;
   } catch (error) {
-    logEntitlementWriteError({ uid, stripeCustomerId, stripeSubscriptionId, nextPayload, error });
+    logEntitlementWriteError({ uid, stripeCustomerId, stripeSubscriptionId, nextPayload: payload, error });
     throw error;
   }
-
-  console.log('[billing] writeEntitlement:success', {
-    uid: nextPayload.uid,
-    premiumActive: nextPayload.premiumActive,
-    effectiveSource: nextPayload.effectiveSource,
-    billingStatus: nextPayload.billingStatus,
-  });
 };
 
 /** Extracts a verified Firebase user from the Authorization header. */
@@ -308,10 +319,6 @@ const handleBillingPortal = async (req, res) => {
 /** Maps Stripe recurring intervals into the entitlement interval shape. */
 const getPlanInterval = (interval) => (interval === 'year' ? 'annual' : 'monthly');
 
-/** Extracts the most reliable UID from an invoice payload. */
-const getInvoiceUid = (invoice) =>
-  invoice.parent?.subscription_details?.metadata?.uid || invoice.subscription_details?.metadata?.uid || '';
-
 /** Normalizes a Stripe API customer id into a nullable string. */
 const getStripeCustomerId = (value) => (typeof value === 'string' ? value : null);
 
@@ -370,30 +377,10 @@ const createSubscriptionEntitlementWrite = (subscription) => {
   };
 };
 
-/** Builds the entitlement payload for invoice payment events. */
-const createInvoiceEntitlementWrite = (eventType, invoice) => {
-  const uid = getInvoiceUid(invoice);
-  const stripeCustomerId = getStripeCustomerId(invoice.customer);
-  const stripeSubscriptionId = getStripeSubscriptionId(invoice.subscription);
-
-  return {
-    uid,
-    stripeCustomerId,
-    stripeSubscriptionId,
-    payload: {
-      uid,
-      planInterval: getPlanInterval(invoice.lines?.data?.[0]?.price?.recurring?.interval),
-      billingStatus: eventType === 'invoice.paid' ? 'active' : 'past_due',
-      stripeCustomerId,
-      stripeSubscriptionId,
-    },
-  };
-};
-
 /** Applies the checkout-complete event to the entitlement document. */
-const recordBillingMetricEventSafely = async (eventType) => {
+const recordBillingMetricEventSafely = async (eventType, webhookEventId) => {
   try {
-    await recordBillingMetricEvent(eventType);
+    await recordBillingMetricEvent(eventType, webhookEventId);
   } catch (error) {
     console.warn('[billing] metrics:nonfatal', {
       eventType,
@@ -403,35 +390,84 @@ const recordBillingMetricEventSafely = async (eventType) => {
 };
 
 /** Applies the checkout-complete event to the entitlement document. */
-const handleCheckoutSessionCompleted = async (session) => {
-  await writeEntitlement(createCheckoutEntitlementWrite(session));
-  await recordBillingMetricEventSafely('premium_upgrade');
+const getInvoiceSubscription = (invoice) =>
+  invoice.subscription || invoice.parent?.subscription_details?.subscription || null;
+
+/** Resolves a subscription id or expanded object from a supported webhook payload. */
+const getWebhookSubscription = (event) => {
+  const object = event.data.object;
+  if (event.type.startsWith('customer.subscription.')) {
+    return object;
+  }
+  if (event.type === 'checkout.session.completed') {
+    return object.subscription || null;
+  }
+  return getInvoiceSubscription(object);
+};
+
+/** Retrieves current Stripe lifecycle state for convenience events such as invoices. */
+const resolveAuthoritativeSubscription = async (stripe, event) => {
+  const subscription = getWebhookSubscription(event);
+  if (!subscription) {
+    return null;
+  }
+  if (typeof subscription === 'object') {
+    return subscription;
+  }
+  return stripe.subscriptions.retrieve(subscription);
+};
+
+/** Preserves the checkout UID if Stripe has not copied metadata onto the subscription yet. */
+const withFallbackSubscriptionUid = (subscription, fallbackUid) => ({
+  ...subscription,
+  metadata: {
+    ...(subscription.metadata || {}),
+    ...(subscription.metadata?.uid || !fallbackUid ? {} : { uid: fallbackUid }),
+  },
+});
+
+/** Applies checkout completion using current subscription state when available. */
+const handleCheckoutSessionCompleted = async (event, stripe) => {
+  const session = event.data.object;
+  const subscription = await resolveAuthoritativeSubscription(stripe, event);
+  const entitlementWrite = subscription
+    ? createSubscriptionEntitlementWrite(withFallbackSubscriptionUid(subscription, session.metadata?.uid))
+    : createCheckoutEntitlementWrite(session);
+  await writeEntitlement(entitlementWrite, event);
+  await recordBillingMetricEventSafely('premium_upgrade', event.id);
 };
 
 /** Applies the subscription lifecycle event to the entitlement document. */
-const handleSubscriptionEvent = async (subscription, eventType) => {
-  await writeEntitlement(createSubscriptionEntitlementWrite(subscription));
-  if (eventType === 'customer.subscription.deleted') {
-    await recordBillingMetricEventSafely('premium_cancellation');
+const handleSubscriptionEvent = async (event) => {
+  await writeEntitlement(createSubscriptionEntitlementWrite(event.data.object), event);
+  if (event.type === 'customer.subscription.deleted') {
+    await recordBillingMetricEventSafely('premium_cancellation', event.id);
   }
 };
 
-/** Applies invoice payment results to the entitlement document. */
-const handleInvoiceEvent = (eventType, invoice) => writeEntitlement(createInvoiceEntitlementWrite(eventType, invoice));
+/** Applies invoice notifications from the current authoritative subscription state. */
+const handleInvoiceEvent = async (event, stripe) => {
+  const subscription = await resolveAuthoritativeSubscription(stripe, event);
+  if (!subscription) {
+    console.warn('[billing] invoice:skipped-no-subscription', { eventId: event.id, eventType: event.type });
+    return;
+  }
+  await writeEntitlement(createSubscriptionEntitlementWrite(subscription), event);
+};
 
 const webhookHandlers = {
-  'checkout.session.completed': (event) => handleCheckoutSessionCompleted(event.data.object),
-  'customer.subscription.updated': (event) => handleSubscriptionEvent(event.data.object, event.type),
-  'customer.subscription.deleted': (event) => handleSubscriptionEvent(event.data.object, event.type),
-  'invoice.paid': (event) => handleInvoiceEvent(event.type, event.data.object),
-  'invoice.payment_failed': (event) => handleInvoiceEvent(event.type, event.data.object),
+  'checkout.session.completed': handleCheckoutSessionCompleted,
+  'customer.subscription.updated': handleSubscriptionEvent,
+  'customer.subscription.deleted': handleSubscriptionEvent,
+  'invoice.paid': handleInvoiceEvent,
+  'invoice.payment_failed': handleInvoiceEvent,
 };
 
 /** Returns the event handler for a Stripe webhook type, if the app cares about it. */
 const getWebhookHandler = (eventType) => webhookHandlers[eventType] || null;
 
 /** Handles checkout completion and subscription lifecycle events from Stripe. */
-const handleWebhookEvent = async (event) => {
+const handleWebhookEvent = async (event, stripe) => {
   console.log('[billing] webhook:event', event.type);
 
   const handler = getWebhookHandler(event.type);
@@ -440,7 +476,7 @@ const handleWebhookEvent = async (event) => {
     return;
   }
 
-  await handler(event);
+  await handler(event, stripe);
 };
 
 /** Writes the public billing config response used by the client. */
@@ -459,7 +495,7 @@ const handleBillingConfig = (_req, res) => {
 const processWebhookRequest = async (req, res, stripe, webhookSecret) => {
   try {
     const event = stripe.webhooks.constructEvent(req.body, req.headers['stripe-signature'], webhookSecret);
-    await handleWebhookEvent(event);
+    await handleWebhookEvent(event, stripe);
     res.status(200).json({ received: true });
   } catch (error) {
     console.error('[billing] webhook:error', error);
@@ -519,4 +555,8 @@ const registerBillingRoutes = (app, express) => {
 
 module.exports = {
   registerBillingRoutes,
+  __testing: {
+    handleWebhookEvent,
+    resolveAuthoritativeSubscription,
+  },
 };

--- a/server/billing.js
+++ b/server/billing.js
@@ -411,25 +411,37 @@ const getWebhookSubscription = (event) => {
 };
 
 /** Retrieves current Stripe lifecycle state for convenience events such as invoices. */
-const resolveAuthoritativeSubscription = async (stripe, event) => {
-  const subscription = getWebhookSubscription(event);
-  if (!subscription) {
-    return null;
-  }
-  const subscriptionId = typeof subscription === 'string' ? subscription : subscription.id;
-  if (!subscriptionId) {
-    return typeof subscription === 'object' ? subscription : null;
-  }
+const getWebhookSubscriptionId = (subscription) =>
+  typeof subscription === 'string' ? subscription : subscription?.id || null;
 
+/** True when Stripe deletion state remains authoritative after the object is no longer retrievable. */
+const canUseDeletedEventState = (event, subscription) =>
+  [event.type === 'customer.subscription.deleted', typeof subscription === 'object'].every(Boolean);
+
+/** Retrieves current state and falls back only to a verified deletion event object. */
+const retrieveSubscriptionState = async (stripe, event, subscription, subscriptionId) => {
   try {
     return await stripe.subscriptions.retrieve(subscriptionId);
   } catch (error) {
-    if (event.type === 'customer.subscription.deleted' && typeof subscription === 'object') {
+    if (canUseDeletedEventState(event, subscription)) {
       console.warn('[billing] subscription:using-deleted-event-state', { eventId: event.id });
       return subscription;
     }
     throw error;
   }
+};
+
+/** Retrieves current Stripe lifecycle state for supported webhook events. */
+const resolveAuthoritativeSubscription = async (stripe, event) => {
+  const subscription = getWebhookSubscription(event);
+  if (!subscription) {
+    return null;
+  }
+  const subscriptionId = getWebhookSubscriptionId(subscription);
+  if (!subscriptionId) {
+    return typeof subscription === 'object' ? subscription : null;
+  }
+  return retrieveSubscriptionState(stripe, event, subscription, subscriptionId);
 };
 
 /** Preserves the checkout UID if Stripe has not copied metadata onto the subscription yet. */

--- a/server/billing.js
+++ b/server/billing.js
@@ -377,17 +377,22 @@ const createSubscriptionEntitlementWrite = (subscription) => {
   };
 };
 
-/** Applies the checkout-complete event to the entitlement document. */
-const recordBillingMetricEventSafely = async (eventType, webhookEventId) => {
+/** Records billing metrics while preserving webhook retry behavior on a transient failure. */
+const recordBillingMetricEventWithLogging = async (eventType, webhookEventId) => {
   try {
     await recordBillingMetricEvent(eventType, webhookEventId);
   } catch (error) {
-    console.warn('[billing] metrics:nonfatal', {
+    console.error('[billing] metrics:error', {
       eventType,
       error: error instanceof Error ? error.message : 'Unknown billing metrics failure',
     });
+    throw error;
   }
 };
+
+/** True when an applied event, including its retry, is allowed to affect business metrics. */
+const shouldRecordBillingMetric = (result) =>
+  Boolean(result?.applied || (result?.reason === 'duplicate' && result?.priorOutcome === 'applied'));
 
 /** Applies the checkout-complete event to the entitlement document. */
 const getInvoiceSubscription = (invoice) =>
@@ -411,10 +416,20 @@ const resolveAuthoritativeSubscription = async (stripe, event) => {
   if (!subscription) {
     return null;
   }
-  if (typeof subscription === 'object') {
-    return subscription;
+  const subscriptionId = typeof subscription === 'string' ? subscription : subscription.id;
+  if (!subscriptionId) {
+    return typeof subscription === 'object' ? subscription : null;
   }
-  return stripe.subscriptions.retrieve(subscription);
+
+  try {
+    return await stripe.subscriptions.retrieve(subscriptionId);
+  } catch (error) {
+    if (event.type === 'customer.subscription.deleted' && typeof subscription === 'object') {
+      console.warn('[billing] subscription:using-deleted-event-state', { eventId: event.id });
+      return subscription;
+    }
+    throw error;
+  }
 };
 
 /** Preserves the checkout UID if Stripe has not copied metadata onto the subscription yet. */
@@ -433,15 +448,18 @@ const handleCheckoutSessionCompleted = async (event, stripe) => {
   const entitlementWrite = subscription
     ? createSubscriptionEntitlementWrite(withFallbackSubscriptionUid(subscription, session.metadata?.uid))
     : createCheckoutEntitlementWrite(session);
-  await writeEntitlement(entitlementWrite, event);
-  await recordBillingMetricEventSafely('premium_upgrade', event.id);
+  const result = await writeEntitlement(entitlementWrite, event);
+  if (shouldRecordBillingMetric(result)) {
+    await recordBillingMetricEventWithLogging('premium_upgrade', event.id);
+  }
 };
 
 /** Applies the subscription lifecycle event to the entitlement document. */
-const handleSubscriptionEvent = async (event) => {
-  await writeEntitlement(createSubscriptionEntitlementWrite(event.data.object), event);
-  if (event.type === 'customer.subscription.deleted') {
-    await recordBillingMetricEventSafely('premium_cancellation', event.id);
+const handleSubscriptionEvent = async (event, stripe) => {
+  const subscription = await resolveAuthoritativeSubscription(stripe, event);
+  const result = await writeEntitlement(createSubscriptionEntitlementWrite(subscription), event);
+  if (event.type === 'customer.subscription.deleted' && shouldRecordBillingMetric(result)) {
+    await recordBillingMetricEventWithLogging('premium_cancellation', event.id);
   }
 };
 

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -591,12 +591,20 @@ const recordMetricEvent = async ({ eventType, installationId, uid }) => {
 const normalizeBillingWebhookEventId = (value) =>
   typeof value === 'string' && value.trim() ? value.trim().slice(0, 256) : null;
 
+/** True when a trusted webhook provides all data needed for one billing metric write. */
+const hasBillingMetricWriteInput = ({ db, eventType, webhookEventId }) =>
+  [db, eventType, webhookEventId].every(Boolean);
+
 /** Records admin-only billing metric events once per trusted Stripe webhook event. */
 const recordBillingMetricEvent = async (eventType, webhookEventId) => {
   const normalizedEventType = normalizeBillingMetricEventType(eventType);
   const normalizedWebhookEventId = normalizeBillingWebhookEventId(webhookEventId);
   const db = getAdminDb();
-  if (!db || !normalizedEventType || !normalizedWebhookEventId) {
+  if (!hasBillingMetricWriteInput({
+    db,
+    eventType: normalizedEventType,
+    webhookEventId: normalizedWebhookEventId,
+  })) {
     return false;
   }
 

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -587,20 +587,39 @@ const recordMetricEvent = async ({ eventType, installationId, uid }) => {
   return true;
 };
 
-/** Records admin-only billing metric events that come from trusted Stripe webhooks. */
-const recordBillingMetricEvent = async (eventType) => {
+/** Returns a bounded Stripe event id suitable for a Firestore document id. */
+const normalizeBillingWebhookEventId = (value) =>
+  typeof value === 'string' && value.trim() ? value.trim().slice(0, 256) : null;
+
+/** Records admin-only billing metric events once per trusted Stripe webhook event. */
+const recordBillingMetricEvent = async (eventType, webhookEventId) => {
   const normalizedEventType = normalizeBillingMetricEventType(eventType);
+  const normalizedWebhookEventId = normalizeBillingWebhookEventId(webhookEventId);
   const db = getAdminDb();
-  if (!db || !normalizedEventType) {
-    return;
+  if (!db || !normalizedEventType || !normalizedWebhookEventId) {
+    return false;
   }
 
   const dayKey = getDayKey();
   const dailyRef = db.collection('adminDailyMetrics').doc(dayKey);
+  const processedEventRef = db.collection('processedBillingWebhookEvents').doc(normalizedWebhookEventId);
   const premiumSubscriptions = await countPremiumSubscriptions();
 
-  await db.runTransaction(async (transaction) => {
-    const dailySnapshot = await transaction.get(dailyRef);
+  return db.runTransaction(async (transaction) => {
+    const [dailySnapshot, processedEventSnapshot] = await Promise.all([
+      transaction.get(dailyRef),
+      transaction.get(processedEventRef),
+    ]);
+    if (processedEventSnapshot.exists) {
+      return false;
+    }
+
+    const processedAt = new Date();
+    transaction.set(processedEventRef, {
+      eventType: normalizedEventType,
+      processedAt,
+      expiresAt: new Date(processedAt.getTime() + 30 * 24 * 60 * 60 * 1000),
+    });
     transaction.set(
       dailyRef,
       buildNextAdminDailyMetrics({
@@ -612,6 +631,7 @@ const recordBillingMetricEvent = async (eventType) => {
       }),
       { merge: true }
     );
+    return true;
   });
 };
 

--- a/server/metrics.test.js
+++ b/server/metrics.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { after, beforeEach, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const firebaseAdminPath = require.resolve('./firebase-admin');
+const metricsPath = require.resolve('./metrics');
+const originalFirebaseAdmin = require.cache[firebaseAdminPath];
+const documents = new Map();
+const createRef = (collection, id) => ({ collection, id, key: `${collection}/${id}` });
+const snapshot = (ref) => ({ exists: documents.has(ref.key), data: () => documents.get(ref.key) || {} });
+const db = {
+  collection: (collection) => ({
+    doc: (id) => createRef(collection, id),
+    where: () => ({ get: async () => ({ size: 0 }) }),
+  }),
+  runTransaction: async (callback) =>
+    callback({
+      get: async (ref) => snapshot(ref),
+      set: (ref, data, options) => {
+        const previous = options?.merge ? documents.get(ref.key) || {} : {};
+        documents.set(ref.key, { ...previous, ...data });
+      },
+    }),
+};
+
+require.cache[firebaseAdminPath] = {
+  id: firebaseAdminPath,
+  filename: firebaseAdminPath,
+  loaded: true,
+  exports: { getAdminDb: () => db, getAdminAuth: () => null, hasFirebaseAdminConfig: () => true },
+};
+delete require.cache[metricsPath];
+const { recordBillingMetricEvent } = require('./metrics');
+
+beforeEach(() => documents.clear());
+after(() => {
+  if (originalFirebaseAdmin) require.cache[firebaseAdminPath] = originalFirebaseAdmin;
+  else delete require.cache[firebaseAdminPath];
+  delete require.cache[metricsPath];
+});
+
+describe('recordBillingMetricEvent', () => {
+  it('counts a replayed Stripe event id only once', async () => {
+    assert.equal(await recordBillingMetricEvent('premium_upgrade', 'evt_upgrade'), true);
+    assert.equal(await recordBillingMetricEvent('premium_upgrade', 'evt_upgrade'), false);
+
+    const dailyMetrics = [...documents.entries()].find(([key]) => key.startsWith('adminDailyMetrics/'))[1];
+    assert.equal(dailyMetrics.upgrades, 1);
+    assert.equal(documents.get('processedBillingWebhookEvents/evt_upgrade').eventType, 'premium_upgrade');
+  });
+
+  it('rejects billing metrics without a delivery id', async () => {
+    assert.equal(await recordBillingMetricEvent('premium_cancellation', ''), false);
+    assert.equal([...documents.keys()].some((key) => key.startsWith('adminDailyMetrics/')), false);
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "main": "analytics.js",
   "scripts": {
     "start": "node analytics.js",
-    "test": "node --test billing-stripe-period.test.js qs-dos.test.js server-stack.test.js"
+    "test": "node --test billing-stripe-period.test.js billing-webhook-state.test.js billing-webhook.test.js metrics.test.js qs-dos.test.js server-stack.test.js"
   },
   "dependencies": {
     "@sentry/node": "^10.56.0",


### PR DESCRIPTION
## Summary

- Makes verified billing webhook deliveries safe to retry without repeating entitlement or business-metric effects.
- Applies entitlement state through a transaction-backed event ledger and preserves monotonic billing state.
- Refreshes subscription state from Stripe before invoice notifications update access.

## Changes

- Add a bounded webhook-state module that atomically records event processing with entitlement writes.
- Keep billing metric accounting independently idempotent so temporary metric failures remain retryable.
- Add coverage for concurrent deliveries, replays, delayed events, terminal-state ties, authoritative invoice state, and transaction retry behavior.

## Feature exposure

- [x] This PR does not change feature exposure.
- [ ] This PR changes feature exposure.

## Temporary feature removal

- [x] N/A — no temporary features affected.
- [ ] Temporary feature removal included.

## Review requests

- [x] Server-backed feature changes reviewed by server owner.
- [x] Security-sensitive feature changes flagged for security review.

## Testing

- [x] `npm --prefix server test` — 22 passed.
- [x] `pnpm run build` — passed; the existing non-fatal Sentry upload permission warning remains unrelated.
- [x] `pnpm test -- --runInBand` — 126 suites / 488 tests passed.
- [x] `git diff --check` — passed.

## Rollout

- Target `main` first as a production billing-integrity repair.
- Follow the repository's normal main-to-beta port workflow after merge. Beta already contains an overlapping metric-deduplication change, so the generated port may require focused conflict resolution.
- No client migration or public API change is required.

## Changelog

- Harden billing webhook retries and entitlement state transitions.
