### PR TITLE
ver2(06a): verificationRelaunch gate wiring + stub

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -8,8 +8,8 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 #### Added
 
-- Wire the `verificationRelaunch` local-only dogfood gate behind the existing classic `/verification` route so signed-in users keep the legacy workspace until the relaunched surface is ready to roll out. The flag stays disabled for beta, staging, and production.
-- Land a temporary `ForecastGradeDashboard` stub so the lazy import resolves before the real shell lands in the next stacked PR.
+- Wire the `verificationRelaunch` gate, surfaces, and classic `/verification` coexistence routing so the Forecast Grade dashboard shell can land in the next stacked PR (06b/06c/07). The flag stays off on every build target until that shell flips it; classic `/verification` is the default in the meantime.
+- Land a temporary `ForecastGradeDashboard` stub so the lazy import resolves before the real shell lands.
 
 ### PR #773
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,13 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #774
+
+#### Added
+
+- Wire the `verificationRelaunch` local-only dogfood gate behind the existing classic `/verification` route so signed-in users keep the legacy workspace until the relaunched surface is ready to roll out. The flag stays disabled for beta, staging, and production.
+- Land a temporary `ForecastGradeDashboard` stub so the lazy import resolves before the real shell lands in the next stacked PR.
+
 ### PR #773
 
 #### Added

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * Temporary stub so verificationRelaunch can wire the route/surfaces before the
+ * real dashboard shell lands in the next stacked PR.
+ */
+const ForecastGradeDashboard: React.FC = () => (
+  <div className="flex h-full items-center justify-center p-6" data-testid="forecast-grade-dashboard">
+    Forecast Grade dashboard
+  </div>
+);
+
+export default ForecastGradeDashboard;

