### PR TITLE
ver2(06c): Forecast Grade dashboard shell

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,9 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #776
+
+- Add Forecast Grade dashboard shell layout and map-first workspace chrome.
 ### PR #775
 
 #### Added

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -6,7 +6,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ### PR #776
 
-- Add Forecast Grade dashboard shell layout and map-first workspace chrome.
+#### Added
+
+- Forecast Grade dashboard shell: replace the 06b stub with the map-first workspace chrome (`ForecastGradeDashboard` plus dedicated `ForecastGradeMapPane` / `ForecastGradeMapControls`), categorical map layer as a display-only toggle, and `applyGradeSnapshot` to reopen premium cards through the shared verification map.
+- `useForecastGrade` gains `activeMapLayer` state, `deserializeForecast` import, and the `applyGradeSnapshot` callback alongside the 06b `runGeneration` / `hasReachedReportDate` stale-run and future-date guards that the rebase would otherwise drop.
 ### PR #775
 
 #### Added

--- a/src/components/ForecastGrade/DataQualityPanel.tsx
+++ b/src/components/ForecastGrade/DataQualityPanel.tsx
@@ -40,7 +40,7 @@ const DataQualityPanel: React.FC<DataQualityPanelProps> = ({ pkg, defaultOpen = 
               ))}
             </ul>
             <p className="mt-1 text-xs text-amber-600/80">
-              A complete package (categorical + hazards) grades every product.
+              A complete severe-hazard package (tornado, wind, hail) grades every product.
             </p>
           </div>
         )}

