### PR TITLE
ver2(04b): composite rollup + orchestrator

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -25,6 +25,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 - Dependency: @sentry/node ^10.67.0 → ^10.68.0 (`server`)
 - Dependency: express-rate-limit ^8.6.0 → ^8.6.1 (`server`)
 
+### PR #772
+
+- Add composite rollup, the `runForecastGrade` orchestrator, and the public `verificationV2` engine entry point. Address the CodeRabbit review on `runForecastGrade` (reuse staged product grades), `gradeProduct` (handle report-only products), and the data-quality gate (count per-product reports).
+
 ### PR #771
 
 - Add event yield and severity intent-layer component scorers for Forecast Grade. `scoreEventYield` filters reports to the supplied hazard product before scoring so reports for other hazards never influence the product's yield.

--- a/src/utils/verificationV2/composite.ts
+++ b/src/utils/verificationV2/composite.ts
@@ -1,0 +1,180 @@
+import type { OutlookData } from '../../types/outlooks';
+import type { StormReport } from '../../types/stormReports';
+import { LIMITED_REPORT_CEILING } from './constants';
+import {
+  COMPONENT_ORDER,
+  PRODUCT_KINDS,
+  PRODUCT_LABELS,
+  composeComponents,
+  notEvaluatedComponent,
+  roundGrade,
+  scoreToLetter,
+  type ComponentScore,
+  type DataQuality,
+  type PackageGrade,
+  type ProductGrade,
+  type ProductKind,
+} from './gradeContract';
+import {
+  buildVerificationGrid,
+  extractProductContours,
+  observedFootprint,
+  reportsForProduct,
+  unionAll,
+} from './neighborhood';
+import {
+  evaluateGrid,
+  scoreFalseAlarmDiscipline,
+  scoreProbabilitySkill,
+  scoreSpatialContingency,
+} from './probSpatial';
+import { scoreEventYield, scoreSeverity } from './yieldSeverity';
+
+/**
+ * Composite rollup for the gfc-ver-1 engine (PR 04 — yield-composite).
+ *
+ * Combines the five components into a product grade (renormalizing N/A out),
+ * rolls present products into an equal-weight package grade, and derives the
+ * Good / Limited / Blocked data-quality gate.
+ */
+
+const orderedComponents = (components: ComponentScore[]): ComponentScore[] => {
+  const byKey = new Map(components.map((component) => [component.key, component]));
+  return COMPONENT_ORDER.map(
+    (key) => byKey.get(key) ?? notEvaluatedComponent(key, 'Component not evaluated.')
+  );
+};
+
+/** Grades a single product, returning a Not-evaluated shell when nothing exists. */
+export const gradeProduct = (
+  product: ProductKind,
+  outlooks: OutlookData,
+  reports: StormReport[]
+): ProductGrade => {
+  const contours = extractProductContours(outlooks, product);
+  const productReports = reportsForProduct(reports, product);
+  const hasForecast = contours.length > 0;
+
+  if (!hasForecast && productReports.length === 0) {
+    return {
+      product,
+      label: PRODUCT_LABELS[product],
+      grade: null,
+      letter: null,
+      applicable: false,
+      reportCount: 0,
+      components: COMPONENT_ORDER.map((key) => notEvaluatedComponent(key, 'Product not present in this package.')),
+    };
+  }
+
+  const forecastUnion = unionAll(contours.map((contour) => contour.polygon));
+  const observed = observedFootprint(productReports);
+  const grid = buildVerificationGrid(forecastUnion, observed);
+  const evaluation = evaluateGrid(grid, contours, productReports);
+
+  const components = orderedComponents([
+    scoreProbabilitySkill(evaluation),
+    scoreSpatialContingency(contours, productReports),
+    scoreFalseAlarmDiscipline(evaluation),
+    scoreEventYield(contours, productReports),
+    scoreSeverity(product, contours, productReports),
+  ]);
+
+  const grade = composeComponents(components);
+
+  return {
+    product,
+    label: PRODUCT_LABELS[product],
+    grade,
+    letter: scoreToLetter(grade),
+    applicable: components.some((component) => component.applicable),
+    reportCount: productReports.length,
+    components,
+  };
+};
+
+/** Equal-weight mean of present product grades, rounded to one decimal. */
+export const rollUpPackageGrade = (products: ProductGrade[]): number | null => {
+  const graded = products.filter(
+    (product): product is ProductGrade & { grade: number } =>
+      product.applicable && product.grade !== null
+  );
+  if (graded.length === 0) {
+    return null;
+  }
+  const mean = graded.reduce((sum, product) => sum + product.grade, 0) / graded.length;
+  return roundGrade(mean);
+};
+
+export interface DataQualityAssessment {
+  quality: DataQuality;
+  reason: string;
+  /** When true, callers withhold the package grade even if products graded. */
+  withholdPackageGrade: boolean;
+}
+
+/**
+ * Derives the data-quality gate. Geometry is a gate, not a weight: a package with
+ * no forecast geometry (or unreadable reports) is Blocked; a sparse non-quiet run
+ * is Limited with the package grade withheld; a clean quiet day is Good.
+ */
+export const assessDataQuality = (
+  hasGeometry: boolean,
+  reportCount: number,
+  reportsError: boolean
+): DataQualityAssessment => {
+  if (reportsError) {
+    return { quality: 'Blocked', reason: 'Storm reports could not be loaded.', withholdPackageGrade: true };
+  }
+  if (!hasGeometry) {
+    return { quality: 'Blocked', reason: 'No forecast geometry to grade.', withholdPackageGrade: true };
+  }
+  if (reportCount === 0) {
+    return { quality: 'Good', reason: 'No reports', withholdPackageGrade: false };
+  }
+  if (reportCount <= LIMITED_REPORT_CEILING) {
+    return {
+      quality: 'Limited',
+      reason: `Only ${reportCount} relevant report${reportCount === 1 ? '' : 's'}; package grade withheld.`,
+      withholdPackageGrade: true,
+    };
+  }
+  return { quality: 'Good', reason: 'Forecast and reports available.', withholdPackageGrade: false };
+};
+
+export interface BuildPackageOptions {
+  formulaVersion: string;
+  outlooks: OutlookData;
+  reports: StormReport[];
+  reportsError?: boolean;
+  generatedAt?: string;
+}
+
+/** Builds the full package grade across every product with the quality gate applied. */
+export const buildPackageGrade = ({
+  formulaVersion,
+  outlooks,
+  reports,
+  reportsError = false,
+  generatedAt,
+}: BuildPackageOptions): PackageGrade => {
+  const products = PRODUCT_KINDS.map((product) => gradeProduct(product, outlooks, reports));
+  const hasGeometry = PRODUCT_KINDS.some(
+    (product) => extractProductContours(outlooks, product).length > 0
+  );
+
+  const quality = assessDataQuality(hasGeometry, reports.length, reportsError);
+  const rolledGrade = rollUpPackageGrade(products);
+  const grade = quality.withholdPackageGrade ? null : rolledGrade;
+
+  return {
+    formulaVersion,
+    grade,
+    letter: scoreToLetter(grade),
+    products,
+    dataQuality: quality.quality,
+    dataQualityReason: quality.reason,
+    hasReports: reports.length > 0,
+    generatedAt: generatedAt ?? new Date().toISOString(),
+  };
+};

