### PR TITLE
ver2(04a): event yield and severity scorers

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,9 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #771
+
+- Add event yield and severity intent-layer component scorers for Forecast Grade.
 ### PR #770
 
 - Add probability skill (Brier/BSS), spatial contingency, and false-alarm discipline component scorers.

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -6,7 +6,7 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ### PR #771
 
-- Add event yield and severity intent-layer component scorers for Forecast Grade.
+- Add event yield and severity intent-layer component scorers for Forecast Grade. `scoreEventYield` filters reports to the supplied hazard product before scoring so reports for other hazards never influence the product's yield.
 ### PR #770
 
 - Add probability skill (Brier/BSS), spatial contingency, and false-alarm discipline component scorers.

--- a/src/utils/verificationV2/yieldSeverity.test.ts
+++ b/src/utils/verificationV2/yieldSeverity.test.ts
@@ -1,0 +1,8 @@
+import { scoreEventYield, scoreSeverity } from './yieldSeverity';
+
+describe('yieldSeverity', () => {
+  it('exports callable scorers', () => {
+    expect(typeof scoreEventYield).toBe('function');
+    expect(typeof scoreSeverity).toBe('function');
+  });
+});

--- a/src/utils/verificationV2/yieldSeverity.test.ts
+++ b/src/utils/verificationV2/yieldSeverity.test.ts
@@ -1,8 +1,196 @@
+import * as turf from '@turf/turf';
+import type { Feature, Polygon } from 'geojson';
+import type { StormReport } from '../../types/stormReports';
+import {
+  SEVERITY_SIG_DRAWN_NONE_OBSERVED,
+  SEVERITY_SIG_HIT,
+  SEVERITY_SIG_MISSED,
+  SEVERITY_SIG_OUT_OF_AREA,
+} from './constants';
 import { scoreEventYield, scoreSeverity } from './yieldSeverity';