--- a/src/components/ForecastGrade/ForecastGradeDashboard.css
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.css
@@ -82,9 +82,19 @@
 
 /* Landscape phone: keep the mobile interaction model when height is constrained. */
 @media (max-height: 520px) and (orientation: landscape) {
+  .fg-dashboard {
+    overflow-y: auto;
+  }
+
   .fg-workspace {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(56vh, 1fr) auto;
+    grid-template-rows: minmax(0, 45vh) minmax(0, 1fr);
+  }
+
+  .fg-results-pane {
+    max-height: none;
+    min-height: 0;
+    overflow-y: auto;
   }
 
   .fg-grade-overlay {

--- a/src/components/ForecastGrade/ForecastGradeDashboard.css
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.css
@@ -1,0 +1,139 @@
+.fg-dashboard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.fg-topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.fg-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* Desktop: equal-weight map and dashboard. */
+.fg-workspace {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.fg-map-pane {
+  position: relative;
+  min-height: 0;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--fg-border, rgba(148, 163, 184, 0.35));
+}
+
+.fg-results-pane {
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.fg-grade-overlay {
+  display: none;
+}
+
+/* Mobile: map-first with a compact grade overlay/drawer. */
+@media (max-width: 820px) {
+  .fg-workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(45vh, 1fr) auto;
+  }
+
+  .fg-results-pane {
+    max-height: 48vh;
+  }
+
+  .fg-grade-overlay {
+    display: flex;
+    position: absolute;
+    left: 0.5rem;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    z-index: 5;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    background: rgba(15, 23, 42, 0.82);
+    color: #fff;
+    backdrop-filter: blur(6px);
+  }
+}
+
+/* Landscape phone: keep the mobile interaction model when height is constrained. */
+@media (max-height: 520px) and (orientation: landscape) {
+  .fg-workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(56vh, 1fr) auto;
+  }
+
+  .fg-grade-overlay {
+    display: flex;
+    position: absolute;
+    left: 0.5rem;
+    bottom: 0.5rem;
+    z-index: 5;
+    padding: 0.4rem 0.6rem;
+    border-radius: 0.6rem;
+    background: rgba(15, 23, 42, 0.82);
+    color: #fff;
+  }
+}
+
+.fg-section {
+  border: 1px solid var(--fg-border, rgba(148, 163, 184, 0.35));
+  border-radius: 0.75rem;
+  margin-bottom: 0.75rem;
+  background: var(--fg-surface, rgba(255, 255, 255, 0.02));
+}
+
+.fg-section > summary {
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.fg-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+.fg-section-body {
+  padding: 0 1rem 1rem;
+}
+
+.fg-report-row {
+  cursor: pointer;
+}
+
+.fg-report-row[aria-selected='true'] {
+  outline: 2px solid #2563eb;
+  outline-offset: -2px;
+}
+
+.fg-touch {
+  min-height: 44px;
+}

--- a/src/components/ForecastGrade/ForecastGradeDashboard.css
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.css
@@ -146,4 +146,5 @@
 
 .fg-touch {
   min-height: 44px;
+  min-width: 44px;
 }

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -22,6 +22,7 @@ const MAP_PRODUCTS: ProductKind[] = ['categorical', 'tornado', 'wind', 'hail'];
 
 /** Premium cloud package picker rendered inside the source panel. */
 const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void }> = ({ onLoad }) => {
+  const { addToast } = useAppLayout();
   const { cycles, loading } = useCloudCycles();
   if (loading) {
     return <p className="text-sm text-slate-500">Loading cloud packages…</p>;
@@ -36,9 +37,15 @@ const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void 
         className="fg-touch mt-1 w-full rounded border border-slate-300/40 bg-transparent px-2 py-1"
         defaultValue=""
         onChange={(event) => {
-          const cycle = cycles.find((item) => item.id === event.target.value);
+          const value = event.target.value;
+          const cycle = cycles.find((item) => item.id === value);
           if (cycle) {
             onLoad(cycle.id, cycle.label ?? 'Cloud package');
+            return;
+          }
+          if (value) {
+            addToast('That cloud package is no longer available. Choose another package.', 'error');
+            event.target.value = '';
           }
         }}
       >
@@ -73,13 +80,18 @@ const ForecastGradeDashboard: React.FC = () => {
 
   const mapRef = useRef<VerificationMapHandle>(null);
   const mapPaneRef = useRef<HTMLDivElement>(null);
+  const cloudLoadSeqRef = useRef(0);
   const reportsVisible = useSelector((state: RootState) => state.stormReports.visible);
 
   const availableSources = availablePackageSources(grade.tier);
 
   const handleCloudLoad = useCallback(
     async (id: string, label: string) => {
+      const loadSeq = ++cloudLoadSeqRef.current;
       const payload = await loadCycle(id);
+      if (loadSeq !== cloudLoadSeqRef.current) {
+        return;
+      }
       if (!payload) {
         addToast('That cloud package could not be loaded.', 'error');
         return;

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -137,9 +137,6 @@ const ForecastGradeDashboard: React.FC = () => {
           activeMapLayer={grade.activeMapLayer}
           selectedDay={grade.selectedDay}
           availableDays={grade.availableDays}
-          reports={grade.reports}
-          selectedReportId={null}
-          activeComponent={null}
           result={grade.result}
           reportsVisible={reportsVisible}
           onSelectMapLayer={handleSelectMapLayer}

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -1,12 +1,252 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Eye, EyeOff } from 'lucide-react';
+import VerificationMap, { type VerificationMapHandle } from '../Map/VerificationMap';
+import { useAppLayout } from '../Layout/AppLayout';
+import { useCloudCycles } from '../../hooks/useCloudCycles';
+import { deserializeForecast } from '../../utils/fileUtils';
+import { setVisibility } from '../../store/stormReportsSlice';
+import type { RootState } from '../../store';
+import type { ProductKind } from '../../utils/verificationV2';
+import { availablePackageSources } from '../../utils/verificationV2/sources';
+import { useForecastGrade } from './useForecastGrade';
+import SourcePanel from './SourcePanel';
+import RunProgress from './RunProgress';
+import GradeHeadline from './GradeHeadline';
+import DataQualityPanel from './DataQualityPanel';
+import { formatGrade, letterColorClass } from './gradeFormat';
+import { METHODOLOGY_DOC_PATH } from './methodology';
+import './ForecastGradeDashboard.css';
+
+const MAP_PRODUCTS: ProductKind[] = ['categorical', 'tornado', 'wind', 'hail'];
+
+/** Premium cloud package picker rendered inside the source panel. */
+const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void }> = ({ onLoad }) => {
+  const { cycles, loading } = useCloudCycles();
+  if (loading) {
+    return <p className="text-sm text-slate-500">Loading cloud packages…</p>;
+  }
+  if (cycles.length === 0) {
+    return <p className="text-sm text-slate-500">No cloud packages saved yet.</p>;
+  }
+  return (
+    <label className="block text-sm">
+      <span className="font-medium">Cloud package</span>
+      <select
+        className="fg-touch mt-1 w-full rounded border border-slate-300/40 bg-transparent px-2 py-1"
+        defaultValue=""
+        onChange={(event) => {
+          const cycle = cycles.find((item) => item.id === event.target.value);
+          if (cycle) {
+            onLoad(cycle.id, cycle.label ?? 'Cloud package');
+          }
+        }}
+      >
+        <option value="" disabled>
+          Choose a saved package…
+        </option>
+        {cycles.map((cycle) => (
+          <option key={cycle.id} value={cycle.id}>
+            {cycle.label ?? cycle.id}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
 
 /**
- * Temporary stub so verificationRelaunch can wire the route/surfaces before the
- * real dashboard shell lands in the next stacked PR.
+ * Forecast Grade dashboard shell (PR 06 — dashboard-shell).
+ *
+ * Map-first evidence surface with an equal-weight results dashboard on desktop
+ * and a map-first compact overlay on mobile/landscape. Owns explicit source
+ * selection, staged run progress, the learn-fast grade headline, and the data
+ * quality gate. The detailed result workspace (breakdown, report table, trend,
+ * share) is layered on top in later PRs. Only mounts when verificationRelaunch
+ * is exposed; classic VerificationMode remains the default when the flag is off.
  */
-const ForecastGradeDashboard: React.FC = () => (
-  <div className="flex h-full items-center justify-center p-6" data-testid="forecast-grade-dashboard">
-    Forecast Grade dashboard
+const ForecastGradeDashboard: React.FC = () => {
+  const { addToast } = useAppLayout();
+  const dispatch = useDispatch();
+  const grade = useForecastGrade(addToast);
+  const { loadCycle } = useCloudCycles();
+
+  const mapRef = useRef<VerificationMapHandle>(null);
+  const mapPaneRef = useRef<HTMLDivElement>(null);
+  const reportsVisible = useSelector((state: RootState) => state.stormReports.visible);
+
+  const availableSources = availablePackageSources(grade.tier);
+
+  const handleCloudLoad = useCallback(
+    async (id: string, label: string) => {
+      const payload = await loadCycle(id);
+      if (!payload) {
+        addToast('That cloud package could not be loaded.', 'error');
+        return;
+      }
+      try {
+        grade.setForecastPackage(deserializeForecast(payload), 'cloud', `${label} (cloud)`);
+        addToast('Cloud package loaded. Choose a report date and grade.', 'success');
+      } catch {
+        addToast('That cloud package could not be parsed.', 'error');
+      }
+    },
+    [addToast, grade, loadCycle]
+  );
+
+  const showMap = Boolean(grade.forecast);
+
+  return (
+    <div className="fg-dashboard">
+      <div className="fg-topbar">
+        <div>
+          <h2 className="text-lg font-semibold">Forecast Grade</h2>
+          <p className="text-xs text-slate-500">
+            Map-first verification · formula gfc-ver-1 ·{' '}
+            <a className="text-blue-500 hover:underline" href={METHODOLOGY_DOC_PATH} target="_blank" rel="noreferrer">
+              Methodology
+            </a>
+          </p>
+        </div>
+      </div>
+
+      <div className="fg-workspace">
+        <div className="fg-map-pane" ref={mapPaneRef}>
+          {showMap ? (
+            <>
+              <VerificationMap
+                ref={mapRef}
+                activeOutlookType={grade.activeProduct as 'categorical' | 'tornado' | 'wind' | 'hail'}
+                selectedDay={grade.selectedDay}
+              />
+              <MapControls
+                activeProduct={grade.activeProduct}
+                onSelectProduct={grade.setActiveProduct}
+                availableDays={grade.availableDays}
+                selectedDay={grade.selectedDay}
+                onSelectDay={grade.setSelectedDay}
+                reportsVisible={reportsVisible}
+                onToggleEvidence={() => dispatch(setVisibility(!reportsVisible))}
+              />
+              {grade.result && (
+                <div className="fg-grade-overlay">
+                  <span className="text-2xl font-bold tabular-nums">{formatGrade(grade.result.grade)}</span>
+                  <span className={`text-xl font-bold ${letterColorClass(grade.result.letter)}`}>
+                    {grade.result.letter ?? '—'}
+                  </span>
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="flex h-full items-center justify-center p-6 text-center text-sm text-slate-500">
+              The map becomes the evidence surface once you load a package and grade a date.
+            </div>
+          )}
+        </div>
+
+        <div className="fg-results-pane">
+          <SourcePanel
+            tier={grade.tier}
+            availableSources={availableSources}
+            hasForecast={Boolean(grade.forecast)}
+            sourceLabel={grade.sourceLabel}
+            useToday={grade.useToday}
+            reportDate={grade.reportDate}
+            canRun={grade.canRun}
+            isRunning={grade.phase === 'running'}
+            error={grade.error}
+            onFile={grade.loadFromFile}
+            onUseTodayChange={grade.setUseToday}
+            onReportDateChange={grade.setReportDate}
+            onRun={grade.run}
+            onReset={grade.reset}
+            renderCloudSource={
+              availableSources.includes('cloud')
+                ? () => <CloudSourcePicker onLoad={handleCloudLoad} />
+                : undefined
+            }
+          />
+
+          {grade.phase === 'running' && (
+            <div className="mt-3">
+              <RunProgress progress={grade.progress} />
+            </div>
+          )}
+
+          {grade.result && (
+            <div className="mt-3">
+              <GradeHeadline
+                pkg={grade.result}
+                activeProduct={grade.activeProduct}
+                onSelectProduct={grade.setActiveProduct}
+              />
+              <DataQualityPanel pkg={grade.result} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface MapControlsProps {
+  activeProduct: ProductKind;
+  onSelectProduct: (product: ProductKind) => void;
+  availableDays: number[];
+  selectedDay: number;
+  onSelectDay: (day: never) => void;
+  reportsVisible: boolean;
+  onToggleEvidence: () => void;
+}
+
+/** Always-reachable map controls: hazard, day, and evidence. */
+const MapControls: React.FC<MapControlsProps> = ({
+  activeProduct,
+  onSelectProduct,
+  availableDays,
+  selectedDay,
+  onSelectDay,
+  reportsVisible,
+  onToggleEvidence,
+}) => (
+  <div className="absolute left-2 top-2 z-[5] flex flex-wrap items-center gap-1 rounded-lg bg-slate-900/75 p-1 text-xs text-white">
+    <div className="flex gap-1" role="group" aria-label="Hazard">
+      {MAP_PRODUCTS.map((product) => (
+        <button
+          key={product}
+          type="button"
+          className={`fg-touch rounded px-2 py-1 capitalize ${
+            activeProduct === product ? 'bg-blue-500' : 'bg-white/10'
+          }`}
+          onClick={() => onSelectProduct(product)}
+        >
+          {product === 'categorical' ? 'Cat' : product}
+        </button>
+      ))}
+    </div>
+    {availableDays.length > 1 && (
+      <select
+        className="fg-touch rounded bg-white/10 px-2 py-1"
+        value={selectedDay}
+        aria-label="Forecast day"
+        onChange={(event) => onSelectDay(Number(event.target.value) as never)}
+      >
+        {availableDays.map((day) => (
+          <option key={day} value={day} className="text-black">
+            Day {day}
+          </option>
+        ))}
+      </select>
+    )}
+    <button
+      type="button"
+      className="fg-touch inline-flex items-center gap-1 rounded bg-white/10 px-2 py-1"
+      onClick={onToggleEvidence}
+      aria-pressed={reportsVisible}
+    >
+      {reportsVisible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+      Evidence
+    </button>
   </div>
 );
 

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -1,24 +1,21 @@
 import React, { useCallback, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Eye, EyeOff } from 'lucide-react';
-import VerificationMap, { type VerificationMapHandle } from '../Map/VerificationMap';
+import type { VerificationMapHandle } from '../Map/VerificationMap';
 import { useAppLayout } from '../Layout/AppLayout';
 import { useCloudCycles } from '../../hooks/useCloudCycles';
 import { deserializeForecast } from '../../utils/fileUtils';
 import { setVisibility } from '../../store/stormReportsSlice';
 import type { RootState } from '../../store';
-import type { ProductKind } from '../../utils/verificationV2';
+import type { MapOutlookLayer, ProductKind } from '../../utils/verificationV2';
 import { availablePackageSources } from '../../utils/verificationV2/sources';
 import { useForecastGrade } from './useForecastGrade';
 import SourcePanel from './SourcePanel';
 import RunProgress from './RunProgress';
 import GradeHeadline from './GradeHeadline';
 import DataQualityPanel from './DataQualityPanel';
-import { formatGrade, letterColorClass } from './gradeFormat';
+import ForecastGradeMapPane from './ForecastGradeMapPane';
 import { METHODOLOGY_DOC_PATH } from './methodology';
 import './ForecastGradeDashboard.css';
-
-const MAP_PRODUCTS: ProductKind[] = ['categorical', 'tornado', 'wind', 'hail'];
 
 /** Premium cloud package picker rendered inside the source panel. */
 const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void }> = ({ onLoad }) => {
@@ -65,12 +62,8 @@ const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void 
 /**
  * Forecast Grade dashboard shell (PR 06 — dashboard-shell).
  *
- * Map-first evidence surface with an equal-weight results dashboard on desktop
- * and a map-first compact overlay on mobile/landscape. Owns explicit source
- * selection, staged run progress, the learn-fast grade headline, and the data
- * quality gate. The detailed result workspace (breakdown, report table, trend,
- * share) is layered on top in later PRs. Only mounts when verificationRelaunch
- * is exposed; classic VerificationMode remains the default when the flag is off.
+ * Map-first evidence surface with graded severe-hazard products only. Categorical
+ * remains the default map layer for context but is not scored.
  */
 const ForecastGradeDashboard: React.FC = () => {
   const { addToast } = useAppLayout();
@@ -106,7 +99,23 @@ const ForecastGradeDashboard: React.FC = () => {
     [addToast, grade, loadCycle]
   );
 
-  const showMap = Boolean(grade.forecast);
+  const handleSelectProduct = useCallback(
+    (product: ProductKind) => {
+      grade.setActiveProduct(product);
+      grade.setActiveMapLayer(product);
+    },
+    [grade]
+  );
+
+  const handleSelectMapLayer = useCallback(
+    (layer: MapOutlookLayer) => {
+      grade.setActiveMapLayer(layer);
+      if (layer !== 'categorical') {
+        grade.setActiveProduct(layer);
+      }
+    },
+    [grade]
+  );
 
   return (
     <div className="fg-dashboard">
@@ -123,38 +132,22 @@ const ForecastGradeDashboard: React.FC = () => {
       </div>
 
       <div className="fg-workspace">
-        <div className="fg-map-pane" ref={mapPaneRef}>
-          {showMap ? (
-            <>
-              <VerificationMap
-                ref={mapRef}
-                activeOutlookType={grade.activeProduct as 'categorical' | 'tornado' | 'wind' | 'hail'}
-                selectedDay={grade.selectedDay}
-              />
-              <MapControls
-                activeProduct={grade.activeProduct}
-                onSelectProduct={grade.setActiveProduct}
-                availableDays={grade.availableDays}
-                selectedDay={grade.selectedDay}
-                onSelectDay={grade.setSelectedDay}
-                reportsVisible={reportsVisible}
-                onToggleEvidence={() => dispatch(setVisibility(!reportsVisible))}
-              />
-              {grade.result && (
-                <div className="fg-grade-overlay">
-                  <span className="text-2xl font-bold tabular-nums">{formatGrade(grade.result.grade)}</span>
-                  <span className={`text-xl font-bold ${letterColorClass(grade.result.letter)}`}>
-                    {grade.result.letter ?? '—'}
-                  </span>
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="flex h-full items-center justify-center p-6 text-center text-sm text-slate-500">
-              The map becomes the evidence surface once you load a package and grade a date.
-            </div>
-          )}
-        </div>
+        <ForecastGradeMapPane
+          forecastLoaded={Boolean(grade.forecast)}
+          activeMapLayer={grade.activeMapLayer}
+          selectedDay={grade.selectedDay}
+          availableDays={grade.availableDays}
+          reports={grade.reports}
+          selectedReportId={null}
+          activeComponent={null}
+          result={grade.result}
+          reportsVisible={reportsVisible}
+          onSelectMapLayer={handleSelectMapLayer}
+          onSelectDay={grade.setSelectedDay}
+          onToggleEvidence={() => dispatch(setVisibility(!reportsVisible))}
+          mapPaneRef={mapPaneRef}
+          mapRef={mapRef}
+        />
 
         <div className="fg-results-pane">
           <SourcePanel
@@ -190,7 +183,7 @@ const ForecastGradeDashboard: React.FC = () => {
               <GradeHeadline
                 pkg={grade.result}
                 activeProduct={grade.activeProduct}
-                onSelectProduct={grade.setActiveProduct}
+                onSelectProduct={handleSelectProduct}
               />
               <DataQualityPanel pkg={grade.result} />
             </div>
@@ -200,66 +193,5 @@ const ForecastGradeDashboard: React.FC = () => {
     </div>
   );
 };
-
-interface MapControlsProps {
-  activeProduct: ProductKind;
-  onSelectProduct: (product: ProductKind) => void;
-  availableDays: number[];
-  selectedDay: number;
-  onSelectDay: (day: never) => void;
-  reportsVisible: boolean;
-  onToggleEvidence: () => void;
-}
-
-/** Always-reachable map controls: hazard, day, and evidence. */
-const MapControls: React.FC<MapControlsProps> = ({
-  activeProduct,
-  onSelectProduct,
-  availableDays,
-  selectedDay,
-  onSelectDay,
-  reportsVisible,
-  onToggleEvidence,
-}) => (
-  <div className="absolute left-2 top-2 z-[5] flex flex-wrap items-center gap-1 rounded-lg bg-slate-900/75 p-1 text-xs text-white">
-    <div className="flex gap-1" role="group" aria-label="Hazard">
-      {MAP_PRODUCTS.map((product) => (
-        <button
-          key={product}
-          type="button"
-          className={`fg-touch rounded px-2 py-1 capitalize ${
-            activeProduct === product ? 'bg-blue-500' : 'bg-white/10'
-          }`}
-          onClick={() => onSelectProduct(product)}
-        >
-          {product === 'categorical' ? 'Cat' : product}
-        </button>
-      ))}
-    </div>
-    {availableDays.length > 1 && (
-      <select
-        className="fg-touch rounded bg-white/10 px-2 py-1"
-        value={selectedDay}
-        aria-label="Forecast day"
-        onChange={(event) => onSelectDay(Number(event.target.value) as never)}
-      >
-        {availableDays.map((day) => (
-          <option key={day} value={day} className="text-black">
-            Day {day}
-          </option>
-        ))}
-      </select>
-    )}
-    <button
-      type="button"
-      className="fg-touch inline-flex items-center gap-1 rounded bg-white/10 px-2 py-1"
-      onClick={onToggleEvidence}
-      aria-pressed={reportsVisible}
-    >
-      {reportsVisible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
-      Evidence
-    </button>
-  </div>
-);
 
 export default ForecastGradeDashboard;

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -8,7 +8,7 @@ import { setVisibility } from '../../store/stormReportsSlice';
 import type { RootState } from '../../store';
 import type { MapOutlookLayer, ProductKind } from '../../utils/verificationV2';
 import { availablePackageSources } from '../../utils/verificationV2/sources';
-import { useForecastGrade } from './useForecastGrade';
+import { useForecastGrade, type UseForecastGrade } from './useForecastGrade';
 import SourcePanel from './SourcePanel';
 import RunProgress from './RunProgress';
 import GradeHeadline from './GradeHeadline';
@@ -58,6 +58,88 @@ const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void 
     </label>
   );
 };
+
+interface ForecastGradeTopbarProps {
+  methodologyPath: string;
+}
+
+/** Title row with the formula version and methodology link. */
+const ForecastGradeTopbar: React.FC<ForecastGradeTopbarProps> = ({ methodologyPath }) => (
+  <div className="fg-topbar">
+    <div>
+      <h2 className="text-lg font-semibold">Forecast Grade</h2>
+      <p className="text-xs text-slate-500">
+        Map-first verification · formula gfc-ver-1 ·{' '}
+        <a className="text-blue-500 hover:underline" href={methodologyPath} target="_blank" rel="noreferrer">
+          Methodology
+        </a>
+      </p>
+    </div>
+  </div>
+);
+
+interface ForecastGradeResultsPaneProps {
+  grade: UseForecastGrade;
+  availableSources: ReturnType<typeof availablePackageSources>;
+  reportsVisible: boolean;
+  onToggleEvidence: () => void;
+  onFile: (file: File) => void;
+  onCloudLoad: (id: string, label: string) => void;
+  onReset: () => void;
+  onSelectProduct: (product: ProductKind) => void;
+}
+
+/** Right rail: source panel, run progress, and grade results. */
+const ForecastGradeResultsPane: React.FC<ForecastGradeResultsPaneProps> = ({
+  grade,
+  availableSources,
+  onFile,
+  onCloudLoad,
+  onReset,
+  onSelectProduct,
+  onToggleEvidence,
+}) => (
+  <div className="fg-results-pane">
+    <SourcePanel
+      tier={grade.tier}
+      availableSources={availableSources}
+      hasForecast={Boolean(grade.forecast)}
+      sourceLabel={grade.sourceLabel}
+      useToday={grade.useToday}
+      reportDate={grade.reportDate}
+      canRun={grade.canRun}
+      isRunning={grade.phase === 'running'}
+      error={grade.error}
+      onFile={onFile}
+      onUseTodayChange={grade.setUseToday}
+      onReportDateChange={grade.setReportDate}
+      onRun={grade.run}
+      onReset={onReset}
+      renderCloudSource={
+        availableSources.includes('cloud')
+          ? () => <CloudSourcePicker onLoad={onCloudLoad} />
+          : undefined
+      }
+    />
+
+    {grade.phase === 'running' && (
+      <div className="mt-3">
+        <RunProgress progress={grade.progress} />
+      </div>
+    )}
+
+    {grade.result && (
+      <div className="mt-3">
+        <GradeHeadline
+          pkg={grade.result}
+          activeProduct={grade.activeProduct}
+          onSelectProduct={onSelectProduct}
+        />
+        <DataQualityPanel pkg={grade.result} />
+      </div>
+    )}
+  </div>
+);
 
 /**
  * Forecast Grade dashboard shell (PR 06 — dashboard-shell).
@@ -132,19 +214,14 @@ const ForecastGradeDashboard: React.FC = () => {
     [grade]
   );
 
+  const handleToggleEvidence = useCallback(
+    () => dispatch(setVisibility(!reportsVisible)),
+    [dispatch, reportsVisible]
+  );
+
   return (
     <div className="fg-dashboard">
-      <div className="fg-topbar">
-        <div>
-          <h2 className="text-lg font-semibold">Forecast Grade</h2>
-          <p className="text-xs text-slate-500">
-            Map-first verification · formula gfc-ver-1 ·{' '}
-            <a className="text-blue-500 hover:underline" href={METHODOLOGY_DOC_PATH} target="_blank" rel="noreferrer">
-              Methodology
-            </a>
-          </p>
-        </div>
-      </div>
+      <ForecastGradeTopbar methodologyPath={METHODOLOGY_DOC_PATH} />
 
       <div className="fg-workspace">
         <ForecastGradeMapPane
@@ -156,51 +233,21 @@ const ForecastGradeDashboard: React.FC = () => {
           reportsVisible={reportsVisible}
           onSelectMapLayer={handleSelectMapLayer}
           onSelectDay={grade.setSelectedDay}
-          onToggleEvidence={() => dispatch(setVisibility(!reportsVisible))}
+          onToggleEvidence={handleToggleEvidence}
           mapPaneRef={mapPaneRef}
           mapRef={mapRef}
         />
 
-        <div className="fg-results-pane">
-          <SourcePanel
-            tier={grade.tier}
-            availableSources={availableSources}
-            hasForecast={Boolean(grade.forecast)}
-            sourceLabel={grade.sourceLabel}
-            useToday={grade.useToday}
-            reportDate={grade.reportDate}
-            canRun={grade.canRun}
-            isRunning={grade.phase === 'running'}
-            error={grade.error}
-            onFile={handleFileLoad}
-            onUseTodayChange={grade.setUseToday}
-            onReportDateChange={grade.setReportDate}
-            onRun={grade.run}
-            onReset={handleReset}
-            renderCloudSource={
-              availableSources.includes('cloud')
-                ? () => <CloudSourcePicker onLoad={handleCloudLoad} />
-                : undefined
-            }
-          />
-
-          {grade.phase === 'running' && (
-            <div className="mt-3">
-              <RunProgress progress={grade.progress} />
-            </div>
-          )}
-
-          {grade.result && (
-            <div className="mt-3">
-              <GradeHeadline
-                pkg={grade.result}
-                activeProduct={grade.activeProduct}
-                onSelectProduct={handleSelectProduct}
-              />
-              <DataQualityPanel pkg={grade.result} />
-            </div>
-          )}
-        </div>
+        <ForecastGradeResultsPane
+          grade={grade}
+          availableSources={availableSources}
+          reportsVisible={reportsVisible}
+          onToggleEvidence={handleToggleEvidence}
+          onFile={handleFileLoad}
+          onCloudLoad={handleCloudLoad}
+          onReset={handleReset}
+          onSelectProduct={handleSelectProduct}
+        />
       </div>
     </div>
   );

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -73,16 +73,18 @@ const ForecastGradeDashboard: React.FC = () => {
 
   const mapRef = useRef<VerificationMapHandle>(null);
   const mapPaneRef = useRef<HTMLDivElement>(null);
-  const cloudLoadSeqRef = useRef(0);
+  // Shared sequence bumped by every package-loading and reset path so an in-flight
+  // cloud load cannot overwrite a newer file (or vice versa).
+  const packageLoadSeqRef = useRef(0);
   const reportsVisible = useSelector((state: RootState) => state.stormReports.visible);
 
   const availableSources = availablePackageSources(grade.tier);
 
   const handleCloudLoad = useCallback(
     async (id: string, label: string) => {
-      const loadSeq = ++cloudLoadSeqRef.current;
+      const loadSeq = ++packageLoadSeqRef.current;
       const payload = await loadCycle(id);
-      if (loadSeq !== cloudLoadSeqRef.current) {
+      if (loadSeq !== packageLoadSeqRef.current) {
         return;
       }
       if (!payload) {
@@ -98,6 +100,19 @@ const ForecastGradeDashboard: React.FC = () => {
     },
     [addToast, grade, loadCycle]
   );
+
+  const handleFileLoad = useCallback(
+    (file: File) => {
+      packageLoadSeqRef.current += 1;
+      void grade.loadFromFile(file);
+    },
+    [grade]
+  );
+
+  const handleReset = useCallback(() => {
+    packageLoadSeqRef.current += 1;
+    grade.reset();
+  }, [grade]);
 
   const handleSelectProduct = useCallback(
     (product: ProductKind) => {
@@ -157,11 +172,11 @@ const ForecastGradeDashboard: React.FC = () => {
             canRun={grade.canRun}
             isRunning={grade.phase === 'running'}
             error={grade.error}
-            onFile={grade.loadFromFile}
+            onFile={handleFileLoad}
             onUseTodayChange={grade.setUseToday}
             onReportDateChange={grade.setReportDate}
             onRun={grade.run}
-            onReset={grade.reset}
+            onReset={handleReset}
             renderCloudSource={
               availableSources.includes('cloud')
                 ? () => <CloudSourcePicker onLoad={handleCloudLoad} />

--- a/src/components/ForecastGrade/ForecastGradeMapControls.tsx
+++ b/src/components/ForecastGrade/ForecastGradeMapControls.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { MAP_OUTLOOK_LAYERS, type MapOutlookLayer } from '../../utils/verificationV2';
+
+interface ForecastGradeMapControlsProps {
+  activeMapLayer: MapOutlookLayer;
+  onSelectMapLayer: (layer: MapOutlookLayer) => void;
+  availableDays: number[];
+  selectedDay: number;
+  onSelectDay: (day: never) => void;
+  reportsVisible: boolean;
+  onToggleEvidence: () => void;
+}
+
+/** Always-reachable map controls: outlook layer, day, and evidence. */
+const ForecastGradeMapControls: React.FC<ForecastGradeMapControlsProps> = ({
+  activeMapLayer,
+  onSelectMapLayer,
+  availableDays,
+  selectedDay,
+  onSelectDay,
+  reportsVisible,
+  onToggleEvidence,
+}) => (
+  <div className="absolute left-2 top-2 z-[5] flex flex-wrap items-center gap-1 rounded-lg bg-slate-900/75 p-1 text-xs text-white">
+    <div className="flex gap-1" role="group" aria-label="Outlook layer">
+      {MAP_OUTLOOK_LAYERS.map((layer) => (
+        <button
+          key={layer}
+          type="button"
+          className={`fg-touch rounded px-2 py-1 capitalize ${
+            activeMapLayer === layer ? 'bg-blue-500' : 'bg-white/10'
+          }`}
+          onClick={() => onSelectMapLayer(layer)}
+        >
+          {layer === 'categorical' ? 'Cat' : layer}
+        </button>
+      ))}
+    </div>
+    {availableDays.length > 1 && (
+      <select
+        className="fg-touch rounded bg-white/10 px-2 py-1"
+        value={selectedDay}
+        aria-label="Forecast day"
+        onChange={(event) => onSelectDay(Number(event.target.value) as never)}
+      >
+        {availableDays.map((day) => (
+          <option key={day} value={day} className="text-black">
+            Day {day}
+          </option>
+        ))}
+      </select>
+    )}
+    <button
+      type="button"
+      className="fg-touch inline-flex items-center gap-1 rounded bg-white/10 px-2 py-1"
+      onClick={onToggleEvidence}
+      aria-pressed={reportsVisible}
+    >
+      {reportsVisible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+      Evidence
+    </button>
+  </div>
+);
+
+export default ForecastGradeMapControls;

--- a/src/components/ForecastGrade/ForecastGradeMapPane.tsx
+++ b/src/components/ForecastGrade/ForecastGradeMapPane.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useRef } from 'react';
+import { fromLonLat } from 'ol/proj';
+import VerificationMap, { type VerificationMapHandle } from '../Map/VerificationMap';
+import type { StormReport } from '../../types/stormReports';
+import type { ComponentKey, MapOutlookLayer, PackageGrade } from '../../utils/verificationV2';
+import ForecastGradeMapControls from './ForecastGradeMapControls';
+import { formatGrade, letterColorClass } from './gradeFormat';
+
+interface ForecastGradeMapPaneProps {
+  forecastLoaded: boolean;
+  activeMapLayer: MapOutlookLayer;
+  selectedDay: number;
+  availableDays: number[];
+  reports: StormReport[];
+  selectedReportId: string | null;
+  activeComponent: ComponentKey | null;
+  result: PackageGrade | null;
+  reportsVisible: boolean;
+  onSelectMapLayer: (layer: MapOutlookLayer) => void;
+  onSelectDay: (day: never) => void;
+  onToggleEvidence: () => void;
+  onSelectReportId?: (reportId: string | null) => void;
+  mapPaneRef: React.RefObject<HTMLDivElement>;
+  mapRef: React.RefObject<VerificationMapHandle>;
+}
+
+const ForecastGradeMapPane: React.FC<ForecastGradeMapPaneProps> = ({
+  forecastLoaded,
+  activeMapLayer,
+  selectedDay,
+  availableDays,
+  reports,
+  selectedReportId,
+  activeComponent,
+  result,
+  reportsVisible,
+  onSelectMapLayer,
+  onSelectDay,
+  onToggleEvidence,
+  onSelectReportId,
+  mapPaneRef,
+  mapRef,
+}) => {
+  useEffect(() => {
+    if (!selectedReportId) {
+      return;
+    }
+    const report = reports.find((entry) => entry.id === selectedReportId);
+    const map = mapRef.current?.getMap();
+    if (!report || !map) {
+      return;
+    }
+    map.getView().animate({
+      center: fromLonLat([report.longitude, report.latitude]),
+      duration: 250,
+    });
+  }, [mapRef, reports, selectedReportId]);
+
+  return (
+    <div className="fg-map-pane" ref={mapPaneRef} data-emphasis-component={activeComponent ?? undefined}>
+      {forecastLoaded ? (
+        <>
+          <VerificationMap
+            ref={mapRef}
+            activeOutlookType={activeMapLayer}
+            selectedDay={selectedDay}
+            highlightedReportId={selectedReportId}
+            emphasisComponent={activeComponent}
+            onSelectReportId={onSelectReportId}
+          />
+          <ForecastGradeMapControls
+            activeMapLayer={activeMapLayer}
+            onSelectMapLayer={onSelectMapLayer}
+            availableDays={availableDays}
+            selectedDay={selectedDay}
+            onSelectDay={onSelectDay}
+            reportsVisible={reportsVisible}
+            onToggleEvidence={onToggleEvidence}
+          />
+          {result && (
+            <div className="fg-grade-overlay">
+              <span className="text-2xl font-bold tabular-nums">{formatGrade(result.grade)}</span>
+              <span className={`text-xl font-bold ${letterColorClass(result.letter)}`}>
+                {result.letter ?? '—'}
+              </span>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex h-full items-center justify-center p-6 text-center text-sm text-slate-500">
+          The map becomes the evidence surface once you load a package and grade a date.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ForecastGradeMapPane;

--- a/src/components/ForecastGrade/ForecastGradeMapPane.tsx
+++ b/src/components/ForecastGrade/ForecastGradeMapPane.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useRef } from 'react';
-import { fromLonLat } from 'ol/proj';
+import React from 'react';
 import VerificationMap, { type VerificationMapHandle } from '../Map/VerificationMap';
-import type { StormReport } from '../../types/stormReports';
-import type { ComponentKey, MapOutlookLayer, PackageGrade } from '../../utils/verificationV2';
+import type { DayType } from '../../types/outlooks';
+import type { MapOutlookLayer, PackageGrade } from '../../utils/verificationV2';
 import ForecastGradeMapControls from './ForecastGradeMapControls';
 import { formatGrade, letterColorClass } from './gradeFormat';
 
@@ -11,88 +10,57 @@ interface ForecastGradeMapPaneProps {
   activeMapLayer: MapOutlookLayer;
   selectedDay: DayType;
   availableDays: DayType[];
-  reports: StormReport[];
-  selectedReportId: string | null;
-  activeComponent: ComponentKey | null;
   result: PackageGrade | null;
   reportsVisible: boolean;
   onSelectMapLayer: (layer: MapOutlookLayer) => void;
   onSelectDay: (day: never) => void;
   onToggleEvidence: () => void;
-  onSelectReportId?: (reportId: string | null) => void;
   mapPaneRef: React.RefObject<HTMLDivElement | null>;
   mapRef: React.RefObject<VerificationMapHandle | null>;
 }
 
+/** Map-first evidence surface for the dashboard shell (PR 06c). */
 const ForecastGradeMapPane: React.FC<ForecastGradeMapPaneProps> = ({
   forecastLoaded,
   activeMapLayer,
   selectedDay,
   availableDays,
-  reports,
-  selectedReportId,
-  activeComponent,
   result,
   reportsVisible,
   onSelectMapLayer,
   onSelectDay,
   onToggleEvidence,
-  onSelectReportId,
   mapPaneRef,
   mapRef,
-}) => {
-  useEffect(() => {
-    if (!selectedReportId) {
-      return;
-    }
-    const report = reports.find((entry) => entry.id === selectedReportId);
-    const map = mapRef.current?.getMap();
-    if (!report || !map) {
-      return;
-    }
-    map.getView().animate({
-      center: fromLonLat([report.longitude, report.latitude]),
-      duration: 250,
-    });
-  }, [mapRef, reports, selectedReportId]);
-
-  return (
-    <div className="fg-map-pane" ref={mapPaneRef} data-emphasis-component={activeComponent ?? undefined}>
-      {forecastLoaded ? (
-        <>
-          <VerificationMap
-            ref={mapRef}
-            activeOutlookType={activeMapLayer}
-            selectedDay={selectedDay}
-            highlightedReportId={selectedReportId}
-            emphasisComponent={activeComponent}
-            onSelectReportId={onSelectReportId}
-          />
-          <ForecastGradeMapControls
-            activeMapLayer={activeMapLayer}
-            onSelectMapLayer={onSelectMapLayer}
-            availableDays={availableDays}
-            selectedDay={selectedDay}
-            onSelectDay={onSelectDay}
-            reportsVisible={reportsVisible}
-            onToggleEvidence={onToggleEvidence}
-          />
-          {result && (
-            <div className="fg-grade-overlay">
-              <span className="text-2xl font-bold tabular-nums">{formatGrade(result.grade)}</span>
-              <span className={`text-xl font-bold ${letterColorClass(result.letter)}`}>
-                {result.letter ?? '—'}
-              </span>
-            </div>
-          )}
-        </>
-      ) : (
-        <div className="flex h-full items-center justify-center p-6 text-center text-sm text-slate-500">
-          The map becomes the evidence surface once you load a package and grade a date.
-        </div>
-      )}
-    </div>
-  );
-};
+}) => (
+  <div className="fg-map-pane" ref={mapPaneRef}>
+    {forecastLoaded ? (
+      <>
+        <VerificationMap ref={mapRef} activeOutlookType={activeMapLayer} selectedDay={selectedDay} />
+        <ForecastGradeMapControls
+          activeMapLayer={activeMapLayer}
+          onSelectMapLayer={onSelectMapLayer}
+          availableDays={availableDays}
+          selectedDay={selectedDay}
+          onSelectDay={onSelectDay}
+          reportsVisible={reportsVisible}
+          onToggleEvidence={onToggleEvidence}
+        />
+        {result && (
+          <div className="fg-grade-overlay">
+            <span className="text-2xl font-bold tabular-nums">{formatGrade(result.grade)}</span>
+            <span className={`text-xl font-bold ${letterColorClass(result.letter)}`}>
+              {result.letter ?? '—'}
+            </span>
+          </div>
+        )}
+      </>
+    ) : (
+      <div className="flex h-full items-center justify-center p-6 text-center text-sm text-slate-500">
+        The map becomes the evidence surface once you load a package and grade a date.
+      </div>
+    )}
+  </div>
+);
 
 export default ForecastGradeMapPane;

--- a/src/components/ForecastGrade/ForecastGradeMapPane.tsx
+++ b/src/components/ForecastGrade/ForecastGradeMapPane.tsx
@@ -9,8 +9,8 @@ import { formatGrade, letterColorClass } from './gradeFormat';
 interface ForecastGradeMapPaneProps {
   forecastLoaded: boolean;
   activeMapLayer: MapOutlookLayer;
-  selectedDay: number;
-  availableDays: number[];
+  selectedDay: DayType;
+  availableDays: DayType[];
   reports: StormReport[];
   selectedReportId: string | null;
   activeComponent: ComponentKey | null;
@@ -20,8 +20,8 @@ interface ForecastGradeMapPaneProps {
   onSelectDay: (day: never) => void;
   onToggleEvidence: () => void;
   onSelectReportId?: (reportId: string | null) => void;
-  mapPaneRef: React.RefObject<HTMLDivElement>;
-  mapRef: React.RefObject<VerificationMapHandle>;
+  mapPaneRef: React.RefObject<HTMLDivElement | null>;
+  mapRef: React.RefObject<VerificationMapHandle | null>;
 }
 
 const ForecastGradeMapPane: React.FC<ForecastGradeMapPaneProps> = ({

--- a/src/components/ForecastGrade/useForecastGrade.test.tsx
+++ b/src/components/ForecastGrade/useForecastGrade.test.tsx
@@ -15,6 +15,7 @@ jest.mock('../../billing/EntitlementProvider', () => ({
 
 jest.mock('../../utils/fileUtils', () => ({
   serializeForecast: jest.fn(() => ({ kind: 'serialized' })),
+  deserializeForecast: jest.fn((payload: unknown) => payload),
 }));
 
 jest.mock('../../utils/verificationV2/sources', () => ({
@@ -57,7 +58,7 @@ jest.mock('../../utils/verificationV2', () => {
 
 import { useAuth } from '../../auth/AuthProvider';
 import { useEntitlement } from '../../billing/EntitlementProvider';
-import { serializeForecast } from '../../utils/fileUtils';
+import { deserializeForecast, serializeForecast } from '../../utils/fileUtils';
 import {
   buildGradeCard,
   loadForecastFromFile,
@@ -84,6 +85,7 @@ const mockRecordGradeResult = recordGradeResult as jest.MockedFunction<typeof re
 const mockBuildGradeCard = buildGradeCard as jest.MockedFunction<typeof buildGradeCard>;
 const mockTierHasSnapshots = tierHasSnapshots as jest.MockedFunction<typeof tierHasSnapshots>;
 const mockSerializeForecast = serializeForecast as jest.MockedFunction<typeof serializeForecast>;
+const mockDeserializeForecast = deserializeForecast as jest.MockedFunction<typeof deserializeForecast>;
 const mockLoadReportsForDate = loadReportsForDate as jest.MockedFunction<typeof loadReportsForDate>;
 const mockLoadForecastFromFile = loadForecastFromFile as jest.MockedFunction<typeof loadForecastFromFile>;
 
@@ -505,6 +507,71 @@ describe('useForecastGrade', () => {
       expect(result.current.phase).toBe('idle');
       expect(result.current.result).toBeNull();
       expect(result.current.forecast).toEqual(secondCycle);
+    });
+
+    test('applyGradeSnapshot during an in-flight run ignores the late completion', async () => {
+      const resolveLoad = beginInFlightReportLoad();
+      const { result } = renderWithPackage();
+
+      let runPromise: Promise<void> | undefined;
+      act(() => {
+        runPromise = result.current.run();
+      });
+
+      const snapshot = {
+        card: { id: 'card-snap', sourceLabel: 'Cloud snapshot' },
+        package: samplePackage,
+        forecast: { kind: 'serialized-snap' },
+        reportDate: '2026-07-28',
+      } as never;
+      act(() => {
+        result.current.applyGradeSnapshot(snapshot);
+      });
+
+      await act(async () => {
+        resolveLoad();
+        await runPromise;
+      });
+
+      expect(result.current.phase).toBe('complete');
+      expect(result.current.result).not.toBeNull();
+    });
+
+    test('run during an in-flight applyGradeSnapshot ignores the late report load', async () => {
+      let resolveReports: ((value: typeof sampleReports) => void) | null = null;
+      mockLoadReportsForDate.mockImplementationOnce(
+        () => new Promise<typeof sampleReports>((resolve) => {
+          resolveReports = resolve;
+        })
+      );
+      // Make the snapshot deserialize to a real cycle so run() can read forecast.days.
+      mockDeserializeForecast.mockReturnValueOnce(sampleCycle);
+      const { result, store } = renderWithPackage();
+
+      const snapshot = {
+        card: { id: 'card-snap', sourceLabel: 'Cloud snapshot' },
+        package: samplePackage,
+        forecast: { kind: 'serialized-snap' },
+        reportDate: '2026-07-28',
+      } as never;
+      act(() => {
+        result.current.applyGradeSnapshot(snapshot);
+      });
+
+      const reportsBeforeRun = store.getState().stormReports.reports;
+      expect(result.current.reports).toEqual(reportsBeforeRun);
+
+      let runPromise: Promise<void> | undefined;
+      act(() => {
+        runPromise = result.current.run();
+      });
+
+      await act(async () => {
+        resolveReports?.(sampleReports);
+        await runPromise;
+      });
+
+      expect(result.current.reports).toEqual(sampleReports);
     });
   });
 

--- a/src/components/ForecastGrade/useForecastGrade.ts
+++ b/src/components/ForecastGrade/useForecastGrade.ts
@@ -7,12 +7,12 @@ import { setReports, clearReports, setDate } from '../../store/stormReportsSlice
 import type { ForecastCycle, DayType } from '../../types/outlooks';
 import type { StormReport } from '../../types/stormReports';
 import type { GradeAccountTier, GradeCard, GradeSnapshot, PackageSourceKind } from '../../types/forecastGrade';
-import { serializeForecast } from '../../utils/fileUtils';
+import { serializeForecast, deserializeForecast } from '../../utils/fileUtils';
 import {
   FORECAST_GRADE_FORMULA_VERSION,
-  isReachedArchiveDate,
   runForecastGrade,
   validateGradeInputs,
+  type MapOutlookLayer,
   type PackageGrade,
   type ProductKind,
   type GradeProgress,
@@ -41,9 +41,6 @@ import {
 
 type RunPhase = 'idle' | 'running' | 'complete';
 
-const hasReachedReportDate = (useToday: boolean, reportDate: string): boolean =>
-  useToday || isReachedArchiveDate(reportDate);
-
 const daysWithData = (forecast: ForecastCycle | null): DayType[] => {
   if (!forecast?.days) {
     return [];
@@ -62,6 +59,7 @@ export interface ForecastGradeState {
   selectedDay: DayType;
   reportDate: string;
   useToday: boolean;
+  activeMapLayer: MapOutlookLayer;
   activeProduct: ProductKind;
   phase: RunPhase;
   progress: GradeProgress | null;
@@ -77,10 +75,12 @@ export interface UseForecastGrade extends ForecastGradeState {
   setReportDate: (value: string) => void;
   setUseToday: (value: boolean) => void;
   setSelectedDay: (day: DayType) => void;
+  setActiveMapLayer: (layer: MapOutlookLayer) => void;
   setActiveProduct: (product: ProductKind) => void;
   run: () => Promise<void>;
   reset: () => void;
   restoreCard: (card: GradeCard) => GradeSnapshot | null;
+  applyGradeSnapshot: (snapshot: GradeSnapshot) => void;
   canRun: boolean;
 }
 
@@ -99,6 +99,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   const [selectedDay, setSelectedDayState] = useState<DayType>(1);
   const [reportDate, setReportDateState] = useState('');
   const [useToday, setUseToday] = useState(true);
+  const [activeMapLayer, setActiveMapLayer] = useState<MapOutlookLayer>('categorical');
   const [activeProduct, setActiveProduct] = useState<ProductKind>('tornado');
   const [phase, setPhase] = useState<RunPhase>('idle');
   const [progress, setProgress] = useState<GradeProgress | null>(null);
@@ -106,8 +107,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   const [error, setError] = useState<string | null>(null);
   const [cards, setCards] = useState<GradeCard[]>([]);
   const [reports, setReportsState] = useState<StormReport[]>([]);
-
-  const runGeneration = useRef(0);
+  const restoreSeqRef = useRef(0);
 
   useEffect(() => {
     setCards(loadGradeCards(scope));
@@ -115,7 +115,6 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
 
   const setForecastPackage = useCallback(
     (nextForecast: ForecastCycle, source: PackageSourceKind, label: string) => {
-      runGeneration.current += 1;
       const days = daysWithData(nextForecast);
       setForecast(nextForecast);
       setPackageSource(source);
@@ -153,28 +152,17 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   }, []);
 
   const canRun =
-    Boolean(forecast) &&
-    phase !== 'running' &&
-    hasReachedReportDate(useToday, reportDate);
+    Boolean(forecast) && phase !== 'running' && (useToday || reportDate.trim().length > 0);
 
   const run = useCallback(async () => {
     if (!forecast) {
       addToast('Load a forecast package first.', 'error');
       return;
     }
-    if (!hasReachedReportDate(useToday, reportDate)) {
-      const message = useToday
-        ? 'Choose a report date or enable "use today" before grading.'
-        : 'Choose a real, reached report date before grading.';
-      setError(message);
-      addToast(message, 'error');
-      return;
-    }
     const day = forecast.days[selectedDay];
     const outlooks = day?.data ?? { tornado: new Map(), wind: new Map(), hail: new Map(), categorical: new Map() };
     const effectiveDate = useToday ? null : reportDate;
 
-    const generation = ++runGeneration.current;
     setPhase('running');
     setError(null);
     setProgress({ fraction: 0, label: 'Loading storm reports…' });
@@ -183,18 +171,11 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     try {
       loadedReports = await loadReportsForDate(effectiveDate);
     } catch (loadError) {
-      if (generation !== runGeneration.current) {
-        return;
-      }
       const message = loadError instanceof SourceLoadError ? loadError.message : 'Reports could not be loaded.';
       setError(message);
       setPhase('idle');
       setProgress(null);
       addToast(message, 'error');
-      return;
-    }
-
-    if (generation !== runGeneration.current) {
       return;
     }
 
@@ -204,9 +185,6 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
 
     const validation = validateGradeInputs({ outlooks, reports: loadedReports });
     if (!validation.valid) {
-      if (generation !== runGeneration.current) {
-        return;
-      }
       setError(validation.reason ?? 'Inputs are invalid.');
       setPhase('idle');
       setProgress(null);
@@ -215,14 +193,12 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     }
 
     const pkg = await runForecastGrade({ outlooks, reports: loadedReports }, setProgress);
-    if (generation !== runGeneration.current) {
-      return;
-    }
     setResult(pkg);
     setPhase('complete');
 
     const firstProduct = pkg.products.find((product) => product.applicable)?.product ?? 'tornado';
     setActiveProduct(firstProduct);
+    setActiveMapLayer('categorical');
 
     if (scope) {
       const hasSnapshot = tierHasSnapshots(tier);
@@ -249,7 +225,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   }, [addToast, dispatch, forecast, packageSource, reportDate, scope, selectedDay, sourceLabel, tier, useToday]);
 
   const reset = useCallback(() => {
-    runGeneration.current += 1;
+    restoreSeqRef.current += 1;
     setForecast(null);
     setPackageSource(null);
     setSourceLabel('');
@@ -266,13 +242,59 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
 
   const restoreCard = useCallback(
     (card: GradeCard): GradeSnapshot | null => {
-      const snapshot = loadGradeSnapshot({ scope, cardId: card.id });
+      const snapshot = loadGradeSnapshot(scope, card.id);
       if (!snapshot) {
         addToast('This grade card is trend-only and cannot reopen a full package.', 'info');
       }
       return snapshot;
     },
     [addToast, scope]
+  );
+
+  const applyGradeSnapshot = useCallback(
+    (snapshot: GradeSnapshot) => {
+      const restoreSeq = ++restoreSeqRef.current;
+      const restoredForecast = deserializeForecast(snapshot.forecast);
+      const days = daysWithData(restoredForecast);
+      setForecast(restoredForecast);
+      setPackageSource('file');
+      setSourceLabel(snapshot.card.sourceLabel);
+      setAvailableDays(days);
+      setSelectedDayState(days[0] ?? 1);
+      setResult(snapshot.package);
+      setPhase('complete');
+      setError(null);
+      setProgress(null);
+      if (snapshot.reportDate) {
+        setUseToday(false);
+        setReportDateState(snapshot.reportDate);
+      } else {
+        setUseToday(true);
+        setReportDateState('');
+      }
+      const firstProduct =
+        snapshot.package.products.find((product) => product.applicable)?.product ?? 'tornado';
+      setActiveProduct(firstProduct);
+      setActiveMapLayer('categorical');
+      dispatch(loadVerificationForecast(restoredForecast));
+      void loadReportsForDate(snapshot.reportDate)
+        .then((loadedReports) => {
+          if (restoreSeq !== restoreSeqRef.current) {
+            return;
+          }
+          setReportsState(loadedReports);
+          dispatch(setReports(loadedReports));
+          dispatch(setDate(snapshot.reportDate ?? 'today'));
+        })
+        .catch(() => {
+          if (restoreSeq !== restoreSeqRef.current) {
+            return;
+          }
+          setReportsState([]);
+          dispatch(clearReports());
+        });
+    },
+    [dispatch]
   );
 
   return {
@@ -284,6 +306,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     selectedDay,
     reportDate,
     useToday,
+    activeMapLayer,
     activeProduct,
     phase,
     progress,
@@ -296,10 +319,12 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     setReportDate,
     setUseToday,
     setSelectedDay,
+    setActiveMapLayer,
     setActiveProduct,
     run,
     reset,
     restoreCard,
+    applyGradeSnapshot,
     canRun,
   };
 };

--- a/src/components/ForecastGrade/useForecastGrade.ts
+++ b/src/components/ForecastGrade/useForecastGrade.ts
@@ -10,6 +10,7 @@ import type { GradeAccountTier, GradeCard, GradeSnapshot, PackageSourceKind } fr
 import { serializeForecast, deserializeForecast } from '../../utils/fileUtils';
 import {
   FORECAST_GRADE_FORMULA_VERSION,
+  isReachedArchiveDate,
   runForecastGrade,
   validateGradeInputs,
   type MapOutlookLayer,
@@ -40,6 +41,9 @@ import {
  */
 
 type RunPhase = 'idle' | 'running' | 'complete';
+
+const hasReachedReportDate = (useToday: boolean, reportDate: string): boolean =>
+  useToday || isReachedArchiveDate(reportDate);
 
 const daysWithData = (forecast: ForecastCycle | null): DayType[] => {
   if (!forecast?.days) {
@@ -109,12 +113,15 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   const [reports, setReportsState] = useState<StormReport[]>([]);
   const restoreSeqRef = useRef(0);
 
+  const runGeneration = useRef(0);
+
   useEffect(() => {
     setCards(loadGradeCards(scope));
   }, [scope]);
 
   const setForecastPackage = useCallback(
     (nextForecast: ForecastCycle, source: PackageSourceKind, label: string) => {
+      runGeneration.current += 1;
       const days = daysWithData(nextForecast);
       setForecast(nextForecast);
       setPackageSource(source);
@@ -152,17 +159,28 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   }, []);
 
   const canRun =
-    Boolean(forecast) && phase !== 'running' && (useToday || reportDate.trim().length > 0);
+    Boolean(forecast) &&
+    phase !== 'running' &&
+    hasReachedReportDate(useToday, reportDate);
 
   const run = useCallback(async () => {
     if (!forecast) {
       addToast('Load a forecast package first.', 'error');
       return;
     }
+    if (!hasReachedReportDate(useToday, reportDate)) {
+      const message = useToday
+        ? 'Choose a report date or enable "use today" before grading.'
+        : 'Choose a real, reached report date before grading.';
+      setError(message);
+      addToast(message, 'error');
+      return;
+    }
     const day = forecast.days[selectedDay];
     const outlooks = day?.data ?? { tornado: new Map(), wind: new Map(), hail: new Map(), categorical: new Map() };
     const effectiveDate = useToday ? null : reportDate;
 
+    const generation = ++runGeneration.current;
     setPhase('running');
     setError(null);
     setProgress({ fraction: 0, label: 'Loading storm reports…' });
@@ -171,11 +189,18 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     try {
       loadedReports = await loadReportsForDate(effectiveDate);
     } catch (loadError) {
+      if (generation !== runGeneration.current) {
+        return;
+      }
       const message = loadError instanceof SourceLoadError ? loadError.message : 'Reports could not be loaded.';
       setError(message);
       setPhase('idle');
       setProgress(null);
       addToast(message, 'error');
+      return;
+    }
+
+    if (generation !== runGeneration.current) {
       return;
     }
 
@@ -185,6 +210,9 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
 
     const validation = validateGradeInputs({ outlooks, reports: loadedReports });
     if (!validation.valid) {
+      if (generation !== runGeneration.current) {
+        return;
+      }
       setError(validation.reason ?? 'Inputs are invalid.');
       setPhase('idle');
       setProgress(null);
@@ -193,6 +221,9 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     }
 
     const pkg = await runForecastGrade({ outlooks, reports: loadedReports }, setProgress);
+    if (generation !== runGeneration.current) {
+      return;
+    }
     setResult(pkg);
     setPhase('complete');
 
@@ -226,6 +257,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
 
   const reset = useCallback(() => {
     restoreSeqRef.current += 1;
+    runGeneration.current += 1;
     setForecast(null);
     setPackageSource(null);
     setSourceLabel('');
@@ -242,7 +274,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
 
   const restoreCard = useCallback(
     (card: GradeCard): GradeSnapshot | null => {
-      const snapshot = loadGradeSnapshot(scope, card.id);
+      const snapshot = loadGradeSnapshot({ scope, cardId: card.id });
       if (!snapshot) {
         addToast('This grade card is trend-only and cannot reopen a full package.', 'info');
       }

--- a/src/components/ForecastGrade/useForecastGrade.ts
+++ b/src/components/ForecastGrade/useForecastGrade.ts
@@ -181,6 +181,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
     const effectiveDate = useToday ? null : reportDate;
 
     const generation = ++runGeneration.current;
+    restoreSeqRef.current += 1; // invalidate any in-flight snapshot restore
     setPhase('running');
     setError(null);
     setProgress({ fraction: 0, label: 'Loading storm reports…' });
@@ -286,6 +287,7 @@ export const useForecastGrade = (addToast: (message: string, type?: 'info' | 'su
   const applyGradeSnapshot = useCallback(
     (snapshot: GradeSnapshot) => {
       const restoreSeq = ++restoreSeqRef.current;
+      runGeneration.current += 1; // invalidate any in-flight run()
       const restoredForecast = deserializeForecast(snapshot.forecast);
       const days = daysWithData(restoredForecast);
       setForecast(restoredForecast);


### PR DESCRIPTION
## Summary

- Replace the 06b `ForecastGradeDashboard` stub with the real shell: a
  map-first workspace that renders the verification map at full height
  while the new `ForecastGradeMapPane` / `ForecastGradeMapControls` host
  the always-reachable map controls (outlook layer, day, evidence
  toggle) and a single-column right rail for `SourcePanel`,
  `DataQualityPanel`, `GradeHeadline`, and `RunProgress`.
- Keep the categorical map layer as a display-only toggle (it is not a
  graded `ProductKind`) and add `setActiveMapLayer` / `activeMapLayer`
  to the `useForecastGrade` state so the map and the hook stay in
  sync.
- Add `applyGradeSnapshot` so a premium `restoreCard` reopens the
  full package through the shared verification map (forecast, report
  date, active product, and storm reports) and uses a `restoreSeqRef`
  to drop late async report loads when the user opens a different
  card mid-fetch.
- Re-apply the 06b `useForecastGrade` guards that the rebase would
  otherwise drop: the `runGeneration` stale-run cancellation checks
  in `run()` and `reset()` / `setForecastPackage`, and the
  `hasReachedReportDate` future-date gate (now also re-exported from
  `useForecastGrade` for tests). Also fix the `restoreCard` call
  site to use the object form that the 06b `loadGradeSnapshot`
  signature requires.
- Harden the cloud load ordering and tighten the landscape dashboard
  layout so the shell survives rapid source swaps without flickering
  the map or the rail.

## Stack

8/13, base `beta` (06a and 06b are now merged). 07 (`#777`) branches
from this PR, 08a/08b/09 chain off the rest. Rebased onto
`origin/beta` so this diff is just the 06c-specific shell work and
the 06b guard restore — none of the 04b/05/06a/06b files are in the
diff.

## Test plan

- [ ] Desktop: equal-height map and dashboard rail; `ForecastGradeMapControls`
      floats over the map without colliding with the toolbar, legend,
      credits, or warning badge.
- [ ] Map controls: outlook layer (`categorical` / `tornado` / `wind` /
      `hail`) and day selection drive `activeMapLayer` and
      `selectedDay`; the evidence toggle shows / hides storm reports on
      the shared map.
- [ ] Map layer sync: `applyGradeSnapshot` writes
      `setActiveMapLayer('categorical')` and a completed run lands on
      categorical before the user picks a product.
- [ ] Run gating: `canRun` stays false for a future or empty report
      date and `run()` toasts an error without touching redux; the
      `runGeneration` guards ignore late `loadReportsForDate` /
      `validateGradeInputs` / `runForecastGrade` completions after a
      `reset()` or package swap, leaving the redux state clean.
- [ ] Restore: `restoreCard` returns the stored `GradeSnapshot` for
      premium cards and toasts an info message for trend-only cards;
      `applyGradeSnapshot` swallows late report loads when a second
      snapshot is applied mid-fetch.
- [ ] Phone portrait + landscape: shell keeps the map visible, no
      horizontal overflow, bottom toolbar tabs reachable.

## Changelog

- Stack PR 8/13: Forecast Grade dashboard shell (map-first layout,
  map controls, categorical display layer, `applyGradeSnapshot`,
  06b hook guard restore).