--- a/src/utils/verificationV2/composite.ts
+++ b/src/utils/verificationV2/composite.ts
@@ -28,6 +28,7 @@ import {
   scoreProbabilitySkill,
   scoreSpatialContingency,
 } from './probSpatial';
+import { FORECAST_GRADE_FORMULA_VERSION } from './formulaVersion';
 import { scoreEventYield, scoreSeverity } from './yieldSeverity';
 
 /**
@@ -143,7 +144,7 @@ export const assessDataQuality = (
 };
 
 export interface BuildPackageOptions {
-  formulaVersion: string;
+  formulaVersion: typeof FORECAST_GRADE_FORMULA_VERSION;
   outlooks: OutlookData;
   reports: StormReport[];
   reportsError?: boolean;

--- a/src/utils/verificationV2/composite.ts
+++ b/src/utils/verificationV2/composite.ts
@@ -157,8 +157,9 @@ export const buildPackageGrade = ({
   reports,
   reportsError = false,
   generatedAt,
-}: BuildPackageOptions): PackageGrade => {
-  const products = PRODUCT_KINDS.map((product) => gradeProduct(product, outlooks, reports));
+  products: providedProducts,
+}: BuildPackageOptions & { products?: ProductGrade[] }): PackageGrade => {
+  const products = providedProducts ?? PRODUCT_KINDS.map((product) => gradeProduct(product, outlooks, reports));
   const hasGeometry = PRODUCT_KINDS.some(
     (product) => extractProductContours(outlooks, product).length > 0
   );

--- a/src/utils/verificationV2/composite.ts
+++ b/src/utils/verificationV2/composite.ts
@@ -127,7 +127,7 @@ export const assessDataQuality = (
     return { quality: 'Blocked', reason: 'Storm reports could not be loaded.', withholdPackageGrade: true };
   }
   if (!hasGeometry) {
-    return { quality: 'Blocked', reason: 'No forecast geometry to grade.', withholdPackageGrade: true };
+    return { quality: 'Blocked', reason: 'No severe hazard geometry to grade.', withholdPackageGrade: true };
   }
   if (reportCount === 0) {
     return { quality: 'Good', reason: 'No reports', withholdPackageGrade: false };
@@ -157,9 +157,8 @@ export const buildPackageGrade = ({
   reports,
   reportsError = false,
   generatedAt,
-  products: providedProducts,
-}: BuildPackageOptions & { products?: ProductGrade[] }): PackageGrade => {
-  const products = providedProducts ?? PRODUCT_KINDS.map((product) => gradeProduct(product, outlooks, reports));
+}: BuildPackageOptions): PackageGrade => {
+  const products = PRODUCT_KINDS.map((product) => gradeProduct(product, outlooks, reports));
   const hasGeometry = PRODUCT_KINDS.some(
     (product) => extractProductContours(outlooks, product).length > 0
   );

--- a/src/utils/verificationV2/composite.ts
+++ b/src/utils/verificationV2/composite.ts
@@ -56,15 +56,18 @@ export const gradeProduct = (
   const productReports = reportsForProduct(reports, product);
   const hasForecast = contours.length > 0;
 
-  if (!hasForecast && productReports.length === 0) {
+  if (!hasForecast) {
+    const reason = productReports.length === 0
+      ? 'Product not present in this package.'
+      : 'No forecast issued for this product; reports cannot be evaluated.';
     return {
       product,
       label: PRODUCT_LABELS[product],
       grade: null,
       letter: null,
       applicable: false,
-      reportCount: 0,
-      components: COMPONENT_ORDER.map((key) => notEvaluatedComponent(key, 'Product not present in this package.')),
+      reportCount: productReports.length,
+      components: COMPONENT_ORDER.map((key) => notEvaluatedComponent(key, reason)),
     };
   }
 
@@ -151,6 +154,18 @@ export interface BuildPackageOptions {
   generatedAt?: string;
 }
 
+/**
+ * Counts reports relevant to the products that actually have geometry, so
+ * unrelated hazard reports can't mask a sparse product. Returns 0 if no
+ * forecast was issued for any hazard product.
+ */
+const relevantReportCount = (outlooks: OutlookData, reports: StormReport[]): number => {
+  const counts = PRODUCT_KINDS
+    .filter((product) => extractProductContours(outlooks, product).length > 0)
+    .map((product) => reportsForProduct(reports, product).length);
+  return counts.length === 0 ? 0 : Math.max(...counts);
+};
+
 /** Builds the full package grade across every product with the quality gate applied. */
 export const buildPackageGrade = ({
   formulaVersion,
@@ -164,7 +179,8 @@ export const buildPackageGrade = ({
     (product) => extractProductContours(outlooks, product).length > 0
   );
 
-  const quality = assessDataQuality(hasGeometry, reports.length, reportsError);
+  const relevantCount = relevantReportCount(outlooks, reports);
+  const quality = assessDataQuality(hasGeometry, relevantCount, reportsError);
   const rolledGrade = rollUpPackageGrade(products);
   const grade = quality.withholdPackageGrade ? null : rolledGrade;
 
@@ -175,7 +191,7 @@ export const buildPackageGrade = ({
     products,
     dataQuality: quality.quality,
     dataQualityReason: quality.reason,
-    hasReports: reports.length > 0,
+    hasReports: relevantCount > 0,
     generatedAt: generatedAt ?? new Date().toISOString(),
   };
 };

--- a/src/utils/verificationV2/composite.ts
+++ b/src/utils/verificationV2/composite.ts
@@ -77,7 +77,7 @@ export const gradeProduct = (
     scoreProbabilitySkill(evaluation),
     scoreSpatialContingency(contours, productReports),
     scoreFalseAlarmDiscipline(evaluation),
-    scoreEventYield(contours, productReports),
+    scoreEventYield(product, contours, reports),
     scoreSeverity(product, contours, productReports),
   ]);
 

--- a/src/utils/verificationV2/gradeForecast.test.ts
+++ b/src/utils/verificationV2/gradeForecast.test.ts
@@ -1,0 +1,165 @@
+import { gradeForecast, validateGradeInputs } from './gradeForecast';
+import { scoreToLetter, type ComponentKey, type ProductGrade } from './gradeContract';
+import { FORECAST_GRADE_FORMULA_VERSION } from './formulaVersion';
+import {
+  circleContour,
+  makeReport,
+  scatterReports,
+  tornadoOutlook,
+} from './testFixtures';
+import type { OutlookData } from '../../types/outlooks';
+
+const CENTER: [number, number] = [-97, 37];
+
+const componentOf = (product: ProductGrade | undefined, key: ComponentKey) =>
+  product?.components.find((component) => component.key === key);
+
+const tornadoProduct = (grade: ReturnType<typeof gradeForecast>) =>
+  grade.products.find((product) => product.product === 'tornado');
+
+describe('gfc-ver-1 letter bands', () => {
+  test.each([
+    [95, 'A'],
+    [90, 'A'],
+    [82.4, 'B'],
+    [70, 'C'],
+    [60, 'D'],
+    [59.9, 'F'],
+    [null, null],
+  ] as const)('maps %s to %s', (grade, letter) => {
+    expect(scoreToLetter(grade)).toBe(letter);
+  });
+});
+
+describe('gfc-ver-1 input validation', () => {
+  test('blocks a package with no geometry', () => {
+    const empty: OutlookData = { tornado: new Map(), wind: new Map(), hail: new Map(), categorical: new Map() };
+    expect(validateGradeInputs({ outlooks: empty, reports: [] }).valid).toBe(false);
+  });
+
+  test('blocks when the report fetch failed', () => {
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    expect(validateGradeInputs({ outlooks, reports: [], reportsError: true }).valid).toBe(false);
+  });
+
+  test('accepts a package with geometry and report array', () => {
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    expect(validateGradeInputs({ outlooks, reports: [] }).valid).toBe(true);
+  });
+});
+
+describe('gfc-ver-1 data quality gate', () => {
+  test('quiet day is Good with a No reports label and still produces a grade', () => {
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    const grade = gradeForecast({ outlooks, reports: [], generatedAt: '2026-01-01T00:00:00.000Z' });
+
+    expect(grade.dataQuality).toBe('Good');
+    expect(grade.dataQualityReason).toBe('No reports');
+    expect(grade.hasReports).toBe(false);
+    expect(grade.grade).not.toBeNull();
+    // Overforecast quiet day should score poorly.
+    expect(grade.grade as number).toBeLessThan(60);
+    expect(grade.formulaVersion).toBe(FORECAST_GRADE_FORMULA_VERSION);
+  });
+
+  test('sparse non-quiet run is Limited and withholds the package grade', () => {
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    const reports = [makeReport('tornado', CENTER[0], CENTER[1])];
+    const grade = gradeForecast({ outlooks, reports });
+
+    expect(grade.dataQuality).toBe('Limited');
+    expect(grade.grade).toBeNull();
+    // Components are still computed and shown even when the grade is withheld.
+    const skill = componentOf(tornadoProduct(grade), 'probabilitySkill');
+    expect(skill?.applicable).toBe(true);
+  });
+
+  test('blocks when reports fail to load', () => {
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    const grade = gradeForecast({ outlooks, reports: [], reportsError: true });
+    expect(grade.dataQuality).toBe('Blocked');
+    expect(grade.grade).toBeNull();
+  });
+});
+
+describe('gfc-ver-1 event yield intent', () => {
+  test('huge 30% core with a single report fails yield', () => {
+    const outlooks = tornadoOutlook('30%', circleContour(CENTER[0], CENTER[1], 160));
+    const reports = [makeReport('tornado', CENTER[0], CENTER[1])];
+    const grade = gradeForecast({ outlooks, reports });
+    const yieldComponent = componentOf(tornadoProduct(grade), 'eventYield');
+
+    expect(yieldComponent?.applicable).toBe(true);
+    expect(yieldComponent?.score as number).toBeLessThan(0.3);
+  });
+
+  test('tiny 45% core with one report is softened below full yield', () => {
+    const outlooks = tornadoOutlook('45%', circleContour(CENTER[0], CENTER[1], 20));
+    const reports = [makeReport('tornado', CENTER[0], CENTER[1])];
+    const grade = gradeForecast({ outlooks, reports });
+    const yieldComponent = componentOf(tornadoProduct(grade), 'eventYield');
+
+    expect(yieldComponent?.score as number).toBeGreaterThan(0);
+    expect(yieldComponent?.score as number).toBeLessThan(1);
+  });
+
+  test('tiny 45% core with many reports reaches full yield', () => {
+    const outlooks = tornadoOutlook('45%', circleContour(CENTER[0], CENTER[1], 20));
+    const reports = scatterReports('tornado', CENTER[0], CENTER[1], 8, 0.05);
+    const grade = gradeForecast({ outlooks, reports });
+    const yieldComponent = componentOf(tornadoProduct(grade), 'eventYield');
+
+    expect(yieldComponent?.score as number).toBeGreaterThan(0.9);
+  });
+});
+
+describe('gfc-ver-1 false-alarm discipline and skill', () => {
+  test('dense congestion scenario grades well across components', () => {
+    const outlooks = tornadoOutlook('15%', circleContour(CENTER[0], CENTER[1], 90));
+    const reports = scatterReports('tornado', CENTER[0], CENTER[1], 12, 0.4);
+    const grade = gradeForecast({ outlooks, reports });
+    const product = tornadoProduct(grade);
+
+    expect(grade.dataQuality).toBe('Good');
+    expect(product?.grade).not.toBeNull();
+    const far = componentOf(product, 'farDiscipline');
+    const skill = componentOf(product, 'probabilitySkill');
+    expect(far?.applicable).toBe(true);
+    expect(skill?.applicable).toBe(true);
+  });
+
+  test('quiet overforecast drives false-alarm discipline toward zero', () => {
+    const outlooks = tornadoOutlook('30%', circleContour(CENTER[0], CENTER[1], 120));
+    const grade = gradeForecast({ outlooks, reports: [] });
+    const far = componentOf(tornadoProduct(grade), 'farDiscipline');
+    expect(far?.applicable).toBe(true);
+    expect(far?.score as number).toBeLessThan(0.05);
+  });
+});
+
+describe('gfc-ver-1 severity', () => {
+  test('significant contour with no significant report applies the soft penalty', () => {
+    const outlooks = tornadoOutlook('15%#', circleContour(CENTER[0], CENTER[1], 90));
+    const reports = scatterReports('tornado', CENTER[0], CENTER[1], 6, 0.3);
+    const grade = gradeForecast({ outlooks, reports });
+    const severity = componentOf(tornadoProduct(grade), 'severity');
+    expect(severity?.applicable).toBe(true);
+    expect(severity?.score).toBeCloseTo(0.7, 5);
+  });
+
+  test('significant contour with a significant report scores a hit', () => {
+    const outlooks = tornadoOutlook('15%#', circleContour(CENTER[0], CENTER[1], 90));
+    const reports = [makeReport('tornado', CENTER[0], CENTER[1], 'EF3'), ...scatterReports('tornado', CENTER[0], CENTER[1], 4, 0.3)];
+    const grade = gradeForecast({ outlooks, reports });
+    const severity = componentOf(tornadoProduct(grade), 'severity');
+    expect(severity?.score).toBeCloseTo(1, 5);
+  });
+
+  test('severity is not evaluated when neither sig contour nor sig report exists', () => {
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 90));
+    const reports = scatterReports('tornado', CENTER[0], CENTER[1], 5, 0.3);
+    const grade = gradeForecast({ outlooks, reports });
+    const severity = componentOf(tornadoProduct(grade), 'severity');
+    expect(severity?.applicable).toBe(false);
+  });
+});

