### PR TITLE
ver2(05): sources + capability-aware grade history

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -6,6 +6,8 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ### PR #773
 
+#### Added
+
 - Add explicit package source adapters (`loadForecastFromFile`, `loadReportsForDate`) and capability-aware `resolveAccountTier` / `availablePackageSources` for the Forecast Grade dashboard. Signed-in tiers keep 25-card trend history; premium also stores restorable immutable snapshots, scoped per user id.
 - Convert ISO `YYYY-MM-DD` report dates to SPC `YYMMDD` before archive fetch so the file-based source works with native date inputs. Move the converter into a dedicated `archiveDate` module and validate against a real calendar.
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,11 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #773
+
+- Add explicit package source adapters (`loadForecastFromFile`, `loadReportsForDate`) and capability-aware `resolveAccountTier` / `availablePackageSources` for the Forecast Grade dashboard. Signed-in tiers keep 25-card trend history; premium also stores restorable immutable snapshots, scoped per user id.
+- Convert ISO `YYYY-MM-DD` report dates to SPC `YYMMDD` before archive fetch so the file-based source works with native date inputs. Move the converter into a dedicated `archiveDate` module and validate against a real calendar.
+
 ### PR #787
 
 - Dependency: @radix-ui/react-dialog ^1.1.20 → ^1.1.23

--- a/src/types/forecastGrade.ts
+++ b/src/types/forecastGrade.ts
@@ -1,0 +1,46 @@
+import type { GFCForecastSaveData } from './outlooks';
+import type {
+  DataQuality,
+  LetterGrade,
+  PackageGrade,
+  ProductKind,
+} from '../utils/verificationV2/gradeContract';
+
+/**
+ * Persistence + source types for the Forecast Grade dashboard (PR 05).
+ *
+ * Grade cards are the lightweight, trend-only history synced for signed-in users.
+ * Snapshots are the immutable full records (premium) that can restore a package.
+ */
+
+/** Account capability tier that drives available sources and history depth. */
+export type GradeAccountTier = 'signed-out' | 'free' | 'premium';
+
+/** Where the forecast package for a run came from. Reports are always SPC. */
+export type PackageSourceKind = 'file' | 'cloud';
+
+/** A lightweight, trend-only history entry. Does not restore a full package. */
+export interface GradeCard {
+  id: string;
+  createdAt: string;
+  /** SPC report date (yyyy-mm-dd) or null for a today/live run. */
+  reportDate: string | null;
+  formulaVersion: string;
+  grade: number | null;
+  letter: LetterGrade | null;
+  dataQuality: DataQuality;
+  /** Per-product grades for hazard-filterable trend charts. */
+  productGrades: Partial<Record<ProductKind, number | null>>;
+  sourceLabel: string;
+  /** True only when an immutable full snapshot was stored (premium). */
+  hasSnapshot: boolean;
+}
+
+/** Immutable full record persisted for premium accounts to enable restore. */
+export interface GradeSnapshot {
+  card: GradeCard;
+  package: PackageGrade;
+  /** Serialized forecast package captured at run time (formula-version stamped). */
+  forecast: GFCForecastSaveData;
+  reportDate: string | null;
+}

--- a/src/utils/verificationV2/archiveDate.ts
+++ b/src/utils/verificationV2/archiveDate.ts
@@ -1,0 +1,38 @@
+const isValidCalendarDate = (year: number, month: number, day: number): boolean => {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+};
+
+/**
+ * Converts an ISO `YYYY-MM-DD` date (from a native date input) into the SPC
+ * archive `YYMMDD` format. Values already in `YYMMDD` are returned unchanged.
+ */
+export const toArchiveDate = (reportDate: string): string | null => {
+  const iso = reportDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (iso) {
+    const year = Number(iso[1]);
+    const month = Number(iso[2]);
+    const day = Number(iso[3]);
+    if (!isValidCalendarDate(year, month, day)) {
+      return null;
+    }
+    return `${iso[1].slice(2)}${iso[2]}${iso[3]}`;
+  }
+
+  const archive = reportDate.match(/^(\d{2})(\d{2})(\d{2})$/);
+  if (archive) {
+    const year = 2000 + Number(archive[1]);
+    const month = Number(archive[2]);
+    const day = Number(archive[3]);
+    if (!isValidCalendarDate(year, month, day)) {
+      return null;
+    }
+    return reportDate;
+  }
+
+  return null;
+};

--- a/src/utils/verificationV2/archiveDate.ts
+++ b/src/utils/verificationV2/archiveDate.ts
@@ -7,31 +7,50 @@ const isValidCalendarDate = (year: number, month: number, day: number): boolean 
   );
 };
 
