### PR TITLE
[codex] Restrict Auto-TSTM generation to scheduled ingestion

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### Pending
+
+- Route Auto-TSTM previews exclusively through scheduled cached guidance and retire the direct generation API.
+
 ### PR #759
 
 - Replace GA4 and the legacy collector with privacy-gated, self-hosted Umami telemetry that keeps beta and production reporting separate.

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,7 +4,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
-### Pending
+### PR #763
 
 - Route Auto-TSTM previews exclusively through scheduled cached guidance and retire the direct generation API.
 

--- a/docs/operations/auto-tstm-operations.md
+++ b/docs/operations/auto-tstm-operations.md
@@ -4,16 +4,15 @@ Operational notes for the cached Auto-TSTM server API introduced in TSTM-03 (#47
 
 ## Public read policy
 
-Auto-TSTM routes are **unauthenticated** and intended for public read once the deployment exposes the capability:
+Auto-TSTM exposes only cached, read-only guidance routes once the deployment enables the capability:
 
 | Route | Method | Auth | Work when disabled |
 | --- | --- | --- | --- |
 | `/api/tstm/latest` | GET | None | Capability gate returns `404` before cache reads |
 | `/api/tstm/status` | GET | None | Capability gate returns `404` before cache reads |
-| `/api/tstm/generate` | POST | None | Capability gate returns `404` before Python worker spawn |
 | `/api/capabilities/status` | GET | None | Always available; lists exposed server capabilities |
 
-Disabled routes perform **no expensive work** (no generator spawn, no cache reads beyond the gate).
+Interactive requests cannot start generator workers. Generation runs only through the process-owned scheduled ingestion loop. Disabled routes perform **no expensive work** (no cache reads beyond the gate).
 
 Registry exposure (`autoTstm.exposure.*`) and deployment env (`TSTM_GENERATION_ENABLED=true`) must both be enabled before routes accept traffic. Emergency disable overrides are documented in [emergency-feature-disable.md](./emergency-feature-disable.md).
 
@@ -23,10 +22,7 @@ Registry exposure (`autoTstm.exposure.*`) and deployment env (`TSTM_GENERATION_E
 | --- | --- |
 | `GET /api/tstm/latest` | 120 requests / minute / client |
 | `GET /api/tstm/status` | 120 requests / minute / client |
-| `POST /api/tstm/generate` | 2 requests / minute / client |
 | `GET /api/capabilities/status` | 120 requests / minute / client |
-
-Generate requests also accept at most **4 KB** JSON bodies.
 
 ## Structured errors
 

--- a/docs/operations/emergency-feature-disable.md
+++ b/docs/operations/emergency-feature-disable.md
@@ -137,7 +137,7 @@ curl http://127.0.0.1:3006/api/capabilities/status
 curl 'http://127.0.0.1:3006/api/tstm/latest?day=1&period=full'
 ```
 
-4. Confirm the status payload includes `TSTM_GENERATION_ENABLED` with reason `emergency_disabled`, `/api/tstm/status` reports `"ingestionEnabled": false`, cached guidance routes return `404`, and no Python worker starts.
+4. Confirm the status payload includes `TSTM_GENERATION_ENABLED` with reason `emergency_disabled`, cached guidance routes return `404`, and no Python worker starts.
 5. Remove the emergency env var, restore `TSTM_INGESTION_ENABLED=true` if needed, restart the server, and confirm normal disabled/enabled behavior resumes according to the registry matrix.
 
 ## Public status endpoint security

--- a/docs/operations/emergency-feature-disable.md
+++ b/docs/operations/emergency-feature-disable.md
@@ -79,15 +79,13 @@ From a shell with access to the beta site:
 
 ```bash
 curl -s https://beta-gfc.weatherboysuper.com/api/capabilities/status
-curl -s -X POST https://beta-gfc.weatherboysuper.com/api/tstm/generate \
-  -H 'content-type: application/json' \
-  -d '{"day":1,"cycleDate":"2026-06-13"}'
+curl -s 'https://beta-gfc.weatherboysuper.com/api/tstm/latest?day=1&period=full'
 ```
 
 Expected results:
 
 - Status endpoint reports `"available": false` with `"reason": "emergency_disabled"`.
-- Generate endpoint returns `404` with `{ "error": "Auto-TSTM is not enabled on this deployment." }`.
+- Direct generation remains unavailable; cached guidance routes return `404` with `{ "error": "Auto-TSTM is not enabled on this deployment." }`.
 - Server logs include lines like:
   - `[capabilities] emergency_disabled=["TSTM_GENERATION_ENABLED"] target=beta`
   - `[capabilities] rejected capability=TSTM_GENERATION_ENABLED reason=emergency_disabled`
@@ -136,12 +134,10 @@ node server/analytics.js
 
 ```powershell
 curl http://127.0.0.1:3006/api/capabilities/status
-curl -X POST http://127.0.0.1:3006/api/tstm/generate `
-  -H 'content-type: application/json' `
-  -d '{"day":1,"cycleDate":"2026-06-13"}'
+curl 'http://127.0.0.1:3006/api/tstm/latest?day=1&period=full'
 ```
 
-4. Confirm the status payload includes `TSTM_GENERATION_ENABLED` with reason `emergency_disabled`, `/api/tstm/status` reports `"ingestionEnabled": false`, the generate route returns `404`, and no Python worker starts.
+4. Confirm the status payload includes `TSTM_GENERATION_ENABLED` with reason `emergency_disabled`, `/api/tstm/status` reports `"ingestionEnabled": false`, cached guidance routes return `404`, and no Python worker starts.
 5. Remove the emergency env var, restore `TSTM_INGESTION_ENABLED=true` if needed, restart the server, and confirm normal disabled/enabled behavior resumes according to the registry matrix.
 
 ## Public status endpoint security

--- a/server/testing/autoTstm.exposure.test.js
+++ b/server/testing/autoTstm.exposure.test.js
@@ -7,8 +7,6 @@ const {
   assertCapabilityRouteRejectsWithoutWork,
   disabledCapabilityStatusFixtures,
 } = require('./featureExposureHarness');
-const { allTargetsEnabledRouteOptions } = require('./featureExposureTargetMatrix');
-
 const startServer = (env, runGenerator, routeOptions = {}) => {
   const app = express();
   registerTstmRoutes(app, express, { env, runGenerator, ...routeOptions });
@@ -18,46 +16,9 @@ const startServer = (env, runGenerator, routeOptions = {}) => {
   });
 };
 
-const getGenerateUrl = (server) => {
-  const address = server.address();
-  return `http://127.0.0.1:${address.port}/api/tstm/generate`;
-};
-
 const getLatestUrl = (server, query = '') => {
   const address = server.address();
   return `http://127.0.0.1:${address.port}/api/tstm/latest${query}`;
-};
-
-const postGenerateRequest = (server) =>
-  fetch(getGenerateUrl(server), {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
-  });
-
-/** Asserts the generate route rejects without invoking the generator. */
-const assertGenerateRouteRejectsWithoutWork = async ({ env, routeOptions = {}, expectedBody }) => {
-  let calls = 0;
-  const server = await startServer(
-    env,
-    async () => {
-      calls += 1;
-      return {};
-    },
-    routeOptions
-  );
-
-  try {
-    const response = await postGenerateRequest(server);
-    const assert = require('node:assert/strict');
-    assert.equal(response.status, 404);
-    if (expectedBody) {
-      assert.deepEqual(await response.json(), expectedBody);
-    }
-    assert.equal(calls, 0);
-  } finally {
-    server.close();
-  }
 };
 
 /** Asserts the latest route rejects without invoking the generator. */
@@ -86,16 +47,6 @@ const assertLatestRouteRejectsWithoutWork = async ({ env, routeOptions = {}, exp
 };
 
 describe('autoTstm exposure contract', () => {
-  it('rejects generate requests for registry-disabled fixtures', async () => {
-    await assertGenerateRouteRejectsWithoutWork({
-      env: disabledCapabilityStatusFixtures.registry_disabled.env,
-      routeOptions: disabledCapabilityStatusFixtures.registry_disabled.routeOptions,
-      expectedBody: {
-        error: 'Auto-TSTM is not enabled on this deployment.',
-      },
-    });
-  });
-
   it('rejects latest requests for registry-disabled fixtures', async () => {
     await assertLatestRouteRejectsWithoutWork({
       env: disabledCapabilityStatusFixtures.registry_disabled.env,
@@ -106,25 +57,9 @@ describe('autoTstm exposure contract', () => {
     });
   });
 
-  it('rejects generate requests when only deployment env is enabled', async () => {
-    await assertGenerateRouteRejectsWithoutWork({
-      env: { TSTM_GENERATION_ENABLED: 'true', SERVER_TARGET: 'local' },
-    });
-  });
-
   it('rejects latest requests when only deployment env is enabled', async () => {
     await assertLatestRouteRejectsWithoutWork({
       env: { TSTM_GENERATION_ENABLED: 'true', SERVER_TARGET: 'local' },
-    });
-  });
-
-  it('rejects generate requests for emergency-disabled fixtures', async () => {
-    await assertGenerateRouteRejectsWithoutWork({
-      env: disabledCapabilityStatusFixtures.emergency_disabled.env,
-      routeOptions: disabledCapabilityStatusFixtures.emergency_disabled.routeOptions,
-      expectedBody: {
-        error: 'Auto-TSTM is not enabled on this deployment.',
-      },
     });
   });
 
@@ -146,28 +81,5 @@ describe('autoTstm exposure contract', () => {
         error: 'Auto-TSTM is not enabled on this deployment.',
       },
     });
-  });
-
-  it('allows work only when registry exposure and deployment env are both enabled', async () => {
-    let calls = 0;
-    const server = await startServer(
-      {
-        TSTM_GENERATION_ENABLED: 'true',
-      },
-      async () => {
-        calls += 1;
-        return { ok: true };
-      },
-      allTargetsEnabledRouteOptions()
-    );
-
-    try {
-      const response = await postGenerateRequest(server);
-      const assert = require('node:assert/strict');
-      assert.equal(response.status, 200);
-      assert.equal(calls, 1);
-    } finally {
-      server.close();
-    }
   });
 });

--- a/server/tstm.js
+++ b/server/tstm.js
@@ -40,18 +40,6 @@ const isTstmGenerationEnabled = (env = process.env, options = {}) =>
  */
 const isSupportedDay = (day) => day === 1 || day === 2;
 
-/** Normalizes the request payload passed to the Python process. */
-const createGenerationPayload = (body = {}) => ({
-  day: Number(body.day),
-  cycleDate: typeof body.cycleDate === 'string' ? body.cycleDate : '',
-  issueDate: typeof body.issueDate === 'string' ? body.issueDate : undefined,
-  validDate: typeof body.validDate === 'string' ? body.validDate : undefined,
-  issuanceTime: typeof body.issuanceTime === 'string' ? body.issuanceTime : undefined,
-});
-// Thresholds are not accepted from the client; the Python generator uses its
-// own DEFAULT_THRESHOLDS (core=0.30, support=0.10) and echoes them in the
-// response so the client can display the exact values used.
-
 /** Finds a common local Conda Python on Windows. */
 const getDefaultCondaPython = () => {
   if (process.platform !== 'win32') return null;
@@ -127,17 +115,6 @@ const runTstmGenerator = (payload, options = {}) => new Promise((resolve, reject
   child.stdin.end(JSON.stringify(payload));
 });
 
-/** Validates a request before any process can be started. */
-const validatePayload = (payload) => {
-  if (!isSupportedDay(payload.day)) {
-    return 'SPC calibrated thunder generation is only available for Day 1 and Day 2.';
-  }
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(payload.cycleDate)) {
-    return 'A valid cycleDate in YYYY-MM-DD format is required.';
-  }
-  return null;
-};
-
 /** Handles GET /api/tstm/latest — serves pre-cached ingestion data. */
 const handleLatestRequest = (env, target) => (req, res) => {
   const day = Number(req.query.day);
@@ -187,48 +164,16 @@ const handleStatusRequest = (env, target) => (_req, res) => {
   res.json(getTstmCacheHealth(target, env));
 };
 
-/** Registers the preserved endpoint in a fail-closed, default-off state. */
+/** Registers public cached-read routes in a fail-closed, default-off state. */
 const registerTstmRoutes = (app, express, options = {}) => {
   const env = options.env || process.env;
-  const runGenerator = options.runGenerator || runTstmGenerator;
   const rateLimit = options.rateLimit || require('express-rate-limit');
-  const generationLimiter = rateLimit({
-    windowMs: 60 * 1000,
-    limit: 2,
-    standardHeaders: true,
-    legacyHeaders: false,
-  });
   const readLimiter = options.readRateLimit || createTstmReadRateLimit(rateLimit, options.readRateLimitOptions);
   const capabilityOptions = {
     env,
     exposureOverride: options.exposureOverride,
     target: options.target,
   };
-  app.post(
-    '/api/tstm/generate',
-    createServerCapabilityGate(TSTM_CAPABILITY_KEY, capabilityOptions),
-    generationLimiter,
-    express.json({ limit: '4kb' }),
-    async (req, res) => {
-      const payload = createGenerationPayload(req.body);
-      const validationError = validatePayload(payload);
-      if (validationError) {
-        res.status(400).json({ error: validationError });
-        return;
-      }
-      try {
-        res.json(await runGenerator(payload));
-      } catch {
-        sendTstmApiError(
-          res,
-          503,
-          'Auto-TSTM guidance is temporarily unavailable.',
-          TSTM_ERROR_REASON.UNAVAILABLE,
-        );
-      }
-    },
-  );
-
   const { getServerTarget: getTarget } = require('./lib/serverTarget');
   const target = options.target || getTarget(env);
   app.get(
@@ -260,7 +205,6 @@ const registerTstmIngestion = (app, express, options = {}) => {
 };
 
 module.exports = {
-  createGenerationPayload,
   createTstmReadRateLimit,
   handleLatestRequest,
   handleStatusRequest,
@@ -270,5 +214,4 @@ module.exports = {
   registerTstmRoutes,
   runTstmGenerator,
   TSTM_READ_RATE_LIMIT_MAX,
-  validatePayload,
 };

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -16,18 +16,13 @@ const {
 } = require('./tstm');
 const { allTargetsEnabledRouteOptions } = require('./testing/featureExposureTargetMatrix');
 
-const startServer = (env, runGenerator, routeOptions = {}) => {
+const startServer = (env, routeOptions = {}) => {
   const app = express();
-  registerTstmRoutes(app, express, { env, runGenerator, ...routeOptions });
+  registerTstmRoutes(app, express, { env, ...routeOptions });
   return new Promise((resolve, reject) => {
     const server = app.listen(0, '127.0.0.1', () => resolve(server));
     server.on('error', reject);
   });
-};
-
-const getUrl = (server) => {
-  const address = server.address();
-  return `http://127.0.0.1:${address.port}/api/tstm/generate`;
 };
 
 const createFakeChild = () => {
@@ -38,13 +33,6 @@ const createFakeChild = () => {
   child.kill = () => child.emit('close', null);
   return child;
 };
-
-const postGenerateRequest = (server, headers = {}) =>
-  fetch(getUrl(server), {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', ...headers },
-    body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
-  });
 
 const SAMPLE_CACHED_ROUTE = {
   run: '2026-06-13T12:00:00Z',
@@ -118,19 +106,17 @@ describe('Auto-TSTM server foundation', () => {
   });
 
   it('never exposes direct generation, even when the capability is enabled', async () => {
-    let calls = 0;
     const server = await startServer(
       { TSTM_GENERATION_ENABLED: 'true' },
-      async () => {
-        calls += 1;
-        return {};
-      },
       allTargetsEnabledRouteOptions()
     );
     try {
-      const response = await postGenerateRequest(server, { authorization: 'Bearer any-token' });
+      const response = await fetch(`http://127.0.0.1:${server.address().port}/api/tstm/generate`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
+      });
       assert.equal(response.status, 404);
-      assert.equal(calls, 0);
     } finally {
       server.close();
     }

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -9,12 +9,10 @@ const os = require('os');
 const path = require('path');
 const express = require('express');
 const {
-  createGenerationPayload,
   isTstmGenerationEnabled,
   registerTstmIngestion,
   registerTstmRoutes,
   runTstmGenerator,
-  validatePayload,
 } = require('./tstm');
 const { allTargetsEnabledRouteOptions } = require('./testing/featureExposureTargetMatrix');
 
@@ -41,10 +39,10 @@ const createFakeChild = () => {
   return child;
 };
 
-const postGenerateRequest = (server) =>
+const postGenerateRequest = (server, headers = {}) =>
   fetch(getUrl(server), {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...headers },
     body: JSON.stringify({ day: 1, cycleDate: '2026-06-13' }),
   });
 
@@ -102,30 +100,6 @@ const withTstmRouteResponse = async ({
   }
 };
 
-/** Asserts a disabled generate route returns 404 without invoking the generator. */
-const assertGenerateRouteRejectsWithoutWork = async ({ env, routeOptions = {}, expectedBody }) => {
-  let calls = 0;
-  const server = await startServer(
-    env,
-    async () => {
-      calls += 1;
-      return {};
-    },
-    routeOptions
-  );
-
-  try {
-    const response = await postGenerateRequest(server);
-    assert.equal(response.status, 404);
-    if (expectedBody) {
-      assert.deepEqual(await response.json(), expectedBody);
-    }
-    assert.equal(calls, 0);
-  } finally {
-    server.close();
-  }
-};
-
 describe('Auto-TSTM server foundation', () => {
   it('stays disabled unless registry exposure and deployment env are both enabled', () => {
     assert.equal(isTstmGenerationEnabled({}), false);
@@ -137,63 +111,20 @@ describe('Auto-TSTM server foundation', () => {
     );
   });
 
-  it('normalizes and validates request payloads', () => {
-    const payload = createGenerationPayload({ day: '2', cycleDate: '2026-06-13', ignored: true });
-    assert.deepEqual(payload, {
-      day: 2,
-      cycleDate: '2026-06-13',
-      issueDate: undefined,
-      validDate: undefined,
-      issuanceTime: undefined,
-    });
-    assert.equal(validatePayload(payload), null);
-    assert.match(validatePayload({ ...payload, day: 3 }), /Day 1 and Day 2/);
-    assert.match(validatePayload({ ...payload, cycleDate: 'bad' }), /cycleDate/);
-  });
-
-  it('does not invoke the generator while disabled', async () => {
-    await assertGenerateRouteRejectsWithoutWork({
-      env: {},
-      expectedBody: {
-        error: 'Auto-TSTM is not enabled on this deployment.',
-      },
-    });
-  });
-
-  it('does not invoke the generator when only the deployment env is enabled', async () => {
-    await assertGenerateRouteRejectsWithoutWork({
-      env: { TSTM_GENERATION_ENABLED: 'true' },
-    });
-  });
-
-  it('does not invoke the generator when emergency disable is active', async () => {
-    await assertGenerateRouteRejectsWithoutWork({
-      env: {
-        TSTM_GENERATION_ENABLED: 'true',
-        EMERGENCY_DISABLED_CAPABILITIES: 'TSTM_GENERATION_ENABLED',
-      },
-      routeOptions: allTargetsEnabledRouteOptions(),
-      expectedBody: {
-        error: 'Auto-TSTM is not enabled on this deployment.',
-      },
-    });
-  });
-
-  it('returns sanitized errors when enabled work fails', async () => {
+  it('never exposes direct generation, even when the capability is enabled', async () => {
+    let calls = 0;
     const server = await startServer(
       { TSTM_GENERATION_ENABLED: 'true' },
       async () => {
-        throw new Error('internal path and stderr');
+        calls += 1;
+        return {};
       },
       allTargetsEnabledRouteOptions()
     );
     try {
-      const response = await postGenerateRequest(server);
-      assert.equal(response.status, 503);
-      assert.deepEqual(await response.json(), {
-        error: 'Auto-TSTM guidance is temporarily unavailable.',
-        reason: 'unavailable',
-      });
+      const response = await postGenerateRequest(server, { authorization: 'Bearer any-token' });
+      assert.equal(response.status, 404);
+      assert.equal(calls, 0);
     } finally {
       server.close();
     }

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -100,6 +100,12 @@ const withTstmRouteResponse = async ({
   }
 };
 
+/** Exercises one TSTM route and asserts only its HTTP status. */
+const assertTstmRouteStatus = (options, expectedStatus) =>
+  withTstmRouteResponse(options, async (response) => {
+    assert.equal(response.status, expectedStatus);
+  });
+
 describe('Auto-TSTM server foundation', () => {
   it('stays disabled unless registry exposure and deployment env are both enabled', () => {
     assert.equal(isTstmGenerationEnabled({}), false);
@@ -257,27 +263,23 @@ describe('GET /api/tstm/latest', () => {
   });
 
   it('returns 400 for invalid day parameter', async () => {
-    await withTstmRouteResponse({
+    await assertTstmRouteStatus({
       tmpDir,
       env: { TSTM_GENERATION_ENABLED: 'true', TSTM_CACHE_DIR: tmpDir },
       routePath: '/api/tstm/latest',
       query: '?day=3',
-    }, async (res) => {
-      assert.equal(res.status, 400);
-    });
+    }, 400);
   });
 
   it('returns 404 when capability is disabled', async () => {
-    await withTstmRouteResponse({
+    await assertTstmRouteStatus({
       tmpDir,
       env: { TSTM_CACHE_DIR: tmpDir },
       cache: SAMPLE_CACHED_ROUTE,
       routeOptions: {},
       routePath: '/api/tstm/latest',
       query: '?day=1',
-    }, async (res) => {
-      assert.equal(res.status, 404);
-    });
+    }, 404);
   });
 
   it('returns 404 when cached data has expired', async () => {
@@ -367,14 +369,12 @@ describe('GET /api/tstm/status', () => {
   });
 
   it('returns 404 when capability is disabled without reading cache', async () => {
-    await withTstmRouteResponse({
+    await assertTstmRouteStatus({
       tmpDir,
       env: { TSTM_CACHE_DIR: tmpDir },
       cache: SAMPLE_CACHED_ROUTE,
       routeOptions: {},
       routePath: '/api/tstm/status',
-    }, async (res) => {
-      assert.equal(res.status, 404);
-    });
+    }, 404);
   });
 });

--- a/src/utils/tstmGeneration.test.ts
+++ b/src/utils/tstmGeneration.test.ts
@@ -7,7 +7,6 @@ import {
   parseTstmGenerationResponse,
   readTstmLatestFailureReason,
   requestLatestTstmData,
-  requestTstmGeneration,
 } from './tstmGeneration';
 import {
   isServerCapabilityAvailable,
@@ -138,46 +137,6 @@ describe('tstmGeneration utilities', () => {
       calibratedThunderSupportProbability: 0.1,
     });
     expect(() => parseTstmGenerationResponse({ features: [] })).toThrow(/invalid response/);
-  });
-
-  test('requests guidance and surfaces structured server errors', async () => {
-    const originalFetch = global.fetch;
-    global.fetch = jest.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          features: [],
-          run: '2026-06-13T12:00:00Z',
-          forecastHours: [24],
-          effectiveStart: '2026-06-13T12:00:00Z',
-          effectiveEnd: '2026-06-14T12:00:00Z',
-          warnings: [],
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        json: async () => ({ error: 'Auto-TSTM is not enabled on this deployment.' }),
-      }) as jest.Mock;
-    try {
-      await expect(requestTstmGeneration({ day: 1, cycleDate: '2026-06-13' }))
-        .resolves.toMatchObject({ features: [] });
-      await expect(requestTstmGeneration({ day: 1, cycleDate: '2026-06-13' }))
-        .rejects.toThrow(/not enabled/);
-      expect(
-        isServerCapabilityAvailable('TSTM_GENERATION_ENABLED', {
-          loaded: true,
-          capabilities: {
-            TSTM_GENERATION_ENABLED: {
-              available: true,
-              reason: 'available',
-            },
-          },
-        })
-      ).toBe(false);
-    } finally {
-      global.fetch = originalFetch;
-    }
   });
 
   test('reads structured latest failure reasons from API payloads', () => {

--- a/src/utils/tstmGeneration.ts
+++ b/src/utils/tstmGeneration.ts
@@ -6,7 +6,6 @@ import type {
 } from '../types/tstmGeneration';
 import { markServerCapabilityUnavailable } from '../config/serverCapabilityStatus';
 
-const TSTM_GENERATION_ENDPOINT = '/api/tstm/generate';
 const TSTM_CAPABILITY_KEY = 'TSTM_GENERATION_ENABLED';
 const DISABLED_CAPABILITY_MESSAGE = 'Auto-TSTM is not enabled on this deployment.';
 
@@ -19,10 +18,6 @@ const readTstmGenerationErrorMessage = (payload: unknown): string | null => {
   const error = (payload as { error?: unknown }).error;
   return typeof error === 'string' ? error : null;
 };
-
-/** Returns the error message for a failed Auto-TSTM generation request. */
-const getTstmGenerationErrorMessage = (payload: unknown): string =>
-  readTstmGenerationErrorMessage(payload) ?? 'Auto-TSTM guidance is temporarily unavailable.';
 
 /** Marks the server capability unavailable when the API returns the standard disabled response. */
 const handleDisabledTstmCapability = (response: Response, error: string): void => {
@@ -142,29 +137,6 @@ export const parseTstmGenerationResponse = (payload: unknown): TstmGenerationRes
     generatedAt: typeof response.generatedAt === 'string' ? response.generatedAt : '',
     features: normalizeGeneratedTstmFeatures(response.features),
   } as TstmGenerationResponse;
-};
-
-/** Requests cached guidance. No UI calls this function while the capability remains disabled. */
-export const requestTstmGeneration = async (
-  request: TstmGenerationRequest,
-  signal?: AbortSignal
-): Promise<TstmGenerationResponse> => {
-  if (!canGenerateTstmForDay(request.day)) {
-    throw new Error('SPC calibrated thunder generation is only available for Day 1 and Day 2.');
-  }
-  const response = await fetch(TSTM_GENERATION_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(request),
-    signal,
-  });
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = getTstmGenerationErrorMessage(payload);
-    handleDisabledTstmCapability(response, error);
-    throw new Error(error);
-  }
-  return parseTstmGenerationResponse(payload);
 };
 
 const TSTM_LATEST_ENDPOINT = '/api/tstm/latest';


### PR DESCRIPTION
## Summary

- serve Auto-TSTM previews exclusively from the scheduled guidance cache
- retire the direct generation API and its unused browser client helper
- preserve the serialized ingestion loop, capability gates, cached-read limits, and public-safe status route
- update operational and emergency-disable documentation to match the narrowed boundary

## Why

Auto-TSTM already refreshes guidance through the process-owned scheduled ingestion loop, and the forecast editor consumes that cached result. Keeping a second interactive generation path added unnecessary resource and operational risk without supporting the active user workflow. This change makes the browser-facing surface read-only while retaining normal beta preview behavior.

## Verification

- `node --test tstm.test.js testing/autoTstm.exposure.test.js tstm-ingestion.test.js` — 53 passed
- `npm test` in `server/` — 88 passed
- `pnpm test -- --runTestsByPath src/utils/tstmGeneration.test.ts --runInBand` — 9 passed
- `pnpm test -- --runInBand` — 165 suites, 864 tests passed
- `pnpm run validate:feature-exposure` — passed
- `pnpm run test:exposure` — 23 server and 55 frontend exposure tests passed
- `pnpm run build` — Vite production build completed

## Review notes

This is intentionally limited to the beta-only Auto-TSTM surface. It does not introduce Auto-TSTM code into `main`, change cached guidance payloads, or change forecast-editor behavior.