--- a/src/utils/verificationV2/gradeForecast.test.ts
+++ b/src/utils/verificationV2/gradeForecast.test.ts
@@ -32,9 +32,19 @@ describe('gfc-ver-1 letter bands', () => {
 });
 
 describe('gfc-ver-1 input validation', () => {
-  test('blocks a package with no geometry', () => {
+  test('blocks a package with no severe hazard geometry', () => {
     const empty: OutlookData = { tornado: new Map(), wind: new Map(), hail: new Map(), categorical: new Map() };
     expect(validateGradeInputs({ outlooks: empty, reports: [] }).valid).toBe(false);
+  });
+
+  test('blocks categorical-only packages without severe hazard contours', () => {
+    const categoricalOnly: OutlookData = {
+      tornado: new Map(),
+      wind: new Map(),
+      hail: new Map(),
+      categorical: new Map([['SLGT', circleContour(CENTER[0], CENTER[1], 120)]]),
+    };
+    expect(validateGradeInputs({ outlooks: categoricalOnly, reports: [] }).valid).toBe(false);
   });
 
   test('blocks when the report fetch failed', () => {

--- a/src/utils/verificationV2/gradeForecast.test.ts
+++ b/src/utils/verificationV2/gradeForecast.test.ts
@@ -1,4 +1,4 @@
-import { gradeForecast, validateGradeInputs } from './gradeForecast';
+import { gradeForecast, runForecastGrade, validateGradeInputs } from './gradeForecast';
 import { scoreToLetter, type ComponentKey, type ProductGrade } from './gradeContract';
 import { FORECAST_GRADE_FORMULA_VERSION } from './formulaVersion';
 import {
@@ -171,5 +171,88 @@ describe('gfc-ver-1 severity', () => {
     const grade = gradeForecast({ outlooks, reports });
     const severity = componentOf(tornadoProduct(grade), 'severity');
     expect(severity?.applicable).toBe(false);
+  });
+});
+
+describe('gfc-ver-1 product presence and per-hazard gating', () => {
+  test('report-only product returns inapplicable without scoring components', () => {
+    // Tornado has a 10% contour; hail does not. Hail has 4 reports anyway.
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    const reports = scatterReports('hail', CENTER[0], CENTER[1], 4, 0.3);
+    const grade = gradeForecast({ outlooks, reports });
+
+    const hail = grade.products.find((product) => product.product === 'hail');
+    expect(hail?.applicable).toBe(false);
+    expect(hail?.grade).toBeNull();
+    expect(hail?.reportCount).toBe(4);
+    // No component for a report-only product should report a numeric score.
+    hail?.components.forEach((component) => {
+      expect(component.score).toBeNull();
+    });
+  });
+
+  test('unrelated-hazard reports do not mask a sparse forecast product', () => {
+    // Tornado has geometry, but zero tornado reports. Hail has 8 unrelated reports.
+    // Data quality should reflect tornado being unobserved, not "Good" because of
+    // the 8 unrelated hail reports.
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    const reports = scatterReports('hail', CENTER[0], CENTER[1], 8, 0.3);
+    const grade = gradeForecast({ outlooks, reports });
+
+    expect(grade.dataQuality).toBe('Good');
+    expect(grade.dataQualityReason).toBe('No reports');
+    expect(grade.hasReports).toBe(false);
+    // Tornado was the only product with geometry, so the package still grades it.
+    expect(grade.grade).not.toBeNull();
+  });
+
+  test('only tornado-relevant reports gate the Limited threshold', () => {
+    // 1 tornado report + 20 unrelated wind reports should still be Limited
+    // because the tornado product is the one with geometry and is sparse.
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    const tornadoReports = [makeReport('tornado', CENTER[0], CENTER[1])];
+    const windReports = scatterReports('wind', CENTER[0], CENTER[1], 20, 0.3);
+    const grade = gradeForecast({ outlooks, reports: [...tornadoReports, ...windReports] });
+
+    expect(grade.dataQuality).toBe('Limited');
+    expect(grade.grade).toBeNull();
+  });
+});
+
+describe('gfc-ver-1 staged runForecastGrade', () => {
+  test('reuses staged product grades and matches the synchronous gradeForecast result', async () => {
+    const outlooks = tornadoOutlook('15%', circleContour(CENTER[0], CENTER[1], 90));
+    const reports = scatterReports('tornado', CENTER[0], CENTER[1], 12, 0.4);
+
+    const sync = gradeForecast({ outlooks, reports, generatedAt: '2026-01-01T00:00:00.000Z' });
+    const staged = await runForecastGrade(
+      { outlooks, reports, generatedAt: '2026-01-01T00:00:00.000Z' },
+      () => undefined
+    );
+
+    expect(staged.grade).toBe(sync.grade);
+    expect(staged.letter).toBe(sync.letter);
+    expect(staged.dataQuality).toBe(sync.dataQuality);
+    expect(staged.dataQualityReason).toBe(sync.dataQualityReason);
+    expect(staged.hasReports).toBe(sync.hasReports);
+    expect(staged.products.length).toBe(sync.products.length);
+  });
+
+  test('reports staged progress and yields between products', async () => {
+    const outlooks = tornadoOutlook('10%', circleContour(CENTER[0], CENTER[1], 120));
+    const reports: ReturnType<typeof makeReport>[] = [];
+    const fractions: number[] = [];
+
+    await runForecastGrade({ outlooks, reports }, (progress) => {
+      fractions.push(progress.fraction);
+    });
+
+    // Fractions must be non-decreasing and end at 1.
+    fractions.forEach((fraction, index) => {
+      if (index > 0) {
+        expect(fraction).toBeGreaterThanOrEqual(fractions[index - 1]);
+      }
+    });
+    expect(fractions[fractions.length - 1]).toBe(1);
   });
 });

--- a/src/utils/verificationV2/gradeForecast.test.ts
+++ b/src/utils/verificationV2/gradeForecast.test.ts
@@ -42,7 +42,7 @@ describe('gfc-ver-1 input validation', () => {
       tornado: new Map(),
       wind: new Map(),
       hail: new Map(),
-      categorical: new Map([['SLGT', circleContour(CENTER[0], CENTER[1], 120)]]),
+      categorical: new Map([['SLGT', [circleContour(CENTER[0], CENTER[1], 120)]]]),
     };
     expect(validateGradeInputs({ outlooks: categoricalOnly, reports: [] }).valid).toBe(false);
   });

--- a/src/utils/verificationV2/gradeForecast.ts
+++ b/src/utils/verificationV2/gradeForecast.ts
@@ -45,7 +45,10 @@ export const validateGradeInputs = (input: Partial<GradeForecastInput>): GradeIn
     (product) => extractProductContours(input.outlooks as OutlookData, product).length > 0
   );
   if (!hasGeometry) {
-    return { valid: false, reason: 'The forecast package has no outlook geometry to grade.' };
+    return {
+      valid: false,
+      reason: 'The forecast package has no severe hazard geometry to grade.',
+    };
   }
   return { valid: true };
 };
@@ -112,7 +115,6 @@ export const runForecastGrade = async (
     reports,
     reportsError,
     generatedAt,
-    products,
   });
 
   onProgress?.({ fraction: 1, label: 'Complete' });

--- a/src/utils/verificationV2/gradeForecast.ts
+++ b/src/utils/verificationV2/gradeForecast.ts
@@ -112,6 +112,7 @@ export const runForecastGrade = async (
     reports,
     reportsError,
     generatedAt,
+    products,
   });
 
   onProgress?.({ fraction: 1, label: 'Complete' });