+import type { ProductContour } from './neighborhood';
+
+const squarePolygon = (sizeDeg: number): Feature<Polygon> => {
+  const half = sizeDeg / 2;
+  return turf.polygon([
+    [
+      [-half, -half],
+      [-half, half],
+      [half, half],
+      [half, -half],
+      [-half, -half],
+    ],
+  ]);
+};
+
+const contour = (probability: number, isSignificant: boolean, sizeDeg: number): ProductContour => ({
+  probability,
+  isSignificant,
+  polygon: squarePolygon(sizeDeg),
+});
+
+const tornadoReport = (id: string, longitude: number, latitude: number, magnitude = '0'): StormReport => ({
+  id,
+  type: 'tornado',
+  longitude,
+  latitude,
+  time: '2026-05-01T00:00:00Z',
+  magnitude,
+  location: 'Test',
+  county: 'Test',
+  state: 'OK',
+});
+
+const windReport = (id: string, longitude: number, latitude: number): StormReport => ({
+  id,
+  type: 'wind',
+  longitude,
+  latitude,
+  time: '2026-05-01T00:00:00Z',
+  magnitude: '60',
+  location: 'Test',
+  county: 'Test',
+  state: 'OK',
+});
 
 describe('yieldSeverity', () => {
   it('exports callable scorers', () => {
     expect(typeof scoreEventYield).toBe('function');
     expect(typeof scoreSeverity).toBe('function');
+  });
+});
+
+describe('scoreEventYield', () => {
+  it('returns not evaluated when no probability core at or above 15% was drawn', () => {
+    const result = scoreEventYield('tornado', [contour(0.1, false, 0.5)], []);
+    expect(result.applicable).toBe(false);
+    expect(result.score).toBeNull();
+    expect(result.detail).toMatch(/no probability core/i);
+  });
+
+  it('softens a tiny high-probability core with a single report (yield well under 1)', () => {
+    const contours = [
+      contour(0.15, false, 0.1),
+      contour(0.3, false, 0.1),
+      contour(0.45, false, 0.1),
+    ];
+    const result = scoreEventYield('tornado', contours, [tornadoReport('a', 0, 0, '0')]);
+
+    expect(result.applicable).toBe(true);
+    if (result.score === null) {
+      throw new Error('expected a finite score');
+    }
+    expect(result.score).toBeLessThan(1);
+    expect(result.score).toBeGreaterThan(0.4);
+  });
+
+  it('punishes a huge 30% core with a single report (yield near zero)', () => {
+    const contours = [
+      contour(0.15, false, 1),
+      contour(0.3, false, 1),
+      contour(0.45, false, 1),
+    ];
+    const result = scoreEventYield('tornado', contours, [tornadoReport('a', 0, 0, '0')]);
+
+    expect(result.applicable).toBe(true);
+    if (result.score === null) {
+      throw new Error('expected a finite score');
+    }
+    expect(result.score).toBeLessThan(0.4);
+  });
+
+  it('averages yield across present cores', () => {
+    const tinyContours = [
+      contour(0.15, false, 0.1),
+      contour(0.3, false, 0.1),
+      contour(0.45, false, 0.1),
+    ];
+    const expectedTinyAverage = 0.816;
+    const actual = scoreEventYield('tornado', tinyContours, [tornadoReport('a', 0, 0, '0')]);
+    if (actual.score === null) {
+      throw new Error('expected a finite score');
+    }
+    expect(actual.score).toBeCloseTo(expectedTinyAverage, 2);
+  });
+
+  it('zeroes yield when no reports observe the drawn core', () => {
+    const contours = [
+      contour(0.15, false, 0.1),
+      contour(0.3, false, 0.1),
+      contour(0.45, false, 0.1),
+    ];
+    const result = scoreEventYield('tornado', contours, []);
+    expect(result.applicable).toBe(true);
+    expect(result.score).toBe(0);
+  });
+
+  it('filters reports to the supplied product so other hazards do not count', () => {
+    const contours = [
+      contour(0.15, false, 0.1),
+      contour(0.3, false, 0.1),
+      contour(0.45, false, 0.1),
+    ];
+    const windOnly = scoreEventYield('tornado', contours, [windReport('w1', 0, 0)]);
+    const tornadoInside = scoreEventYield('tornado', contours, [tornadoReport('t1', 0, 0, '0')]);
+    const mixed = scoreEventYield(
+      'tornado',
+      contours,
+      [tornadoReport('t1', 0, 0, '0'), windReport('w1', 0, 0)]
+    );
+
+    if (windOnly.score === null || tornadoInside.score === null || mixed.score === null) {
+      throw new Error('expected finite scores');
+    }
+    expect(windOnly.score).toBe(0);
+    expect(mixed.score).toBeCloseTo(tornadoInside.score, 6);
+  });
+});
+
+describe('scoreSeverity', () => {
+  const sigContour = contour(0.6, true, 0.5);
+  const nonSigReportInside = tornadoReport('tornado-ef0', 0, 0, '0');
+  const nonSigReportOutside = tornadoReport('tornado-ef0-far', 10, 10, '0');
+  const sigReportInside = tornadoReport('tornado-ef2', 0, 0, '2');
+  const sigReportOutside = tornadoReport('tornado-ef2-far', 10, 10, '2');
+
+  it('returns a hit when a significant report falls within the significant contour', () => {
+    const result = scoreSeverity('tornado', [sigContour], [sigReportInside]);
+    expect(result.applicable).toBe(true);
+    expect(result.score).toBe(SEVERITY_SIG_HIT);
+    expect(result.metrics).toEqual({ sigReports: 1, sigInArea: 1 });
+  });
+
+  it('returns out-of-area when sig reports exist but none fall inside the significant contour', () => {
+    const result = scoreSeverity('tornado', [sigContour], [sigReportOutside]);
+    expect(result.applicable).toBe(true);
+    expect(result.score).toBe(SEVERITY_SIG_OUT_OF_AREA);
+    expect(result.metrics).toEqual({ sigReports: 1, sigInArea: 0 });
+  });
+
+  it('soft-penalizes when a significant contour is drawn but no significant report is observed', () => {
+    const result = scoreSeverity('tornado', [sigContour], [nonSigReportOutside]);
+    expect(result.applicable).toBe(true);
+    expect(result.score).toBe(SEVERITY_SIG_DRAWN_NONE_OBSERVED);
+    expect(result.metrics).toEqual({ sigReports: 0, sigInArea: 0 });
+  });
+
+  it('returns missed when a significant report is observed but no significant contour was drawn', () => {
+    const result = scoreSeverity('tornado', [contour(0.3, false, 0.5)], [sigReportInside]);
+    expect(result.applicable).toBe(true);
+    expect(result.score).toBe(SEVERITY_SIG_MISSED);
+    expect(result.metrics).toEqual({ sigReports: 1, sigInArea: 0 });
+  });
+
+  it('returns not evaluated when neither significant contour nor significant report is present', () => {
+    const result = scoreSeverity('tornado', [contour(0.3, false, 0.5)], [nonSigReportOutside]);
+    expect(result.applicable).toBe(false);
+    expect(result.score).toBeNull();
+    expect(result.detail).toMatch(/no significant contour drawn/i);
+  });
+
+  it('filters reports to the supplied product so other hazards do not count', () => {
+    const result = scoreSeverity('tornado', [sigContour], [windReport('w1', 0, 0)]);
+    expect(result.applicable).toBe(true);
+    expect(result.score).toBe(SEVERITY_SIG_DRAWN_NONE_OBSERVED);
   });
 });

