### PR TITLE
ver2(02): SPC 25-mile neighborhood + area geometry

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,9 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #769
+
+- Add SPC 25-mile neighborhood and Armchair-style area geometry helpers for Forecast Grade spatial scoring.
 ### PR #768
 
 - Start Verification v2 / Forecast Grade (`gfc-ver-1`) with the versioned formula contract (constants, bands, and component weight scaffolding) behind upcoming `verificationRelaunch` work. Follow-up stacked PRs add the engine, sources, gated dashboard, share card, and docs (#769–#780; umbrella index #766).

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -6,6 +6,8 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ### PR #769
 
+#### Added
+
 - Add SPC 25-mile neighborhood and Armchair-style area geometry helpers for Forecast Grade spatial scoring.
 ### PR #768
 

--- a/src/utils/verificationV2/neighborhood.test.ts
+++ b/src/utils/verificationV2/neighborhood.test.ts
@@ -1,0 +1,206 @@
+import * as turf from '@turf/turf';
+import type { Feature, Point } from 'geojson';
+import type { OutlookData } from '../../types/outlooks';
+import type { StormReport } from '../../types/stormReports';
+import {
+  GRID_SPACING_KM,
+  MAX_GRID_CELLS,
+  SPC_NEIGHBORHOOD_MILES,
+} from './constants';
+import {
+  areaKm2,
+  buildVerificationGrid,
+  estimateGridCellCount,
+  extractProductContours,
+  forecastProbabilityAt,
+  gridEndpointCount,
+  intersectionAreaKm2,
+  isSignificantKey,
+  isSignificantReport,
+  isWithinNeighborhood,
+  observedFootprint,
+  parseMagnitude,
+  probabilityFromKey,
+  reportsForProduct,
+  reportsNearRegion,
+  unionAll,
+  type AreaPolygon,
+} from './neighborhood';
+
+const squarePolygon = (
+  west: number,
+  south: number,
+  east: number,
+  north: number
+): AreaPolygon =>
+  turf.polygon([
+    [
+      [west, south],
+      [east, south],
+      [east, north],
+      [west, north],
+      [west, south],
+    ],
+  ]) as AreaPolygon;
+
+const report = (overrides: Partial<StormReport> = {}): StormReport => ({
+  id: 'r1',
+  type: 'tornado',
+  latitude: 35,
+  longitude: -97,
+  time: '2026-07-25T18:00:00Z',
+  location: 'Norman',
+  county: 'Cleveland',
+  state: 'OK',
+  ...overrides,
+});
+
+describe('neighborhood', () => {
+  describe('probability and significance parsing', () => {
+    it('parses contour key probabilities and significance markers', () => {
+      expect(probabilityFromKey('tornado', '15%')).toBe(0.15);
+      expect(probabilityFromKey('wind', '30%#')).toBe(0.3);
+      expect(probabilityFromKey('hail', 'not-a-probability')).toBe(0);
+      expect(isSignificantKey('15%#')).toBe(true);
+      expect(isSignificantKey('15%')).toBe(false);
+    });
+
+    it('parses report magnitudes and significance thresholds', () => {
+      expect(parseMagnitude(report({ magnitude: 'EF2' }))).toBe(2);
+      expect(parseMagnitude(report({ magnitude: undefined }))).toBe(0);
+      expect(parseMagnitude(report({ magnitude: 'bad' }))).toBe(0);
+      expect(isSignificantReport(report({ type: 'wind', magnitude: '80 mph' }))).toBe(true);
+      expect(isSignificantReport(report({ type: 'wind', magnitude: '60 mph' }))).toBe(false);
+    });
+  });
+
+  describe('extractProductContours', () => {
+    it('extracts valid polygons and skips malformed features', () => {
+      const outlooks: OutlookData = {
+        tornado: new Map([
+          [
+            '15%#',
+            [
+              squarePolygon(-98, 34, -96, 36),
+              turf.point([-97, 35]) as Feature<Point>,
+            ],
+          ],
+        ]),
+      };
+
+      const contours = extractProductContours(outlooks, 'tornado');
+      expect(contours).toHaveLength(1);
+      expect(contours[0]).toEqual(
+        expect.objectContaining({ probability: 0.15, isSignificant: true })
+      );
+    });
+
+    it('returns an empty list when the product map is missing', () => {
+      expect(extractProductContours({}, 'wind')).toEqual([]);
+    });
+  });
+
+  describe('reportsForProduct', () => {
+    it('keeps only reports for the requested hazard', () => {
+      const reports = [
+        report({ id: 't1', type: 'tornado' }),
+        report({ id: 'w1', type: 'wind' }),
+      ];
+      expect(reportsForProduct(reports, 'tornado')).toHaveLength(1);
+      expect(reportsForProduct(reports, 'tornado')[0].id).toBe('t1');
+    });
+  });
+
+  describe('polygon operations', () => {
+    it('unions overlapping polygons and computes area/intersection', () => {
+      const left = squarePolygon(-99, 34, -97, 36);
+      const right = squarePolygon(-98, 34, -96, 36);
+      const merged = unionAll([left, right]);
+      expect(merged).not.toBeNull();
+      expect(areaKm2(merged)).toBeGreaterThan(areaKm2(left));
+      expect(intersectionAreaKm2(left, right)).toBeGreaterThan(0);
+      expect(unionAll([])).toBeNull();
+    });
+  });
+
+  describe('25-mile neighborhood behavior', () => {
+    it('treats points inside the radius as in-neighborhood and outside as not', () => {
+      const origin = report({ latitude: 35, longitude: -97 });
+      const inside = turf.destination([-97, 35], SPC_NEIGHBORHOOD_MILES - 0.1, 90, {
+        units: 'miles',
+      }).geometry.coordinates;
+      const outside = turf.destination([-97, 35], SPC_NEIGHBORHOOD_MILES + 0.5, 90, {
+        units: 'miles',
+      }).geometry.coordinates;
+
+      expect(isWithinNeighborhood(inside, [origin])).toBe(true);
+      expect(isWithinNeighborhood(outside, [origin])).toBe(false);
+    });
+
+    it('buffers reports into an observed footprint and counts nearby reports', () => {
+      const reports = [
+        report({ id: 'a', latitude: 35, longitude: -97 }),
+        report({ id: 'b', latitude: 36, longitude: -100 }),
+      ];
+      const footprint = observedFootprint(reports);
+      expect(footprint).not.toBeNull();
+
+      const region = squarePolygon(-97.5, 34.5, -96.5, 35.5);
+      expect(reportsNearRegion(region, reports)).toBe(1);
+    });
+
+    it('selects the highest enclosing contour probability at a point', () => {
+      const contours = [
+        { probability: 0.15, isSignificant: false, polygon: squarePolygon(-98, 34, -96, 36) },
+        { probability: 0.3, isSignificant: true, polygon: squarePolygon(-97.5, 34.5, -96.5, 35.5) },
+      ];
+      expect(forecastProbabilityAt([-97, 35], contours)).toBe(0.3);
+      expect(forecastProbabilityAt([-120, 45], contours)).toBe(0);
+    });
+  });
+
+  describe('gridEndpointCount and estimateGridCellCount', () => {
+    it('uses endpoint-inclusive counts for square and thin envelopes', () => {
+      expect(gridEndpointCount(100, 10)).toBe(11);
+      expect(gridEndpointCount(5, 10)).toBe(1);
+      expect(estimateGridCellCount(100, 20, 10)).toBe(11 * 3);
+      expect(estimateGridCellCount(2000, 2000, 10)).toBeGreaterThan(MAX_GRID_CELLS);
+    });
+  });
+
+  describe('buildVerificationGrid', () => {
+    it('returns an empty grid when no envelope is available', () => {
+      expect(buildVerificationGrid(null, null)).toEqual({
+        points: [],
+        spacingKm: GRID_SPACING_KM,
+      });
+    });
+
+    it('builds a modest grid for a small envelope', () => {
+      const forecast = squarePolygon(-98, 34, -96, 36);
+      const grid = buildVerificationGrid(forecast, null);
+      expect(grid.points.length).toBeGreaterThan(0);
+      expect(grid.points.length).toBeLessThanOrEqual(MAX_GRID_CELLS);
+      expect(grid.spacingKm).toBe(GRID_SPACING_KM);
+    });
+
+    it('coarsens spacing so square and thin continental envelopes stay under the cell cap', () => {
+      const continentalSquare = squarePolygon(-125, 24, -66, 50);
+      const thinEnvelope = squarePolygon(-125, 35, -66, 36);
+
+      const squareGrid = buildVerificationGrid(continentalSquare, null);
+      const thinGrid = buildVerificationGrid(thinEnvelope, null);
+
+      expect(squareGrid.points.length).toBeLessThanOrEqual(MAX_GRID_CELLS);
+      expect(thinGrid.points.length).toBeLessThanOrEqual(MAX_GRID_CELLS);
+      expect(squareGrid.spacingKm).toBeGreaterThan(GRID_SPACING_KM);
+      expect(
+        estimateGridCellCount(
+          turf.distance([-125, 24], [-66, 24], { units: 'kilometers' }),
+          turf.distance([-125, 24], [-125, 50], { units: 'kilometers' }),
+          squareGrid.spacingKm
+        )
+      ).toBeLessThanOrEqual(MAX_GRID_CELLS);
+    });
+  });
+});

--- a/src/utils/verificationV2/neighborhood.ts
+++ b/src/utils/verificationV2/neighborhood.ts
@@ -3,7 +3,6 @@ import type { Feature, MultiPolygon, Polygon, Position } from 'geojson';
 import type { OutlookData } from '../../types/outlooks';
 import type { StormReport } from '../../types/stormReports';
 import {
-  CATEGORICAL_PROBABILITY,
   GRID_SPACING_KM,
   MAX_GRID_CELLS,
   SIGNIFICANT_THRESHOLD,
@@ -33,17 +32,11 @@ export interface ProductContour {
 export const isSignificantKey = (key: string): boolean => key.includes('#');
 
 /**
- * Resolves the probability fraction (0–1) a contour key represents for a
- * product. Categorical keys map through the versioned categorical table; hazard
- * keys parse their leading percent value.
+ * Resolves the probability fraction (0–1) a hazard contour key represents by
+ * parsing its leading percent value.
  */
-export const probabilityFromKey = (product: ProductKind, key: string): number => {
-  const clean = key.replace('#', '').trim().toUpperCase();
-
-  if (product === 'categorical') {
-    return CATEGORICAL_PROBABILITY[clean] ?? 0;
-  }
-
+export const probabilityFromKey = (_product: ProductKind, key: string): number => {
+  const clean = key.replace('#', '').trim();
   const match = clean.match(/([\d.]+)/);
   if (!match) {
     return 0;
@@ -52,8 +45,7 @@ export const probabilityFromKey = (product: ProductKind, key: string): number =>
 };
 
 /** Report types that count toward a product's verification. */
-export const relevantReportTypes = (product: ProductKind): HazardKind[] =>
-  product === 'categorical' ? ['tornado', 'wind', 'hail'] : [product];
+export const relevantReportTypes = (product: ProductKind): HazardKind[] => [product];
 
 /** Selects the reports relevant to a product. */
 export const reportsForProduct = (reports: StormReport[], product: ProductKind): StormReport[] => {

--- a/src/utils/verificationV2/neighborhood.ts
+++ b/src/utils/verificationV2/neighborhood.ts
@@ -1,0 +1,315 @@
+import * as turf from '@turf/turf';
+import type { Feature, MultiPolygon, Polygon, Position } from 'geojson';
+import type { OutlookData } from '../../types/outlooks';
+import type { StormReport } from '../../types/stormReports';
+import {
+  CATEGORICAL_PROBABILITY,
+  GRID_SPACING_KM,
+  MAX_GRID_CELLS,
+  SIGNIFICANT_THRESHOLD,
+  SPC_NEIGHBORHOOD_MILES,
+} from './constants';
+import type { HazardKind, ProductKind } from './gradeContract';
+
+/**
+ * Neighborhood + area geometry for the gfc-ver-1 engine (PR 02 — neighborhood-area).
+ *
+ * Implements the SPC spatial contract: severe within 25 miles of any point in a
+ * contour, with reports buffered by 25 miles. There is intentionally no
+ * distance-from-polygon decay inside the halo — a location is either within the
+ * neighborhood or it is not.
+ */
+
+export type AreaPolygon = Feature<Polygon | MultiPolygon>;
+
+/** A single forecast contour with its resolved probability and significance. */
+export interface ProductContour {
+  probability: number;
+  isSignificant: boolean;
+  polygon: AreaPolygon;
+}
+
+/** Returns true when an outlook map key encodes a significant (hatched) threat. */
+export const isSignificantKey = (key: string): boolean => key.includes('#');
+
+/**
+ * Resolves the probability fraction (0–1) a contour key represents for a
+ * product. Categorical keys map through the versioned categorical table; hazard
+ * keys parse their leading percent value.
+ */
+export const probabilityFromKey = (product: ProductKind, key: string): number => {
+  const clean = key.replace('#', '').trim().toUpperCase();
+
+  if (product === 'categorical') {
+    return CATEGORICAL_PROBABILITY[clean] ?? 0;
+  }
+
+  const match = clean.match(/([\d.]+)/);
+  if (!match) {
+    return 0;
+  }
+  return Number(match[1]) / 100;
+};
+
+/** Report types that count toward a product's verification. */
+export const relevantReportTypes = (product: ProductKind): HazardKind[] =>
+  product === 'categorical' ? ['tornado', 'wind', 'hail'] : [product];
+
+/** Selects the reports relevant to a product. */
+export const reportsForProduct = (reports: StormReport[], product: ProductKind): StormReport[] => {
+  const types = relevantReportTypes(product);
+  return reports.filter((report) => types.includes(report.type as HazardKind));
+};
+
+/** Coerces a report magnitude string into a comparable number (0 when absent). */
+export const parseMagnitude = (report: StormReport): number => {
+  if (!report.magnitude) {
+    return 0;
+  }
+  const match = String(report.magnitude).match(/([\d.]+)/);
+  return match ? Number(match[1]) : 0;
+};
+
+/** True when a report meets the significant-severity threshold for its hazard. */
+export const isSignificantReport = (report: StormReport): boolean => {
+  const threshold = SIGNIFICANT_THRESHOLD[report.type as HazardKind];
+  if (threshold === undefined) {
+    return false;
+  }
+  return parseMagnitude(report) >= threshold;
+};
+
+const asAreaPolygon = (feature: Feature): AreaPolygon | null => {
+  if (feature.geometry?.type === 'Polygon' || feature.geometry?.type === 'MultiPolygon') {
+    return feature as AreaPolygon;
+  }
+  return null;
+};
+
+/**
+ * Extracts the forecast contours for a product from an outlook, resolving each
+ * key's probability and significance. Malformed geometries are skipped.
+ */
+export const extractProductContours = (
+  outlooks: OutlookData,
+  product: ProductKind
+): ProductContour[] => {
+  const map = outlooks[product];
+  if (!map) {
+    return [];
+  }
+
+  const contours: ProductContour[] = [];
+  for (const [key, features] of map.entries()) {
+    const probability = probabilityFromKey(product, key);
+    const isSignificant = isSignificantKey(key);
+    for (const feature of features) {
+      const polygon = asAreaPolygon(feature);
+      if (polygon) {
+        contours.push({ probability, isSignificant, polygon });
+      }
+    }
+  }
+  return contours;
+};
+
+/** Unions many polygons into a single feature, tolerating malformed inputs. */
+export const unionAll = (polygons: AreaPolygon[]): AreaPolygon | null => {
+  const valid = polygons.filter(Boolean);
+  if (valid.length === 0) {
+    return null;
+  }
+
+  let accumulator: AreaPolygon | null = valid[0];
+  for (let index = 1; index < valid.length; index += 1) {
+    if (!accumulator) {
+      accumulator = valid[index];
+      continue;
+    }
+    try {
+      const merged = turf.union(
+        turf.featureCollection([accumulator, valid[index]])
+      ) as AreaPolygon | null;
+      if (merged) {
+        accumulator = merged;
+      }
+    } catch {
+      // Keep the running union if a pairwise union fails on bad geometry.
+    }
+  }
+  return accumulator;
+};
+
+/** Area of a polygon feature in square kilometers (0 when null/invalid). */
+export const areaKm2 = (polygon: AreaPolygon | null): number => {
+  if (!polygon) {
+    return 0;
+  }
+  try {
+    return turf.area(polygon) / 1_000_000;
+  } catch {
+    return 0;
+  }
+};
+
+/** Area of the intersection of two polygons in square kilometers. */
+export const intersectionAreaKm2 = (a: AreaPolygon | null, b: AreaPolygon | null): number => {
+  if (!a || !b) {
+    return 0;
+  }
+  try {
+    const intersection = turf.intersect(turf.featureCollection([a, b])) as AreaPolygon | null;
+    return areaKm2(intersection);
+  } catch {
+    return 0;
+  }
+};
+
+/** Buffers a report point by the SPC neighborhood radius (25 miles). */
+export const bufferReport = (report: StormReport): AreaPolygon | null => {
+  try {
+    const point = turf.point([report.longitude, report.latitude]);
+    return turf.buffer(point, SPC_NEIGHBORHOOD_MILES, { units: 'miles' }) as AreaPolygon | null;
+  } catch {
+    return null;
+  }
+};
+
+/** Union of every report's 25-mile halo — the observed severe footprint. */
+export const observedFootprint = (reports: StormReport[]): AreaPolygon | null => {
+  const halos: AreaPolygon[] = [];
+  for (const report of reports) {
+    const halo = bufferReport(report);
+    if (halo) {
+      halos.push(halo);
+    }
+  }
+  return unionAll(halos);
+};
+
+/** Highest forecast probability whose contour contains the point (0 if none). */
+export const forecastProbabilityAt = (
+  point: Position,
+  contours: ProductContour[]
+): number => {
+  const turfPoint = turf.point(point);
+  let best = 0;
+  for (const contour of contours) {
+    if (contour.probability <= best) {
+      continue;
+    }
+    try {
+      if (turf.booleanPointInPolygon(turfPoint, contour.polygon)) {
+        best = contour.probability;
+      }
+    } catch {
+      // Ignore malformed contour geometry.
+    }
+  }
+  return best;
+};
+
+/** True when a point lies within 25 miles of any of the supplied reports. */
+export const isWithinNeighborhood = (point: Position, reports: StormReport[]): boolean => {
+  const turfPoint = turf.point(point);
+  for (const report of reports) {
+    try {
+      const distance = turf.distance(turfPoint, turf.point([report.longitude, report.latitude]), {
+        units: 'miles',
+      });
+      if (distance <= SPC_NEIGHBORHOOD_MILES) {
+        return true;
+      }
+    } catch {
+      // Skip reports with invalid coordinates.
+    }
+  }
+  return false;
+};
+
+/** Count of reports whose location is within 25 miles of a region. */
+export const reportsNearRegion = (region: AreaPolygon | null, reports: StormReport[]): number => {
+  if (!region) {
+    return 0;
+  }
+  let buffered: AreaPolygon | null = region;
+  try {
+    buffered = turf.buffer(region, SPC_NEIGHBORHOOD_MILES, { units: 'miles' }) as AreaPolygon | null;
+  } catch {
+    buffered = region;
+  }
+  if (!buffered) {
+    return 0;
+  }
+
+  let count = 0;
+  for (const report of reports) {
+    try {
+      if (turf.booleanPointInPolygon(turf.point([report.longitude, report.latitude]), buffered)) {
+        count += 1;
+      }
+    } catch {
+      // Skip malformed report coordinates.
+    }
+  }
+  return count;
+};
+
+/** The ~10 km grid the probability/spatial components are evaluated over. */
+export interface VerificationGrid {
+  /** [lon, lat] cell centroids. */
+  points: Position[];
+  spacingKm: number;
+}
+
+/** Bounding box of a set of features, or null when empty. */
+const combinedBbox = (features: AreaPolygon[]): [number, number, number, number] | null => {
+  if (features.length === 0) {
+    return null;
+  }
+  try {
+    return turf.bbox(turf.featureCollection(features)) as [number, number, number, number];
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Builds the evaluation grid over the forecast envelope plus the observed
+ * footprint. Spacing coarsens automatically to stay under the cell ceiling so a
+ * continental-scale envelope still runs in bounded time.
+ */
+export const buildVerificationGrid = (
+  forecast: AreaPolygon | null,
+  observed: AreaPolygon | null
+): VerificationGrid => {
+  const features = [forecast, observed].filter((feature): feature is AreaPolygon => Boolean(feature));
+  const bbox = combinedBbox(features);
+  if (!bbox) {
+    return { points: [], spacingKm: GRID_SPACING_KM };
+  }
+
+  const [minX, minY, maxX, maxY] = bbox;
+  const widthKm = turf.distance([minX, minY], [maxX, minY], { units: 'kilometers' });
+  const heightKm = turf.distance([minX, minY], [minX, maxY], { units: 'kilometers' });
+
+  let spacingKm = GRID_SPACING_KM;
+  const estimatedCells = (widthKm / spacingKm + 1) * (heightKm / spacingKm + 1);
+  if (estimatedCells > MAX_GRID_CELLS) {
+    const areaKm = Math.max(widthKm * heightKm, 1);
+    spacingKm = Math.sqrt(areaKm / MAX_GRID_CELLS);
+  }
+
+  let grid;
+  try {
+    grid = turf.pointGrid(bbox, spacingKm, { units: 'kilometers' });
+  } catch {
+    return { points: [], spacingKm };
+  }
+
+  const points = grid.features
+    .map((feature) => feature.geometry?.coordinates)
+    .filter((coordinates): coordinates is Position => Array.isArray(coordinates));
+
+  return { points, spacingKm };
+};

--- a/src/utils/verificationV2/neighborhood.ts
+++ b/src/utils/verificationV2/neighborhood.ts
@@ -266,6 +266,62 @@ const combinedBbox = (features: AreaPolygon[]): [number, number, number, number]
   }
 };
 
+/** Integer endpoint count along one axis (matches Turf pointGrid semantics). */
+export const gridEndpointCount = (spanKm: number, spacingKm: number): number => {
+  if (spacingKm <= 0 || !Number.isFinite(spanKm)) {
+    return 1;
+  }
+  return Math.max(1, Math.floor(spanKm / spacingKm) + 1);
+};
+
+/** Estimated grid point count before calling Turf pointGrid. */
+export const estimateGridCellCount = (
+  widthKm: number,
+  heightKm: number,
+  spacingKm: number
+): number => gridEndpointCount(widthKm, spacingKm) * gridEndpointCount(heightKm, spacingKm);
+
+const spacingForCellCeiling = (
+  widthKm: number,
+  heightKm: number,
+  baseSpacingKm: number,
+  maxCells: number
+): number => {
+  if (estimateGridCellCount(widthKm, heightKm, baseSpacingKm) <= maxCells) {
+    return baseSpacingKm;
+  }
+
+  let low = baseSpacingKm;
+  let high = baseSpacingKm;
+  while (estimateGridCellCount(widthKm, heightKm, high) > maxCells) {
+    high *= 2;
+  }
+
+  for (let index = 0; index < 64; index += 1) {
+    const mid = (low + high) / 2;
+    if (estimateGridCellCount(widthKm, heightKm, mid) > maxCells) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+  return high;
+};
+
+const collectGridPoints = (
+  bbox: [number, number, number, number],
+  spacingKm: number
+): Position[] => {
+  try {
+    const grid = turf.pointGrid(bbox, spacingKm, { units: 'kilometers' });
+    return grid.features
+      .map((feature) => feature.geometry?.coordinates)
+      .filter((coordinates): coordinates is Position => Array.isArray(coordinates));
+  } catch {
+    return [];
+  }
+};
+
 /**
  * Builds the evaluation grid over the forecast envelope plus the observed
  * footprint. Spacing coarsens automatically to stay under the cell ceiling so a
@@ -285,23 +341,13 @@ export const buildVerificationGrid = (
   const widthKm = turf.distance([minX, minY], [maxX, minY], { units: 'kilometers' });
   const heightKm = turf.distance([minX, minY], [minX, maxY], { units: 'kilometers' });
 
-  let spacingKm = GRID_SPACING_KM;
-  const estimatedCells = (widthKm / spacingKm + 1) * (heightKm / spacingKm + 1);
-  if (estimatedCells > MAX_GRID_CELLS) {
-    const areaKm = Math.max(widthKm * heightKm, 1);
-    spacingKm = Math.sqrt(areaKm / MAX_GRID_CELLS);
-  }
+  let spacingKm = spacingForCellCeiling(widthKm, heightKm, GRID_SPACING_KM, MAX_GRID_CELLS);
+  let points = collectGridPoints(bbox, spacingKm);
 
-  let grid;
-  try {
-    grid = turf.pointGrid(bbox, spacingKm, { units: 'kilometers' });
-  } catch {
-    return { points: [], spacingKm };
+  for (let attempt = 0; attempt < 16 && points.length > MAX_GRID_CELLS; attempt += 1) {
+    spacingKm *= Math.sqrt(points.length / MAX_GRID_CELLS);
+    points = collectGridPoints(bbox, spacingKm);
   }
-
-  const points = grid.features
-    .map((feature) => feature.geometry?.coordinates)
-    .filter((coordinates): coordinates is Position => Array.isArray(coordinates));
 
   return { points, spacingKm };
 };


### PR DESCRIPTION
## Summary
- SPC 25-mile neighborhood + Armchair-style area geometry helpers.

## Stack2/13 
base `stack/ver2-01-formula` depends on #TBD-01

## Test plan
- [ ] Spot-check buffer/neighborhood helpersDepends on #768.

## Changelog
- Stack PR 2/13: SPC 25-mile neighborhood + Armchair-style area geometry helpers.