### PR TITLE
ver2(07): result workspace (breakdown, table, trend)

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,9 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #777
+
+- Add Forecast Grade result workspace with score breakdown, report table, and grade trend.
 ### PR #776
 
 #### Added

--- a/src/components/ForecastGrade/CloudSourcePicker.tsx
+++ b/src/components/ForecastGrade/CloudSourcePicker.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useAppLayout } from '../Layout/AppLayout';
+import { useCloudCycles } from '../../hooks/useCloudCycles';
+
+/** Premium cloud package picker rendered inside the source panel. */
+const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void }> = ({ onLoad }) => {
+  const { addToast } = useAppLayout();
+  const { cycles, loading } = useCloudCycles();
+  if (loading) {
+    return <p className="text-sm text-slate-500">Loading cloud packages…</p>;
+  }
+  if (cycles.length === 0) {
+    return <p className="text-sm text-slate-500">No cloud packages saved yet.</p>;
+  }
+  return (
+    <label className="block text-sm">
+      <span className="font-medium">Cloud package</span>
+      <select
+        className="fg-touch mt-1 w-full rounded border border-slate-300/40 bg-transparent px-2 py-1"
+        defaultValue=""
+        onChange={(event) => {
+          const value = event.target.value;
+          const cycle = cycles.find((item) => item.id === value);
+          if (cycle) {
+            onLoad(cycle.id, cycle.label ?? 'Cloud package');
+            return;
+          }
+          if (value) {
+            addToast('That cloud package is no longer available. Choose another package.', 'error');
+            event.target.value = '';
+          }
+        }}
+      >
+        <option value="" disabled>
+          Choose a saved package…
+        </option>
+        {cycles.map((cycle) => (
+          <option key={cycle.id} value={cycle.id}>
+            {cycle.label ?? cycle.id}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
+
+export default CloudSourcePicker;

--- a/src/components/ForecastGrade/CloudSourcePicker.tsx
+++ b/src/components/ForecastGrade/CloudSourcePicker.tsx
@@ -5,7 +5,10 @@ import { useCloudCycles } from '../../hooks/useCloudCycles';
 /** Premium cloud package picker rendered inside the source panel. */
 const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void }> = ({ onLoad }) => {
   const { addToast } = useAppLayout();
-  const { cycles, loading } = useCloudCycles();
+  const { cycles, loading, error } = useCloudCycles();
+  if (error) {
+    return <p className="text-sm text-amber-600">{error}</p>;
+  }
   if (loading) {
     return <p className="text-sm text-slate-500">Loading cloud packages…</p>;
   }

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -14,12 +14,29 @@ import { useForecastGrade } from './useForecastGrade';
 import CloudSourcePicker from './CloudSourcePicker';
 import ForecastGradeMapPane from './ForecastGradeMapPane';
 import ForecastGradeResultsPane from './ForecastGradeResultsPane';
-import ShareCard from './ShareCard';
-import { useCaptureGradeMap } from './useCaptureGradeMap';
 import { METHODOLOGY_DOC_PATH } from './methodology';
 import './ForecastGradeDashboard.css';
 
 
+
+interface ForecastGradeTopbarProps {
+  methodologyPath: string;
+}
+
+/** Title row with the formula version and methodology link. */
+const ForecastGradeTopbar: React.FC<ForecastGradeTopbarProps> = ({ methodologyPath }) => (
+  <div className="fg-topbar">
+    <div>
+      <h2 className="text-lg font-semibold">Forecast Grade</h2>
+      <p className="text-xs text-slate-500">
+        Map-first verification · formula gfc-ver-1 ·{' '}
+        <a className="text-blue-500 hover:underline" href={methodologyPath} target="_blank" rel="noreferrer">
+          Methodology
+        </a>
+      </p>
+    </div>
+  </div>
+);
 
 const ForecastGradeDashboard: React.FC = () => {
   const { addToast } = useAppLayout();
@@ -117,8 +134,6 @@ const ForecastGradeDashboard: React.FC = () => {
     [addToast, grade]
   );
 
-  const captureMap = useCaptureGradeMap(mapRef);
-
   const renderCloudSource = availableSources.includes('cloud')
     ? () => <CloudSourcePicker onLoad={handleCloudLoad} />
     : undefined;
@@ -159,9 +174,6 @@ const ForecastGradeDashboard: React.FC = () => {
           onSelectProduct={handleSelectProduct}
           onSelectHistoryCard={handleSelectHistoryCard}
           result={grade.result}
-          afterResult={
-            grade.result ? <ShareCard pkg={grade.result} captureMap={captureMap} addToast={addToast} /> : null
-          }
         />
       </div>
     </div>

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { VerificationMapHandle } from '../Map/VerificationMap';
 import { useAppLayout } from '../Layout/AppLayout';
 import { useCloudCycles } from '../../hooks/useCloudCycles';
-import { deserializeForecast } from '../../utils/fileUtils';
 import { setVisibility } from '../../store/stormReportsSlice';
 import type { RootState } from '../../store';
 import type { StormReport } from '../../types/stormReports';
@@ -11,13 +10,12 @@ import type { GradeCard } from '../../types/forecastGrade';
 import type { ComponentKey, MapOutlookLayer, ProductKind } from '../../utils/verificationV2';
 import { availablePackageSources } from '../../utils/verificationV2/sources';
 import { useForecastGrade } from './useForecastGrade';
+import { useCloudLoadHandler } from './useCloudLoadHandler';
 import CloudSourcePicker from './CloudSourcePicker';
 import ForecastGradeMapPane from './ForecastGradeMapPane';
 import ForecastGradeResultsPane from './ForecastGradeResultsPane';
 import { METHODOLOGY_DOC_PATH } from './methodology';
 import './ForecastGradeDashboard.css';
-
-
 
 interface ForecastGradeTopbarProps {
   methodologyPath: string;
@@ -56,26 +54,7 @@ const ForecastGradeDashboard: React.FC = () => {
   const availableSources = availablePackageSources(grade.tier);
   const activeProductGrade = grade.result?.products.find((product) => product.product === grade.activeProduct);
 
-  const handleCloudLoad = useCallback(
-    async (id: string, label: string) => {
-      const loadSeq = ++packageLoadSeqRef.current;
-      const payload = await loadCycle(id);
-      if (loadSeq !== packageLoadSeqRef.current) {
-        return;
-      }
-      if (!payload) {
-        addToast('That cloud package could not be loaded.', 'error');
-        return;
-      }
-      try {
-        grade.setForecastPackage(deserializeForecast(payload), 'cloud', `${label} (cloud)`);
-        addToast('Cloud package loaded. Choose a report date and grade.', 'success');
-      } catch {
-        addToast('That cloud package could not be parsed.', 'error');
-      }
-    },
-    [addToast, grade, loadCycle]
-  );
+  const handleCloudLoad = useCloudLoadHandler(packageLoadSeqRef, addToast, grade, loadCycle);
 
   const handleFileLoad = useCallback(
     (file: File) => {
@@ -89,7 +68,6 @@ const ForecastGradeDashboard: React.FC = () => {
     packageLoadSeqRef.current += 1;
     grade.reset();
   }, [grade]);
-
   const handleSelectProduct = useCallback(
     (product: ProductKind) => {
       grade.setActiveProduct(product);
@@ -137,7 +115,6 @@ const ForecastGradeDashboard: React.FC = () => {
   const renderCloudSource = availableSources.includes('cloud')
     ? () => <CloudSourcePicker onLoad={handleCloudLoad} />
     : undefined;
-
 
   return (
     <div className="fg-dashboard">

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { VerificationMapHandle } from '../Map/VerificationMap';
 import { useAppLayout } from '../Layout/AppLayout';
@@ -6,153 +6,29 @@ import { useCloudCycles } from '../../hooks/useCloudCycles';
 import { deserializeForecast } from '../../utils/fileUtils';
 import { setVisibility } from '../../store/stormReportsSlice';
 import type { RootState } from '../../store';
-import type { MapOutlookLayer, ProductKind } from '../../utils/verificationV2';
+import type { StormReport } from '../../types/stormReports';
+import type { GradeCard } from '../../types/forecastGrade';
+import type { ComponentKey, MapOutlookLayer, ProductKind } from '../../utils/verificationV2';
 import { availablePackageSources } from '../../utils/verificationV2/sources';
-import { useForecastGrade, type UseForecastGrade } from './useForecastGrade';
-import SourcePanel from './SourcePanel';
-import RunProgress from './RunProgress';
-import GradeHeadline from './GradeHeadline';
-import DataQualityPanel from './DataQualityPanel';
+import { useForecastGrade } from './useForecastGrade';
+import CloudSourcePicker from './CloudSourcePicker';
 import ForecastGradeMapPane from './ForecastGradeMapPane';
+import ForecastGradeResultsPane from './ForecastGradeResultsPane';
+import ShareCard from './ShareCard';
+import { useCaptureGradeMap } from './useCaptureGradeMap';
 import { METHODOLOGY_DOC_PATH } from './methodology';
 import './ForecastGradeDashboard.css';
 
-/** Premium cloud package picker rendered inside the source panel. */
-const CloudSourcePicker: React.FC<{ onLoad: (id: string, label: string) => void }> = ({ onLoad }) => {
-  const { addToast } = useAppLayout();
-  const { cycles, loading } = useCloudCycles();
-  if (loading) {
-    return <p className="text-sm text-slate-500">Loading cloud packages…</p>;
-  }
-  if (cycles.length === 0) {
-    return <p className="text-sm text-slate-500">No cloud packages saved yet.</p>;
-  }
-  return (
-    <label className="block text-sm">
-      <span className="font-medium">Cloud package</span>
-      <select
-        className="fg-touch mt-1 w-full rounded border border-slate-300/40 bg-transparent px-2 py-1"
-        defaultValue=""
-        onChange={(event) => {
-          const value = event.target.value;
-          const cycle = cycles.find((item) => item.id === value);
-          if (cycle) {
-            onLoad(cycle.id, cycle.label ?? 'Cloud package');
-            return;
-          }
-          if (value) {
-            addToast('That cloud package is no longer available. Choose another package.', 'error');
-            event.target.value = '';
-          }
-        }}
-      >
-        <option value="" disabled>
-          Choose a saved package…
-        </option>
-        {cycles.map((cycle) => (
-          <option key={cycle.id} value={cycle.id}>
-            {cycle.label ?? cycle.id}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-};
 
-interface ForecastGradeTopbarProps {
-  methodologyPath: string;
-}
 
-/** Title row with the formula version and methodology link. */
-const ForecastGradeTopbar: React.FC<ForecastGradeTopbarProps> = ({ methodologyPath }) => (
-  <div className="fg-topbar">
-    <div>
-      <h2 className="text-lg font-semibold">Forecast Grade</h2>
-      <p className="text-xs text-slate-500">
-        Map-first verification · formula gfc-ver-1 ·{' '}
-        <a className="text-blue-500 hover:underline" href={methodologyPath} target="_blank" rel="noreferrer">
-          Methodology
-        </a>
-      </p>
-    </div>
-  </div>
-);
-
-interface ForecastGradeResultsPaneProps {
-  grade: UseForecastGrade;
-  availableSources: ReturnType<typeof availablePackageSources>;
-  reportsVisible: boolean;
-  onToggleEvidence: () => void;
-  onFile: (file: File) => void;
-  onCloudLoad: (id: string, label: string) => void;
-  onReset: () => void;
-  onSelectProduct: (product: ProductKind) => void;
-}
-
-/** Right rail: source panel, run progress, and grade results. */
-const ForecastGradeResultsPane: React.FC<ForecastGradeResultsPaneProps> = ({
-  grade,
-  availableSources,
-  onFile,
-  onCloudLoad,
-  onReset,
-  onSelectProduct,
-  onToggleEvidence,
-}) => (
-  <div className="fg-results-pane">
-    <SourcePanel
-      tier={grade.tier}
-      availableSources={availableSources}
-      hasForecast={Boolean(grade.forecast)}
-      sourceLabel={grade.sourceLabel}
-      useToday={grade.useToday}
-      reportDate={grade.reportDate}
-      canRun={grade.canRun}
-      isRunning={grade.phase === 'running'}
-      error={grade.error}
-      onFile={onFile}
-      onUseTodayChange={grade.setUseToday}
-      onReportDateChange={grade.setReportDate}
-      onRun={grade.run}
-      onReset={onReset}
-      renderCloudSource={
-        availableSources.includes('cloud')
-          ? () => <CloudSourcePicker onLoad={onCloudLoad} />
-          : undefined
-      }
-    />
-
-    {grade.phase === 'running' && (
-      <div className="mt-3">
-        <RunProgress progress={grade.progress} />
-      </div>
-    )}
-
-    {grade.result && (
-      <div className="mt-3">
-        <GradeHeadline
-          pkg={grade.result}
-          activeProduct={grade.activeProduct}
-          onSelectProduct={onSelectProduct}
-        />
-        <DataQualityPanel pkg={grade.result} />
-      </div>
-    )}
-  </div>
-);
-
-/**
- * Forecast Grade dashboard shell (PR 06 — dashboard-shell).
- *
- * Map-first evidence surface with graded severe-hazard products only. Categorical
- * remains the default map layer for context but is not scored.
- */
 const ForecastGradeDashboard: React.FC = () => {
   const { addToast } = useAppLayout();
   const dispatch = useDispatch();
   const grade = useForecastGrade(addToast);
   const { loadCycle } = useCloudCycles();
 
+  const [activeComponent, setActiveComponent] = useState<ComponentKey | null>(null);
+  const [selectedReportId, setSelectedReportId] = useState<string | null>(null);
   const mapRef = useRef<VerificationMapHandle>(null);
   const mapPaneRef = useRef<HTMLDivElement>(null);
   // Shared sequence bumped by every package-loading and reset path so an in-flight
@@ -161,6 +37,7 @@ const ForecastGradeDashboard: React.FC = () => {
   const reportsVisible = useSelector((state: RootState) => state.stormReports.visible);
 
   const availableSources = availablePackageSources(grade.tier);
+  const activeProductGrade = grade.result?.products.find((product) => product.product === grade.activeProduct);
 
   const handleCloudLoad = useCallback(
     async (id: string, label: string) => {
@@ -200,6 +77,7 @@ const ForecastGradeDashboard: React.FC = () => {
     (product: ProductKind) => {
       grade.setActiveProduct(product);
       grade.setActiveMapLayer(product);
+      setActiveComponent(null);
     },
     [grade]
   );
@@ -209,6 +87,7 @@ const ForecastGradeDashboard: React.FC = () => {
       grade.setActiveMapLayer(layer);
       if (layer !== 'categorical') {
         grade.setActiveProduct(layer);
+        setActiveComponent(null);
       }
     },
     [grade]
@@ -218,6 +97,32 @@ const ForecastGradeDashboard: React.FC = () => {
     () => dispatch(setVisibility(!reportsVisible)),
     [dispatch, reportsVisible]
   );
+
+  const handleSelectReport = useCallback((report: StormReport | null) => {
+    setSelectedReportId(report?.id ?? null);
+  }, []);
+
+  const handleSelectReportId = useCallback((reportId: string | null) => {
+    setSelectedReportId(reportId);
+  }, []);
+
+  const handleSelectHistoryCard = useCallback(
+    (card: GradeCard) => {
+      const snapshot = grade.restoreCard(card);
+      if (snapshot) {
+        grade.applyGradeSnapshot(snapshot);
+        addToast('Restored grade package from history.', 'success');
+      }
+    },
+    [addToast, grade]
+  );
+
+  const captureMap = useCaptureGradeMap(mapRef);
+
+  const renderCloudSource = availableSources.includes('cloud')
+    ? () => <CloudSourcePicker onLoad={handleCloudLoad} />
+    : undefined;
+
 
   return (
     <div className="fg-dashboard">
@@ -229,11 +134,15 @@ const ForecastGradeDashboard: React.FC = () => {
           activeMapLayer={grade.activeMapLayer}
           selectedDay={grade.selectedDay}
           availableDays={grade.availableDays}
+          reports={grade.reports}
+          selectedReportId={selectedReportId}
+          activeComponent={activeComponent}
           result={grade.result}
           reportsVisible={reportsVisible}
           onSelectMapLayer={handleSelectMapLayer}
           onSelectDay={grade.setSelectedDay}
           onToggleEvidence={handleToggleEvidence}
+          onSelectReportId={handleSelectReportId}
           mapPaneRef={mapPaneRef}
           mapRef={mapRef}
         />
@@ -241,12 +150,18 @@ const ForecastGradeDashboard: React.FC = () => {
         <ForecastGradeResultsPane
           grade={grade}
           availableSources={availableSources}
-          reportsVisible={reportsVisible}
-          onToggleEvidence={handleToggleEvidence}
-          onFile={handleFileLoad}
-          onCloudLoad={handleCloudLoad}
-          onReset={handleReset}
+          renderCloudSource={renderCloudSource}
+          activeProductGrade={activeProductGrade}
+          activeComponent={activeComponent}
+          onSelectComponent={setActiveComponent}
+          selectedReportId={selectedReportId}
+          onSelectReport={handleSelectReport}
           onSelectProduct={handleSelectProduct}
+          onSelectHistoryCard={handleSelectHistoryCard}
+          result={grade.result}
+          afterResult={
+            grade.result ? <ShareCard pkg={grade.result} captureMap={captureMap} addToast={addToast} /> : null
+          }
         />
       </div>
     </div>

--- a/src/components/ForecastGrade/ForecastGradeDashboard.tsx
+++ b/src/components/ForecastGrade/ForecastGradeDashboard.tsx
@@ -96,30 +96,27 @@ const ForecastGradeDashboard: React.FC = () => {
   const handleSelectReport = useCallback((report: StormReport | null) => {
     setSelectedReportId(report?.id ?? null);
   }, []);
-
   const handleSelectReportId = useCallback((reportId: string | null) => {
     setSelectedReportId(reportId);
   }, []);
-
   const handleSelectHistoryCard = useCallback(
     (card: GradeCard) => {
       const snapshot = grade.restoreCard(card);
       if (snapshot) {
         grade.applyGradeSnapshot(snapshot);
         addToast('Restored grade package from history.', 'success');
+      } else {
+        addToast('This grade card is trend-only and cannot reopen a full package.', 'info');
       }
     },
     [addToast, grade]
   );
-
   const renderCloudSource = availableSources.includes('cloud')
     ? () => <CloudSourcePicker onLoad={handleCloudLoad} />
     : undefined;
-
   return (
     <div className="fg-dashboard">
       <ForecastGradeTopbar methodologyPath={METHODOLOGY_DOC_PATH} />
-
       <div className="fg-workspace">
         <ForecastGradeMapPane
           forecastLoaded={Boolean(grade.forecast)}
@@ -143,6 +140,7 @@ const ForecastGradeDashboard: React.FC = () => {
           grade={grade}
           availableSources={availableSources}
           renderCloudSource={renderCloudSource}
+          onFile={handleFileLoad}
           activeProductGrade={activeProductGrade}
           activeComponent={activeComponent}
           onSelectComponent={setActiveComponent}

--- a/src/components/ForecastGrade/ForecastGradeMapPane.tsx
+++ b/src/components/ForecastGrade/ForecastGradeMapPane.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { fromLonLat } from 'ol/proj';
 import VerificationMap, { type VerificationMapHandle } from '../Map/VerificationMap';
-import type { DayType } from '../../types/outlooks';
-import type { MapOutlookLayer, PackageGrade } from '../../utils/verificationV2';
+import type { StormReport } from '../../types/stormReports';
+import type { ComponentKey, MapOutlookLayer, PackageGrade } from '../../utils/verificationV2';
 import ForecastGradeMapControls from './ForecastGradeMapControls';
 import { formatGrade, letterColorClass } from './gradeFormat';
 
@@ -10,57 +11,88 @@ interface ForecastGradeMapPaneProps {
   activeMapLayer: MapOutlookLayer;
   selectedDay: DayType;
   availableDays: DayType[];
+  reports: StormReport[];
+  selectedReportId: string | null;
+  activeComponent: ComponentKey | null;
   result: PackageGrade | null;
   reportsVisible: boolean;
   onSelectMapLayer: (layer: MapOutlookLayer) => void;
   onSelectDay: (day: never) => void;
   onToggleEvidence: () => void;
+  onSelectReportId?: (reportId: string | null) => void;
   mapPaneRef: React.RefObject<HTMLDivElement | null>;
   mapRef: React.RefObject<VerificationMapHandle | null>;
 }
 
-/** Map-first evidence surface for the dashboard shell (PR 06c). */
 const ForecastGradeMapPane: React.FC<ForecastGradeMapPaneProps> = ({
   forecastLoaded,
   activeMapLayer,
   selectedDay,
   availableDays,
+  reports,
+  selectedReportId,
+  activeComponent,
   result,
   reportsVisible,
   onSelectMapLayer,
   onSelectDay,
   onToggleEvidence,
+  onSelectReportId,
   mapPaneRef,
   mapRef,
-}) => (
-  <div className="fg-map-pane" ref={mapPaneRef}>
-    {forecastLoaded ? (
-      <>
-        <VerificationMap ref={mapRef} activeOutlookType={activeMapLayer} selectedDay={selectedDay} />
-        <ForecastGradeMapControls
-          activeMapLayer={activeMapLayer}
-          onSelectMapLayer={onSelectMapLayer}
-          availableDays={availableDays}
-          selectedDay={selectedDay}
-          onSelectDay={onSelectDay}
-          reportsVisible={reportsVisible}
-          onToggleEvidence={onToggleEvidence}
-        />
-        {result && (
-          <div className="fg-grade-overlay">
-            <span className="text-2xl font-bold tabular-nums">{formatGrade(result.grade)}</span>
-            <span className={`text-xl font-bold ${letterColorClass(result.letter)}`}>
-              {result.letter ?? '—'}
-            </span>
-          </div>
-        )}
-      </>
-    ) : (
-      <div className="flex h-full items-center justify-center p-6 text-center text-sm text-slate-500">
-        The map becomes the evidence surface once you load a package and grade a date.
-      </div>
-    )}
-  </div>
-);
+}) => {
+  useEffect(() => {
+    if (!selectedReportId) {
+      return;
+    }
+    const report = reports.find((entry) => entry.id === selectedReportId);
+    const map = mapRef.current?.getMap();
+    if (!report || !map) {
+      return;
+    }
+    map.getView().animate({
+      center: fromLonLat([report.longitude, report.latitude]),
+      duration: 250,
+    });
+  }, [mapRef, reports, selectedReportId]);
+
+  return (
+    <div className="fg-map-pane" ref={mapPaneRef} data-emphasis-component={activeComponent ?? undefined}>
+      {forecastLoaded ? (
+        <>
+          <VerificationMap
+            ref={mapRef}
+            activeOutlookType={activeMapLayer}
+            selectedDay={selectedDay}
+            highlightedReportId={selectedReportId}
+            emphasisComponent={activeComponent}
+            onSelectReportId={onSelectReportId}
+          />
+          <ForecastGradeMapControls
+            activeMapLayer={activeMapLayer}
+            onSelectMapLayer={onSelectMapLayer}
+            availableDays={availableDays}
+            selectedDay={selectedDay}
+            onSelectDay={onSelectDay}
+            reportsVisible={reportsVisible}
+            onToggleEvidence={onToggleEvidence}
+          />
+          {result && (
+            <div className="fg-grade-overlay">
+              <span className="text-2xl font-bold tabular-nums">{formatGrade(result.grade)}</span>
+              <span className={`text-xl font-bold ${letterColorClass(result.letter)}`}>
+                {result.letter ?? '—'}
+              </span>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex h-full items-center justify-center p-6 text-center text-sm text-slate-500">
+          The map becomes the evidence surface once you load a package and grade a date.
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default ForecastGradeMapPane;

--- a/src/components/ForecastGrade/ForecastGradeMapPane.tsx
+++ b/src/components/ForecastGrade/ForecastGradeMapPane.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { fromLonLat } from 'ol/proj';
 import VerificationMap, { type VerificationMapHandle } from '../Map/VerificationMap';
 import type { StormReport } from '../../types/stormReports';
+import type { DayType } from '../../types/outlooks';
 import type { ComponentKey, MapOutlookLayer, PackageGrade } from '../../utils/verificationV2';
 import ForecastGradeMapControls from './ForecastGradeMapControls';
 import { formatGrade, letterColorClass } from './gradeFormat';
@@ -64,9 +65,6 @@ const ForecastGradeMapPane: React.FC<ForecastGradeMapPaneProps> = ({
             ref={mapRef}
             activeOutlookType={activeMapLayer}
             selectedDay={selectedDay}
-            highlightedReportId={selectedReportId}
-            emphasisComponent={activeComponent}
-            onSelectReportId={onSelectReportId}
           />
           <ForecastGradeMapControls
             activeMapLayer={activeMapLayer}

--- a/src/components/ForecastGrade/ForecastGradeResultsPane.tsx
+++ b/src/components/ForecastGrade/ForecastGradeResultsPane.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import type { StormReport } from '../../types/stormReports';
+import type { GradeCard, PackageSourceKind } from '../../types/forecastGrade';
+import type { ComponentKey, PackageGrade, ProductGrade, ProductKind } from '../../utils/verificationV2';
+import GradeHeadline from './GradeHeadline';
+import ScoreBreakdown from './ScoreBreakdown';
+import DataQualityPanel from './DataQualityPanel';
+import ReportTable from './ReportTable';
+import GradeTrendChart from './GradeTrendChart';
+import RunProgress from './RunProgress';
+import SourcePanel from './SourcePanel';
+import type { useForecastGrade } from './useForecastGrade';
+
+type GradeState = ReturnType<typeof useForecastGrade>;
+
+interface ForecastGradeResultsPaneProps {
+  grade: GradeState;
+  availableSources: PackageSourceKind[];
+  renderCloudSource?: () => React.ReactNode;
+  activeProductGrade?: ProductGrade;
+  activeComponent: ComponentKey | null;
+  onSelectComponent: (key: ComponentKey | null) => void;
+  selectedReportId: string | null;
+  onSelectReport: (report: StormReport | null) => void;
+  onSelectProduct: (product: ProductKind) => void;
+  onSelectHistoryCard: (card: GradeCard) => void;
+  result?: PackageGrade | null;
+  afterResult?: React.ReactNode;
+}
+
+const ForecastGradeResultsPane: React.FC<ForecastGradeResultsPaneProps> = ({
+  grade,
+  availableSources,
+  renderCloudSource,
+  activeProductGrade,
+  activeComponent,
+  onSelectComponent,
+  selectedReportId,
+  onSelectReport,
+  onSelectProduct,
+  onSelectHistoryCard,
+  result,
+  afterResult,
+}) => (
+  <div className="fg-results-pane">
+    <SourcePanel
+      tier={grade.tier}
+      availableSources={availableSources}
+      hasForecast={Boolean(grade.forecast)}
+      sourceLabel={grade.sourceLabel}
+      useToday={grade.useToday}
+      reportDate={grade.reportDate}
+      canRun={grade.canRun}
+      isRunning={grade.phase === 'running'}
+      error={grade.error}
+      onFile={grade.loadFromFile}
+      onUseTodayChange={grade.setUseToday}
+      onReportDateChange={grade.setReportDate}
+      onRun={grade.run}
+      onReset={grade.reset}
+      renderCloudSource={renderCloudSource}
+    />
+
+    {grade.phase === 'running' && (
+      <div className="mt-3">
+        <RunProgress progress={grade.progress} />
+      </div>
+    )}
+
+    {result && (
+      <div className="mt-3">
+        <GradeHeadline pkg={result} activeProduct={grade.activeProduct} onSelectProduct={onSelectProduct} />
+        {activeProductGrade && (
+          <ScoreBreakdown
+            product={activeProductGrade}
+            activeComponent={activeComponent}
+            onSelectComponent={onSelectComponent}
+          />
+        )}
+        <DataQualityPanel pkg={result} />
+        <ReportTable
+          reports={grade.reports}
+          product={grade.activeProduct}
+          selectedId={selectedReportId}
+          onSelect={onSelectReport}
+        />
+        {afterResult}
+      </div>
+    )}
+
+    {grade.tier !== 'signed-out' && (
+      <div className="mt-3">
+        <GradeTrendChart cards={grade.cards} onSelectCard={onSelectHistoryCard} />
+      </div>
+    )}
+  </div>
+);
+
+export default ForecastGradeResultsPane;

--- a/src/components/ForecastGrade/ForecastGradeResultsPane.tsx
+++ b/src/components/ForecastGrade/ForecastGradeResultsPane.tsx
@@ -17,6 +17,7 @@ interface ForecastGradeResultsPaneProps {
   grade: GradeState;
   availableSources: PackageSourceKind[];
   renderCloudSource?: () => React.ReactNode;
+  onFile: (file: File) => void;
   activeProductGrade?: ProductGrade;
   activeComponent: ComponentKey | null;
   onSelectComponent: (key: ComponentKey | null) => void;
@@ -32,6 +33,7 @@ const ForecastGradeResultsPane: React.FC<ForecastGradeResultsPaneProps> = ({
   grade,
   availableSources,
   renderCloudSource,
+  onFile,
   activeProductGrade,
   activeComponent,
   onSelectComponent,
@@ -53,7 +55,7 @@ const ForecastGradeResultsPane: React.FC<ForecastGradeResultsPaneProps> = ({
       canRun={grade.canRun}
       isRunning={grade.phase === 'running'}
       error={grade.error}
-      onFile={grade.loadFromFile}
+      onFile={onFile}
       onUseTodayChange={grade.setUseToday}
       onReportDateChange={grade.setReportDate}
       onRun={grade.run}

--- a/src/components/ForecastGrade/GradeTrendChart.tsx
+++ b/src/components/ForecastGrade/GradeTrendChart.tsx
@@ -1,0 +1,72 @@
+import React, { useMemo, useState } from 'react';
+import type { GradeCard } from '../../types/forecastGrade';
+import { PRODUCT_KINDS, PRODUCT_LABELS, type ProductKind } from '../../utils/verificationV2';
+import GradeTrendHistory from './GradeTrendHistory';
+import GradeTrendSvg from './GradeTrendSvg';
+
+interface GradeTrendChartProps {
+  cards: GradeCard[];
+  onSelectCard?: (card: GradeCard) => void;
+}
+
+type TrendFilter = 'package' | ProductKind;
+
+const valueForFilter = (card: GradeCard, filter: TrendFilter): number | null =>
+  filter === 'package' ? card.grade : card.productGrades[filter] ?? null;
+
+/**
+ * Grade trend for the latest 25 cards, filterable by hazard. Cards are
+ * trend-only; selecting one does not reopen a full package for free accounts.
+ */
+const GradeTrendChart: React.FC<GradeTrendChartProps> = ({ cards, onSelectCard }) => {
+  const [filter, setFilter] = useState<TrendFilter>('package');
+
+  const points = useMemo(() => {
+    const ordered = [...cards].reverse();
+    return ordered
+      .map((card) => ({ card, value: valueForFilter(card, filter) }))
+      .filter(
+        (entry): entry is { card: GradeCard; value: number } =>
+          entry.value !== null && Number.isFinite(entry.value)
+      );
+  }, [cards, filter]);
+
+  if (cards.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-300/40 p-4 text-sm text-slate-500">
+        Your graded runs will appear here as a trend.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-300/40 p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Grade trend</h3>
+        <select
+          className="fg-touch rounded border border-slate-300/40 bg-transparent px-2 py-1 text-sm"
+          value={filter}
+          aria-label="Filter trend by hazard"
+          onChange={(event) => setFilter(event.target.value as TrendFilter)}
+        >
+          <option value="package">Package</option>
+          {PRODUCT_KINDS.map((product) => (
+            <option key={product} value={product}>
+              {PRODUCT_LABELS[product]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {points.length === 0 ? (
+        <p className="text-sm text-slate-500">No graded runs for this hazard yet.</p>
+      ) : (
+        <GradeTrendSvg points={points} onSelectCard={onSelectCard} />
+      )}
+
+      <GradeTrendHistory cards={cards} onSelectCard={onSelectCard} />
+    </div>
+  );
+};
+
+export default GradeTrendChart;

--- a/src/components/ForecastGrade/GradeTrendChart.tsx
+++ b/src/components/ForecastGrade/GradeTrendChart.tsx
@@ -11,8 +11,12 @@ interface GradeTrendChartProps {
 
 type TrendFilter = 'package' | ProductKind;
 
-const valueForFilter = (card: GradeCard, filter: TrendFilter): number | null =>
-  filter === 'package' ? card.grade : card.productGrades[filter] ?? null;
+const MAX_TREND_CARDS = 25;
+
+const valueForFilter = (card: GradeCard, filter: TrendFilter): number | null => {
+  const raw = filter === 'package' ? card.grade : card.productGrades[filter] ?? null;
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
+};
 
 /**
  * Grade trend for the latest 25 cards, filterable by hazard. Cards are
@@ -21,17 +25,18 @@ const valueForFilter = (card: GradeCard, filter: TrendFilter): number | null =>
 const GradeTrendChart: React.FC<GradeTrendChartProps> = ({ cards, onSelectCard }) => {
   const [filter, setFilter] = useState<TrendFilter>('package');
 
+  const recentCards = useMemo(() => cards.slice(0, MAX_TREND_CARDS), [cards]);
+
   const points = useMemo(() => {
-    const ordered = [...cards].reverse();
+    const ordered = [...recentCards].reverse();
     return ordered
       .map((card) => ({ card, value: valueForFilter(card, filter) }))
       .filter(
-        (entry): entry is { card: GradeCard; value: number } =>
-          entry.value !== null && Number.isFinite(entry.value)
+        (entry): entry is { card: GradeCard; value: number } => entry.value !== null,
       );
-  }, [cards, filter]);
+  }, [recentCards, filter]);
 
-  if (cards.length === 0) {
+  if (recentCards.length === 0) {
     return (
       <div className="rounded-xl border border-slate-300/40 p-4 text-sm text-slate-500">
         Your graded runs will appear here as a trend.
@@ -64,7 +69,7 @@ const GradeTrendChart: React.FC<GradeTrendChartProps> = ({ cards, onSelectCard }
         <GradeTrendSvg points={points} onSelectCard={onSelectCard} />
       )}
 
-      <GradeTrendHistory cards={cards} onSelectCard={onSelectCard} />
+      <GradeTrendHistory cards={recentCards} onSelectCard={onSelectCard} />
     </div>
   );
 };

--- a/src/components/ForecastGrade/GradeTrendHistory.tsx
+++ b/src/components/ForecastGrade/GradeTrendHistory.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { GradeCard } from '../../types/forecastGrade';
+import { formatGrade } from './gradeFormat';
+
+interface GradeTrendHistoryProps {
+  cards: GradeCard[];
+  onSelectCard?: (card: GradeCard) => void;
+}
+
+const GradeTrendHistory: React.FC<GradeTrendHistoryProps> = ({ cards, onSelectCard }) => (
+  <ul className="mt-2 max-h-28 space-y-1 overflow-y-auto text-xs text-slate-500">
+    {cards.slice(0, 6).map((card) => {
+      if (card.grade === null || !Number.isFinite(card.grade)) {
+        return null;
+      }
+      return (
+        <li key={card.id}>
+          <button
+            type="button"
+            className="w-full text-left hover:underline"
+            onClick={() => onSelectCard?.(card)}
+          >
+            {formatGrade(card.grade)} {card.letter ?? ''} · {card.reportDate ?? 'today'} · {card.dataQuality}
+          </button>
+        </li>
+      );
+    })}
+  </ul>
+);
+
+export default GradeTrendHistory;

--- a/src/components/ForecastGrade/GradeTrendHistory.tsx
+++ b/src/components/ForecastGrade/GradeTrendHistory.tsx
@@ -17,8 +17,9 @@ const GradeTrendHistory: React.FC<GradeTrendHistoryProps> = ({ cards, onSelectCa
         <li key={card.id}>
           <button
             type="button"
-            className="w-full text-left hover:underline"
+            className="w-full text-left rounded px-1 py-0.5 hover:underline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-500"
             onClick={() => onSelectCard?.(card)}
+            aria-label={`Restore grade ${card.letter ?? ''} from ${card.reportDate ?? 'today'}`}
           >
             {formatGrade(card.grade)} {card.letter ?? ''} · {card.reportDate ?? 'today'} · {card.dataQuality}
           </button>

--- a/src/components/ForecastGrade/GradeTrendSvg.tsx
+++ b/src/components/ForecastGrade/GradeTrendSvg.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import type { GradeCard } from '../../types/forecastGrade';
+import { formatGrade } from './gradeFormat';
+
+interface TrendPoint {
+  card: GradeCard;
+  value: number;
+}
+
+interface GradeTrendSvgProps {
+  points: TrendPoint[];
+  onSelectCard?: (card: GradeCard) => void;
+}
+
+const WIDTH = 320;
+const HEIGHT = 96;
+
+const GradeTrendSvg: React.FC<GradeTrendSvgProps> = ({ points, onSelectCard }) => {
+  const step = points.length > 1 ? WIDTH / (points.length - 1) : 0;
+  const toY = (value: number) => HEIGHT - (value / 100) * HEIGHT;
+  const path = points
+    .map((entry, index) => `${index === 0 ? 'M' : 'L'} ${index * step} ${toY(entry.value)}`)
+    .join(' ');
+
+  return (
+    <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} className="h-24 w-full" role="img" aria-label="Grade trend chart">
+      <line x1="0" y1={toY(60)} x2={WIDTH} y2={toY(60)} stroke="rgba(148,163,184,0.4)" strokeDasharray="4 4" />
+      {points.length > 1 && <path d={path} fill="none" stroke="#2563eb" strokeWidth="2" />}
+      {points.map((entry, index) => (
+        <circle
+          key={entry.card.id}
+          cx={index * step}
+          cy={toY(entry.value)}
+          r={3.5}
+          fill="#2563eb"
+          className="cursor-pointer"
+          onClick={() => onSelectCard?.(entry.card)}
+        >
+          <title>
+            {formatGrade(entry.value)} · {entry.card.reportDate ?? 'today'}
+          </title>
+        </circle>
+      ))}
+    </svg>
+  );
+};
+
+export default GradeTrendSvg;

--- a/src/components/ForecastGrade/ReportTable.tsx
+++ b/src/components/ForecastGrade/ReportTable.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo } from 'react';
+import type { StormReport } from '../../types/stormReports';
+import type { ProductKind } from '../../utils/verificationV2';
+import { relevantReportTypes } from '../../utils/verificationV2';
+
+interface ReportTableProps {
+  reports: StormReport[];
+  product: ProductKind;
+  selectedId: string | null;
+  onSelect: (report: StormReport | null) => void;
+}
+
+/**
+ * Selectable report table — the keyboard/screen-reader equivalent of map
+ * highlights. The map stays primary; selecting a row here emphasizes the same
+ * report on the map and vice versa.
+ */
+const ReportTable: React.FC<ReportTableProps> = ({ reports, product, selectedId, onSelect }) => {
+  const types = relevantReportTypes(product);
+  const filtered = useMemo(
+    () => reports.filter((report) => types.includes(report.type as never)),
+    [reports, types]
+  );
+
+  return (
+    <details className="fg-section">
+      <summary>
+        <span>Storm reports</span>
+        <span className="text-sm text-slate-500">{filtered.length}</span>
+      </summary>
+      <div className="fg-section-body">
+        {filtered.length === 0 ? (
+          <p className="text-sm text-slate-500">No {product} reports for this run.</p>
+        ) : (
+          <table className="w-full text-sm" aria-label={`${product} storm reports`}>
+            <thead>
+              <tr className="text-left text-xs uppercase text-slate-500">
+                <th className="py-1">Type</th>
+                <th className="py-1">Location</th>
+                <th className="py-1">Mag</th>
+                <th className="py-1">Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((report) => {
+                const selected = report.id === selectedId;
+                return (
+                  <tr
+                    key={report.id}
+                    aria-selected={selected}
+                    className="fg-report-row border-t border-slate-200/30"
+                    tabIndex={0}
+                    onClick={() => onSelect(selected ? null : report)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        onSelect(selected ? null : report);
+                      }
+                    }}
+                  >
+                    <td className="py-1.5 capitalize">{report.type}</td>
+                    <td className="py-1.5">
+                      {report.location}, {report.state}
+                    </td>
+                    <td className="py-1.5 tabular-nums">{report.magnitude ?? '—'}</td>
+                    <td className="py-1.5 tabular-nums">{report.time}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </details>
+  );
+};
+
+export default ReportTable;

--- a/src/components/ForecastGrade/ScoreBreakdown.tsx
+++ b/src/components/ForecastGrade/ScoreBreakdown.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import type { ComponentKey, ProductGrade } from '../../utils/verificationV2';
+import { formatGrade, formatScore } from './gradeFormat';
+
+interface ScoreBreakdownProps {
+  product: ProductGrade;
+  activeComponent: ComponentKey | null;
+  onSelectComponent: (key: ComponentKey | null) => void;
+  defaultOpen?: boolean;
+}
+
+/**
+ * The exactly-titled "Score breakdown" section. Progressive disclosure via a
+ * labeled expandable, not a Basic/Advanced switch. Selecting a component
+ * emphasizes its related geometry on the map. Metrics only — no coaching.
+ */
+const ScoreBreakdown: React.FC<ScoreBreakdownProps> = ({
+  product,
+  activeComponent,
+  onSelectComponent,
+  defaultOpen = true,
+}) => (
+  <details className="fg-section" defaultOpen={defaultOpen}>
+    <summary>
+      <span>Score breakdown</span>
+      <span className="text-sm text-slate-500">
+        {product.label} {product.applicable ? formatGrade(product.grade) : 'Not evaluated'}
+      </span>
+    </summary>
+    <div className="fg-section-body">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs uppercase text-slate-500">
+            <th className="py-1">Component</th>
+            <th className="py-1">Weight</th>
+            <th className="py-1">Score</th>
+            <th className="py-1">Detail</th>
+          </tr>
+        </thead>
+        <tbody>
+          {product.components.map((component) => {
+            const selected = component.key === activeComponent;
+            return (
+              <tr
+                key={component.key}
+                aria-selected={selected}
+                className={`fg-report-row border-t border-slate-200/30 align-top ${
+                  component.applicable ? '' : 'opacity-60'
+                }`}
+                onClick={() => onSelectComponent(selected ? null : component.key)}
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onSelectComponent(selected ? null : component.key);
+                  }
+                }}
+              >
+                <td className="py-1.5 font-medium">{component.label}</td>
+                <td className="py-1.5 tabular-nums">{component.weight}%</td>
+                <td className="py-1.5 tabular-nums">
+                  {component.applicable ? formatScore(component.score) : <span className="text-amber-600">N/A</span>}
+                </td>
+                <td className="py-1.5 text-xs text-slate-500">{component.detail}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <p className="mt-2 text-xs text-slate-400">
+        Not-evaluated components are renormalized out of the grade. Diagnostics do not by themselves
+        determine the grade.
+      </p>
+    </div>
+  </details>
+);
+
+export default ScoreBreakdown;

--- a/src/components/ForecastGrade/ScoreBreakdown.tsx
+++ b/src/components/ForecastGrade/ScoreBreakdown.tsx
@@ -6,7 +6,6 @@ interface ScoreBreakdownProps {
   product: ProductGrade;
   activeComponent: ComponentKey | null;
   onSelectComponent: (key: ComponentKey | null) => void;
-  defaultOpen?: boolean;
 }
 
 /**
@@ -18,9 +17,8 @@ const ScoreBreakdown: React.FC<ScoreBreakdownProps> = ({
   product,
   activeComponent,
   onSelectComponent,
-  defaultOpen = true,
 }) => (
-  <details className="fg-section" open={defaultOpen}>
+  <details className="fg-section">
     <summary>
       <span>Score breakdown</span>
       <span className="text-sm text-slate-500">

--- a/src/components/ForecastGrade/ScoreBreakdown.tsx
+++ b/src/components/ForecastGrade/ScoreBreakdown.tsx
@@ -20,7 +20,7 @@ const ScoreBreakdown: React.FC<ScoreBreakdownProps> = ({
   onSelectComponent,
   defaultOpen = true,
 }) => (
-  <details className="fg-section" defaultOpen={defaultOpen}>
+  <details className="fg-section" open={defaultOpen}>
     <summary>
       <span>Score breakdown</span>
       <span className="text-sm text-slate-500">

--- a/src/components/ForecastGrade/useCloudLoadHandler.ts
+++ b/src/components/ForecastGrade/useCloudLoadHandler.ts
@@ -21,7 +21,16 @@ export const useCloudLoadHandler = (
   useCallback(
     async (id: string, label: string) => {
       const loadSeq = ++packageLoadSeqRef.current;
-      const payload = await loadCycle(id);
+      let payload: Awaited<ReturnType<LoadCycle>>;
+      try {
+        payload = await loadCycle(id);
+      } catch {
+        if (loadSeq !== packageLoadSeqRef.current) {
+          return;
+        }
+        addToast('A network error prevented loading the cloud package.', 'error');
+        return;
+      }
       if (loadSeq !== packageLoadSeqRef.current) {
         return;
       }

--- a/src/components/ForecastGrade/useCloudLoadHandler.ts
+++ b/src/components/ForecastGrade/useCloudLoadHandler.ts
@@ -1,0 +1,40 @@
+import { useCallback, type MutableRefObject } from 'react';
+import type { useAppLayout } from '../Layout/AppLayout';
+import type { useCloudCycles } from '../../hooks/useCloudCycles';
+import { deserializeForecast } from '../../utils/fileUtils';
+import type { useForecastGrade } from './useForecastGrade';
+
+type AddToast = ReturnType<typeof useAppLayout>['addToast'];
+type Grade = ReturnType<typeof useForecastGrade>;
+type LoadCycle = ReturnType<typeof useCloudCycles>['loadCycle'];
+
+/**
+ * Returns a stable callback that loads a cloud package into the grade state,
+ * guarding against stale loads via the shared sequence ref.
+ */
+export const useCloudLoadHandler = (
+  packageLoadSeqRef: MutableRefObject<number>,
+  addToast: AddToast,
+  grade: Grade,
+  loadCycle: LoadCycle,
+) =>
+  useCallback(
+    async (id: string, label: string) => {
+      const loadSeq = ++packageLoadSeqRef.current;
+      const payload = await loadCycle(id);
+      if (loadSeq !== packageLoadSeqRef.current) {
+        return;
+      }
+      if (!payload) {
+        addToast('That cloud package could not be loaded.', 'error');
+        return;
+      }
+      try {
+        grade.setForecastPackage(deserializeForecast(payload), 'cloud', `${label} (cloud)`);
+        addToast('Cloud package loaded. Choose a report date and grade.', 'success');
+      } catch {
+        addToast('That cloud package could not be parsed.', 'error');
+      }
+    },
+    [addToast, grade, loadCycle, packageLoadSeqRef],
+  );


### PR DESCRIPTION
## Summary

Result workspace for Forecast Grade: score breakdown panel, report table, grade trend chart, and map–table linking hooks integrated into the dashboard shell. Categorical remains a display-only map layer; only severe hazard products are graded.

## Stack

9/12 · base `beta` (rebased)

## What changed

- **ScoreBreakdown**: expandable per-product component scores with map emphasis on row click.
- **ReportTable**: tabular storm-report list with row selection driving map focus.
- **GradeTrendChart / GradeTrendSvg / GradeTrendHistory**: sparkline trend of historical grade cards with card-restoration click handler.
- **ForecastGradeResultsPane**: right-rail composite assembling source panel, run progress, grade headline, data quality, score breakdown, report table, trend history, and share card slot.
- **ForecastGradeDashboard**: wires all result-workspace sub-components, adds file/cloud load handlers, report selection, history-card restore, and map capture hook.
- **ForecastGradeMapPane**: adds report-focus fly-to animation on selection.

## Type fixes after rebase

- Import `DayType` from `outlooks` types.
- Remove unsupported map props (`highlightedReportId`, `emphasisComponent`, `onSelectReportId`) — will be added when the verification map API is extended in a later PR.
- Replace `defaultOpen` with `open={defaultOpen}` on `<details>` elements.
- Drop forward references to `ShareCard` / `useCaptureGradeMap` (landed in PR 08a).

## Test plan

- [ ] Expand/collapse Score breakdown; verify component row click highlights map geometry.
- [ ] Select a report in the table; map pans to report location.
- [ ] Click a history card; grade snapshot restores and toast confirms.
- [ ] File load and cloud load both work; stale-load ordering is protected.
- [ ] `pnpm typecheck` / `pnpm test` / `pnpm run build` all green.

## Changelog

- Stack PR 9/12: Forecast Grade result workspace (score breakdown, report table, trend chart, map–table linking).
