### PR TITLE
ver2(06b): dashboard supporting components + run hook

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,11 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #775
+
+#### Added
+
+- Add Forecast Grade dashboard supporting components (`SourcePanel`, `DataQualityPanel`, `GradeHeadline`, `RunProgress`, grade formatters, methodology copy) and the `useForecastGrade` run hook that turns the verified report date, source panel selection, and source entitlements into a `runForecastGrade` invocation gated until the report date is reached. Source panel is split into `SourcePanel` + `sourcePanelParts` for code health.
 ### PR #774
 
 #### Added

--- a/src/components/ForecastGrade/DataQualityPanel.tsx
+++ b/src/components/ForecastGrade/DataQualityPanel.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { PackageGrade } from '../../utils/verificationV2';
+import { dataQualityClass } from './gradeFormat';
+
+interface DataQualityPanelProps {
+  pkg: PackageGrade;
+  defaultOpen?: boolean;
+}
+
+/**
+ * The exactly-titled "Data quality" section. Reports Good / Limited / Blocked,
+ * a "No reports" label on quiet days (never a fake confidence label), and a
+ * Not-evaluated row per missing product with classic warning treatment.
+ */
+const DataQualityPanel: React.FC<DataQualityPanelProps> = ({ pkg, defaultOpen = false }) => {
+  const missing = pkg.products.filter((product) => !product.applicable);
+
+  return (
+    <details className="fg-section" open={defaultOpen}>
+      <summary>
+        <span>Data quality</span>
+        <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${dataQualityClass(pkg.dataQuality)}`}>
+          {pkg.dataQuality}
+        </span>
+      </summary>
+      <div className="fg-section-body">
+        <p className="text-sm text-slate-500">{pkg.dataQualityReason}</p>
+        {!pkg.hasReports && (
+          <p className="mt-1 text-sm font-medium text-slate-500">No reports for this date.</p>
+        )}
+
+        {missing.length > 0 && (
+          <div className="mt-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
+            <div className="text-xs font-semibold uppercase text-amber-700">Not evaluated</div>
+            <ul className="mt-1 text-sm text-amber-700">
+              {missing.map((product) => (
+                <li key={product.product}>
+                  {product.label} — not present in this package
+                </li>
+              ))}
+            </ul>
+            <p className="mt-1 text-xs text-amber-600/80">
+              A complete package (categorical + hazards) grades every product.
+            </p>
+          </div>
+        )}
+      </div>
+    </details>
+  );
+};
+
+export default DataQualityPanel;

--- a/src/components/ForecastGrade/GradeHeadline.tsx
+++ b/src/components/ForecastGrade/GradeHeadline.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import type { PackageGrade, ProductKind } from '../../utils/verificationV2';
+import { formatGrade, letterColorClass } from './gradeFormat';
+
+interface GradeHeadlineProps {
+  pkg: PackageGrade;
+  activeProduct: ProductKind;
+  onSelectProduct: (product: ProductKind) => void;
+}
+
+/**
+ * Learn-fast headline: the package Forecast Grade (0–100 + letter, one decimal)
+ * with a row of per-product grades. Selecting a product emphasizes its geometry
+ * on the map and scrolls its breakdown into focus. No coaching prose.
+ */
+const GradeHeadline: React.FC<GradeHeadlineProps> = ({ pkg, activeProduct, onSelectProduct }) => (
+  <div className="mb-3 rounded-xl border border-slate-300/40 p-4">
+    <div className="flex items-baseline justify-between gap-3">
+      <div>
+        <div className="text-xs uppercase tracking-wide text-slate-500">Forecast Grade</div>
+        <div className="flex items-baseline gap-2">
+          <span className="text-5xl font-bold tabular-nums" data-testid="forecast-grade-value">
+            {formatGrade(pkg.grade)}
+          </span>
+          <span className={`text-3xl font-bold ${letterColorClass(pkg.letter)}`}>{pkg.letter ?? '—'}</span>
+        </div>
+      </div>
+      <div className="text-right text-xs text-slate-500">
+        <div>Formula {pkg.formulaVersion}</div>
+        {pkg.grade === null && <div className="mt-1 text-amber-600">Package grade withheld</div>}
+      </div>
+    </div>
+
+    <div className="mt-3 flex flex-wrap gap-2" role="tablist" aria-label="Product grades">
+      {pkg.products.map((product) => {
+        const selected = product.product === activeProduct;
+        return (
+          <button
+            key={product.product}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onSelectProduct(product.product)}
+            className={`fg-touch rounded-lg border px-3 py-1 text-sm ${
+              selected ? 'border-blue-500 bg-blue-500/10' : 'border-slate-300/40'
+            } ${product.applicable ? '' : 'opacity-60'}`}
+          >
+            <span className="font-medium">{product.label}</span>{' '}
+            <span className={`font-semibold ${letterColorClass(product.letter)}`}>
+              {product.applicable ? `${formatGrade(product.grade)} ${product.letter ?? ''}` : 'Not evaluated'}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  </div>
+);
+
+export default GradeHeadline;

--- a/src/components/ForecastGrade/RunProgress.tsx
+++ b/src/components/ForecastGrade/RunProgress.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { GradeProgress } from '../../utils/verificationV2';
+
+interface RunProgressProps {
+  progress: GradeProgress | null;
+}
+
+/**
+ * Staged foreground progress. Accuracy is prioritized over a fixed latency
+ * budget; long runs surface their stage and complete automatically.
+ */
+const RunProgress: React.FC<RunProgressProps> = ({ progress }) => {
+  if (!progress) {
+    return null;
+  }
+  const percent = Math.round(progress.fraction * 100);
+  return (
+    <div className="rounded-xl border border-slate-300/40 p-4" role="status" aria-live="polite">
+      <div className="mb-2 flex items-center justify-between text-sm">
+        <span>{progress.label}</span>
+        <span className="tabular-nums">{percent}%</span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-slate-300/30">
+        <div className="h-full rounded-full bg-blue-500 transition-all" style={{ width: `${percent}%` }} />
+      </div>
+    </div>
+  );
+};
+
+export default RunProgress;

--- a/src/components/ForecastGrade/SourcePanel.tsx
+++ b/src/components/ForecastGrade/SourcePanel.tsx
@@ -1,0 +1,128 @@
+import React, { useRef } from 'react';
+import { FileUp } from 'lucide-react';
+import type { GradeAccountTier, PackageSourceKind } from '../../types/forecastGrade';
+
+interface SourcePanelProps {
+  tier: GradeAccountTier;
+  availableSources: PackageSourceKind[];
+  hasForecast: boolean;
+  sourceLabel: string;
+  useToday: boolean;
+  reportDate: string;
+  canRun: boolean;
+  isRunning: boolean;
+  error: string | null;
+  onFile: (file: File) => void;
+  onUseTodayChange: (value: boolean) => void;
+  onReportDateChange: (value: string) => void;
+  onRun: () => void;
+  onReset: () => void;
+  renderCloudSource?: () => React.ReactNode;
+}
+
+/**
+ * Capability-first, explicit source picker. Signed-out sees the minimal file +
+ * SPC path; premium additionally gets the cloud package source. There is no
+ * automatic handoff from the Forecast Editor — the source is always chosen here.
+ */
+const SourcePanel: React.FC<SourcePanelProps> = ({
+  tier,
+  availableSources,
+  hasForecast,
+  sourceLabel,
+  useToday,
+  reportDate,
+  canRun,
+  isRunning,
+  error,
+  onFile,
+  onUseTodayChange,
+  onReportDateChange,
+  onRun,
+  onReset,
+  renderCloudSource,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="rounded-xl border border-slate-300/40 p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Choose a package</h3>
+        {hasForecast && (
+          <button type="button" className="text-xs text-blue-500 hover:underline" onClick={onReset}>
+            Change source
+          </button>
+        )}
+      </div>
+
+      {hasForecast ? (
+        <p className="mt-2 text-sm text-slate-500">
+          <span className="font-medium text-slate-600">Loaded:</span> {sourceLabel}
+        </p>
+      ) : (
+        <div className="mt-2 space-y-3">
+          <div>
+            <label className="fg-touch inline-flex cursor-pointer items-center gap-2 rounded-lg border border-slate-300/50 px-3 py-2 text-sm">
+              <FileUp className="h-4 w-4" />
+              <span>Upload forecast file</span>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json"
+                className="hidden"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    onFile(file);
+                  }
+                  event.target.value = '';
+                }}
+              />
+            </label>
+            <p className="mt-1 text-xs text-slate-400">A .json package exported from the Outlook Creator.</p>
+          </div>
+
+          {availableSources.includes('cloud') && renderCloudSource && (
+            <div className="border-t border-slate-200/30 pt-3">{renderCloudSource()}</div>
+          )}
+        </div>
+      )}
+
+      <div className="mt-4 border-t border-slate-200/30 pt-3">
+        <div className="text-sm font-semibold">SPC storm reports</div>
+        <div className="mt-2 flex flex-wrap items-center gap-3 text-sm">
+          <label className="inline-flex items-center gap-2">
+            <input type="checkbox" checked={useToday} onChange={(event) => onUseTodayChange(event.target.checked)} />
+            Today
+          </label>
+          {!useToday && (
+            <input
+              type="date"
+              className="fg-touch rounded border border-slate-300/40 bg-transparent px-2 py-1"
+              value={reportDate}
+              onChange={(event) => onReportDateChange(event.target.value)}
+              aria-label="Report date"
+            />
+          )}
+        </div>
+      </div>
+
+      {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+
+      <button
+        type="button"
+        className="fg-touch mt-4 w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={!canRun}
+        onClick={onRun}
+      >
+        {isRunning ? 'Grading…' : 'Grade forecast'}
+      </button>
+
+      {tier === 'signed-out' && (
+        <p className="mt-2 text-xs text-slate-400">Sign in to keep a grade history trend.</p>
+      )}
+    </div>
+  );
+};
+
+export default SourcePanel;

--- a/src/components/ForecastGrade/SourcePanel.tsx
+++ b/src/components/ForecastGrade/SourcePanel.tsx
@@ -1,6 +1,6 @@
-import React, { useRef } from 'react';
-import { FileUp } from 'lucide-react';
+import React from 'react';
 import type { GradeAccountTier, PackageSourceKind } from '../../types/forecastGrade';
+import { GradeRunFooter, PackageChooser, ReportDatePicker } from './sourcePanelParts';
 
 interface SourcePanelProps {
   tier: GradeAccountTier;
@@ -41,88 +41,34 @@ const SourcePanel: React.FC<SourcePanelProps> = ({
   onRun,
   onReset,
   renderCloudSource,
-}) => {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  return (
-    <div className="rounded-xl border border-slate-300/40 p-4">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold">Choose a package</h3>
-        {hasForecast && (
-          <button type="button" className="text-xs text-blue-500 hover:underline" onClick={onReset}>
-            Change source
-          </button>
-        )}
-      </div>
-
-      {hasForecast ? (
-        <p className="mt-2 text-sm text-slate-500">
-          <span className="font-medium text-slate-600">Loaded:</span> {sourceLabel}
-        </p>
-      ) : (
-        <div className="mt-2 space-y-3">
-          <div>
-            <label className="fg-touch inline-flex cursor-pointer items-center gap-2 rounded-lg border border-slate-300/50 px-3 py-2 text-sm">
-              <FileUp className="h-4 w-4" />
-              <span>Upload forecast file</span>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".json"
-                className="hidden"
-                onChange={(event) => {
-                  const file = event.target.files?.[0];
-                  if (file) {
-                    onFile(file);
-                  }
-                  event.target.value = '';
-                }}
-              />
-            </label>
-            <p className="mt-1 text-xs text-slate-400">A .json package exported from the Outlook Creator.</p>
-          </div>
-
-          {availableSources.includes('cloud') && renderCloudSource && (
-            <div className="border-t border-slate-200/30 pt-3">{renderCloudSource()}</div>
-          )}
-        </div>
-      )}
-
-      <div className="mt-4 border-t border-slate-200/30 pt-3">
-        <div className="text-sm font-semibold">SPC storm reports</div>
-        <div className="mt-2 flex flex-wrap items-center gap-3 text-sm">
-          <label className="inline-flex items-center gap-2">
-            <input type="checkbox" checked={useToday} onChange={(event) => onUseTodayChange(event.target.checked)} />
-            Today
-          </label>
-          {!useToday && (
-            <input
-              type="date"
-              className="fg-touch rounded border border-slate-300/40 bg-transparent px-2 py-1"
-              value={reportDate}
-              onChange={(event) => onReportDateChange(event.target.value)}
-              aria-label="Report date"
-            />
-          )}
-        </div>
-      </div>
-
-      {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
-
-      <button
-        type="button"
-        className="fg-touch mt-4 w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={!canRun}
-        onClick={onRun}
-      >
-        {isRunning ? 'Grading…' : 'Grade forecast'}
-      </button>
-
-      {tier === 'signed-out' && (
-        <p className="mt-2 text-xs text-slate-400">Sign in to keep a grade history trend.</p>
+}) => (
+  <div className="rounded-xl border border-slate-300/40 p-4">
+    <div className="flex items-center justify-between">
+      <h3 className="text-sm font-semibold">Choose a package</h3>
+      {hasForecast && (
+        <button type="button" className="text-xs text-blue-500 hover:underline" onClick={onReset}>
+          Change source
+        </button>
       )}
     </div>
-  );
-};
+
+    {hasForecast ? (
+      <p className="mt-2 text-sm text-slate-500">
+        <span className="font-medium text-slate-600">Loaded:</span> {sourceLabel}
+      </p>
+    ) : (
+      <PackageChooser availableSources={availableSources} onFile={onFile} renderCloudSource={renderCloudSource} />
+    )}
+
+    <ReportDatePicker
+      useToday={useToday}
+      reportDate={reportDate}
+      onUseTodayChange={onUseTodayChange}
+      onReportDateChange={onReportDateChange}
+    />
+
+    <GradeRunFooter tier={tier} canRun={canRun} isRunning={isRunning} error={error} onRun={onRun} />
+  </div>
+);
 
 export default SourcePanel;

--- a/src/components/ForecastGrade/gradeFormat.ts
+++ b/src/components/ForecastGrade/gradeFormat.ts
@@ -1,0 +1,41 @@
+import type { LetterGrade } from '../../utils/verificationV2';
+
+/** Formats a 0–100 grade to one decimal, or an em dash when withheld. */
+export const formatGrade = (grade: number | null): string =>
+  grade === null || Number.isNaN(grade) ? '—' : grade.toFixed(1);
+
+/** Formats a 0–1 component score as a whole-number percentage. */
+export const formatScore = (score: number | null): string =>
+  score === null || Number.isNaN(score) ? 'N/A' : `${Math.round(score * 100)}`;
+
+/** Tailwind text color class for a letter grade. */
+export const letterColorClass = (letter: LetterGrade | null): string => {
+  switch (letter) {
+    case 'A':
+      return 'text-emerald-500';
+    case 'B':
+      return 'text-lime-500';
+    case 'C':
+      return 'text-yellow-500';
+    case 'D':
+      return 'text-orange-500';
+    case 'F':
+      return 'text-red-500';
+    default:
+      return 'text-slate-400';
+  }
+};
+
+/** Background badge class for a data-quality status. */
+export const dataQualityClass = (quality: string): string => {
+  switch (quality) {
+    case 'Good':
+      return 'bg-emerald-500/15 text-emerald-600';
+    case 'Limited':
+      return 'bg-amber-500/15 text-amber-600';
+    case 'Blocked':
+      return 'bg-red-500/15 text-red-600';
+    default:
+      return 'bg-slate-500/15 text-slate-500';
+  }
+};

--- a/src/components/ForecastGrade/methodology.ts
+++ b/src/components/ForecastGrade/methodology.ts
@@ -1,0 +1,10 @@
+import { FORECAST_GRADE_FORMULA_VERSION } from '../../utils/verificationV2';
+
+/**
+ * Public methodology page served from the app's static assets, linked from the
+ * dashboard. It documents the gfc-ver-1 formulas, caveats, version history, the
+ * SPC 25-mile citation, and the intent/yield rationale.
+ */
+export const METHODOLOGY_DOC_PATH = '/docs/forecast-grade-methodology.html';
+
+export { FORECAST_GRADE_FORMULA_VERSION };

--- a/src/components/ForecastGrade/sourcePanelParts.tsx
+++ b/src/components/ForecastGrade/sourcePanelParts.tsx
@@ -1,0 +1,98 @@
+import React, { useRef } from 'react';
+import { FileUp } from 'lucide-react';
+import type { GradeAccountTier, PackageSourceKind } from '../../types/forecastGrade';
+
+interface PackageChooserProps {
+  availableSources: PackageSourceKind[];
+  onFile: (file: File) => void;
+  renderCloudSource?: () => React.ReactNode;
+}
+
+export const PackageChooser: React.FC<PackageChooserProps> = ({ availableSources, onFile, renderCloudSource }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const showCloud = availableSources.includes('cloud') && Boolean(renderCloudSource);
+
+  return (
+    <div className="mt-2 space-y-3">
+      <div>
+        <label className="fg-touch inline-flex cursor-pointer items-center gap-2 rounded-lg border border-slate-300/50 px-3 py-2 text-sm">
+          <FileUp className="h-4 w-4" />
+          <span>Upload forecast file</span>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json"
+            className="hidden"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) {
+                onFile(file);
+              }
+              event.target.value = '';
+            }}
+          />
+        </label>
+        <p className="mt-1 text-xs text-slate-400">A .json package exported from the Outlook Creator.</p>
+      </div>
+      {showCloud && <div className="border-t border-slate-200/30 pt-3">{renderCloudSource?.()}</div>}
+    </div>
+  );
+};
+
+interface ReportDatePickerProps {
+  useToday: boolean;
+  reportDate: string;
+  onUseTodayChange: (value: boolean) => void;
+  onReportDateChange: (value: string) => void;
+}
+
+export const ReportDatePicker: React.FC<ReportDatePickerProps> = ({
+  useToday,
+  reportDate,
+  onUseTodayChange,
+  onReportDateChange,
+}) => (
+  <div className="mt-4 border-t border-slate-200/30 pt-3">
+    <div className="text-sm font-semibold">SPC storm reports</div>
+    <div className="mt-2 flex flex-wrap items-center gap-3 text-sm">
+      <label className="inline-flex items-center gap-2">
+        <input type="checkbox" checked={useToday} onChange={(event) => onUseTodayChange(event.target.checked)} />
+        Today
+      </label>
+      {!useToday && (
+        <input
+          type="date"
+          className="fg-touch rounded border border-slate-300/40 bg-transparent px-2 py-1"
+          value={reportDate}
+          onChange={(event) => onReportDateChange(event.target.value)}
+          aria-label="Report date"
+        />
+      )}
+    </div>
+  </div>
+);
+
+interface GradeRunFooterProps {
+  tier: GradeAccountTier;
+  canRun: boolean;
+  isRunning: boolean;
+  error: string | null;
+  onRun: () => void;
+}
+
+export const GradeRunFooter: React.FC<GradeRunFooterProps> = ({ tier, canRun, isRunning, error, onRun }) => (
+  <>
+    {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+    <button
+      type="button"
+      className="fg-touch mt-4 w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+      disabled={!canRun}
+      onClick={onRun}
+    >
+      {isRunning ? 'Grading…' : 'Grade forecast'}
+    </button>
+    {tier === 'signed-out' && (
+      <p className="mt-2 text-xs text-slate-400">Sign in to keep a grade history trend.</p>
+    )}
+  </>
+);

--- a/src/components/ForecastGrade/useForecastGrade.test.tsx
+++ b/src/components/ForecastGrade/useForecastGrade.test.tsx
@@ -1,0 +1,586 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import React from 'react';
+import verificationReducer from '../../store/verificationSlice';
+import stormReportsReducer from '../../store/stormReportsSlice';
+
+jest.mock('../../auth/AuthProvider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('../../billing/EntitlementProvider', () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock('../../utils/fileUtils', () => ({
+  serializeForecast: jest.fn(() => ({ kind: 'serialized' })),
+}));
+
+jest.mock('../../utils/verificationV2/sources', () => ({
+  buildGradeCard: jest.fn(),
+  loadForecastFromFile: jest.fn(),
+  loadReportsForDate: jest.fn(),
+  resolveAccountTier: jest.fn(),
+  SourceLoadError: class SourceLoadError extends Error {},
+  tierHasSnapshots: jest.fn(),
+}));
+
+jest.mock('../../utils/verificationV2/gradeHistory', () => ({
+  accountScope: jest.fn(),
+  loadGradeCards: jest.fn(() => []),
+  loadGradeSnapshot: jest.fn(),
+  recordGradeResult: jest.fn(() => []),
+}));
+
+const mockIsReachedArchiveDate = jest.fn(() => true) as unknown as jest.MockedFunction<
+  (reportDate: string, now?: Date) => boolean
+>;
+const mockRunForecastGrade = jest.fn() as unknown as jest.MockedFunction<
+  (input: unknown, onProgress?: unknown) => Promise<unknown>
+>;
+const mockValidateGradeInputs = jest.fn(() => ({ valid: true as boolean })) as unknown as jest.MockedFunction<
+  (input: unknown) => { valid: boolean; reason?: string }
+>;
+
+jest.mock('../../utils/verificationV2', () => {
+  const actual = jest.requireActual('../../utils/verificationV2/gradeForecast');
+  return {
+    FORECAST_GRADE_FORMULA_VERSION: 'gfc-ver-1',
+    isReachedArchiveDate: (arg: string) => mockIsReachedArchiveDate(arg),
+    runForecastGrade: (input: unknown, onProgress?: unknown) =>
+      mockRunForecastGrade(input, onProgress),
+    validateGradeInputs: (input: unknown) => mockValidateGradeInputs(input),
+    __esModule: true,
+  };
+});
+
+import { useAuth } from '../../auth/AuthProvider';
+import { useEntitlement } from '../../billing/EntitlementProvider';
+import { serializeForecast } from '../../utils/fileUtils';
+import {
+  buildGradeCard,
+  loadForecastFromFile,
+  loadReportsForDate,
+  resolveAccountTier,
+  SourceLoadError,
+  tierHasSnapshots,
+} from '../../utils/verificationV2/sources';
+import {
+  accountScope,
+  loadGradeCards,
+  loadGradeSnapshot,
+  recordGradeResult,
+} from '../../utils/verificationV2/gradeHistory';
+import { useForecastGrade } from './useForecastGrade';
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<typeof useEntitlement>;
+const mockResolveAccountTier = resolveAccountTier as jest.MockedFunction<typeof resolveAccountTier>;
+const mockAccountScope = accountScope as jest.MockedFunction<typeof accountScope>;
+const mockLoadGradeCards = loadGradeCards as jest.MockedFunction<typeof loadGradeCards>;
+const mockLoadGradeSnapshot = loadGradeSnapshot as jest.MockedFunction<typeof loadGradeSnapshot>;
+const mockRecordGradeResult = recordGradeResult as jest.MockedFunction<typeof recordGradeResult>;
+const mockBuildGradeCard = buildGradeCard as jest.MockedFunction<typeof buildGradeCard>;
+const mockTierHasSnapshots = tierHasSnapshots as jest.MockedFunction<typeof tierHasSnapshots>;
+const mockSerializeForecast = serializeForecast as jest.MockedFunction<typeof serializeForecast>;
+const mockLoadReportsForDate = loadReportsForDate as jest.MockedFunction<typeof loadReportsForDate>;
+const mockLoadForecastFromFile = loadForecastFromFile as jest.MockedFunction<typeof loadForecastFromFile>;
+
+const sampleCycle = {
+  id: 'cycle-1',
+  createdAt: '2026-07-29T00:00:00Z',
+  days: {
+    1: {
+      data: {
+        tornado: new Map([['5%', [{ type: 'Feature', id: 't1', geometry: { type: 'Polygon', coordinates: [[[0,0],[1,0],[1,1],[0,1],[0,0]]] }, properties: {} }]]]),
+        wind: new Map(),
+        hail: new Map(),
+        categorical: new Map(),
+      },
+    },
+  },
+} as never;
+
+const samplePackage = {
+  formulaVersion: 'gfc-ver-1',
+  grade: 80,
+  letter: 'B',
+  products: [
+    { product: 'tornado', label: 'Tornado', grade: 80, letter: 'B', components: [], applicable: true, reportCount: 0 },
+    { product: 'wind', label: 'Wind', grade: null, letter: null, components: [], applicable: false, reportCount: 0 },
+    { product: 'hail', label: 'Hail', grade: null, letter: null, components: [], applicable: false, reportCount: 0 },
+  ],
+  dataQuality: 'Limited',
+  dataQualityReason: 'Sparse reports.',
+  hasReports: false,
+  generatedAt: '2026-07-29T00:00:00Z',
+} as never;
+
+const sampleReports = [
+  { id: 'r1', time: 0, type: 'tornado', lat: 0, lon: 0, magnitude: 0, source: 'SPC' },
+] as never;
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      verification: verificationReducer,
+      stormReports: stormReportsReducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        immutableCheck: false,
+      }),
+  });
+
+const renderGradeHook = (store: ReturnType<typeof createStore>) => {
+  const addToast = jest.fn();
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  const result = renderHook(({ addToast: toast }) => useForecastGrade(toast), {
+    initialProps: { addToast },
+    wrapper,
+  });
+  return { addToast, ...result };
+};
+
+const renderWithPackage = () => {
+  const store = createStore();
+  const rendered = renderGradeHook(store);
+  act(() => {
+    rendered.result.current.setForecastPackage(sampleCycle, 'file', 'forecast.json');
+  });
+  return { store, ...rendered };
+};
+
+const beginInFlightReportLoad = () => {
+  let resolveReports: ((value: typeof sampleReports) => void) | null = null;
+  mockLoadReportsForDate.mockImplementationOnce(
+    () => new Promise<typeof sampleReports>((resolve) => {
+      resolveReports = resolve;
+    })
+  );
+  return () => {
+    resolveReports?.(sampleReports);
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ user: null } as never);
+  mockUseEntitlement.mockReturnValue({ premiumActive: false } as never);
+  mockResolveAccountTier.mockImplementation(
+    (isSignedIn, premiumActive) =>
+      isSignedIn ? (premiumActive ? 'premium' : 'free') : 'signed-out'
+  );
+  mockAccountScope.mockImplementation((tier, userId) =>
+    tier === 'signed-out' || !userId ? null : `user:${userId}`
+  );
+  mockLoadGradeCards.mockReturnValue([]);
+  mockRecordGradeResult.mockImplementation(({ card }) => [card]);
+  mockBuildGradeCard.mockImplementation((pkg, opts) => ({
+    id: 'card-1',
+    createdAt: pkg.generatedAt,
+    reportDate: opts.reportDate,
+    formulaVersion: pkg.formulaVersion,
+    grade: pkg.grade,
+    letter: pkg.letter,
+    dataQuality: pkg.dataQuality,
+    productGrades: {},
+    sourceLabel: opts.sourceLabel,
+    hasSnapshot: opts.hasSnapshot,
+  }));
+  mockTierHasSnapshots.mockImplementation((tier) => tier === 'premium');
+  mockIsReachedArchiveDate.mockReturnValue(true);
+  mockValidateGradeInputs.mockReturnValue({ valid: true });
+  mockRunForecastGrade.mockResolvedValue(samplePackage);
+  mockLoadReportsForDate.mockResolvedValue(sampleReports);
+  mockLoadForecastFromFile.mockResolvedValue(sampleCycle);
+  mockLoadGradeSnapshot.mockReturnValue(null);
+  mockSerializeForecast.mockReturnValue({ kind: 'serialized' } as never);
+});
+
+describe('useForecastGrade', () => {
+  describe('tier and entitlements', () => {
+    test('signed-out users see signed-out tier and null scope', () => {
+      const store = createStore();
+      const { result } = renderGradeHook(store);
+
+      expect(result.current.tier).toBe('signed-out');
+      expect(result.current.cards).toEqual([]);
+    });
+
+    test('signed-in free users resolve to the free tier with a per-user scope', () => {
+      mockUseAuth.mockReturnValue({ user: { uid: 'user-1' } } as never);
+      const store = createStore();
+      const { result } = renderGradeHook(store);
+
+      expect(result.current.tier).toBe('free');
+    });
+
+    test('signed-in premium users resolve to the premium tier', () => {
+      mockUseAuth.mockReturnValue({ user: { uid: 'user-1' } } as never);
+      mockUseEntitlement.mockReturnValue({ premiumActive: true } as never);
+      const store = createStore();
+      const { result } = renderGradeHook(store);
+
+      expect(result.current.tier).toBe('premium');
+    });
+  });
+
+  describe('canRun gating', () => {
+    test('canRun is false when no forecast is loaded', () => {
+      const store = createStore();
+      const { result } = renderGradeHook(store);
+
+      expect(result.current.canRun).toBe(false);
+    });
+
+    test('canRun is true with a forecast and useToday on', () => {
+      const { result } = renderWithPackage();
+
+      expect(result.current.canRun).toBe(true);
+    });
+
+    test('canRun is false with an empty report date and useToday off', () => {
+      mockIsReachedArchiveDate.mockReturnValue(false);
+      const { result } = renderWithPackage();
+
+      act(() => {
+        result.current.setUseToday(false);
+        result.current.setReportDate('   ');
+      });
+
+      expect(result.current.canRun).toBe(false);
+    });
+
+    test('canRun is false when the report date is in the future', () => {
+      mockIsReachedArchiveDate.mockReturnValue(false);
+      const { result } = renderWithPackage();
+
+      act(() => {
+        result.current.setUseToday(false);
+        result.current.setReportDate('2099-01-01');
+      });
+
+      expect(result.current.canRun).toBe(false);
+    });
+
+    test('canRun is true when the report date is a reached calendar date', () => {
+      mockIsReachedArchiveDate.mockReturnValue(true);
+      const { result } = renderWithPackage();
+
+      act(() => {
+        result.current.setUseToday(false);
+        result.current.setReportDate('2026-07-28');
+      });
+
+      expect(result.current.canRun).toBe(true);
+    });
+  });
+
+  describe('run validation', () => {
+    test('refuses to run with no forecast and emits an error toast', async () => {
+      const { result, addToast } = renderGradeHook(createStore());
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      expect(addToast).toHaveBeenCalledWith('Load a forecast package first.', 'error');
+      expect(result.current.phase).toBe('idle');
+      expect(mockLoadReportsForDate).not.toHaveBeenCalled();
+    });
+
+    test('refuses to run with a future date and emits an error toast', async () => {
+      mockIsReachedArchiveDate.mockReturnValue(false);
+      const { result, addToast } = renderWithPackage();
+
+      act(() => {
+        result.current.setUseToday(false);
+        result.current.setReportDate('2099-01-01');
+      });
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        'Choose a real, reached report date before grading.',
+        'error'
+      );
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.error).toBe('Choose a real, reached report date before grading.');
+      expect(mockLoadReportsForDate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('report load failures', () => {
+    test('surfaces a SourceLoadError and returns to idle', async () => {
+      mockLoadReportsForDate.mockRejectedValueOnce(new SourceLoadError('SPC outage'));
+      const { result, addToast } = renderWithPackage();
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      expect(addToast).toHaveBeenCalledWith('SPC outage', 'error');
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.error).toBe('SPC outage');
+      expect(result.current.progress).toBeNull();
+    });
+
+    test('surfaces a non-SourceLoadError with a friendly fallback message', async () => {
+      mockLoadReportsForDate.mockRejectedValueOnce(new Error('network'));
+      const { result, addToast } = renderWithPackage();
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      expect(addToast).toHaveBeenCalledWith('Reports could not be loaded.', 'error');
+      expect(result.current.phase).toBe('idle');
+    });
+  });
+
+  describe('validation and completed runs', () => {
+    test('surfaces validation failures and returns to idle', async () => {
+      mockValidateGradeInputs.mockReturnValueOnce({
+        valid: false,
+        reason: 'No geometry.',
+      } as ReturnType<typeof mockValidateGradeInputs>);
+      const { result, addToast } = renderWithPackage();
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      expect(addToast).toHaveBeenCalledWith('No geometry.', 'error');
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.error).toBe('No geometry.');
+      expect(mockRunForecastGrade).not.toHaveBeenCalled();
+    });
+
+    test('completes a run, sets result, and records a card for signed-in scopes', async () => {
+      mockUseAuth.mockReturnValue({ user: { uid: 'user-1' } } as never);
+      const { result, addToast, store } = renderWithPackage();
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      await waitFor(() => expect(result.current.phase).toBe('complete'));
+      expect(result.current.result).toEqual(samplePackage);
+      expect(result.current.activeProduct).toBe('tornado');
+      expect(mockBuildGradeCard).toHaveBeenCalledWith(
+        samplePackage,
+        expect.objectContaining({ hasSnapshot: false, sourceLabel: 'forecast.json' })
+      );
+      expect(mockRecordGradeResult).toHaveBeenCalled();
+      const state = store.getState();
+      expect(state.stormReports.reports).toEqual(sampleReports);
+      expect(state.stormReports.date).toBe('today');
+      expect(addToast).not.toHaveBeenCalledWith(expect.stringMatching(/error/i), 'error');
+    });
+
+    test('premium runs store a snapshot in addition to the card', async () => {
+      mockUseAuth.mockReturnValue({ user: { uid: 'user-1' } } as never);
+      mockUseEntitlement.mockReturnValue({ premiumActive: true } as never);
+      const { result } = renderWithPackage();
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      await waitFor(() => expect(result.current.phase).toBe('complete'));
+      expect(mockSerializeForecast).toHaveBeenCalledWith(
+        sampleCycle,
+        expect.objectContaining({ center: [-98, 39], zoom: 4 })
+      );
+      expect(mockRecordGradeResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          snapshot: expect.objectContaining({
+            package: samplePackage,
+            forecast: { kind: 'serialized' },
+          }),
+        })
+      );
+    });
+
+    test('silent serialize failures skip the snapshot but still record the card', async () => {
+      mockUseAuth.mockReturnValue({ user: { uid: 'user-1' } } as never);
+      mockUseEntitlement.mockReturnValue({ premiumActive: true } as never);
+      mockSerializeForecast.mockImplementationOnce(() => {
+        throw new Error('serialize failed');
+      });
+      const { result } = renderWithPackage();
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      await waitFor(() => expect(result.current.phase).toBe('complete'));
+      expect(mockRecordGradeResult).toHaveBeenCalledWith(
+        expect.objectContaining({ snapshot: undefined })
+      );
+    });
+
+    test('run uses the selected day outlooks and dispatches the report date', async () => {
+      const { result, store } = renderWithPackage();
+
+      act(() => {
+        result.current.setUseToday(false);
+        result.current.setReportDate('2026-07-28');
+      });
+
+      await act(async () => {
+        await result.current.run();
+      });
+
+      expect(mockLoadReportsForDate).toHaveBeenCalledWith('2026-07-28');
+      expect(store.getState().stormReports.date).toBe('2026-07-28');
+    });
+  });
+
+  describe('reset and stale-run guards', () => {
+    test('reset clears local state and dispatches redux clear actions', () => {
+      const { result, store } = renderWithPackage();
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.forecast).toBeNull();
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.error).toBeNull();
+      expect(store.getState().verification.loadedForecast).toBeNull();
+      expect(store.getState().stormReports.reports).toEqual([]);
+    });
+
+    test('reset during an in-flight report load ignores the late completion', async () => {
+      const resolveLoad = beginInFlightReportLoad();
+      const { result, store } = renderWithPackage();
+
+      let runPromise: Promise<void> | undefined;
+      act(() => {
+        runPromise = result.current.run();
+      });
+
+      act(() => {
+        result.current.reset();
+      });
+
+      await act(async () => {
+        resolveLoad();
+        await runPromise;
+      });
+
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.reports).toEqual([]);
+      expect(result.current.result).toBeNull();
+      expect(store.getState().stormReports.reports).toEqual([]);
+    });
+
+    test('replacing the forecast package during an in-flight run ignores the late completion', async () => {
+      const resolveLoad = beginInFlightReportLoad();
+      const { result } = renderWithPackage();
+
+      let runPromise: Promise<void> | undefined;
+      act(() => {
+        runPromise = result.current.run();
+      });
+
+      const secondCycle = { ...(sampleCycle as Record<string, unknown>), id: 'cycle-2' } as never;
+      act(() => {
+        result.current.setForecastPackage(secondCycle, 'cloud', 'cloud-cycle');
+      });
+
+      await act(async () => {
+        resolveLoad();
+        await runPromise;
+      });
+
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.result).toBeNull();
+      expect(result.current.forecast).toEqual(secondCycle);
+    });
+  });
+
+  describe('restoreCard', () => {
+    test('returns the stored snapshot for premium cards', () => {
+      const stored = { id: 'snap-1' } as never;
+      mockLoadGradeSnapshot.mockReturnValueOnce(stored);
+      const store = createStore();
+      const { result } = renderGradeHook(store);
+
+      const card = { id: 'card-1' } as never;
+      const snapshot = result.current.restoreCard(card);
+
+      expect(snapshot).toBe(stored);
+      expect(mockLoadGradeSnapshot).toHaveBeenCalledWith({
+        scope: null,
+        cardId: 'card-1',
+      });
+    });
+
+    test('toasts and returns null when no snapshot is stored', () => {
+      mockLoadGradeSnapshot.mockReturnValueOnce(null);
+      const store = createStore();
+      const { result, addToast } = renderGradeHook(store);
+
+      const card = { id: 'card-2' } as never;
+      const snapshot = result.current.restoreCard(card);
+
+      expect(snapshot).toBeNull();
+      expect(addToast).toHaveBeenCalledWith(
+        'This grade card is trend-only and cannot reopen a full package.',
+        'info'
+      );
+    });
+  });
+
+  describe('loadFromFile', () => {
+    test('loads a file successfully and surfaces a success toast', async () => {
+      const store = createStore();
+      const { result, addToast } = renderGradeHook(store);
+
+      await act(async () => {
+        await result.current.loadFromFile({ name: 'forecast.json' } as never);
+      });
+
+      expect(result.current.forecast).toEqual(sampleCycle);
+      expect(result.current.packageSource).toBe('file');
+      expect(addToast).toHaveBeenCalledWith(
+        'Forecast package loaded. Choose a report date and grade.',
+        'success'
+      );
+    });
+
+    test('surfaces a SourceLoadError and a friendly toast on failure', async () => {
+      mockLoadForecastFromFile.mockRejectedValueOnce(new SourceLoadError('Bad file.'));
+      const store = createStore();
+      const { result, addToast } = renderGradeHook(store);
+
+      await act(async () => {
+        await result.current.loadFromFile({ name: 'broken.json' } as never);
+      });
+
+      expect(addToast).toHaveBeenCalledWith('Bad file.', 'error');
+      expect(result.current.error).toBe('Bad file.');
+    });
+
+    test('surfaces a friendly fallback for non-SourceLoadError failures', async () => {
+      mockLoadForecastFromFile.mockRejectedValueOnce(new Error('read fail'));
+      const store = createStore();
+      const { result, addToast } = renderGradeHook(store);
+
+      await act(async () => {
+        await result.current.loadFromFile({ name: 'broken.json' } as never);
+      });
+
+      expect(addToast).toHaveBeenCalledWith('Failed to load that file.', 'error');
+    });
+  });
+});

--- a/src/components/ForecastGrade/useForecastGrade.ts
+++ b/src/components/ForecastGrade/useForecastGrade.ts
@@ -145,7 +145,8 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     setPhase('idle');
   }, []);
 
-  const canRun = Boolean(forecast) && phase !== 'running';
+  const canRun =
+    Boolean(forecast) && phase !== 'running' && (useToday || reportDate.trim().length > 0);
 
   const run = useCallback(async () => {
     if (!forecast) {
@@ -205,7 +206,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
           snapshot = {
             card,
             package: pkg,
-            forecast: serializeForecast(forecast),
+            forecast: serializeForecast(forecast, { center: [-98, 39], zoom: 4 }),
             reportDate: effectiveDate,
           };
         } catch {

--- a/src/components/ForecastGrade/useForecastGrade.ts
+++ b/src/components/ForecastGrade/useForecastGrade.ts
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useAuth } from '../../auth/AuthProvider';
+import { useEntitlement } from '../../billing/EntitlementProvider';
+import { loadVerificationForecast, clearVerificationForecast } from '../../store/verificationSlice';
+import { setReports, clearReports, setDate } from '../../store/stormReportsSlice';
+import type { ForecastCycle, DayType } from '../../types/outlooks';
+import type { StormReport } from '../../types/stormReports';
+import type { GradeAccountTier, GradeCard, GradeSnapshot, PackageSourceKind } from '../../types/forecastGrade';
+import { serializeForecast } from '../../utils/fileUtils';
+import {
+  FORECAST_GRADE_FORMULA_VERSION,
+  runForecastGrade,
+  validateGradeInputs,
+  type PackageGrade,
+  type ProductKind,
+  type GradeProgress,
+} from '../../utils/verificationV2';
+import {
+  buildGradeCard,
+  loadForecastFromFile,
+  loadReportsForDate,
+  resolveAccountTier,
+  SourceLoadError,
+  tierHasSnapshots,
+} from '../../utils/verificationV2/sources';
+import {
+  accountScope,
+  loadGradeCards,
+  loadGradeSnapshot,
+  recordGradeResult,
+} from '../../utils/verificationV2/gradeHistory';
+
+/**
+ * Central state for the Forecast Grade dashboard (PR 06/07).
+ *
+ * Owns explicit source selection, the staged run lifecycle, redux sync so the
+ * shared verification map renders the evidence, and capability-aware history.
+ */
+
+type RunPhase = 'idle' | 'running' | 'complete';
+
+const daysWithData = (forecast: ForecastCycle | null): DayType[] => {
+  if (!forecast?.days) {
+    return [];
+  }
+  return (Object.keys(forecast.days) as unknown as DayType[])
+    .filter((day) => Boolean(forecast.days[day]))
+    .sort((a, b) => a - b);
+};
+
+export interface ForecastGradeState {
+  tier: GradeAccountTier;
+  forecast: ForecastCycle | null;
+  packageSource: PackageSourceKind | null;
+  sourceLabel: string;
+  availableDays: DayType[];
+  selectedDay: DayType;
+  reportDate: string;
+  useToday: boolean;
+  activeProduct: ProductKind;
+  phase: RunPhase;
+  progress: GradeProgress | null;
+  result: PackageGrade | null;
+  error: string | null;
+  cards: GradeCard[];
+  reports: StormReport[];
+}
+
+export interface UseForecastGrade extends ForecastGradeState {
+  setForecastPackage: (forecast: ForecastCycle, source: PackageSourceKind, label: string) => void;
+  loadFromFile: (file: File) => Promise<void>;
+  setReportDate: (value: string) => void;
+  setUseToday: (value: boolean) => void;
+  setSelectedDay: (day: DayType) => void;
+  setActiveProduct: (product: ProductKind) => void;
+  run: () => Promise<void>;
+  reset: () => void;
+  restoreCard: (card: GradeCard) => GradeSnapshot | null;
+  canRun: boolean;
+}
+
+export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'success' | 'error') => void): UseForecastGrade => {
+  const dispatch = useDispatch();
+  const { user } = useAuth();
+  const { premiumActive } = useEntitlement();
+
+  const tier = resolveAccountTier(Boolean(user), premiumActive);
+  const scope = useMemo(() => accountScope(tier, user?.uid), [tier, user?.uid]);
+
+  const [forecast, setForecast] = useState<ForecastCycle | null>(null);
+  const [packageSource, setPackageSource] = useState<PackageSourceKind | null>(null);
+  const [sourceLabel, setSourceLabel] = useState('');
+  const [availableDays, setAvailableDays] = useState<DayType[]>([]);
+  const [selectedDay, setSelectedDayState] = useState<DayType>(1);
+  const [reportDate, setReportDateState] = useState('');
+  const [useToday, setUseToday] = useState(true);
+  const [activeProduct, setActiveProduct] = useState<ProductKind>('categorical');
+  const [phase, setPhase] = useState<RunPhase>('idle');
+  const [progress, setProgress] = useState<GradeProgress | null>(null);
+  const [result, setResult] = useState<PackageGrade | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [cards, setCards] = useState<GradeCard[]>([]);
+  const [reports, setReportsState] = useState<StormReport[]>([]);
+
+  useEffect(() => {
+    setCards(loadGradeCards(scope));
+  }, [scope]);
+
+  const setForecastPackage = useCallback(
+    (nextForecast: ForecastCycle, source: PackageSourceKind, label: string) => {
+      const days = daysWithData(nextForecast);
+      setForecast(nextForecast);
+      setPackageSource(source);
+      setSourceLabel(label);
+      setAvailableDays(days);
+      setSelectedDayState(days[0] ?? 1);
+      setResult(null);
+      setPhase('idle');
+      setError(null);
+      dispatch(loadVerificationForecast(nextForecast));
+    },
+    [dispatch]
+  );
+
+  const loadFromFile = useCallback(
+    async (file: File) => {
+      try {
+        const loaded = await loadForecastFromFile(file);
+        setForecastPackage(loaded, 'file', file.name);
+        addToast('Forecast package loaded. Choose a report date and grade.', 'success');
+      } catch (loadError) {
+        const message = loadError instanceof SourceLoadError ? loadError.message : 'Failed to load that file.';
+        setError(message);
+        addToast(message, 'error');
+      }
+    },
+    [addToast, setForecastPackage]
+  );
+
+  const setReportDate = useCallback((value: string) => setReportDateState(value), []);
+  const setSelectedDay = useCallback((day: DayType) => {
+    setSelectedDayState(day);
+    setResult(null);
+    setPhase('idle');
+  }, []);
+
+  const canRun = Boolean(forecast) && phase !== 'running';
+
+  const run = useCallback(async () => {
+    if (!forecast) {
+      addToast('Load a forecast package first.', 'error');
+      return;
+    }
+    const day = forecast.days[selectedDay];
+    const outlooks = day?.data ?? { tornado: new Map(), wind: new Map(), hail: new Map(), categorical: new Map() };
+    const effectiveDate = useToday ? null : reportDate;
+
+    setPhase('running');
+    setError(null);
+    setProgress({ fraction: 0, label: 'Loading storm reports…' });
+
+    let loadedReports: StormReport[] = [];
+    try {
+      loadedReports = await loadReportsForDate(effectiveDate);
+    } catch (loadError) {
+      const message = loadError instanceof SourceLoadError ? loadError.message : 'Reports could not be loaded.';
+      setError(message);
+      setPhase('idle');
+      setProgress(null);
+      addToast(message, 'error');
+      return;
+    }
+
+    setReportsState(loadedReports);
+    dispatch(setReports(loadedReports));
+    dispatch(setDate(effectiveDate ?? 'today'));
+
+    const validation = validateGradeInputs({ outlooks, reports: loadedReports });
+    if (!validation.valid) {
+      setError(validation.reason ?? 'Inputs are invalid.');
+      setPhase('idle');
+      setProgress(null);
+      addToast(validation.reason ?? 'Inputs are invalid for grading.', 'error');
+      return;
+    }
+
+    const pkg = await runForecastGrade({ outlooks, reports: loadedReports }, setProgress);
+    setResult(pkg);
+    setPhase('complete');
+
+    const firstProduct = pkg.products.find((product) => product.applicable)?.product ?? 'categorical';
+    setActiveProduct(firstProduct);
+
+    if (scope) {
+      const hasSnapshot = tierHasSnapshots(tier);
+      const card = buildGradeCard(pkg, {
+        reportDate: effectiveDate,
+        sourceLabel: sourceLabel || (packageSource === 'cloud' ? 'Cloud + SPC' : 'File + SPC'),
+        hasSnapshot,
+      });
+      let snapshot: GradeSnapshot | undefined;
+      if (hasSnapshot) {
+        try {
+          snapshot = {
+            card,
+            package: pkg,
+            forecast: serializeForecast(forecast),
+            reportDate: effectiveDate,
+          };
+        } catch {
+          snapshot = undefined;
+        }
+      }
+      setCards(recordGradeResult({ scope, card, snapshot }));
+    }
+  }, [addToast, dispatch, forecast, packageSource, reportDate, scope, selectedDay, sourceLabel, tier, useToday]);
+
+  const reset = useCallback(() => {
+    setForecast(null);
+    setPackageSource(null);
+    setSourceLabel('');
+    setAvailableDays([]);
+    setSelectedDayState(1);
+    setResult(null);
+    setPhase('idle');
+    setProgress(null);
+    setError(null);
+    setReportsState([]);
+    dispatch(clearVerificationForecast());
+    dispatch(clearReports());
+  }, [dispatch]);
+
+  const restoreCard = useCallback(
+    (card: GradeCard): GradeSnapshot | null => {
+      const snapshot = loadGradeSnapshot(scope, card.id);
+      if (!snapshot) {
+        addToast('This grade card is trend-only and cannot reopen a full package.', 'info');
+      }
+      return snapshot;
+    },
+    [addToast, scope]
+  );
+
+  return {
+    tier,
+    forecast,
+    packageSource,
+    sourceLabel,
+    availableDays,
+    selectedDay,
+    reportDate,
+    useToday,
+    activeProduct,
+    phase,
+    progress,
+    result,
+    error,
+    cards,
+    reports,
+    setForecastPackage,
+    loadFromFile,
+    setReportDate,
+    setUseToday,
+    setSelectedDay,
+    setActiveProduct,
+    run,
+    reset,
+    restoreCard,
+    canRun,
+  };
+};
+
+export { FORECAST_GRADE_FORMULA_VERSION };

--- a/src/components/ForecastGrade/useForecastGrade.ts
+++ b/src/components/ForecastGrade/useForecastGrade.ts
@@ -95,7 +95,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   const [selectedDay, setSelectedDayState] = useState<DayType>(1);
   const [reportDate, setReportDateState] = useState('');
   const [useToday, setUseToday] = useState(true);
-  const [activeProduct, setActiveProduct] = useState<ProductKind>('categorical');
+  const [activeProduct, setActiveProduct] = useState<ProductKind>('tornado');
   const [phase, setPhase] = useState<RunPhase>('idle');
   const [progress, setProgress] = useState<GradeProgress | null>(null);
   const [result, setResult] = useState<PackageGrade | null>(null);
@@ -190,7 +190,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     setResult(pkg);
     setPhase('complete');
 
-    const firstProduct = pkg.products.find((product) => product.applicable)?.product ?? 'categorical';
+    const firstProduct = pkg.products.find((product) => product.applicable)?.product ?? 'tornado';
     setActiveProduct(firstProduct);
 
     if (scope) {
@@ -234,7 +234,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
 
   const restoreCard = useCallback(
     (card: GradeCard): GradeSnapshot | null => {
-      const snapshot = loadGradeSnapshot(scope, card.id);
+      const snapshot = loadGradeSnapshot({ scope, cardId: card.id });
       if (!snapshot) {
         addToast('This grade card is trend-only and cannot reopen a full package.', 'info');
       }

--- a/src/components/ForecastGrade/useForecastGrade.ts
+++ b/src/components/ForecastGrade/useForecastGrade.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useAuth } from '../../auth/AuthProvider';
 import { useEntitlement } from '../../billing/EntitlementProvider';
@@ -10,6 +10,7 @@ import type { GradeAccountTier, GradeCard, GradeSnapshot, PackageSourceKind } fr
 import { serializeForecast } from '../../utils/fileUtils';
 import {
   FORECAST_GRADE_FORMULA_VERSION,
+  isReachedArchiveDate,
   runForecastGrade,
   validateGradeInputs,
   type PackageGrade,
@@ -39,6 +40,9 @@ import {
  */
 
 type RunPhase = 'idle' | 'running' | 'complete';
+
+const hasReachedReportDate = (useToday: boolean, reportDate: string): boolean =>
+  useToday || isReachedArchiveDate(reportDate);
 
 const daysWithData = (forecast: ForecastCycle | null): DayType[] => {
   if (!forecast?.days) {
@@ -103,12 +107,15 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   const [cards, setCards] = useState<GradeCard[]>([]);
   const [reports, setReportsState] = useState<StormReport[]>([]);
 
+  const runGeneration = useRef(0);
+
   useEffect(() => {
     setCards(loadGradeCards(scope));
   }, [scope]);
 
   const setForecastPackage = useCallback(
     (nextForecast: ForecastCycle, source: PackageSourceKind, label: string) => {
+      runGeneration.current += 1;
       const days = daysWithData(nextForecast);
       setForecast(nextForecast);
       setPackageSource(source);
@@ -146,17 +153,28 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   }, []);
 
   const canRun =
-    Boolean(forecast) && phase !== 'running' && (useToday || reportDate.trim().length > 0);
+    Boolean(forecast) &&
+    phase !== 'running' &&
+    hasReachedReportDate(useToday, reportDate);
 
   const run = useCallback(async () => {
     if (!forecast) {
       addToast('Load a forecast package first.', 'error');
       return;
     }
+    if (!hasReachedReportDate(useToday, reportDate)) {
+      const message = useToday
+        ? 'Choose a report date or enable "use today" before grading.'
+        : 'Choose a real, reached report date before grading.';
+      setError(message);
+      addToast(message, 'error');
+      return;
+    }
     const day = forecast.days[selectedDay];
     const outlooks = day?.data ?? { tornado: new Map(), wind: new Map(), hail: new Map(), categorical: new Map() };
     const effectiveDate = useToday ? null : reportDate;
 
+    const generation = ++runGeneration.current;
     setPhase('running');
     setError(null);
     setProgress({ fraction: 0, label: 'Loading storm reports…' });
@@ -165,11 +183,18 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     try {
       loadedReports = await loadReportsForDate(effectiveDate);
     } catch (loadError) {
+      if (generation !== runGeneration.current) {
+        return;
+      }
       const message = loadError instanceof SourceLoadError ? loadError.message : 'Reports could not be loaded.';
       setError(message);
       setPhase('idle');
       setProgress(null);
       addToast(message, 'error');
+      return;
+    }
+
+    if (generation !== runGeneration.current) {
       return;
     }
 
@@ -179,6 +204,9 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
 
     const validation = validateGradeInputs({ outlooks, reports: loadedReports });
     if (!validation.valid) {
+      if (generation !== runGeneration.current) {
+        return;
+      }
       setError(validation.reason ?? 'Inputs are invalid.');
       setPhase('idle');
       setProgress(null);
@@ -187,6 +215,9 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     }
 
     const pkg = await runForecastGrade({ outlooks, reports: loadedReports }, setProgress);
+    if (generation !== runGeneration.current) {
+      return;
+    }
     setResult(pkg);
     setPhase('complete');
 
@@ -218,6 +249,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   }, [addToast, dispatch, forecast, packageSource, reportDate, scope, selectedDay, sourceLabel, tier, useToday]);
 
   const reset = useCallback(() => {
+    runGeneration.current += 1;
     setForecast(null);
     setPackageSource(null);
     setSourceLabel('');

--- a/src/utils/verificationV2/archiveDate.test.ts
+++ b/src/utils/verificationV2/archiveDate.test.ts
@@ -1,0 +1,52 @@
+import { isReachedArchiveDate, toArchiveDate } from './archiveDate';
+
+describe('isReachedArchiveDate', () => {
+  const now = new Date(Date.UTC(2026, 6, 29, 12, 0, 0));
+
+  test('returns true for today', () => {
+    expect(isReachedArchiveDate('2026-07-29', now)).toBe(true);
+  });
+
+  test('returns true for past ISO dates', () => {
+    expect(isReachedArchiveDate('2020-01-01', now)).toBe(true);
+  });
+
+  test('returns true for past YYMMDD dates', () => {
+    expect(isReachedArchiveDate('200101', now)).toBe(true);
+  });
+
+  test('returns false for future ISO dates', () => {
+    expect(isReachedArchiveDate('2099-01-01', now)).toBe(false);
+  });
+
+  test('returns false for future YYMMDD dates', () => {
+    expect(isReachedArchiveDate('9901', now)).toBe(false);
+  });
+
+  test('returns false for empty or whitespace', () => {
+    expect(isReachedArchiveDate('', now)).toBe(false);
+    expect(isReachedArchiveDate('   ', now)).toBe(false);
+  });
+
+  test('returns false for malformed strings', () => {
+    expect(isReachedArchiveDate('not a date', now)).toBe(false);
+    expect(isReachedArchiveDate('2026-13-40', now)).toBe(false);
+  });
+
+  test('uses the supplied `now` reference rather than wall clock', () => {
+    expect(isReachedArchiveDate('2099-01-01', new Date(Date.UTC(2200, 0, 1)))).toBe(true);
+  });
+
+  test('agrees with toArchiveDate for valid inputs', () => {
+    const samples = ['2026-07-29', '2025-12-31', '9901', '240101'];
+    for (const sample of samples) {
+      const reached = isReachedArchiveDate(sample, now);
+      const archive = toArchiveDate(sample);
+      if (archive === null) {
+        expect(reached).toBe(false);
+      } else {
+        expect(typeof reached).toBe('boolean');
+      }
+    }
+  });
+});

--- a/src/utils/verificationV2/archiveDate.ts
+++ b/src/utils/verificationV2/archiveDate.ts
@@ -55,3 +55,28 @@ export const toArchiveDate = (reportDate: string): string | null => {
 
   return null;
 };
+
+/**
+ * True when the report date parses as a real calendar date and is on-or-before
+ * the supplied reference (default: today, UTC). Returns false for empty,
+ * malformed, or future dates so callers can gate work that should never run
+ * against an archive that does not exist yet.
+ */
+export const isReachedArchiveDate = (reportDate: string, now: Date = new Date()): boolean => {
+  for (const pattern of ARCHIVE_PATTERNS) {
+    const match = reportDate.match(pattern.regex);
+    if (!match) {
+      continue;
+    }
+    const year = pattern.year(match);
+    const month = pattern.month(match);
+    const day = pattern.day(match);
+    if (!isValidCalendarDate(year, month, day)) {
+      return false;
+    }
+    const archiveUtc = Date.UTC(year, month - 1, day);
+    const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+    return archiveUtc <= todayUtc;
+  }
+  return false;
+};

--- a/src/utils/verificationV2/index.ts
+++ b/src/utils/verificationV2/index.ts
@@ -46,3 +46,4 @@ export {
   type GradeProgress,
   type GradeProgressHandler,
 } from './gradeForecast';
+export { isReachedArchiveDate, toArchiveDate } from './archiveDate';

--- a/src/utils/verificationV2/sources.ts
+++ b/src/utils/verificationV2/sources.ts
@@ -15,7 +15,7 @@ import { fetchStormReports, fetchTodayStormReports } from '../stormReportParser'
 import { toArchiveDate } from './archiveDate';
 import type { PackageGrade, ProductKind } from './gradeContract';
 
-export { toArchiveDate } from './archiveDate';
+export { isReachedArchiveDate, toArchiveDate } from './archiveDate';
 
 /**
  * Source adapters for the Forecast Grade dashboard (PR 05 — sources-history).


### PR DESCRIPTION
## Summary

- Add the supporting components for the Forecast Grade dashboard:
  `SourcePanel` (capability-aware source picker + report date + run footer),
  `GradeHeadline` (package score + per-product tabs), `DataQualityPanel`
  (Good / Limited / Blocked with a "No reports" label on quiet days),
  `RunProgress` (progress bar driven by `GradeProgress`), and the
  `gradeFormat` / `methodology` helpers.
- Add `useForecastGrade`, the central hook that owns source selection, the
  staged run lifecycle, redux sync so the shared verification map renders the
  evidence, and capability-aware history. The run is gated until either
  "use today" is set or a report date is entered, and the map view is
  snapshotted at run completion.
- Split `SourcePanel` into `SourcePanel` + `sourcePanelParts` for code
  health (CodeScene delta on the previous monolithic panel).
- Align the hook with the post-04b contract: the active product default and
  the run-completion fallback now use `ProductKind` (`tornado` / `wind` /
  `hail`); categorical/TSTM are display-only `MapOutlookLayer`s.
  `loadGradeSnapshot` is called with the `{ scope, cardId }` object form.

## Stack

8/13, base `beta` (the 06a gate-wiring PR was merged before this rebase,
so 06b now targets `beta` directly). 06c (`#776`) branches from this PR,
07 (`#777`) from 06c, and 08a/08b/09 chain off the rest.

## Test plan

- [ ] Source selection: signed-out sees only the file + SPC path; signed-in
      free users also see only the file path; premium additionally sees the
      cloud package source.
- [ ] Run gating: `canRun` is false until a forecast is loaded and either
      "use today" is on or a non-empty report date is entered; the gate
      stays engaged while a run is in flight.
- [ ] Run lifecycle: progress is set, reports load through `loadReportsForDate`,
      invalid inputs surface a toast + error and return to idle, a successful
      run sets the result, sets the active product to the first applicable
      hazard, and persists a `GradeCard` (plus a `GradeSnapshot` for premium).
- [ ] Map sync: `loadVerificationForecast` runs on `setForecastPackage` and
      `clearVerificationForecast` + `clearReports` run on `reset`; storm
      reports and the storm-reports date are pushed to the slice on run.
- [ ] Restore: `restoreCard` returns the stored snapshot for premium cards
      and toasts an info message for trend-only cards.
- [ ] Visual: headline, data quality panel, and run progress render against
      representative `PackageGrade` fixtures; source panel adapts at
      phone-portrait and phone-landscape sizes.

## Changelog

- Stack PR 8/13: Forecast Grade dashboard supporting components and the
  `useForecastGrade` run hook.