--- a/src/config/featureExposure.acknowledgements.json
+++ b/src/config/featureExposure.acknowledgements.json
@@ -19,8 +19,9 @@
     "betaEnablementApproved": true
   },
   "verificationRelaunch": {
-    "reason": "Registry-only until verification relaunch surfaces merge; core /verification is separate; adoption contract in src/config/v17WorkstreamAdoption.exposure.test.ts",
-    "trackingIssue": 530
+    "reason": "Forecast Grade v2 dashboard dogfoods on local only; classic /verification remains the default when the flag is off. Disabled-side-effect coverage in src/pages/verificationRelaunch.exposure.test.tsx (lazy route + FEATURE_SIDE_EFFECT_MODULES), gate coverage in src/pages/VerificationPage.test.tsx, and the adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts. Beta/staging/production stay disabled.",
+    "trackingIssue": 430,
+    "localDevelopmentApproved": true
   },
   "customProducts": {
     "reason": "Custom Products completed local implementation, UI review, and regression/E2E coverage under #431. Owner approval enables the beta tester rollout; staging and production remain disabled. Adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts and end-to-end coverage is in e2e/custom-products.spec.ts.",

--- a/src/config/featureExposure.acknowledgements.json
+++ b/src/config/featureExposure.acknowledgements.json
@@ -19,9 +19,8 @@
     "betaEnablementApproved": true
   },
   "verificationRelaunch": {
-    "reason": "Forecast Grade v2 dashboard dogfoods on local only; classic /verification remains the default when the flag is off. Disabled-side-effect coverage in src/pages/verificationRelaunch.exposure.test.tsx (lazy route + FEATURE_SIDE_EFFECT_MODULES), gate coverage in src/pages/VerificationPage.test.tsx, and the adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts. Beta/staging/production stay disabled.",
-    "trackingIssue": 430,
-    "localDevelopmentApproved": true
+    "reason": "Gate, surface, and classic coexistence wiring land in 06a so the Forecast Grade dashboard shell can dogfood in 06b/06c/07. The flag stays off on every build target until the shell PRs flip it; classic /verification remains the default. Disabled-side-effect coverage is in src/pages/verificationRelaunch.exposure.test.tsx (lazy route + FEATURE_SIDE_EFFECT_MODULES), gate coverage in src/pages/VerificationPage.test.tsx, and the adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts.",
+    "trackingIssue": 430
   },
   "customProducts": {
     "reason": "Custom Products completed local implementation, UI review, and regression/E2E coverage under #431. Owner approval enables the beta tester rollout; staging and production remain disabled. Adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts and end-to-end coverage is in e2e/custom-products.spec.ts.",

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -121,10 +121,18 @@ describe('featureExposure registry', () => {
       'collaborationRoom',
     ] as const;
 
-    for (const feature of workstreamKeys.filter((feature) => !['forecastWorkflowV2', 'customProducts'].includes(feature))) {
+    for (const feature of workstreamKeys.filter(
+      (feature) => !['forecastWorkflowV2', 'customProducts', 'verificationRelaunch'].includes(feature)
+    )) {
       for (const target of ['local', 'beta', 'staging', 'production'] as const) {
         expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
       }
+    }
+
+    // verificationRelaunch dogfoods on local only; beta/staging/production stay off.
+    expect(isFeatureExposedOnTarget('verificationRelaunch', 'local')).toBe(true);
+    for (const target of ['beta', 'staging', 'production'] as const) {
+      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(false);
     }
 
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'local')).toBe(true);

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -122,16 +122,15 @@ describe('featureExposure registry', () => {
     ] as const;
 
     for (const feature of workstreamKeys.filter(
-      (feature) => !['forecastWorkflowV2', 'customProducts', 'verificationRelaunch'].includes(feature)
+      (feature) => !['forecastWorkflowV2', 'customProducts'].includes(feature)
     )) {
       for (const target of ['local', 'beta', 'staging', 'production'] as const) {
         expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
       }
     }
 
-    // verificationRelaunch dogfoods on local only; beta/staging/production stay off.
-    expect(isFeatureExposedOnTarget('verificationRelaunch', 'local')).toBe(true);
-    for (const target of ['beta', 'staging', 'production'] as const) {
+    // verificationRelaunch stays off on every target until the dashboard shell lands in 06b/06c/07.
+    for (const target of ['local', 'beta', 'staging', 'production'] as const) {
       expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(false);
     }
 

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -124,7 +124,7 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 429,
   },
   verificationRelaunch: {
-    exposure: { ...ALL_TARGETS_OFF },
+    exposure: { ...ALL_TARGETS_OFF, local: true },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -124,7 +124,7 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 429,
   },
   verificationRelaunch: {
-    exposure: { ...ALL_TARGETS_OFF, local: true },
+    exposure: { ...ALL_TARGETS_OFF },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,

--- a/src/config/featureSurfaces.ts
+++ b/src/config/featureSurfaces.ts
@@ -30,4 +30,8 @@ export const GATED_ROUTE_DEFINITIONS = [
 export const FEATURE_SIDE_EFFECT_MODULES = {
   autoTstm: ['../utils/tstmGeneration'],
   customProducts: ['../lib/customProductsRepository'],
+  verificationRelaunch: [
+    '../components/ForecastGrade/ForecastGradeDashboard',
+    '../utils/verificationV2',
+  ],
 } as const satisfies Partial<Record<FeatureKey, readonly string[]>>;

--- a/src/config/v17WorkstreamAdoption.exposure.test.ts
+++ b/src/config/v17WorkstreamAdoption.exposure.test.ts
@@ -28,7 +28,10 @@ describe('v1.7 workstream adoption contract', () => {
   });
 
   test.each(
-    V17_WORKSTREAM_KEYS.filter((feature) => !['autoTstm', 'forecastWorkflowV2', 'customProducts'].includes(feature))
+    V17_WORKSTREAM_KEYS.filter(
+      (feature) =>
+        !['autoTstm', 'forecastWorkflowV2', 'customProducts', 'verificationRelaunch'].includes(feature)
+    )
   )(
     '%s stays disabled on every build target',
     (feature) => {
@@ -38,6 +41,14 @@ describe('v1.7 workstream adoption contract', () => {
       }
     }
   );
+
+  test('verificationRelaunch dogfoods on local only', () => {
+    for (const target of BUILD_TARGETS) {
+      const expected = target === 'local';
+      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(expected);
+      expect(FEATURE_EXPOSURE_REGISTRY.verificationRelaunch.exposure[target]).toBe(expected);
+    }
+  });
 
   test('customProducts is enabled for local development and beta testing only', () => {
     for (const target of BUILD_TARGETS) {

--- a/src/config/v17WorkstreamAdoption.exposure.test.ts
+++ b/src/config/v17WorkstreamAdoption.exposure.test.ts
@@ -30,7 +30,7 @@ describe('v1.7 workstream adoption contract', () => {
   test.each(
     V17_WORKSTREAM_KEYS.filter(
       (feature) =>
-        !['autoTstm', 'forecastWorkflowV2', 'customProducts', 'verificationRelaunch'].includes(feature)
+        !['autoTstm', 'forecastWorkflowV2', 'customProducts'].includes(feature)
     )
   )(
     '%s stays disabled on every build target',
@@ -42,11 +42,10 @@ describe('v1.7 workstream adoption contract', () => {
     }
   );
 
-  test('verificationRelaunch dogfoods on local only', () => {
+  test('verificationRelaunch stays disabled until the dashboard shell lands', () => {
     for (const target of BUILD_TARGETS) {
-      const expected = target === 'local';
-      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(expected);
-      expect(FEATURE_EXPOSURE_REGISTRY.verificationRelaunch.exposure[target]).toBe(expected);
+      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(false);
+      expect(FEATURE_EXPOSURE_REGISTRY.verificationRelaunch.exposure[target]).toBe(false);
     }
   });
 

--- a/src/pages/VerificationPage.test.tsx
+++ b/src/pages/VerificationPage.test.tsx
@@ -1,15 +1,38 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import VerificationPage from './VerificationPage';
+import { render, screen, waitFor } from '@testing-library/react';
+import * as featureExposure from '../config/featureExposure';
 
 jest.mock('../components/VerificationMode/VerificationMode', () => () => (
   <div data-testid="verification-mode">Verification Mode</div>
 ));
 
-describe('VerificationPage', () => {
-  it('renders verification mode', () => {
-    render(<VerificationPage />);
+jest.mock('../components/ForecastGrade/ForecastGradeDashboard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="forecast-grade-dashboard">Forecast Grade dashboard</div>,
+}));
 
+const renderPage = () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const VerificationPage = require('./VerificationPage').default;
+  return render(<VerificationPage />);
+};
+
+describe('VerificationPage', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders classic verification mode when verificationRelaunch is off', () => {
+    jest.spyOn(featureExposure, 'isFeatureExposed').mockReturnValue(false);
+    renderPage();
     expect(screen.getByTestId('verification-mode')).toHaveTextContent('Verification Mode');
+  });
+
+  it('renders the Forecast Grade dashboard when verificationRelaunch is on', async () => {
+    jest.spyOn(featureExposure, 'isFeatureExposed').mockReturnValue(true);
+    renderPage();
+    expect(await screen.findByTestId('forecast-grade-dashboard')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('verification-mode')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/VerificationPage.tsx
+++ b/src/pages/VerificationPage.tsx
@@ -1,8 +1,30 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
+import { isFeatureExposed } from '../config/featureExposure';
 import VerificationMode from '../components/VerificationMode/VerificationMode';
 
-/** Page wrapper that mounts the VerificationMode component. */
+// Lazily loaded so the Verification v2 dashboard and its gfc-ver-1 engine never
+// import as a side effect while verificationRelaunch is disabled.
+const ForecastGradeDashboard = lazy(() => import('../components/ForecastGrade/ForecastGradeDashboard'));
+
+/** Verification v2 loading placeholder. */
+const DashboardFallback = () => (
+  <div className="flex h-full items-center justify-center p-6" aria-busy="true" aria-label="Loading Forecast Grade" />
+);
+
+/**
+ * Routes /verification to the classic VerificationMode by default and to the
+ * Forecast Grade dashboard only when verificationRelaunch is exposed on the
+ * current build target. Classic remains fully functional when the flag is off.
+ */
 export const VerificationPage: React.FC = () => {
+  if (isFeatureExposed('verificationRelaunch')) {
+    return (
+      <Suspense fallback={<DashboardFallback />}>
+        <ForecastGradeDashboard />
+      </Suspense>
+    );
+  }
+
   return <VerificationMode />;
 };
 

--- a/src/pages/verificationRelaunch.exposure.test.tsx
+++ b/src/pages/verificationRelaunch.exposure.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BUILD_TARGETS } from '../config/buildTarget';
+import { assertNoFetchTo, withNoAsyncSideEffects } from '../testing/featureExposure/harness';
+
+// Track whether the lazily loaded v2 dashboard module factory ever runs. The
+// prefix `mock` is required for jest.mock factories to reference it.
+const mockV2Load = jest.fn();
+
+jest.mock('../components/VerificationMode/VerificationMode', () => ({
+  __esModule: true,
+  default: () => <div>Classic Verification Mode</div>,
+}));
+
+jest.mock('../components/ForecastGrade/ForecastGradeDashboard', () => {
+  mockV2Load();
+  return {
+    __esModule: true,
+    default: () => <div>V2 Forecast Grade dashboard</div>,
+  };
+});
+
+const renderPage = () => {
+  // Import after mocks/spies are installed so the gate reads the mocked exposure.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const VerificationPage = require('./VerificationPage').default;
+  return render(
+    <MemoryRouter>
+      <VerificationPage />
+    </MemoryRouter>
+  );
+};
+
+describe('verificationRelaunch route gate', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockV2Load.mockClear();
+  });
+
+  test('renders classic VerificationMode and never boots the v2 module while disabled', async () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(false);
+
+    await assertNoFetchTo('spc.noaa.gov', () => {
+      withNoAsyncSideEffects(() => {
+        renderPage();
+      });
+    });
+
+    expect(screen.getByText('Classic Verification Mode')).toBeInTheDocument();
+    expect(screen.queryByText('V2 Forecast Grade dashboard')).not.toBeInTheDocument();
+    expect(mockV2Load).not.toHaveBeenCalled();
+  });
+
+  test('mounts the v2 dashboard only when the flag is exposed', async () => {
+    jest.spyOn(require('../config/featureExposure'), 'isFeatureExposed').mockReturnValue(true);
+
+    renderPage();
+
+    expect(await screen.findByText('V2 Forecast Grade dashboard')).toBeInTheDocument();
+    expect(mockV2Load).toHaveBeenCalled();
+  });
+
+  test('keeps verificationRelaunch off for every non-local build target in the registry', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { isFeatureExposedOnTarget } = require('../config/featureExposure');
+    for (const target of BUILD_TARGETS) {
+      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(target === 'local');
+    }
+  });
+});

--- a/src/pages/verificationRelaunch.exposure.test.tsx
+++ b/src/pages/verificationRelaunch.exposure.test.tsx
@@ -60,11 +60,11 @@ describe('verificationRelaunch route gate', () => {
     expect(mockV2Load).toHaveBeenCalled();
   });
 
-  test('keeps verificationRelaunch off for every non-local build target in the registry', () => {
+  test('keeps verificationRelaunch off for every build target until the dashboard shell lands', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { isFeatureExposedOnTarget } = require('../config/featureExposure');
     for (const target of BUILD_TARGETS) {
-      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(target === 'local');
+      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Wire the `verificationRelaunch` gate, surfaces, and classic `/verification` coexistence routing so the Forecast Grade dashboard shell can land in the next stacked PR (06b/06c/07). The flag stays off on every build target until that shell flips it; classic `/verification` is the default in the meantime.
- Land a temporary `ForecastGradeDashboard` stub so the lazy import resolves before the real shell lands.
- Align the v1.7 exposure contract and update the `verificationRelaunch` acknowledgement to record that the gate is off until the shell PRs flip it.

## Stack

7/13 · base `beta` (rebased after PR #773 merged; the 04b/05 commits already in beta were dropped during the rebase).

## Feature exposure

- [ ] This PR does not change feature exposure
- [x] This PR changes feature exposure (describe below)

`verificationRelaunch`: stays off on **every** build target (local, beta, staging, production) until the Forecast Grade dashboard shell lands in 06b/06c/07. The PR only registers the gate, surfaces, side-effect modules, and the classic `/verification` coexistence so the next PRs can flip the flag and the lazy route resolves.

## Temporary feature removal

- [x] N/A — no temporary features affected

## Review requests

- [ ] Server-backed feature changes reviewed by server owner
- [ ] Security-sensitive feature changes flagged for security review

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test` (185/185 known diagnostics, no new)
- [x] `pnpm test` (176 suites / 995 tests pass)
- [x] `pnpm run build`
- [x] `pnpm test -- --runTestsByPath src/config/featureExposure.test.ts src/config/v17WorkstreamAdoption.exposure.test.ts src/pages/VerificationPage.test.tsx src/pages/verificationRelaunch.exposure.test.tsx` (35 tests pass)
- [x] Flag off still shows classic Verification (no `ForecastGradeDashboard` load) and the registry matrix confirms all targets stay off until the shell lands.

## Changelog

- Stack PR 7/13: `verificationRelaunch` gate wiring, classic `/verification` coexistence, lazy dashboard mount, and a temporary `ForecastGradeDashboard` stub. The flag stays off on every target until 06b/06c/07 flip it.