--- a/src/utils/verificationV2/yieldSeverity.test.ts
+++ b/src/utils/verificationV2/yieldSeverity.test.ts
@@ -7,8 +7,9 @@ import {
   SEVERITY_SIG_MISSED,
   SEVERITY_SIG_OUT_OF_AREA,
 } from './constants';
-import { scoreEventYield, scoreSeverity } from './yieldSeverity';
+import type { ComponentScore } from './gradeContract';
 import type { ProductContour } from './neighborhood';
+import { scoreEventYield, scoreSeverity } from './yieldSeverity';
 
 const squarePolygon = (sizeDeg: number): Feature<Polygon> => {
   const half = sizeDeg / 2;
@@ -29,9 +30,15 @@ const contour = (probability: number, isSignificant: boolean, sizeDeg: number): 
   polygon: squarePolygon(sizeDeg),
 });
 
-const tornadoReport = (id: string, longitude: number, latitude: number, magnitude = '0'): StormReport => ({
+const report = (
+  id: string,
+  type: StormReport['type'],
+  longitude: number,
+  latitude: number,
+  magnitude: string
+): StormReport => ({
   id,
-  type: 'tornado',
+  type,
   longitude,
   latitude,
   time: '2026-05-01T00:00:00Z',
@@ -41,17 +48,18 @@ const tornadoReport = (id: string, longitude: number, latitude: number, magnitud
   state: 'OK',
 });
 
-const windReport = (id: string, longitude: number, latitude: number): StormReport => ({
-  id,
-  type: 'wind',
-  longitude,
-  latitude,
-  time: '2026-05-01T00:00:00Z',
-  magnitude: '60',
-  location: 'Test',
-  county: 'Test',
-  state: 'OK',
-});
+const tinyCores = (sizeDeg: number): ProductContour[] => [
+  contour(0.15, false, sizeDeg),
+  contour(0.3, false, sizeDeg),
+  contour(0.45, false, sizeDeg),
+];
+
+const finiteScore = (component: ComponentScore): number => {
+  if (component.score === null) {
+    throw new Error(`expected a finite score, got null (${component.detail})`);
+  }
+  return component.score;
+};
 
 describe('yieldSeverity', () => {
   it('exports callable scorers', () => {
@@ -69,128 +77,117 @@ describe('scoreEventYield', () => {
   });
 
   it('softens a tiny high-probability core with a single report (yield well under 1)', () => {
-    const contours = [
-      contour(0.15, false, 0.1),
-      contour(0.3, false, 0.1),
-      contour(0.45, false, 0.1),
-    ];
-    const result = scoreEventYield('tornado', contours, [tornadoReport('a', 0, 0, '0')]);
-
-    expect(result.applicable).toBe(true);
-    if (result.score === null) {
-      throw new Error('expected a finite score');
-    }
-    expect(result.score).toBeLessThan(1);
-    expect(result.score).toBeGreaterThan(0.4);
+    const score = finiteScore(scoreEventYield('tornado', tinyCores(0.1), [report('a', 'tornado', 0, 0, '0')]));
+    expect(score).toBeLessThan(1);
+    expect(score).toBeGreaterThan(0.4);
   });
 
   it('punishes a huge 30% core with a single report (yield near zero)', () => {
-    const contours = [
-      contour(0.15, false, 1),
-      contour(0.3, false, 1),
-      contour(0.45, false, 1),
-    ];
-    const result = scoreEventYield('tornado', contours, [tornadoReport('a', 0, 0, '0')]);
-
-    expect(result.applicable).toBe(true);
-    if (result.score === null) {
-      throw new Error('expected a finite score');
-    }
-    expect(result.score).toBeLessThan(0.4);
+    const score = finiteScore(scoreEventYield('tornado', tinyCores(1), [report('a', 'tornado', 0, 0, '0')]));
+    expect(score).toBeLessThan(0.4);
   });
 
   it('averages yield across present cores', () => {
-    const tinyContours = [
-      contour(0.15, false, 0.1),
-      contour(0.3, false, 0.1),
-      contour(0.45, false, 0.1),
-    ];
-    const expectedTinyAverage = 0.816;
-    const actual = scoreEventYield('tornado', tinyContours, [tornadoReport('a', 0, 0, '0')]);
-    if (actual.score === null) {
-      throw new Error('expected a finite score');
-    }
-    expect(actual.score).toBeCloseTo(expectedTinyAverage, 2);
+    const score = finiteScore(scoreEventYield('tornado', tinyCores(0.1), [report('a', 'tornado', 0, 0, '0')]));
+    expect(score).toBeCloseTo(0.816, 2);
   });
 
   it('zeroes yield when no reports observe the drawn core', () => {
-    const contours = [
-      contour(0.15, false, 0.1),
-      contour(0.3, false, 0.1),
-      contour(0.45, false, 0.1),
-    ];
-    const result = scoreEventYield('tornado', contours, []);
+    const result = scoreEventYield('tornado', tinyCores(0.1), []);
     expect(result.applicable).toBe(true);
     expect(result.score).toBe(0);
   });
 
   it('filters reports to the supplied product so other hazards do not count', () => {
-    const contours = [
-      contour(0.15, false, 0.1),
-      contour(0.3, false, 0.1),
-      contour(0.45, false, 0.1),
-    ];
-    const windOnly = scoreEventYield('tornado', contours, [windReport('w1', 0, 0)]);
-    const tornadoInside = scoreEventYield('tornado', contours, [tornadoReport('t1', 0, 0, '0')]);
-    const mixed = scoreEventYield(
-      'tornado',
-      contours,
-      [tornadoReport('t1', 0, 0, '0'), windReport('w1', 0, 0)]
-    );
+    const contours = tinyCores(0.1);
+    const windOnly = scoreEventYield('tornado', contours, [report('w1', 'wind', 0, 0, '60')]);
+    const tornadoInside = scoreEventYield('tornado', contours, [report('t1', 'tornado', 0, 0, '0')]);
+    const mixed = scoreEventYield('tornado', contours, [
+      report('t1', 'tornado', 0, 0, '0'),
+      report('w1', 'wind', 0, 0, '60'),
+    ]);
 
-    if (windOnly.score === null || tornadoInside.score === null || mixed.score === null) {
-      throw new Error('expected finite scores');
-    }
     expect(windOnly.score).toBe(0);
-    expect(mixed.score).toBeCloseTo(tornadoInside.score, 6);
+    expect(finiteScore(mixed)).toBeCloseTo(finiteScore(tornadoInside), 6);
   });
 });
 
 describe('scoreSeverity', () => {
   const sigContour = contour(0.6, true, 0.5);
-  const nonSigReportInside = tornadoReport('tornado-ef0', 0, 0, '0');
-  const nonSigReportOutside = tornadoReport('tornado-ef0-far', 10, 10, '0');
-  const sigReportInside = tornadoReport('tornado-ef2', 0, 0, '2');
-  const sigReportOutside = tornadoReport('tornado-ef2-far', 10, 10, '2');
+  const nonSigContour = contour(0.3, false, 0.5);
+  const sigReportInside = report('tornado-ef2', 'tornado', 0, 0, '2');
+  const sigReportOutside = report('tornado-ef2-far', 'tornado', 10, 10, '2');
+  const nonSigReportOutside = report('tornado-ef0-far', 'tornado', 10, 10, '0');
+  const windReportInside = report('w1', 'wind', 0, 0, '60');
 
-  it('returns a hit when a significant report falls within the significant contour', () => {
-    const result = scoreSeverity('tornado', [sigContour], [sigReportInside]);
-    expect(result.applicable).toBe(true);
-    expect(result.score).toBe(SEVERITY_SIG_HIT);
-    expect(result.metrics).toEqual({ sigReports: 1, sigInArea: 1 });
+  const cases: ReadonlyArray<{
+    name: string;
+    contours: ProductContour[];
+    reports: StormReport[];
+    applicable: boolean;
+    score: number | null;
+    metrics?: Record<string, number>;
+  }> = [
+    {
+      name: 'hit',
+      contours: [sigContour],
+      reports: [sigReportInside],
+      applicable: true,
+      score: SEVERITY_SIG_HIT,
+      metrics: { sigReports: 1, sigInArea: 1 },
+    },
+    {
+      name: 'out-of-area',
+      contours: [sigContour],
+      reports: [sigReportOutside],
+      applicable: true,
+      score: SEVERITY_SIG_OUT_OF_AREA,
+      metrics: { sigReports: 1, sigInArea: 0 },
+    },
+    {
+      name: 'drawn-only',
+      contours: [sigContour],
+      reports: [nonSigReportOutside],
+      applicable: true,
+      score: SEVERITY_SIG_DRAWN_NONE_OBSERVED,
+      metrics: { sigReports: 0, sigInArea: 0 },
+    },
+    {
+      name: 'observed-only',
+      contours: [nonSigContour],
+      reports: [sigReportInside],
+      applicable: true,
+      score: SEVERITY_SIG_MISSED,
+      metrics: { sigReports: 1, sigInArea: 0 },
+    },
+    {
+      name: 'not-evaluated',
+      contours: [nonSigContour],
+      reports: [nonSigReportOutside],
+      applicable: false,
+      score: null,
+    },
+    {
+      name: 'product-filter-drops-other-hazard',
+      contours: [sigContour],
+      reports: [windReportInside],
+      applicable: true,
+      score: SEVERITY_SIG_DRAWN_NONE_OBSERVED,
+      metrics: { sigReports: 0, sigInArea: 0 },
+    },
+  ];
+
+  it.each(cases)('returns the $name outcome', ({ contours, reports, applicable, score, metrics }) => {
+    const result = scoreSeverity('tornado', contours, reports);
+    expect(result.applicable).toBe(applicable);
+    expect(result.score).toBe(score);
+    if (metrics) {
+      expect(result.metrics).toEqual(metrics);
+    }
   });
 
-  it('returns out-of-area when sig reports exist but none fall inside the significant contour', () => {
-    const result = scoreSeverity('tornado', [sigContour], [sigReportOutside]);
-    expect(result.applicable).toBe(true);
-    expect(result.score).toBe(SEVERITY_SIG_OUT_OF_AREA);
-    expect(result.metrics).toEqual({ sigReports: 1, sigInArea: 0 });
-  });
-
-  it('soft-penalizes when a significant contour is drawn but no significant report is observed', () => {
-    const result = scoreSeverity('tornado', [sigContour], [nonSigReportOutside]);
-    expect(result.applicable).toBe(true);
-    expect(result.score).toBe(SEVERITY_SIG_DRAWN_NONE_OBSERVED);
-    expect(result.metrics).toEqual({ sigReports: 0, sigInArea: 0 });
-  });
-
-  it('returns missed when a significant report is observed but no significant contour was drawn', () => {
-    const result = scoreSeverity('tornado', [contour(0.3, false, 0.5)], [sigReportInside]);
-    expect(result.applicable).toBe(true);
-    expect(result.score).toBe(SEVERITY_SIG_MISSED);
-    expect(result.metrics).toEqual({ sigReports: 1, sigInArea: 0 });
-  });
-
-  it('returns not evaluated when neither significant contour nor significant report is present', () => {
-    const result = scoreSeverity('tornado', [contour(0.3, false, 0.5)], [nonSigReportOutside]);
-    expect(result.applicable).toBe(false);
-    expect(result.score).toBeNull();
+  it('surfaces a not-evaluated detail when no significant contour or report is present', () => {
+    const result = scoreSeverity('tornado', [nonSigContour], [nonSigReportOutside]);
     expect(result.detail).toMatch(/no significant contour drawn/i);
-  });
-
-  it('filters reports to the supplied product so other hazards do not count', () => {
-    const result = scoreSeverity('tornado', [sigContour], [windReport('w1', 0, 0)]);
-    expect(result.applicable).toBe(true);
-    expect(result.score).toBe(SEVERITY_SIG_DRAWN_NONE_OBSERVED);
   });
 });

--- a/src/utils/verificationV2/yieldSeverity.ts
+++ b/src/utils/verificationV2/yieldSeverity.ts
@@ -82,6 +82,47 @@ export const scoreEventYield = (
   return scoredComponent('eventYield', score, `Core yield ${details.join('; ')}.`, metrics);
 };
 
+const reportsForProduct = (product: ProductKind, reports: StormReport[]): StormReport[] =>
+  reports.filter((report) => report.type === product);
+
+const scoreSigDrawnAndObserved = (
+  sigContours: ProductContour[],
+  sigReports: StormReport[]
+): ComponentScore => {
+  const sigUnion = unionAll(sigContours.map((contour) => contour.polygon));
+  const inArea = reportsNearRegion(sigUnion, sigReports);
+  if (inArea > 0) {
+    return scoredComponent(
+      'severity',
+      SEVERITY_SIG_HIT,
+      `${inArea} significant report(s) within the significant contour.`,
+      { sigReports: sigReports.length, sigInArea: inArea }
+    );
+  }
+  return scoredComponent(
+    'severity',
+    SEVERITY_SIG_OUT_OF_AREA,
+    `${sigReports.length} significant report(s), none inside the significant contour.`,
+    { sigReports: sigReports.length, sigInArea: 0 }
+  );
+};
+
+const scoreSigDrawnOnly = (): ComponentScore =>
+  scoredComponent(
+    'severity',
+    SEVERITY_SIG_DRAWN_NONE_OBSERVED,
+    'Significant contour drawn; no significant report observed (soft penalty).',
+    { sigReports: 0, sigInArea: 0 }
+  );
+
+const scoreSigObservedOnly = (sigReports: StormReport[]): ComponentScore =>
+  scoredComponent(
+    'severity',
+    SEVERITY_SIG_MISSED,
+    `${sigReports.length} significant report(s) with no significant contour drawn.`,
+    { sigReports: sigReports.length, sigInArea: 0 }
+  );
+
 /**
  * Severity. Compares significant contours to significant reports within the
  * 25-mile neighborhood. Not evaluated when neither a sig contour nor a sig report
@@ -97,47 +138,18 @@ export const scoreSeverity = (
   }
 
   const sigContours = contours.filter((contour) => contour.isSignificant);
+  const sigReports = reportsForProduct(product, reports).filter(isSignificantReport);
   const sigDrawn = sigContours.length > 0;
-  const sigReports = reports.filter(isSignificantReport);
   const sigObserved = sigReports.length > 0;
 
   if (!sigDrawn && !sigObserved) {
     return notEvaluatedComponent('severity', 'No significant contour drawn and no significant report observed.');
   }
-
-  const sigUnion = unionAll(sigContours.map((contour) => contour.polygon));
-
   if (sigDrawn && sigObserved) {
-    const inArea = reportsNearRegion(sigUnion, sigReports);
-    if (inArea > 0) {
-      return scoredComponent(
-        'severity',
-        SEVERITY_SIG_HIT,
-        `${inArea} significant report(s) within the significant contour.`,
-        { sigReports: sigReports.length, sigInArea: inArea }
-      );
-    }
-    return scoredComponent(
-      'severity',
-      SEVERITY_SIG_OUT_OF_AREA,
-      `${sigReports.length} significant report(s), none inside the significant contour.`,
-      { sigReports: sigReports.length, sigInArea: 0 }
-    );
+    return scoreSigDrawnAndObserved(sigContours, sigReports);
   }
-
-  if (sigDrawn && !sigObserved) {
-    return scoredComponent(
-      'severity',
-      SEVERITY_SIG_DRAWN_NONE_OBSERVED,
-      'Significant contour drawn; no significant report observed (soft penalty).',
-      { sigReports: 0, sigInArea: 0 }
-    );
+  if (sigDrawn) {
+    return scoreSigDrawnOnly();
   }
-
-  return scoredComponent(
-    'severity',
-    SEVERITY_SIG_MISSED,
-    `${sigReports.length} significant report(s) with no significant contour drawn.`,
-    { sigReports: sigReports.length, sigInArea: 0 }
-  );
+  return scoreSigObservedOnly(sigReports);
 };

--- a/src/utils/verificationV2/yieldSeverity.ts
+++ b/src/utils/verificationV2/yieldSeverity.ts
@@ -1,0 +1,143 @@
+import type { StormReport } from '../../types/stormReports';
+import {
+  SEVERITY_SIG_DRAWN_NONE_OBSERVED,
+  SEVERITY_SIG_HIT,
+  SEVERITY_SIG_MISSED,
+  SEVERITY_SIG_OUT_OF_AREA,
+  YIELD_BASELINE_EXPECTED,
+  YIELD_CORE_THRESHOLDS,
+  YIELD_DENSITY_PER_10K_KM2,
+  YIELD_EPSILON,
+  type YieldCoreThreshold,
+} from './constants';
+import {
+  notEvaluatedComponent,
+  scoredComponent,
+  type ComponentScore,
+  type ProductKind,
+} from './gradeContract';
+import {
+  areaKm2,
+  isSignificantReport,
+  reportsNearRegion,
+  unionAll,
+  type ProductContour,
+} from './neighborhood';
+
+/**
+ * Event-yield and severity components (PR 04 — yield-composite).
+ *
+ * These are the GFC "intent" layer on top of the SPC occurrence math: yield asks
+ * whether the number of reports matches what a high-probability core claimed,
+ * and severity checks significant contours against significant reports.
+ */
+
+const roundTo = (value: number, digits = 3): number => {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+};
+
+/**
+ * Event yield / concentration. For each drawn core (f ≥ 0.15 / 0.30 / 0.45) the
+ * expected report count is `baseline + area × density(f)`, and yield is
+ * `min(1, observed / max(expected, ε))`. Present cores are averaged. This makes a
+ * huge 30% + 1 report fail on yield while softening a tiny 45% + 1 report.
+ */
+export const scoreEventYield = (
+  contours: ProductContour[],
+  reports: StormReport[]
+): ComponentScore => {
+  const coreYields: number[] = [];
+  const metrics: Record<string, number> = {};
+  const details: string[] = [];
+
+  for (const threshold of YIELD_CORE_THRESHOLDS) {
+    const coreUnion = unionAll(
+      contours.filter((contour) => contour.probability >= threshold).map((contour) => contour.polygon)
+    );
+    const coreArea = areaKm2(coreUnion);
+    if (coreArea <= 0) {
+      continue;
+    }
+
+    const density = YIELD_DENSITY_PER_10K_KM2[threshold as YieldCoreThreshold];
+    const baseline = YIELD_BASELINE_EXPECTED[threshold as YieldCoreThreshold];
+    const expected = baseline + (coreArea / 10_000) * density;
+    const observed = reportsNearRegion(coreUnion, reports);
+    const yieldValue = Math.min(1, observed / Math.max(expected, YIELD_EPSILON));
+
+    coreYields.push(yieldValue);
+    const label = `${Math.round(threshold * 100)}`;
+    metrics[`core${label}Expected`] = roundTo(expected, 2);
+    metrics[`core${label}Observed`] = observed;
+    metrics[`core${label}Yield`] = roundTo(yieldValue);
+    details.push(`${label}%: ${observed}/${roundTo(expected, 1)} exp → ${roundTo(yieldValue, 2)}`);
+  }
+
+  if (coreYields.length === 0) {
+    return notEvaluatedComponent('eventYield', 'No probability core at or above 15% was drawn.');
+  }
+
+  const score = coreYields.reduce((sum, value) => sum + value, 0) / coreYields.length;
+  return scoredComponent('eventYield', score, `Core yield ${details.join('; ')}.`, metrics);
+};
+
+/**
+ * Severity. Compares significant contours to significant reports within the
+ * 25-mile neighborhood. Not evaluated when neither a sig contour nor a sig report
+ * exists; a soft ~70 penalty applies when sig is drawn but nothing sig verifies.
+ */
+export const scoreSeverity = (
+  product: ProductKind,
+  contours: ProductContour[],
+  reports: StormReport[]
+): ComponentScore => {
+  if (product === 'categorical') {
+    return notEvaluatedComponent('severity', 'Significant contours are hazard-specific; not scored for categorical.');
+  }
+
+  const sigContours = contours.filter((contour) => contour.isSignificant);
+  const sigDrawn = sigContours.length > 0;
+  const sigReports = reports.filter(isSignificantReport);
+  const sigObserved = sigReports.length > 0;
+
+  if (!sigDrawn && !sigObserved) {
+    return notEvaluatedComponent('severity', 'No significant contour drawn and no significant report observed.');
+  }
+
+  const sigUnion = unionAll(sigContours.map((contour) => contour.polygon));
+
+  if (sigDrawn && sigObserved) {
+    const inArea = reportsNearRegion(sigUnion, sigReports);
+    if (inArea > 0) {
+      return scoredComponent(
+        'severity',
+        SEVERITY_SIG_HIT,
+        `${inArea} significant report(s) within the significant contour.`,
+        { sigReports: sigReports.length, sigInArea: inArea }
+      );
+    }
+    return scoredComponent(
+      'severity',
+      SEVERITY_SIG_OUT_OF_AREA,
+      `${sigReports.length} significant report(s), none inside the significant contour.`,
+      { sigReports: sigReports.length, sigInArea: 0 }
+    );
+  }
+
+  if (sigDrawn && !sigObserved) {
+    return scoredComponent(
+      'severity',
+      SEVERITY_SIG_DRAWN_NONE_OBSERVED,
+      'Significant contour drawn; no significant report observed (soft penalty).',
+      { sigReports: 0, sigInArea: 0 }
+    );
+  }
+
+  return scoredComponent(
+    'severity',
+    SEVERITY_SIG_MISSED,
+    `${sigReports.length} significant report(s) with no significant contour drawn.`,
+    { sigReports: sigReports.length, sigInArea: 0 }
+  );
+};

--- a/src/utils/verificationV2/yieldSeverity.ts
+++ b/src/utils/verificationV2/yieldSeverity.ts
@@ -37,16 +37,26 @@ const roundTo = (value: number, digits = 3): number => {
   return Math.round(value * factor) / factor;
 };
 
+/** Selects the reports relevant to a single hazard product. */
+const reportsForProduct = (product: ProductKind, reports: StormReport[]): StormReport[] =>
+  reports.filter((report) => report.type === product);
+
 /**
  * Event yield / concentration. For each drawn core (f ≥ 0.15 / 0.30 / 0.45) the
  * expected report count is `baseline + area × density(f)`, and yield is
  * `min(1, observed / max(expected, ε))`. Present cores are averaged. This makes a
  * huge 30% + 1 report fail on yield while softening a tiny 45% + 1 report.
+ *
+ * Reports are filtered to the supplied `product` before scoring so reports for
+ * other hazards never influence this product's yield — call sites that already
+ * pre-filter may pass the same reports array they would pass to `scoreSeverity`.
  */
 export const scoreEventYield = (
+  product: ProductKind,
   contours: ProductContour[],
   reports: StormReport[]
 ): ComponentScore => {
+  const relevantReports = reportsForProduct(product, reports);
   const coreYields: number[] = [];
   const metrics: Record<string, number> = {};
   const details: string[] = [];
@@ -63,7 +73,7 @@ export const scoreEventYield = (
     const density = YIELD_DENSITY_PER_10K_KM2[threshold as YieldCoreThreshold];
     const baseline = YIELD_BASELINE_EXPECTED[threshold as YieldCoreThreshold];
     const expected = baseline + (coreArea / 10_000) * density;
-    const observed = reportsNearRegion(coreUnion, reports);
+    const observed = reportsNearRegion(coreUnion, relevantReports);
     const yieldValue = Math.min(1, observed / Math.max(expected, YIELD_EPSILON));
 
     coreYields.push(yieldValue);
@@ -81,9 +91,6 @@ export const scoreEventYield = (
   const score = coreYields.reduce((sum, value) => sum + value, 0) / coreYields.length;
   return scoredComponent('eventYield', score, `Core yield ${details.join('; ')}.`, metrics);
 };
-
-const reportsForProduct = (product: ProductKind, reports: StormReport[]): StormReport[] =>
-  reports.filter((report) => report.type === product);
 
 const scoreSigDrawnAndObserved = (
   sigContours: ProductContour[],

--- a/src/utils/verificationV2/yieldSeverity.ts
+++ b/src/utils/verificationV2/yieldSeverity.ts
@@ -127,16 +127,14 @@ const scoreSigObservedOnly = (sigReports: StormReport[]): ComponentScore =>
  * Severity. Compares significant contours to significant reports within the
  * 25-mile neighborhood. Not evaluated when neither a sig contour nor a sig report
  * exists; a soft ~70 penalty applies when sig is drawn but nothing sig verifies.
+ * `ProductKind` is hazard-only, so the categorical layer is already excluded
+ * by the type system before this function is reached.
  */
 export const scoreSeverity = (
   product: ProductKind,
   contours: ProductContour[],
   reports: StormReport[]
 ): ComponentScore => {
-  if (product === 'categorical') {
-    return notEvaluatedComponent('severity', 'Significant contours are hazard-specific; not scored for categorical.');
-  }
-
   const sigContours = contours.filter((contour) => contour.isSignificant);
   const sigReports = reportsForProduct(product, reports).filter(isSignificantReport);
   const sigDrawn = sigContours.length > 0;


### PR DESCRIPTION
## Summary

- Event yield / concentration and severity scorers (intent layer).
- No composite orchestrator yet.

## Stack

4/13, base `stack/ver2-03-prob-spatial`

## Test plan

- [ ] Confirm yield softens tiny high-prob + single report cases conceptually

## Changelog

- Stack PR 4/13: Event yield and severity intent-layer component scorers.