--- a/src/utils/verificationV2/gradeForecast.ts
+++ b/src/utils/verificationV2/gradeForecast.ts
@@ -1,0 +1,119 @@
+import type { OutlookData } from '../../types/outlooks';
+import type { StormReport } from '../../types/stormReports';
+import { buildPackageGrade, gradeProduct } from './composite';
+import { FORECAST_GRADE_FORMULA_VERSION } from './formulaVersion';
+import { PRODUCT_KINDS, type PackageGrade } from './gradeContract';
+import { extractProductContours } from './neighborhood';
+
+/**
+ * Top-level Forecast Grade orchestrator (PR 04 — yield-composite).
+ *
+ * Wraps the composite rollup with input validation and a staged, foreground
+ * progress runner. Accuracy is prioritized over a fixed latency budget; long runs
+ * simply report staged progress and complete automatically.
+ */
+
+export interface GradeForecastInput {
+  outlooks: OutlookData;
+  reports: StormReport[];
+  /** True when the SPC report fetch failed (forces a Blocked result). */
+  reportsError?: boolean;
+  /** Overrides the snapshot timestamp (tests). */
+  generatedAt?: string;
+}
+
+export interface GradeInputValidation {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * Validates run inputs. Invalid inputs (no outlook object, non-array reports, or
+ * a failed required report fetch) block the run rather than producing a grade.
+ */
+export const validateGradeInputs = (input: Partial<GradeForecastInput>): GradeInputValidation => {
+  if (!input.outlooks || typeof input.outlooks !== 'object') {
+    return { valid: false, reason: 'Load a forecast package before grading.' };
+  }
+  if (!Array.isArray(input.reports)) {
+    return { valid: false, reason: 'Storm reports are unavailable for this run.' };
+  }
+  if (input.reportsError) {
+    return { valid: false, reason: 'Storm reports could not be loaded for this date.' };
+  }
+  const hasGeometry = PRODUCT_KINDS.some(
+    (product) => extractProductContours(input.outlooks as OutlookData, product).length > 0
+  );
+  if (!hasGeometry) {
+    return { valid: false, reason: 'The forecast package has no outlook geometry to grade.' };
+  }
+  return { valid: true };
+};
+
+/** Synchronously computes the full package grade. */
+export const gradeForecast = ({
+  outlooks,
+  reports,
+  reportsError = false,
+  generatedAt,
+}: GradeForecastInput): PackageGrade =>
+  buildPackageGrade({
+    formulaVersion: FORECAST_GRADE_FORMULA_VERSION,
+    outlooks,
+    reports,
+    reportsError,
+    generatedAt,
+  });
+
+export interface GradeProgress {
+  /** 0–1 completion fraction. */
+  fraction: number;
+  /** Human-readable stage label for the foreground progress UI. */
+  label: string;
+}
+
+export type GradeProgressHandler = (progress: GradeProgress) => void;
+
+const nextFrame = (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+/**
+ * Runs the grade product-by-product, reporting staged foreground progress and
+ * yielding between products so the UI can paint. Completes automatically.
+ */
+export const runForecastGrade = async (
+  input: GradeForecastInput,
+  onProgress?: GradeProgressHandler
+): Promise<PackageGrade> => {
+  const { outlooks, reports, reportsError = false, generatedAt } = input;
+
+  onProgress?.({ fraction: 0.02, label: 'Preparing package and reports…' });
+  await nextFrame();
+
+  const products = [];
+  for (let index = 0; index < PRODUCT_KINDS.length; index += 1) {
+    const product = PRODUCT_KINDS[index];
+    onProgress?.({
+      fraction: 0.05 + (index / PRODUCT_KINDS.length) * 0.85,
+      label: `Grading ${product} product…`,
+    });
+    products.push(gradeProduct(product, outlooks, reports));
+    await nextFrame();
+  }
+
+  onProgress?.({ fraction: 0.95, label: 'Rolling up package grade…' });
+  await nextFrame();
+
+  const snapshot = buildPackageGrade({
+    formulaVersion: FORECAST_GRADE_FORMULA_VERSION,
+    outlooks,
+    reports,
+    reportsError,
+    generatedAt,
+  });
+
+  onProgress?.({ fraction: 1, label: 'Complete' });
+  return snapshot;
+};

--- a/src/utils/verificationV2/gradeForecast.ts
+++ b/src/utils/verificationV2/gradeForecast.ts
@@ -1,9 +1,19 @@
 import type { OutlookData } from '../../types/outlooks';
 import type { StormReport } from '../../types/stormReports';
-import { buildPackageGrade, gradeProduct } from './composite';
+import {
+  assessDataQuality,
+  buildPackageGrade,
+  gradeProduct,
+  rollUpPackageGrade,
+} from './composite';
 import { FORECAST_GRADE_FORMULA_VERSION } from './formulaVersion';
-import { PRODUCT_KINDS, type PackageGrade } from './gradeContract';
-import { extractProductContours } from './neighborhood';
+import {
+  PRODUCT_KINDS,
+  scoreToLetter,
+  type PackageGrade,
+  type ProductGrade,
+} from './gradeContract';
+import { extractProductContours, reportsForProduct } from './neighborhood';
 
 /**
  * Top-level Forecast Grade orchestrator (PR 04 — yield-composite).
@@ -83,8 +93,23 @@ const nextFrame = (): Promise<void> =>
   });
 
 /**
+ * Counts reports relevant to the products that actually have geometry, so
+ * unrelated hazard reports can't mask a sparse product in the staged runner
+ * either. Mirrors `buildPackageGrade` so `runForecastGrade` produces the
+ * same data-quality assessment without re-deriving it.
+ */
+const relevantReportCount = (outlooks: OutlookData, reports: StormReport[]): number => {
+  const counts = PRODUCT_KINDS
+    .filter((product) => extractProductContours(outlooks, product).length > 0)
+    .map((product) => reportsForProduct(reports, product).length);
+  return counts.length === 0 ? 0 : Math.max(...counts);
+};
+
+/**
  * Runs the grade product-by-product, reporting staged foreground progress and
- * yielding between products so the UI can paint. Completes automatically.
+ * yielding between products so the UI can paint. Reuses the already-computed
+ * `products` array for the package rollup instead of recomputing every product
+ * synchronously after the staged loop.
  */
 export const runForecastGrade = async (
   input: GradeForecastInput,
@@ -95,7 +120,7 @@ export const runForecastGrade = async (
   onProgress?.({ fraction: 0.02, label: 'Preparing package and reports…' });
   await nextFrame();
 
-  const products = [];
+  const products: ProductGrade[] = [];
   for (let index = 0; index < PRODUCT_KINDS.length; index += 1) {
     const product = PRODUCT_KINDS[index];
     onProgress?.({
@@ -109,13 +134,22 @@ export const runForecastGrade = async (
   onProgress?.({ fraction: 0.95, label: 'Rolling up package grade…' });
   await nextFrame();
 
-  const snapshot = buildPackageGrade({
+  const hasGeometry = PRODUCT_KINDS.some(
+    (product) => extractProductContours(outlooks, product).length > 0
+  );
+  const relevantCount = relevantReportCount(outlooks, reports);
+  const quality = assessDataQuality(hasGeometry, relevantCount, reportsError);
+  const rolledGrade = quality.withholdPackageGrade ? null : rollUpPackageGrade(products);
+  const snapshot: PackageGrade = {
     formulaVersion: FORECAST_GRADE_FORMULA_VERSION,
-    outlooks,
-    reports,
-    reportsError,
-    generatedAt,
-  });
+    grade: rolledGrade,
+    letter: scoreToLetter(rolledGrade),
+    products,
+    dataQuality: quality.quality,
+    dataQualityReason: quality.reason,
+    hasReports: relevantCount > 0,
+    generatedAt: generatedAt ?? new Date().toISOString(),
+  };
 
   onProgress?.({ fraction: 1, label: 'Complete' });
   return snapshot;

--- a/src/utils/verificationV2/index.ts
+++ b/src/utils/verificationV2/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Public surface of the gfc-ver-1 Forecast Grade engine.
+ *
+ * The engine is pure (no React, no Redux) so it can be unit-tested in isolation
+ * and imported by UI, history persistence, share/export, and docs tooling.
+ */
+export * from './formulaVersion';
+export * from './constants';
+export * from './gradeContract';
+export {
+  extractProductContours,
+  reportsForProduct,
+  relevantReportTypes,
+  isSignificantReport,
+  isSignificantKey,
+  probabilityFromKey,
+  parseMagnitude,
+  observedFootprint,
+  buildVerificationGrid,
+  type ProductContour,
+  type VerificationGrid,
+  type AreaPolygon,
+} from './neighborhood';
+export {
+  evaluateGrid,
+  scoreProbabilitySkill,
+  scoreSpatialContingency,
+  scoreFalseAlarmDiscipline,
+  type GridEvaluation,
+} from './probSpatial';
+export { scoreEventYield, scoreSeverity } from './yieldSeverity';
+export {
+  gradeProduct,
+  rollUpPackageGrade,
+  assessDataQuality,
+  buildPackageGrade,
+  type DataQualityAssessment,
+  type BuildPackageOptions,
+} from './composite';
+export {
+  gradeForecast,
+  runForecastGrade,
+  validateGradeInputs,
+  type GradeForecastInput,
+  type GradeInputValidation,
+  type GradeProgress,
+  type GradeProgressHandler,
+} from './gradeForecast';

--- a/src/utils/verificationV2/testFixtures.ts
+++ b/src/utils/verificationV2/testFixtures.ts
@@ -1,0 +1,63 @@
+import * as turf from '@turf/turf';
+import type { Feature, Polygon } from 'geojson';
+import type { OutlookData } from '../../types/outlooks';
+import type { ReportType, StormReport } from '../../types/stormReports';
+
+/**
+ * Shared scenario fixtures for the gfc-ver-1 engine tests. Kept outside a
+ * *.test file so both the unit suite and the hardening suite can reuse them.
+ */
+
+/** Builds a circular contour of a given radius (km) centered on a point. */
+export const circleContour = (
+  lon: number,
+  lat: number,
+  radiusKm: number
+): Feature<Polygon> => turf.circle([lon, lat], radiusKm, { units: 'kilometers', steps: 64 }) as Feature<Polygon>;
+
+let reportCounter = 0;
+
+/** Builds a storm report at a point with an optional magnitude. */
+export const makeReport = (
+  type: ReportType,
+  lon: number,
+  lat: number,
+  magnitude?: string
+): StormReport => {
+  reportCounter += 1;
+  return {
+    id: `fixture-${reportCounter}`,
+    type,
+    latitude: lat,
+    longitude: lon,
+    time: '2000',
+    magnitude,
+    location: 'Fixture',
+    county: 'Fixture',
+    state: 'KS',
+  };
+};
+
+/** Builds an OutlookData with a single tornado contour keyed by probability. */
+export const tornadoOutlook = (
+  probabilityKey: string,
+  contour: Feature<Polygon>
+): OutlookData => ({
+  tornado: new Map([[probabilityKey, [contour]]]),
+  wind: new Map(),
+  hail: new Map(),
+  categorical: new Map(),
+});
+
+/** Scatters N reports of a type near a center within a small jitter radius. */
+export const scatterReports = (
+  type: ReportType,
+  lon: number,
+  lat: number,
+  count: number,
+  jitterDeg = 0.05
+): StormReport[] =>
+  Array.from({ length: count }, (_unused, index) => {
+    const angle = (index / Math.max(count, 1)) * Math.PI * 2;
+    return makeReport(type, lon + Math.cos(angle) * jitterDeg, lat + Math.sin(angle) * jitterDeg);
+  });


### PR DESCRIPTION
## Summary

- Composite rollup (`buildPackageGrade` / `gradeProduct`), the staged `runForecastGrade` orchestrator, and the public `verificationV2` engine barrel.
- Aligns the call site with the **04a CodeRabbit review contract**: `scoreEventYield(product, contours, reports)` filters reports to the hazard product inside the scorer, so reports for other hazards never influence a product's yield. 04b was originally branched off the pre-review 04a tip, so this PR rebases onto `beta` and restores the reviewed 3-arg signature.
- Adds `gradeForecast.test.ts` covering input validation, the data-quality gate, yield / FAR / severity, and the letter-band mapping.

## Stack

5/13, base `beta` (rebased after PR #771 merged).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test` (173 suites / 960 tests pass)
- [x] `pnpm run build`
- [x] `pnpm test -- --runTestsByPath src/utils/verificationV2/gradeForecast.test.ts src/utils/verificationV2/yieldSeverity.test.ts` (36 tests pass)

## Changelog

- Stack PR 5/13: Composite orchestrator and Forecast Grade engine entry point. Restores 04a's CodeRabbit-approved product filter contract on `scoreEventYield`.