+interface ArchivePattern {
+  regex: RegExp;
+  year: (match: RegExpMatchArray) => number;
+  month: (match: RegExpMatchArray) => number;
+  day: (match: RegExpMatchArray) => number;
+  format: (match: RegExpMatchArray) => string;
+}
+
+const ARCHIVE_PATTERNS: ArchivePattern[] = [
+  {
+    regex: /^(\d{4})-(\d{2})-(\d{2})$/,
+    year: (match) => Number(match[1]),
+    month: (match) => Number(match[2]),
+    day: (match) => Number(match[3]),
+    format: (match) => `${match[1].slice(2)}${match[2]}${match[3]}`,
+  },
+  {
+    regex: /^(\d{2})(\d{2})(\d{2})$/,
+    year: (match) => 2000 + Number(match[1]),
+    month: (match) => Number(match[2]),
+    day: (match) => Number(match[3]),
+    format: (match) => match[0],
+  },
+];
+
 /**
  * Converts an ISO `YYYY-MM-DD` date (from a native date input) into the SPC
  * archive `YYMMDD` format. Values already in `YYMMDD` are returned unchanged.
  */
 export const toArchiveDate = (reportDate: string): string | null => {
-  const iso = reportDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (iso) {
-    const year = Number(iso[1]);
-    const month = Number(iso[2]);
-    const day = Number(iso[3]);
-    if (!isValidCalendarDate(year, month, day)) {
-      return null;
+  for (const pattern of ARCHIVE_PATTERNS) {
+    const match = reportDate.match(pattern.regex);
+    if (!match) {
+      continue;
     }
-    return `${iso[1].slice(2)}${iso[2]}${iso[3]}`;
-  }
 
-  const archive = reportDate.match(/^(\d{2})(\d{2})(\d{2})$/);
-  if (archive) {
-    const year = 2000 + Number(archive[1]);
-    const month = Number(archive[2]);
-    const day = Number(archive[3]);
+    const year = pattern.year(match);
+    const month = pattern.month(match);
+    const day = pattern.day(match);
     if (!isValidCalendarDate(year, month, day)) {
       return null;
     }
-    return reportDate;
+
+    return pattern.format(match);
   }
 
   return null;

--- a/src/utils/verificationV2/gradeHistory.test.ts
+++ b/src/utils/verificationV2/gradeHistory.test.ts
@@ -12,6 +12,7 @@ import {
   resolveAccountTier,
   tierHasHistory,
   tierHasSnapshots,
+  toArchiveDate,
 } from './sources';
 import { gradeForecast } from './gradeForecast';
 import { circleContour, scatterReports, tornadoOutlook } from './testFixtures';
@@ -48,6 +49,11 @@ describe('account tiers and sources', () => {
     expect(availablePackageSources('signed-out')).toEqual(['file']);
     expect(availablePackageSources('free')).toEqual(['file']);
     expect(availablePackageSources('premium')).toEqual(['file', 'cloud']);
+  });
+
+  test('converts ISO date input to SPC archive YYMMDD', () => {
+    expect(toArchiveDate('2024-05-06')).toBe('240506');
+    expect(toArchiveDate('240506')).toBe('240506');
   });
 
   test('history and snapshot capability by tier', () => {

--- a/src/utils/verificationV2/gradeHistory.test.ts
+++ b/src/utils/verificationV2/gradeHistory.test.ts
@@ -54,6 +54,8 @@ describe('account tiers and sources', () => {
   test('converts ISO date input to SPC archive YYMMDD', () => {
     expect(toArchiveDate('2024-05-06')).toBe('240506');
     expect(toArchiveDate('240506')).toBe('240506');
+    expect(toArchiveDate('2024-99-99')).toBeNull();
+    expect(toArchiveDate('2024-5-6')).toBeNull();
   });
 
   test('history and snapshot capability by tier', () => {
@@ -68,7 +70,7 @@ describe('account scope', () => {
   test('signed-out sessions are never persisted', () => {
     expect(accountScope('signed-out')).toBeNull();
     expect(accountScope('free', 'abc')).toBe('user:abc');
-    expect(accountScope('free')).toBe('local:free');
+    expect(accountScope('free')).toBeNull();
   });
 });
 

--- a/src/utils/verificationV2/gradeHistory.test.ts
+++ b/src/utils/verificationV2/gradeHistory.test.ts
@@ -1,0 +1,114 @@
+import {
+  GRADE_HISTORY_LIMIT,
+  accountScope,
+  clearGradeHistory,
+  loadGradeCards,
+  loadGradeSnapshot,
+  recordGradeResult,
+} from './gradeHistory';
+import {
+  availablePackageSources,
+  buildGradeCard,
+  resolveAccountTier,
+  tierHasHistory,
+  tierHasSnapshots,
+} from './sources';
+import { gradeForecast } from './gradeForecast';
+import { circleContour, scatterReports, tornadoOutlook } from './testFixtures';
+import type { GradeCard, GradeSnapshot } from '../../types/forecastGrade';
+
+const scope = 'user:test';
+
+const sampleCard = (overrides: Partial<GradeCard> = {}): GradeCard => ({
+  id: `card-${Math.random().toString(36).slice(2)}`,
+  createdAt: new Date().toISOString(),
+  reportDate: '2026-05-01',
+  formulaVersion: 'gfc-ver-1',
+  grade: 82.4,
+  letter: 'B',
+  dataQuality: 'Good',
+  productGrades: { tornado: 82.4 },
+  sourceLabel: 'File + SPC',
+  hasSnapshot: false,
+  ...overrides,
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('account tiers and sources', () => {
+  test('resolves tier from auth + entitlement', () => {
+    expect(resolveAccountTier(false, false)).toBe('signed-out');
+    expect(resolveAccountTier(true, false)).toBe('free');
+    expect(resolveAccountTier(true, true)).toBe('premium');
+  });
+
+  test('only premium gets the cloud package source', () => {
+    expect(availablePackageSources('signed-out')).toEqual(['file']);
+    expect(availablePackageSources('free')).toEqual(['file']);
+    expect(availablePackageSources('premium')).toEqual(['file', 'cloud']);
+  });
+
+  test('history and snapshot capability by tier', () => {
+    expect(tierHasHistory('signed-out')).toBe(false);
+    expect(tierHasHistory('free')).toBe(true);
+    expect(tierHasSnapshots('free')).toBe(false);
+    expect(tierHasSnapshots('premium')).toBe(true);
+  });
+});
+
+describe('account scope', () => {
+  test('signed-out sessions are never persisted', () => {
+    expect(accountScope('signed-out')).toBeNull();
+    expect(accountScope('free', 'abc')).toBe('user:abc');
+    expect(accountScope('free')).toBe('local:free');
+  });
+});
+
+describe('grade history persistence', () => {
+  test('prepends new runs and never rewrites earlier history', () => {
+    recordGradeResult({ scope, card: sampleCard({ id: 'a', grade: 70 }) });
+    recordGradeResult({ scope, card: sampleCard({ id: 'b', grade: 90 }) });
+
+    const cards = loadGradeCards(scope);
+    expect(cards.map((card) => card.id)).toEqual(['b', 'a']);
+  });
+
+  test('trims to the latest limit', () => {
+    for (let index = 0; index < GRADE_HISTORY_LIMIT + 5; index += 1) {
+      recordGradeResult({ scope, card: sampleCard({ id: `card-${index}` }) });
+    }
+    expect(loadGradeCards(scope)).toHaveLength(GRADE_HISTORY_LIMIT);
+  });
+
+  test('stores and restores premium snapshots and evicts them past the limit', () => {
+    const card = sampleCard({ id: 'snap', hasSnapshot: true });
+    const snapshot = { card, package: { grade: 82.4 }, forecast: {}, reportDate: '2026-05-01' } as unknown as GradeSnapshot;
+    recordGradeResult({ scope, card, snapshot });
+    expect(loadGradeSnapshot(scope, 'snap')).not.toBeNull();
+
+    for (let index = 0; index < GRADE_HISTORY_LIMIT; index += 1) {
+      recordGradeResult({ scope, card: sampleCard({ id: `filler-${index}` }) });
+    }
+    expect(loadGradeSnapshot(scope, 'snap')).toBeNull();
+  });
+
+  test('clears history', () => {
+    recordGradeResult({ scope, card: sampleCard({ id: 'x' }) });
+    clearGradeHistory(scope);
+    expect(loadGradeCards(scope)).toHaveLength(0);
+  });
+});
+
+describe('buildGradeCard', () => {
+  test('distills a package grade into a trend card', () => {
+    const outlooks = tornadoOutlook('15%', circleContour(-97, 37, 90));
+    const pkg = gradeForecast({ outlooks, reports: scatterReports('tornado', -97, 37, 10, 0.4) });
+    const card = buildGradeCard(pkg, { reportDate: '2026-05-01', sourceLabel: 'File + SPC', hasSnapshot: false });
+
+    expect(card.formulaVersion).toBe('gfc-ver-1');
+    expect(card.productGrades.tornado).toBe(pkg.products.find((p) => p.product === 'tornado')?.grade ?? null);
+    expect(card.reportDate).toBe('2026-05-01');
+  });
+});

--- a/src/utils/verificationV2/gradeHistory.test.ts
+++ b/src/utils/verificationV2/gradeHistory.test.ts
@@ -94,12 +94,12 @@ describe('grade history persistence', () => {
     const card = sampleCard({ id: 'snap', hasSnapshot: true });
     const snapshot = { card, package: { grade: 82.4 }, forecast: {}, reportDate: '2026-05-01' } as unknown as GradeSnapshot;
     recordGradeResult({ scope, card, snapshot });
-    expect(loadGradeSnapshot(scope, 'snap')).not.toBeNull();
+    expect(loadGradeSnapshot({ scope, cardId: 'snap' })).not.toBeNull();
 
     for (let index = 0; index < GRADE_HISTORY_LIMIT; index += 1) {
       recordGradeResult({ scope, card: sampleCard({ id: `filler-${index}` }) });
     }
-    expect(loadGradeSnapshot(scope, 'snap')).toBeNull();
+    expect(loadGradeSnapshot({ scope, cardId: 'snap' })).toBeNull();
   });
 
   test('flips hasSnapshot to false on the returned card when the snapshot write fails', () => {
@@ -126,7 +126,7 @@ describe('grade history persistence', () => {
     const card = sampleCard({ id: 'a', hasSnapshot: true });
     const snapshot = { card, package: { grade: 1 }, forecast: {}, reportDate: '2026-05-01' } as unknown as GradeSnapshot;
     recordGradeResult({ scope, card, snapshot });
-    expect(loadGradeSnapshot(scope, 'a')).not.toBeNull();
+    expect(loadGradeSnapshot({ scope, cardId: 'a' })).not.toBeNull();
 
     const setItemSpy = jest
       .spyOn(Storage.prototype, 'setItem')
@@ -140,7 +140,7 @@ describe('grade history persistence', () => {
     try {
       // First filler run fails to persist its card list, so the prior snapshot must remain.
       recordGradeResult({ scope, card: sampleCard({ id: 'b' }) });
-      expect(loadGradeSnapshot(scope, 'a')).not.toBeNull();
+      expect(loadGradeSnapshot({ scope, cardId: 'a' })).not.toBeNull();
     } finally {
       setItemSpy.mockRestore();
     }

--- a/src/utils/verificationV2/gradeHistory.test.ts
+++ b/src/utils/verificationV2/gradeHistory.test.ts
@@ -102,6 +102,50 @@ describe('grade history persistence', () => {
     expect(loadGradeSnapshot(scope, 'snap')).toBeNull();
   });
 
+  test('flips hasSnapshot to false on the returned card when the snapshot write fails', () => {
+    const card = sampleCard({ id: 'quota', hasSnapshot: true });
+    const snapshot = { card, package: { grade: 82.4 }, forecast: {}, reportDate: '2026-05-01' } as unknown as GradeSnapshot;
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation((key: string) => {
+        if (key.startsWith('gfc-forecast-grade-snapshot-v1:')) {
+          throw new Error('Quota exceeded');
+        }
+        return undefined;
+      });
+
+    try {
+      const returned = recordGradeResult({ scope, card, snapshot });
+      expect(returned[0].hasSnapshot).toBe(false);
+    } finally {
+      setItemSpy.mockRestore();
+    }
+  });
+
+  test('does not evict snapshots when the card-list write fails', () => {
+    const card = sampleCard({ id: 'a', hasSnapshot: true });
+    const snapshot = { card, package: { grade: 1 }, forecast: {}, reportDate: '2026-05-01' } as unknown as GradeSnapshot;
+    recordGradeResult({ scope, card, snapshot });
+    expect(loadGradeSnapshot(scope, 'a')).not.toBeNull();
+
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation((key: string) => {
+        if (key.startsWith('gfc-forecast-grade-cards-v1:')) {
+          throw new Error('Quota exceeded');
+        }
+        return undefined;
+      });
+
+    try {
+      // First filler run fails to persist its card list, so the prior snapshot must remain.
+      recordGradeResult({ scope, card: sampleCard({ id: 'b' }) });
+      expect(loadGradeSnapshot(scope, 'a')).not.toBeNull();
+    } finally {
+      setItemSpy.mockRestore();
+    }
+  });
+
   test('clears history', () => {
     recordGradeResult({ scope, card: sampleCard({ id: 'x' }) });
     clearGradeHistory(scope);

--- a/src/utils/verificationV2/gradeHistory.ts
+++ b/src/utils/verificationV2/gradeHistory.ts
@@ -1,0 +1,149 @@
+import type { GradeAccountTier, GradeCard, GradeSnapshot } from '../../types/forecastGrade';
+
+/**
+ * Local persistence for Forecast Grade history (PR 05 — sources-history).
+ *
+ * Grade cards are the trend-only history kept for signed-in accounts (latest 25).
+ * Snapshots are immutable full records stored for premium accounts to enable
+ * restore. Runs never rewrite history — every completed run prepends a new card.
+ * Signed-out sessions keep no history.
+ */
+
+export const GRADE_HISTORY_LIMIT = 25;
+
+const CARDS_PREFIX = 'gfc-forecast-grade-cards-v1';
+const SNAPSHOT_PREFIX = 'gfc-forecast-grade-snapshot-v1';
+
+/** Stable per-account storage scope. Signed-out sessions are not persisted. */
+export const accountScope = (tier: GradeAccountTier, userId?: string): string | null => {
+  if (tier === 'signed-out') {
+    return null;
+  }
+  return userId ? `user:${userId}` : `local:${tier}`;
+};
+
+const cardsKey = (scope: string): string => `${CARDS_PREFIX}:${scope}`;
+const snapshotKey = (scope: string, cardId: string): string =>
+  `${SNAPSHOT_PREFIX}:${scope}:${cardId}`;
+
+const safeStorage = (): Storage | null => {
+  try {
+    return typeof window !== 'undefined' ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+};
+
+/** Reads the trend-only grade cards for a scope, newest first. */
+export const loadGradeCards = (scope: string | null): GradeCard[] => {
+  if (!scope) {
+    return [];
+  }
+  const storage = safeStorage();
+  if (!storage) {
+    return [];
+  }
+  try {
+    const raw = storage.getItem(cardsKey(scope));
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as GradeCard[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+/** Persists a card list (trimmed to the limit) for a scope. */
+const persistCards = (scope: string, cards: GradeCard[]): void => {
+  const storage = safeStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(cardsKey(scope), JSON.stringify(cards.slice(0, GRADE_HISTORY_LIMIT)));
+  } catch {
+    // Ignore quota / serialization failures; history is best-effort.
+  }
+};
+
+export interface RecordGradeOptions {
+  scope: string | null;
+  card: GradeCard;
+  /** Immutable snapshot stored only for premium accounts. */
+  snapshot?: GradeSnapshot;
+}
+
+/**
+ * Records a completed run: prepends the card and trims to the limit. When a
+ * snapshot is supplied (premium), it is written under the card id for restore.
+ * Cards evicted past the limit have their snapshots removed to bound storage.
+ */
+export const recordGradeResult = ({ scope, card, snapshot }: RecordGradeOptions): GradeCard[] => {
+  if (!scope) {
+    return [];
+  }
+  const existing = loadGradeCards(scope);
+  const next = [card, ...existing];
+  const trimmed = next.slice(0, GRADE_HISTORY_LIMIT);
+
+  const storage = safeStorage();
+  if (storage && snapshot) {
+    try {
+      storage.setItem(snapshotKey(scope, card.id), JSON.stringify(snapshot));
+    } catch {
+      // Snapshot persistence is best-effort.
+    }
+  }
+
+  if (storage) {
+    for (const evicted of next.slice(GRADE_HISTORY_LIMIT)) {
+      try {
+        storage.removeItem(snapshotKey(scope, evicted.id));
+      } catch {
+        // Ignore.
+      }
+    }
+  }
+
+  persistCards(scope, trimmed);
+  return trimmed;
+};
+
+/** Loads the immutable full snapshot for a card, if one was stored (premium). */
+export const loadGradeSnapshot = (scope: string | null, cardId: string): GradeSnapshot | null => {
+  if (!scope) {
+    return null;
+  }
+  const storage = safeStorage();
+  if (!storage) {
+    return null;
+  }
+  try {
+    const raw = storage.getItem(snapshotKey(scope, cardId));
+    return raw ? (JSON.parse(raw) as GradeSnapshot) : null;
+  } catch {
+    return null;
+  }
+};
+
+/** Clears all grade history for a scope (cards and snapshots). */
+export const clearGradeHistory = (scope: string | null): void => {
+  if (!scope) {
+    return;
+  }
+  const storage = safeStorage();
+  if (!storage) {
+    return;
+  }
+  const cards = loadGradeCards(scope);
+  try {
+    storage.removeItem(cardsKey(scope));
+    for (const card of cards) {
+      storage.removeItem(snapshotKey(scope, card.id));
+    }
+  } catch {
+    // Ignore.
+  }
+};

--- a/src/utils/verificationV2/gradeHistory.ts
+++ b/src/utils/verificationV2/gradeHistory.ts
@@ -16,10 +16,10 @@ const SNAPSHOT_PREFIX = 'gfc-forecast-grade-snapshot-v1';
 
 /** Stable per-account storage scope. Signed-out sessions are not persisted. */
 export const accountScope = (tier: GradeAccountTier, userId?: string): string | null => {
-  if (tier === 'signed-out') {
+  if (tier === 'signed-out' || !userId) {
     return null;
   }
-  return userId ? `user:${userId}` : `local:${tier}`;
+  return `user:${userId}`;
 };
 
 const cardsKey = (scope: string): string => `${CARDS_PREFIX}:${scope}`;

--- a/src/utils/verificationV2/gradeHistory.ts
+++ b/src/utils/verificationV2/gradeHistory.ts
@@ -75,13 +75,13 @@ const persistCards = (scope: string, cards: GradeCard[]): boolean => {
 };
 
 /** Persists a snapshot under the card id, returning whether the write succeeded. */
-const persistSnapshot = (scope: string, cardId: string, snapshot: GradeSnapshot): boolean => {
+const persistSnapshot = (params: { scope: string; cardId: string; snapshot: GradeSnapshot }): boolean => {
   const storage = safeStorage();
   if (!storage) {
     return false;
   }
   try {
-    storage.setItem(snapshotKey(scope, cardId), JSON.stringify(snapshot));
+    storage.setItem(snapshotKey(params.scope, params.cardId), JSON.stringify(params.snapshot));
     return true;
   } catch {
     // Snapshot persistence is best-effort.
@@ -90,14 +90,14 @@ const persistSnapshot = (scope: string, cardId: string, snapshot: GradeSnapshot)
 };
 
 /** Removes snapshots for the supplied card ids. Best-effort. */
-const evictSnapshots = (scope: string, cardIds: string[]): void => {
+const evictSnapshots = (params: { scope: string; cardIds: string[] }): void => {
   const storage = safeStorage();
   if (!storage) {
     return;
   }
-  for (const id of cardIds) {
+  for (const id of params.cardIds) {
     try {
-      storage.removeItem(snapshotKey(scope, id));
+      storage.removeItem(snapshotKey(params.scope, id));
     } catch {
       // Ignore.
     }
@@ -129,11 +129,13 @@ export const recordGradeResult = ({ scope, card, snapshot }: RecordGradeOptions)
   const trimmed = next.slice(0, GRADE_HISTORY_LIMIT);
   const evicted = next.slice(GRADE_HISTORY_LIMIT);
 
-  const snapshotPersisted = snapshot ? persistSnapshot(scope, card.id, snapshot) : false;
+  const snapshotPersisted = snapshot
+    ? persistSnapshot({ scope, cardId: card.id, snapshot })
+    : false;
   const cardsPersisted = persistCards(scope, trimmed);
 
   if (cardsPersisted) {
-    evictSnapshots(scope, evicted.map((c) => c.id));
+    evictSnapshots({ scope, cardIds: evicted.map((c) => c.id) });
   }
 
   if (snapshot && !snapshotPersisted) {
@@ -143,8 +145,13 @@ export const recordGradeResult = ({ scope, card, snapshot }: RecordGradeOptions)
   return trimmed;
 };
 
+export interface LoadGradeSnapshotParams {
+  scope: string | null;
+  cardId: string;
+}
+
 /** Loads the immutable full snapshot for a card, if one was stored (premium). */
-export const loadGradeSnapshot = (scope: string | null, cardId: string): GradeSnapshot | null => {
+export const loadGradeSnapshot = ({ scope, cardId }: LoadGradeSnapshotParams): GradeSnapshot | null => {
   if (!scope) {
     return null;
   }

--- a/src/utils/verificationV2/gradeHistory.ts
+++ b/src/utils/verificationV2/gradeHistory.ts
@@ -55,16 +55,52 @@ export const loadGradeCards = (scope: string | null): GradeCard[] => {
   }
 };
 
-/** Persists a card list (trimmed to the limit) for a scope. */
-const persistCards = (scope: string, cards: GradeCard[]): void => {
+/**
+ * Persists a card list (trimmed to the limit) for a scope. Returns whether
+ * `setItem` completed successfully so the caller can defer side effects that
+ * should only happen once history is durably updated.
+ */
+const persistCards = (scope: string, cards: GradeCard[]): boolean => {
+  const storage = safeStorage();
+  if (!storage) {
+    return false;
+  }
+  try {
+    storage.setItem(cardsKey(scope), JSON.stringify(cards.slice(0, GRADE_HISTORY_LIMIT)));
+    return true;
+  } catch {
+    // Ignore quota / serialization failures; history is best-effort.
+    return false;
+  }
+};
+
+/** Persists a snapshot under the card id, returning whether the write succeeded. */
+const persistSnapshot = (scope: string, cardId: string, snapshot: GradeSnapshot): boolean => {
+  const storage = safeStorage();
+  if (!storage) {
+    return false;
+  }
+  try {
+    storage.setItem(snapshotKey(scope, cardId), JSON.stringify(snapshot));
+    return true;
+  } catch {
+    // Snapshot persistence is best-effort.
+    return false;
+  }
+};
+
+/** Removes snapshots for the supplied card ids. Best-effort. */
+const evictSnapshots = (scope: string, cardIds: string[]): void => {
   const storage = safeStorage();
   if (!storage) {
     return;
   }
-  try {
-    storage.setItem(cardsKey(scope), JSON.stringify(cards.slice(0, GRADE_HISTORY_LIMIT)));
-  } catch {
-    // Ignore quota / serialization failures; history is best-effort.
+  for (const id of cardIds) {
+    try {
+      storage.removeItem(snapshotKey(scope, id));
+    } catch {
+      // Ignore.
+    }
   }
 };
 
@@ -78,7 +114,11 @@ export interface RecordGradeOptions {
 /**
  * Records a completed run: prepends the card and trims to the limit. When a
  * snapshot is supplied (premium), it is written under the card id for restore.
- * Cards evicted past the limit have their snapshots removed to bound storage.
+ * Cards evicted past the limit have their snapshots removed to bound storage,
+ * but only after the new card list is durably persisted — otherwise a failed
+ * write would orphan the live snapshots. The returned card list reflects
+ * the actual snapshot write so `hasSnapshot` never claims a snapshot that
+ * was not stored.
  */
 export const recordGradeResult = ({ scope, card, snapshot }: RecordGradeOptions): GradeCard[] => {
   if (!scope) {
@@ -87,27 +127,19 @@ export const recordGradeResult = ({ scope, card, snapshot }: RecordGradeOptions)
   const existing = loadGradeCards(scope);
   const next = [card, ...existing];
   const trimmed = next.slice(0, GRADE_HISTORY_LIMIT);
+  const evicted = next.slice(GRADE_HISTORY_LIMIT);
 
-  const storage = safeStorage();
-  if (storage && snapshot) {
-    try {
-      storage.setItem(snapshotKey(scope, card.id), JSON.stringify(snapshot));
-    } catch {
-      // Snapshot persistence is best-effort.
-    }
+  const snapshotPersisted = snapshot ? persistSnapshot(scope, card.id, snapshot) : false;
+  const cardsPersisted = persistCards(scope, trimmed);
+
+  if (cardsPersisted) {
+    evictSnapshots(scope, evicted.map((c) => c.id));
   }
 
-  if (storage) {
-    for (const evicted of next.slice(GRADE_HISTORY_LIMIT)) {
-      try {
-        storage.removeItem(snapshotKey(scope, evicted.id));
-      } catch {
-        // Ignore.
-      }
-    }
+  if (snapshot && !snapshotPersisted) {
+    const corrected: GradeCard = { ...trimmed[0], hasSnapshot: false };
+    return [corrected, ...trimmed.slice(1)];
   }
-
-  persistCards(scope, trimmed);
   return trimmed;
 };
 

--- a/src/utils/verificationV2/sources.test.ts
+++ b/src/utils/verificationV2/sources.test.ts
@@ -1,0 +1,168 @@
+import {
+  availablePackageSources,
+  loadForecastFromCloud,
+  loadForecastFromFile,
+  loadReportsForDate,
+  resolveAccountTier,
+  SourceLoadError,
+  tierHasHistory,
+  tierHasSnapshots,
+  toArchiveDate,
+} from './sources';
+import { loadCloudCycle } from '../../lib/cloudCyclesService';
+import { serializeForecast } from '../fileUtils';
+import type { CloudCycle, CloudOperationResult } from '../../types/cloudCycles';
+
+jest.mock('../../lib/cloudCyclesService', () => ({
+  loadCloudCycle: jest.fn(),
+}));
+
+const mockedLoadCloudCycle = loadCloudCycle as jest.MockedFunction<typeof loadCloudCycle>;
+
+describe('account tiers and sources', () => {
+  test('resolves tier from auth + entitlement', () => {
+    expect(resolveAccountTier(false, false)).toBe('signed-out');
+    expect(resolveAccountTier(true, false)).toBe('free');
+    expect(resolveAccountTier(true, true)).toBe('premium');
+  });
+
+  test('only premium gets the cloud package source', () => {
+    expect(availablePackageSources('signed-out')).toEqual(['file']);
+    expect(availablePackageSources('free')).toEqual(['file']);
+    expect(availablePackageSources('premium')).toEqual(['file', 'cloud']);
+  });
+
+  test('converts ISO date input to SPC archive YYMMDD', () => {
+    expect(toArchiveDate('2024-05-06')).toBe('240506');
+    expect(toArchiveDate('240506')).toBe('240506');
+    expect(toArchiveDate('2024-99-99')).toBeNull();
+    expect(toArchiveDate('2024-5-6')).toBeNull();
+  });
+
+  test('history and snapshot capability by tier', () => {
+    expect(tierHasHistory('signed-out')).toBe(false);
+    expect(tierHasHistory('free')).toBe(true);
+    expect(tierHasSnapshots('free')).toBe(false);
+    expect(tierHasSnapshots('premium')).toBe(true);
+  });
+});
+
+describe('source loaders', () => {
+  const originalFetch = global.fetch;
+
+  const mockFetch = (body: string, ok = true, statusText = 'OK'): void => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok,
+      statusText,
+      text: () => Promise.resolve(body),
+    }) as unknown as typeof global.fetch;
+  };
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    mockedLoadCloudCycle.mockReset();
+  });
+
+  describe('loadReportsForDate', () => {
+    test('fetches archived SPC reports for a valid ISO date', async () => {
+      mockFetch('');
+      const reports = await loadReportsForDate('2024-05-06');
+      expect(reports).toEqual([]);
+      expect(global.fetch).toHaveBeenCalledWith('https://www.spc.noaa.gov/climo/reports/240506_rpts_raw.csv');
+    });
+
+    test('routes null to today\'s SPC reports feed', async () => {
+      mockFetch('');
+      const reports = await loadReportsForDate(null);
+      expect(reports).toEqual([]);
+      expect(global.fetch).toHaveBeenCalledWith('https://www.spc.noaa.gov/climo/reports/today.csv');
+    });
+
+    test('treats blank strings as invalid dates, not as today', async () => {
+      await expect(loadReportsForDate('')).rejects.toBeInstanceOf(SourceLoadError);
+      await expect(loadReportsForDate('not-a-date')).rejects.toBeInstanceOf(SourceLoadError);
+      await expect(loadReportsForDate('2024-99-99')).rejects.toBeInstanceOf(SourceLoadError);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('wraps fetch failures as SourceLoadError', async () => {
+      mockFetch('', false, 'Server Error');
+      await expect(loadReportsForDate('2024-05-06')).rejects.toBeInstanceOf(SourceLoadError);
+    });
+  });
+
+  describe('loadForecastFromFile', () => {
+    const fileFor = (contents: unknown): File => {
+      const text = typeof contents === 'string' ? contents : JSON.stringify(contents);
+      const bytes = new TextEncoder().encode(text);
+      const fileLike = Object.assign(bytes, {
+        name: 'forecast.json',
+        type: 'application/json',
+        arrayBuffer: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+      });
+      return fileLike as unknown as File;
+    };
+
+    const validPayload = serializeForecast(
+      { days: {}, currentDay: 1, cycleDate: '2026-05-01' },
+      { center: [0, 0], zoom: 0 }
+    );
+
+    test('returns a ForecastCycle for a valid uploaded file', async () => {
+      const cycle = await loadForecastFromFile(fileFor(validPayload));
+      expect(cycle.cycleDate).toBe('2026-05-01');
+    });
+
+    test('throws SourceLoadError for malformed file data', async () => {
+      await expect(loadForecastFromFile(fileFor('{not-json'))).rejects.toBeInstanceOf(SourceLoadError);
+    });
+
+    test('throws SourceLoadError when the JSON does not pass validation', async () => {
+      await expect(loadForecastFromFile(fileFor({}))).rejects.toBeInstanceOf(SourceLoadError);
+    });
+  });
+
+  describe('loadForecastFromCloud', () => {
+    const cloudPayload = serializeForecast(
+      { days: {}, currentDay: 1, cycleDate: '2026-05-01' },
+      { center: [0, 0], zoom: 0 }
+    );
+
+    const cloudCycle = (overrides: Partial<CloudCycle> = {}): CloudCycle => ({
+      id: 'cycle-1',
+      userId: 'user-1',
+      label: 'Today',
+      cycleDate: '2026-05-01',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+      forecastDays: 1,
+      totalOutlooks: 0,
+      totalFeatures: 0,
+      isReadOnly: false,
+      payload: cloudPayload,
+      ...overrides,
+    });
+
+    test('loads and deserializes a premium cloud cycle', async () => {
+      mockedLoadCloudCycle.mockResolvedValue({
+        success: true,
+        data: cloudCycle(),
+      } as CloudOperationResult<CloudCycle>);
+
+      const cycle = await loadForecastFromCloud({ userId: 'user-1', cycleId: 'cycle-1' });
+      expect(cycle.cycleDate).toBe('2026-05-01');
+      expect(mockedLoadCloudCycle).toHaveBeenCalledWith({ userId: 'user-1', cycleId: 'cycle-1' });
+    });
+
+    test('throws SourceLoadError when the cloud cycle lookup fails', async () => {
+      mockedLoadCloudCycle.mockResolvedValue({
+        success: false,
+        error: 'Cloud cycle not found',
+      });
+
+      await expect(
+        loadForecastFromCloud({ userId: 'user-1', cycleId: 'missing' })
+      ).rejects.toBeInstanceOf(SourceLoadError);
+    });
+  });
+});

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -1,0 +1,117 @@
+import type { ForecastCycle } from '../../types/outlooks';
+import type { StormReport } from '../../types/stormReports';
+import type {
+  GradeAccountTier,
+  GradeCard,
+  PackageSourceKind,
+} from '../../types/forecastGrade';
+import {
+  deserializeForecast,
+  readForecastImportFile,
+  validateForecastData,
+} from '../fileUtils';
+import { fetchStormReports, fetchTodayStormReports } from '../stormReportParser';
+import type { PackageGrade, ProductKind } from './gradeContract';
+
+/**
+ * Source adapters for the Forecast Grade dashboard (PR 05 — sources-history).
+ *
+ * Source selection is always explicit — there is no automatic handoff from the
+ * Forecast Editor. File + SPC reports are available to everyone; premium adds a
+ * cloud-package source. Adapters validate inputs and surface a blocking error
+ * rather than silently grading malformed data.
+ */
+
+/** Resolves the account capability tier from auth + entitlement state. */
+export const resolveAccountTier = (
+  isSignedIn: boolean,
+  premiumActive: boolean
+): GradeAccountTier => {
+  if (!isSignedIn) {
+    return 'signed-out';
+  }
+  return premiumActive ? 'premium' : 'free';
+};
+
+/** Package sources available to a tier. Reports are always SPC for every tier. */
+export const availablePackageSources = (tier: GradeAccountTier): PackageSourceKind[] =>
+  tier === 'premium' ? ['file', 'cloud'] : ['file'];
+
+/** True when the tier keeps synced grade-card history. */
+export const tierHasHistory = (tier: GradeAccountTier): boolean => tier !== 'signed-out';
+
+/** True when the tier stores restorable full snapshots. */
+export const tierHasSnapshots = (tier: GradeAccountTier): boolean => tier === 'premium';
+
+export class SourceLoadError extends Error {}
+
+/** Loads and validates a forecast package from an uploaded file, or blocks. */
+export const loadForecastFromFile = async (file: File): Promise<ForecastCycle> => {
+  let raw: unknown;
+  try {
+    raw = await readForecastImportFile(file);
+  } catch {
+    throw new SourceLoadError('That file could not be read. Choose a valid GFC forecast JSON.');
+  }
+
+  if (!validateForecastData(raw)) {
+    throw new SourceLoadError('That file is not a valid GFC forecast package.');
+  }
+
+  try {
+    return deserializeForecast(raw);
+  } catch {
+    throw new SourceLoadError('That forecast package could not be parsed.');
+  }
+};
+
+/** Loads SPC storm reports for a date (or today when null), or blocks. */
+export const loadReportsForDate = async (reportDate: string | null): Promise<StormReport[]> => {
+  try {
+    return reportDate ? await fetchStormReports(reportDate) : await fetchTodayStormReports();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Unknown error';
+    throw new SourceLoadError(`Storm reports could not be loaded (${detail}).`);
+  }
+};
+
+const newId = (): string => {
+  try {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // Fall through to the timestamp id below.
+  }
+  return `grade-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+export interface BuildGradeCardOptions {
+  reportDate: string | null;
+  sourceLabel: string;
+  hasSnapshot: boolean;
+}
+
+/** Distills a full package grade into a trend-only history card. */
+export const buildGradeCard = (
+  pkg: PackageGrade,
+  { reportDate, sourceLabel, hasSnapshot }: BuildGradeCardOptions
+): GradeCard => {
+  const productGrades: Partial<Record<ProductKind, number | null>> = {};
+  for (const product of pkg.products) {
+    productGrades[product.product] = product.applicable ? product.grade : null;
+  }
+
+  return {
+    id: newId(),
+    createdAt: pkg.generatedAt,
+    reportDate,
+    formulaVersion: pkg.formulaVersion,
+    grade: pkg.grade,
+    letter: pkg.letter,
+    dataQuality: pkg.dataQuality,
+    productGrades,
+    sourceLabel,
+    hasSnapshot,
+  };
+};

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -65,10 +65,19 @@ export const loadForecastFromFile = async (file: File): Promise<ForecastCycle> =
   }
 };
 
+/**
+ * Converts an ISO `YYYY-MM-DD` date (from a native date input) into the SPC
+ * archive `YYMMDD` format. Values already in `YYMMDD` are returned unchanged.
+ */
+export const toArchiveDate = (reportDate: string): string => {
+  const match = reportDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  return match ? `${match[1].slice(2)}${match[2]}${match[3]}` : reportDate;
+};
+
 /** Loads SPC storm reports for a date (or today when null), or blocks. */
 export const loadReportsForDate = async (reportDate: string | null): Promise<StormReport[]> => {
   try {
-    return reportDate ? await fetchStormReports(reportDate) : await fetchTodayStormReports();
+    return reportDate ? await fetchStormReports(toArchiveDate(reportDate)) : await fetchTodayStormReports();
   } catch (error) {
     const detail = error instanceof Error ? error.message : 'Unknown error';
     throw new SourceLoadError(`Storm reports could not be loaded (${detail}).`);

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -69,15 +69,52 @@ export const loadForecastFromFile = async (file: File): Promise<ForecastCycle> =
  * Converts an ISO `YYYY-MM-DD` date (from a native date input) into the SPC
  * archive `YYMMDD` format. Values already in `YYMMDD` are returned unchanged.
  */
-export const toArchiveDate = (reportDate: string): string => {
-  const match = reportDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  return match ? `${match[1].slice(2)}${match[2]}${match[3]}` : reportDate;
+const isValidCalendarDate = (year: number, month: number, day: number): boolean => {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+};
+
+export const toArchiveDate = (reportDate: string): string | null => {
+  const iso = reportDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (iso) {
+    const year = Number(iso[1]);
+    const month = Number(iso[2]);
+    const day = Number(iso[3]);
+    if (!isValidCalendarDate(year, month, day)) {
+      return null;
+    }
+    return `${iso[1].slice(2)}${iso[2]}${iso[3]}`;
+  }
+
+  const archive = reportDate.match(/^(\d{2})(\d{2})(\d{2})$/);
+  if (archive) {
+    const year = 2000 + Number(archive[1]);
+    const month = Number(archive[2]);
+    const day = Number(archive[3]);
+    if (!isValidCalendarDate(year, month, day)) {
+      return null;
+    }
+    return reportDate;
+  }
+
+  return null;
 };
 
 /** Loads SPC storm reports for a date (or today when null), or blocks. */
 export const loadReportsForDate = async (reportDate: string | null): Promise<StormReport[]> => {
   try {
-    return reportDate ? await fetchStormReports(toArchiveDate(reportDate)) : await fetchTodayStormReports();
+    if (reportDate) {
+      const archiveDate = toArchiveDate(reportDate);
+      if (!archiveDate) {
+        throw new SourceLoadError('Choose a valid report date.');
+      }
+      return await fetchStormReports(archiveDate);
+    }
+    return await fetchTodayStormReports();
   } catch (error) {
     const detail = error instanceof Error ? error.message : 'Unknown error';
     throw new SourceLoadError(`Storm reports could not be loaded (${detail}).`);

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -11,7 +11,10 @@ import {
   validateForecastData,
 } from '../fileUtils';
 import { fetchStormReports, fetchTodayStormReports } from '../stormReportParser';
+import { toArchiveDate } from './archiveDate';
 import type { PackageGrade, ProductKind } from './gradeContract';
+
+export { toArchiveDate } from './archiveDate';
 
 /**
  * Source adapters for the Forecast Grade dashboard (PR 05 — sources-history).
@@ -63,61 +66,6 @@ export const loadForecastFromFile = async (file: File): Promise<ForecastCycle> =
   } catch {
     throw new SourceLoadError('That forecast package could not be parsed.');
   }
-};
-
-/**
- * Converts an ISO `YYYY-MM-DD` date (from a native date input) into the SPC
- * archive `YYMMDD` format. Values already in `YYMMDD` are returned unchanged.
- */
-const isValidCalendarDate = (year: number, month: number, day: number): boolean => {
-  const date = new Date(Date.UTC(year, month - 1, day));
-  return (
-    date.getUTCFullYear() === year &&
-    date.getUTCMonth() === month - 1 &&
-    date.getUTCDate() === day
-  );
-};
-
-const toArchiveYyMmDd = (
-  year: number,
-  month: number,
-  day: number,
-  yy: string,
-  mm: string,
-  dd: string
-): string | null => {
-  if (!isValidCalendarDate(year, month, day)) {
-    return null;
-  }
-  return `${yy}${mm}${dd}`;
-};
-
-export const toArchiveDate = (reportDate: string): string | null => {
-  const iso = reportDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (iso) {
-    return toArchiveYyMmDd(
-      Number(iso[1]),
-      Number(iso[2]),
-      Number(iso[3]),
-      iso[1].slice(2),
-      iso[2],
-      iso[3]
-    );
-  }
-
-  const archive = reportDate.match(/^(\d{2})(\d{2})(\d{2})$/);
-  if (archive) {
-    return toArchiveYyMmDd(
-      2000 + Number(archive[1]),
-      Number(archive[2]),
-      Number(archive[3]),
-      archive[1],
-      archive[2],
-      archive[3]
-    );
-  }
-
-  return null;
 };
 
 /** Loads SPC storm reports for a date (or today when null), or blocks. */

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -78,31 +78,36 @@ const isValidCalendarDate = (year: number, month: number, day: number): boolean 
   );
 };
 
-export const toArchiveDate = (reportDate: string): string | null => {
+const parseIsoArchiveDate = (reportDate: string): string | null => {
   const iso = reportDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (iso) {
-    const year = Number(iso[1]);
-    const month = Number(iso[2]);
-    const day = Number(iso[3]);
-    if (!isValidCalendarDate(year, month, day)) {
-      return null;
-    }
-    return `${iso[1].slice(2)}${iso[2]}${iso[3]}`;
+  if (!iso) {
+    return null;
   }
-
-  const archive = reportDate.match(/^(\d{2})(\d{2})(\d{2})$/);
-  if (archive) {
-    const year = 2000 + Number(archive[1]);
-    const month = Number(archive[2]);
-    const day = Number(archive[3]);
-    if (!isValidCalendarDate(year, month, day)) {
-      return null;
-    }
-    return reportDate;
+  const year = Number(iso[1]);
+  const month = Number(iso[2]);
+  const day = Number(iso[3]);
+  if (!isValidCalendarDate(year, month, day)) {
+    return null;
   }
-
-  return null;
+  return `${iso[1].slice(2)}${iso[2]}${iso[3]}`;
 };
+
+const parseYyMmDdArchiveDate = (reportDate: string): string | null => {
+  const archive = reportDate.match(/^(\d{2})(\d{2})(\d{2})$/);
+  if (!archive) {
+    return null;
+  }
+  const year = 2000 + Number(archive[1]);
+  const month = Number(archive[2]);
+  const day = Number(archive[3]);
+  if (!isValidCalendarDate(year, month, day)) {
+    return null;
+  }
+  return reportDate;
+};
+
+export const toArchiveDate = (reportDate: string): string | null =>
+  parseIsoArchiveDate(reportDate) ?? parseYyMmDdArchiveDate(reportDate);
 
 /** Loads SPC storm reports for a date (or today when null), or blocks. */
 export const loadReportsForDate = async (reportDate: string | null): Promise<StormReport[]> => {

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -78,36 +78,47 @@ const isValidCalendarDate = (year: number, month: number, day: number): boolean 
   );
 };
 
-const parseIsoArchiveDate = (reportDate: string): string | null => {
+const toArchiveYyMmDd = (
+  year: number,
+  month: number,
+  day: number,
+  yy: string,
+  mm: string,
+  dd: string
+): string | null => {
+  if (!isValidCalendarDate(year, month, day)) {
+    return null;
+  }
+  return `${yy}${mm}${dd}`;
+};
+
+export const toArchiveDate = (reportDate: string): string | null => {
   const iso = reportDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (!iso) {
-    return null;
+  if (iso) {
+    return toArchiveYyMmDd(
+      Number(iso[1]),
+      Number(iso[2]),
+      Number(iso[3]),
+      iso[1].slice(2),
+      iso[2],
+      iso[3]
+    );
   }
-  const year = Number(iso[1]);
-  const month = Number(iso[2]);
-  const day = Number(iso[3]);
-  if (!isValidCalendarDate(year, month, day)) {
-    return null;
-  }
-  return `${iso[1].slice(2)}${iso[2]}${iso[3]}`;
-};
 
-const parseYyMmDdArchiveDate = (reportDate: string): string | null => {
   const archive = reportDate.match(/^(\d{2})(\d{2})(\d{2})$/);
-  if (!archive) {
-    return null;
+  if (archive) {
+    return toArchiveYyMmDd(
+      2000 + Number(archive[1]),
+      Number(archive[2]),
+      Number(archive[3]),
+      archive[1],
+      archive[2],
+      archive[3]
+    );
   }
-  const year = 2000 + Number(archive[1]);
-  const month = Number(archive[2]);
-  const day = Number(archive[3]);
-  if (!isValidCalendarDate(year, month, day)) {
-    return null;
-  }
-  return reportDate;
-};
 
-export const toArchiveDate = (reportDate: string): string | null =>
-  parseIsoArchiveDate(reportDate) ?? parseYyMmDdArchiveDate(reportDate);
+  return null;
+};
 
 /** Loads SPC storm reports for a date (or today when null), or blocks. */
 export const loadReportsForDate = async (reportDate: string | null): Promise<StormReport[]> => {

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -49,6 +49,15 @@ export const tierHasSnapshots = (tier: GradeAccountTier): boolean => tier === 'p
 
 export class SourceLoadError extends Error {}
 
+/** Deserializes a saved forecast payload and surfaces a blocking error. */
+const deserializeCycle = (payload: unknown, parseErrorMessage: string): ForecastCycle => {
+  try {
+    return deserializeForecast(payload);
+  } catch {
+    throw new SourceLoadError(parseErrorMessage);
+  }
+};
+
 /** Loads and validates a forecast package from an uploaded file, or blocks. */
 export const loadForecastFromFile = async (file: File): Promise<ForecastCycle> => {
   let raw: unknown;
@@ -62,11 +71,7 @@ export const loadForecastFromFile = async (file: File): Promise<ForecastCycle> =
     throw new SourceLoadError('That file is not a valid GFC forecast package.');
   }
 
-  try {
-    return deserializeForecast(raw);
-  } catch {
-    throw new SourceLoadError('That forecast package could not be parsed.');
-  }
+  return deserializeCycle(raw, 'That forecast package could not be parsed.');
 };
 
 export interface LoadForecastFromCloudParams {
@@ -88,22 +93,22 @@ export const loadForecastFromCloud = async (
       result.error ?? 'That cloud cycle could not be loaded. Choose a saved cycle from your library.'
     );
   }
-  try {
-    return deserializeForecast(result.data.payload);
-  } catch {
-    throw new SourceLoadError('That cloud cycle could not be parsed.');
+  return deserializeCycle(result.data.payload, 'That cloud cycle could not be parsed.');
+};
+
+const resolveArchiveDate = (reportDate: string): string => {
+  const archiveDate = toArchiveDate(reportDate);
+  if (!archiveDate) {
+    throw new SourceLoadError('Choose a valid report date.');
   }
+  return archiveDate;
 };
 
 /** Loads SPC storm reports for a date (or today when null), or blocks. */
 export const loadReportsForDate = async (reportDate: string | null): Promise<StormReport[]> => {
   try {
     if (reportDate !== null) {
-      const archiveDate = toArchiveDate(reportDate);
-      if (!archiveDate) {
-        throw new SourceLoadError('Choose a valid report date.');
-      }
-      return await fetchStormReports(archiveDate);
+      return await fetchStormReports(resolveArchiveDate(reportDate));
     }
     return await fetchTodayStormReports();
   } catch (error) {

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -5,6 +5,7 @@ import type {
   GradeCard,
   PackageSourceKind,
 } from '../../types/forecastGrade';
+import { loadCloudCycle } from '../../lib/cloudCyclesService';
 import {
   deserializeForecast,
   readForecastImportFile,
@@ -68,10 +69,36 @@ export const loadForecastFromFile = async (file: File): Promise<ForecastCycle> =
   }
 };
 
+export interface LoadForecastFromCloudParams {
+  userId: string;
+  cycleId: string;
+}
+
+/**
+ * Loads a saved forecast from the premium cloud library and deserializes it,
+ * or blocks. Routes to the existing `loadCloudCycle` so the cloud source stays
+ * wired to the same Firestore read path the rest of the app uses.
+ */
+export const loadForecastFromCloud = async (
+  params: LoadForecastFromCloudParams
+): Promise<ForecastCycle> => {
+  const result = await loadCloudCycle(params);
+  if (!result.success || !result.data) {
+    throw new SourceLoadError(
+      result.error ?? 'That cloud cycle could not be loaded. Choose a saved cycle from your library.'
+    );
+  }
+  try {
+    return deserializeForecast(result.data.payload);
+  } catch {
+    throw new SourceLoadError('That cloud cycle could not be parsed.');
+  }
+};
+
 /** Loads SPC storm reports for a date (or today when null), or blocks. */
 export const loadReportsForDate = async (reportDate: string | null): Promise<StormReport[]> => {
   try {
-    if (reportDate) {
+    if (reportDate !== null) {
       const archiveDate = toArchiveDate(reportDate);
       if (!archiveDate) {
         throw new SourceLoadError('Choose a valid report date.');
@@ -80,6 +107,9 @@ export const loadReportsForDate = async (reportDate: string | null): Promise<Sto
     }
     return await fetchTodayStormReports();
   } catch (error) {
+    if (error instanceof SourceLoadError) {
+      throw error;
+    }
     const detail = error instanceof Error ? error.message : 'Unknown error';
     throw new SourceLoadError(`Storm reports could not be loaded (${detail}).`);
   }


### PR DESCRIPTION
## Summary

- File + premium cloud source adapters (`loadForecastFromFile`, `loadReportsForDate`), capability-aware `resolveAccountTier` / `availablePackageSources`, and trend-only grade history (25 cards for free, immutable snapshots for premium).
- Fix ISO `YYYY-MM-DD` → SPC `YYMMDD` conversion for archive fetch (moved to a dedicated `archiveDate` module with calendar validation).
- Scope history storage per user id so accounts do not share `localStorage` keys.

## Stack

6/13 · base `beta` (rebased after PR #772 merged with the post-review 04a/04b changes).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test` (174 suites / 975 tests pass)
- [x] `pnpm run build`
- [x] `pnpm test -- --runTestsByPath src/utils/verificationV2/gradeHistory.test.ts` (10 tests pass)

## Changelog

- Stack PR 6/13: Explicit package sources and capability-aware grade history.
