### PR TITLE
ver2(08a): anonymous share card

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -6,6 +6,8 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ### PR #778
 
+#### Added
+
 - Add anonymous Forecast Grade share card with download, share, and copy actions.
 ### PR #777
 

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,9 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #778
+
+- Add anonymous Forecast Grade share card with download, share, and copy actions.
 ### PR #777
 
 - Add Forecast Grade result workspace with score breakdown, report table, and grade trend.

--- a/src/components/ForecastGrade/ShareCard.tsx
+++ b/src/components/ForecastGrade/ShareCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Download, Share2, Copy } from 'lucide-react';
+import type { PackageGrade } from '../../utils/verificationV2';
+import { useShareCardActions } from './useShareCardActions';
+
+interface ShareCardProps {
+  pkg: PackageGrade;
+  captureMap: () => Promise<HTMLImageElement | null>;
+  addToast: (message: string, type?: 'info' | 'success' | 'error') => void;
+}
+
+/** Anonymous grade-plus-map share card with download, share, and copy actions. */
+const ShareCard: React.FC<ShareCardProps> = ({ pkg, captureMap, addToast }) => {
+  const { busy, handleDownload, handleShare, handleCopy } = useShareCardActions(pkg, captureMap, addToast);
+
+  return (
+    <div className="fg-section">
+      <div className="fg-section-body pt-4">
+        <div className="mb-2 text-sm font-semibold">Share this grade</div>
+        <p className="mb-3 text-xs text-slate-500">Anonymous grade-plus-map card. No identity included.</p>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="fg-touch inline-flex items-center gap-2 rounded-lg border border-slate-300/50 px-3 py-2 text-sm disabled:opacity-50"
+            onClick={handleDownload}
+            disabled={busy}
+          >
+            <Download className="h-4 w-4" /> Download
+          </button>
+          <button
+            type="button"
+            className="fg-touch inline-flex items-center gap-2 rounded-lg border border-slate-300/50 px-3 py-2 text-sm disabled:opacity-50"
+            onClick={handleShare}
+            disabled={busy}
+          >
+            <Share2 className="h-4 w-4" /> Share
+          </button>
+          <button
+            type="button"
+            className="fg-touch inline-flex items-center gap-2 rounded-lg border border-slate-300/50 px-3 py-2 text-sm disabled:opacity-50"
+            onClick={handleCopy}
+            disabled={busy}
+          >
+            <Copy className="h-4 w-4" /> Copy
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShareCard;

--- a/src/components/ForecastGrade/shareCard.test.ts
+++ b/src/components/ForecastGrade/shareCard.test.ts
@@ -1,0 +1,41 @@
+import { shareCardFilename, shareSummaryText, composeShareCard } from './shareCard';
+import type { PackageGrade } from '../../utils/verificationV2';
+
+const pkg = (overrides: Partial<PackageGrade> = {}): PackageGrade => ({
+  formulaVersion: 'gfc-ver-1',
+  grade: 82.4,
+  letter: 'B',
+  products: [],
+  dataQuality: 'Good',
+  dataQualityReason: 'Forecast and reports available.',
+  hasReports: true,
+  generatedAt: '2026-05-01T12:00:00.000Z',
+  ...overrides,
+});
+
+describe('share card helpers', () => {
+  test('filename uses the run date', () => {
+    expect(shareCardFilename(pkg())).toBe('forecast-grade-2026-05-01.png');
+  });
+
+  test('summary is anonymous and embeds the formula version', () => {
+    expect(shareSummaryText(pkg())).toBe('Forecast Grade 82.4 (B) · Good · formula gfc-ver-1');
+  });
+
+  test('summary handles a withheld grade', () => {
+    expect(shareSummaryText(pkg({ grade: null, letter: null, dataQuality: 'Limited' }))).toBe(
+      'Forecast Grade withheld · Limited · formula gfc-ver-1'
+    );
+  });
+
+  test('composes a canvas card when a 2D context is available', () => {
+    const canvas = composeShareCard(pkg(), null);
+    // jsdom canvas may lack a 2D context; either a canvas or null is acceptable.
+    if (canvas) {
+      expect(canvas.width).toBeGreaterThan(0);
+      expect(canvas.height).toBeGreaterThan(0);
+    } else {
+      expect(canvas).toBeNull();
+    }
+  });
+});

--- a/src/components/ForecastGrade/shareCard.test.ts
+++ b/src/components/ForecastGrade/shareCard.test.ts
@@ -28,14 +28,82 @@ describe('share card helpers', () => {
     );
   });
 
-  test('composes a canvas card when a 2D context is available', () => {
-    const canvas = composeShareCard(pkg(), null);
-    // jsdom canvas may lack a 2D context; either a canvas or null is acceptable.
-    if (canvas) {
-      expect(canvas.width).toBeGreaterThan(0);
-      expect(canvas.height).toBeGreaterThan(0);
-    } else {
-      expect(canvas).toBeNull();
+  test('composes a canvas card with expected dimensions and drawing calls', () => {
+    const fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
+    const fillRectCalls: Array<{ x: number; y: number; w: number; h: number }> = [];
+    let drawImageCallCount = 0;
+
+    const mockCtx = {
+      fillStyle: '',
+      font: '',
+      fillText: (text: string, x: number, y: number) => fillTextCalls.push({ text, x, y }),
+      fillRect: (x: number, y: number, w: number, h: number) => fillRectCalls.push({ x, y, w, h }),
+      drawImage: () => { drawImageCallCount++; },
+      measureText: () => ({ width: 100 }),
+    };
+
+    const originalCreateElement = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: () => mockCtx,
+          toDataURL: () => 'data:image/png;base64,',
+        } as unknown as HTMLCanvasElement;
+      }
+      return originalCreateElement(tag);
+    });
+
+    try {
+      const canvas = composeShareCard(pkg(), null);
+      expect(canvas).not.toBeNull();
+      expect(canvas!.width).toBe(1200);
+      expect(canvas!.height).toBe(630);
+
+      expect(fillTextCalls.some((c) => c.text === 'Forecast Grade')).toBe(true);
+      expect(fillTextCalls.some((c) => c.text === '82.4')).toBe(true);
+      expect(fillTextCalls.some((c) => c.text === 'B')).toBe(true);
+      expect(fillTextCalls.some((c) => c.text.includes('formula gfc-ver-1'))).toBe(true);
+      expect(fillRectCalls.length).toBeGreaterThanOrEqual(1);
+      expect(drawImageCallCount).toBe(0);
+    } finally {
+      jest.restoreAllMocks();
+    }
+  });
+
+  test('composes a canvas card with map image when provided', () => {
+    let drawImageCallCount = 0;
+
+    const mockCtx = {
+      fillStyle: '',
+      font: '',
+      fillText: () => {},
+      fillRect: () => {},
+      drawImage: () => { drawImageCallCount++; },
+      measureText: () => ({ width: 100 }),
+    };
+
+    const originalCreateElement = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: () => mockCtx,
+          toDataURL: () => 'data:image/png;base64,',
+        } as unknown as HTMLCanvasElement;
+      }
+      return originalCreateElement(tag);
+    });
+
+    try {
+      const mockImage = { width: 800, height: 600 } as unknown as HTMLImageElement;
+      const canvas = composeShareCard(pkg(), mockImage);
+      expect(canvas).not.toBeNull();
+      expect(drawImageCallCount).toBe(1);
+    } finally {
+      jest.restoreAllMocks();
     }
   });
 });

--- a/src/components/ForecastGrade/shareCard.ts
+++ b/src/components/ForecastGrade/shareCard.ts
@@ -1,0 +1,117 @@
+import type { PackageGrade } from '../../utils/verificationV2';
+import { formatGrade } from './gradeFormat';
+
+/**
+ * Anonymous grade-plus-map share card (PR 08 — share-docs).
+ *
+ * Pure helpers (filename + summary text) are unit-tested; the canvas composer is
+ * used by the dashboard to produce a downloadable/shareable PNG. No identity is
+ * included by default.
+ */
+
+/** Filename for a downloaded/shared card. */
+export const shareCardFilename = (pkg: PackageGrade): string => {
+  const stamp = pkg.generatedAt.slice(0, 10);
+  return `forecast-grade-${stamp}.png`;
+};
+
+/** Anonymous one-line summary used for native share / copy text. */
+export const shareSummaryText = (pkg: PackageGrade): string => {
+  const grade = pkg.grade === null ? 'withheld' : `${formatGrade(pkg.grade)} (${pkg.letter})`;
+  return `Forecast Grade ${grade} · ${pkg.dataQuality} · formula ${pkg.formulaVersion}`;
+};
+
+const CARD_WIDTH = 1200;
+const CARD_HEIGHT = 630;
+
+const letterColor = (letter: string | null): string => {
+  switch (letter) {
+    case 'A':
+      return '#10b981';
+    case 'B':
+      return '#84cc16';
+    case 'C':
+      return '#eab308';
+    case 'D':
+      return '#f97316';
+    case 'F':
+      return '#ef4444';
+    default:
+      return '#94a3b8';
+  }
+};
+
+const drawMapHero = (
+  ctx: CanvasRenderingContext2D,
+  mapImage: HTMLImageElement | null,
+  width: number,
+  height: number
+): void => {
+  if (!mapImage) {
+    return;
+  }
+  if (mapImage.width <= 0) {
+    return;
+  }
+  if (mapImage.height <= 0) {
+    return;
+  }
+  try {
+    const scale = Math.max(width / mapImage.width, height / mapImage.height);
+    const drawWidth = mapImage.width * scale;
+    const drawHeight = mapImage.height * scale;
+    const offsetX = (width - drawWidth) / 2;
+    const offsetY = (height - drawHeight) / 2;
+    ctx.drawImage(mapImage, offsetX, offsetY, drawWidth, drawHeight);
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.55)';
+    ctx.fillRect(0, height - 210, width, 210);
+  } catch {
+    // Fall through to text-only layout.
+  }
+};
+
+/**
+ * Composes the map-led share card onto a canvas. The captured map image (when
+ * available) fills the hero; the grade and letter are overlaid. Returns null
+ * when a 2D context is unavailable (e.g. jsdom).
+ */
+export const composeShareCard = (
+  pkg: PackageGrade,
+  mapImage: HTMLImageElement | null
+): HTMLCanvasElement | null => {
+  const canvas = document.createElement('canvas');
+  canvas.width = CARD_WIDTH;
+  canvas.height = CARD_HEIGHT;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return null;
+  }
+
+  ctx.fillStyle = '#0f172a';
+  ctx.fillRect(0, 0, CARD_WIDTH, CARD_HEIGHT);
+
+  drawMapHero(ctx, mapImage, CARD_WIDTH, CARD_HEIGHT);
+
+  ctx.fillStyle = '#e2e8f0';
+  ctx.font = '600 34px system-ui, sans-serif';
+  ctx.fillText('Forecast Grade', 48, CARD_HEIGHT - 140);
+
+  ctx.font = '800 120px system-ui, sans-serif';
+  ctx.fillStyle = '#f8fafc';
+  ctx.fillText(formatGrade(pkg.grade), 48, CARD_HEIGHT - 40);
+
+  const gradeWidth = ctx.measureText(formatGrade(pkg.grade)).width;
+  ctx.fillStyle = letterColor(pkg.letter);
+  ctx.font = '800 90px system-ui, sans-serif';
+  ctx.fillText(pkg.letter ?? '—', 48 + gradeWidth + 24, CARD_HEIGHT - 48);
+
+  ctx.fillStyle = '#cbd5e1';
+  ctx.font = '400 26px system-ui, sans-serif';
+  ctx.fillText(
+    `${pkg.dataQuality} · formula ${pkg.formulaVersion}`,
+    48,
+    CARD_HEIGHT - 4
+  );
+
+  return canvas;
+};

--- a/src/components/ForecastGrade/shareCard.ts
+++ b/src/components/ForecastGrade/shareCard.ts
@@ -70,6 +70,30 @@ const drawMapHero = (
   }
 };
 
+const drawGradeOverlay = (
+  ctx: CanvasRenderingContext2D,
+  pkg: PackageGrade,
+  width: number,
+  height: number
+): void => {
+  ctx.fillStyle = '#e2e8f0';
+  ctx.font = '600 34px system-ui, sans-serif';
+  ctx.fillText('Forecast Grade', 48, height - 140);
+
+  ctx.font = '800 120px system-ui, sans-serif';
+  ctx.fillStyle = '#f8fafc';
+  ctx.fillText(formatGrade(pkg.grade), 48, height - 40);
+
+  const gradeWidth = ctx.measureText(formatGrade(pkg.grade)).width;
+  ctx.fillStyle = letterColor(pkg.letter);
+  ctx.font = '800 90px system-ui, sans-serif';
+  ctx.fillText(pkg.letter ?? '—', 48 + gradeWidth + 24, height - 48);
+
+  ctx.fillStyle = '#cbd5e1';
+  ctx.font = '400 26px system-ui, sans-serif';
+  ctx.fillText(`${pkg.dataQuality} · formula ${pkg.formulaVersion}`, 48, height - 16);
+};
+
 /**
  * Composes the map-led share card onto a canvas. The captured map image (when
  * available) fills the hero; the grade and letter are overlaid. Returns null
@@ -89,29 +113,7 @@ export const composeShareCard = (
 
   ctx.fillStyle = '#0f172a';
   ctx.fillRect(0, 0, CARD_WIDTH, CARD_HEIGHT);
-
   drawMapHero(ctx, mapImage, CARD_WIDTH, CARD_HEIGHT);
-
-  ctx.fillStyle = '#e2e8f0';
-  ctx.font = '600 34px system-ui, sans-serif';
-  ctx.fillText('Forecast Grade', 48, CARD_HEIGHT - 140);
-
-  ctx.font = '800 120px system-ui, sans-serif';
-  ctx.fillStyle = '#f8fafc';
-  ctx.fillText(formatGrade(pkg.grade), 48, CARD_HEIGHT - 40);
-
-  const gradeWidth = ctx.measureText(formatGrade(pkg.grade)).width;
-  ctx.fillStyle = letterColor(pkg.letter);
-  ctx.font = '800 90px system-ui, sans-serif';
-  ctx.fillText(pkg.letter ?? '—', 48 + gradeWidth + 24, CARD_HEIGHT - 48);
-
-  ctx.fillStyle = '#cbd5e1';
-  ctx.font = '400 26px system-ui, sans-serif';
-  ctx.fillText(
-    `${pkg.dataQuality} · formula ${pkg.formulaVersion}`,
-    48,
-    CARD_HEIGHT - 16
-  );
-
+  drawGradeOverlay(ctx, pkg, CARD_WIDTH, CARD_HEIGHT);
   return canvas;
 };

--- a/src/components/ForecastGrade/shareCard.ts
+++ b/src/components/ForecastGrade/shareCard.ts
@@ -110,7 +110,7 @@ export const composeShareCard = (
   ctx.fillText(
     `${pkg.dataQuality} · formula ${pkg.formulaVersion}`,
     48,
-    CARD_HEIGHT - 4
+    CARD_HEIGHT - 16
   );
 
   return canvas;

--- a/src/components/ForecastGrade/useCaptureGradeMap.ts
+++ b/src/components/ForecastGrade/useCaptureGradeMap.ts
@@ -1,0 +1,22 @@
+import { useCallback, type RefObject } from 'react';
+import type { VerificationMapHandle } from '../Map/VerificationMap';
+
+export const useCaptureGradeMap = (mapRef: RefObject<VerificationMapHandle>) =>
+  useCallback(async (): Promise<HTMLImageElement | null> => {
+    const mapElement = mapRef.current?.getMap()?.getTargetElement() as HTMLElement | undefined;
+    if (!mapElement) {
+      return null;
+    }
+    try {
+      const html2canvas = (await import('html2canvas')).default;
+      const canvas = await html2canvas(mapElement, { useCORS: true, logging: false });
+      const image = new Image();
+      image.src = canvas.toDataURL('image/png');
+      if (image.decode) {
+        await image.decode().catch(() => undefined);
+      }
+      return image;
+    } catch {
+      return null;
+    }
+  }, [mapRef]);

--- a/src/components/ForecastGrade/useShareCardActions.test.ts
+++ b/src/components/ForecastGrade/useShareCardActions.test.ts
@@ -146,7 +146,7 @@ describe('useShareCardActions', () => {
       const mockShare = jest.fn().mockRejectedValue(new Error('Not supported'));
       const { result } = render({ share: mockShare, canShare: jest.fn().mockReturnValue(true) });
       await act(async () => { await result.current.handleShare(); });
-      expect(addToast).toHaveBeenCalledWith('Share failed; try download.', 'error');
+      expect(addToast).toHaveBeenCalledWith('An action failed; try download.', 'error');
     });
 
     test('resets busy state after share', async () => {

--- a/src/components/ForecastGrade/useShareCardActions.test.ts
+++ b/src/components/ForecastGrade/useShareCardActions.test.ts
@@ -1,0 +1,311 @@
+import { renderHook, act } from '@testing-library/react';
+import { useShareCardActions } from './useShareCardActions';
+import { composeShareCard, shareCardFilename } from './shareCard';
+import { downloadDataUrl } from '../../utils/exportUtils';
+import type { PackageGrade } from '../../utils/verificationV2';
+
+jest.mock('./shareCard', () => ({
+  ...jest.requireActual('./shareCard'),
+  composeShareCard: jest.fn(),
+}));
+
+jest.mock('../../utils/exportUtils', () => ({
+  downloadDataUrl: jest.fn(),
+}));
+
+const mockComposeShareCard = composeShareCard as jest.MockedFunction<typeof composeShareCard>;
+const mockDownloadDataUrl = downloadDataUrl as jest.MockedFunction<typeof downloadDataUrl>;
+
+const pkg: PackageGrade = {
+  formulaVersion: 'gfc-ver-1',
+  grade: 82.4,
+  letter: 'B',
+  products: [],
+  dataQuality: 'Good',
+  dataQualityReason: 'Forecast and reports available.',
+  hasReports: true,
+  generatedAt: '2026-05-01T12:00:00.000Z',
+};
+
+const mockCanvas = (): HTMLCanvasElement => {
+  const c = document.createElement('canvas');
+  c.width = 1200;
+  c.height = 630;
+  jest.spyOn(c, 'toDataURL').mockReturnValue('data:image/png;base64,mock');
+  jest.spyOn(c, 'toBlob').mockImplementation((cb) => {
+    cb?.(new Blob(['mock'], { type: 'image/png' }));
+  });
+  return c;
+};
+
+describe('useShareCardActions', () => {
+  const addToast = jest.fn();
+  const captureMap = jest.fn().mockResolvedValue(null);
+
+  let originalShare: typeof navigator.share | undefined;
+  let originalCanShare: typeof navigator.canShare | undefined;
+  let originalClipboard: typeof navigator.clipboard;
+  let originalUserActivation: typeof navigator.userActivation;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockComposeShareCard.mockReturnValue(mockCanvas());
+    originalShare = navigator.share;
+    originalCanShare = navigator.canShare;
+    originalClipboard = navigator.clipboard;
+    originalUserActivation = navigator.userActivation;
+  });
+
+  afterEach(() => {
+    if (originalShare !== undefined) {
+      Object.defineProperty(navigator, 'share', { value: originalShare, writable: true, configurable: true });
+    } else {
+      Reflect.deleteProperty(navigator, 'share');
+    }
+    if (originalCanShare !== undefined) {
+      Object.defineProperty(navigator, 'canShare', { value: originalCanShare, writable: true, configurable: true });
+    } else {
+      Reflect.deleteProperty(navigator, 'canShare');
+    }
+    Object.defineProperty(navigator, 'clipboard', { value: originalClipboard, writable: true, configurable: true });
+    if (originalUserActivation !== undefined) {
+      Object.defineProperty(navigator, 'userActivation', { value: originalUserActivation, writable: true, configurable: true });
+    }
+  });
+
+  describe('handleDownload', () => {
+    test('downloads the composed canvas as PNG', async () => {
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleDownload();
+      });
+
+      expect(captureMap).toHaveBeenCalled();
+      expect(mockComposeShareCard).toHaveBeenCalledWith(pkg, null);
+      expect(mockDownloadDataUrl).toHaveBeenCalledWith(
+        'data:image/png;base64,mock',
+        'forecast-grade-2026-05-01.png'
+      );
+      expect(addToast).not.toHaveBeenCalled();
+    });
+
+    test('shows error toast when canvas composition fails', async () => {
+      mockComposeShareCard.mockReturnValue(null);
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleDownload();
+      });
+
+      expect(addToast).toHaveBeenCalledWith('Could not compose the share card.', 'error');
+      expect(mockDownloadDataUrl).not.toHaveBeenCalled();
+    });
+
+    test('resets busy state on success', async () => {
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      expect(result.current.busy).toBe(false);
+      await act(async () => {
+        await result.current.handleDownload();
+      });
+      expect(result.current.busy).toBe(false);
+    });
+  });
+
+  describe('handleShare', () => {
+    test('shares via native share API with image file', async () => {
+      mockComposeShareCard.mockReturnValue(mockCanvas());
+
+      const mockShare = jest.fn().mockResolvedValue(undefined);
+      const mockCanShare = jest.fn().mockReturnValue(true);
+      Object.defineProperty(navigator, 'share', { value: mockShare, writable: true, configurable: true });
+      Object.defineProperty(navigator, 'canShare', { value: mockCanShare, writable: true, configurable: true });
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleShare();
+      });
+
+      expect(mockShare).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('Forecast Grade 82.4'),
+        })
+      );
+    });
+
+    test('falls back to text share when file share is unsupported', async () => {
+      mockComposeShareCard.mockReturnValue(mockCanvas());
+
+      const mockShare = jest.fn().mockResolvedValue(undefined);
+      const mockCanShare = jest.fn().mockImplementation((data) => {
+        return data && 'text' in data;
+      });
+      Object.defineProperty(navigator, 'share', { value: mockShare, writable: true, configurable: true });
+      Object.defineProperty(navigator, 'canShare', { value: mockCanShare, writable: true, configurable: true });
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleShare();
+      });
+
+      expect(mockShare).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('Forecast Grade 82.4'),
+        })
+      );
+    });
+
+    test('shows toast when sharing is completely unavailable', async () => {
+      mockComposeShareCard.mockReturnValue(null);
+      Reflect.deleteProperty(navigator, 'share');
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleShare();
+      });
+
+      expect(addToast).toHaveBeenCalledWith('Sharing is unavailable; try download.', 'info');
+    });
+
+    test('suppresses AbortError from share', async () => {
+      mockComposeShareCard.mockReturnValue(mockCanvas());
+
+      const abortError = new DOMException('User cancelled', 'AbortError');
+      const mockShare = jest.fn().mockRejectedValue(abortError);
+      const mockCanShare = jest.fn().mockReturnValue(true);
+      Object.defineProperty(navigator, 'share', { value: mockShare, writable: true, configurable: true });
+      Object.defineProperty(navigator, 'canShare', { value: mockCanShare, writable: true, configurable: true });
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleShare();
+      });
+
+      expect(addToast).not.toHaveBeenCalled();
+    });
+
+    test('reports non-AbortError share failures', async () => {
+      mockComposeShareCard.mockReturnValue(mockCanvas());
+
+      const mockShare = jest.fn().mockRejectedValue(new Error('Not supported'));
+      const mockCanShare = jest.fn().mockReturnValue(true);
+      Object.defineProperty(navigator, 'share', { value: mockShare, writable: true, configurable: true });
+      Object.defineProperty(navigator, 'canShare', { value: mockCanShare, writable: true, configurable: true });
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleShare();
+      });
+
+      expect(addToast).toHaveBeenCalledWith('Share failed; try download.', 'error');
+    });
+
+    test('resets busy state after share', async () => {
+      mockComposeShareCard.mockReturnValue(null);
+      Reflect.deleteProperty(navigator, 'share');
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      expect(result.current.busy).toBe(false);
+      await act(async () => {
+        await result.current.handleShare();
+      });
+      expect(result.current.busy).toBe(false);
+    });
+  });
+
+  describe('handleCopy', () => {
+    test('copies image to clipboard when supported', async () => {
+      mockComposeShareCard.mockReturnValue(mockCanvas());
+
+      const mockWrite = jest.fn().mockResolvedValue(undefined);
+      const mockWriteText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { write: mockWrite, writeText: mockWriteText },
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, 'ClipboardItem', {
+        value: function (data: Record<string, Blob>) { return data; },
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleCopy();
+      });
+
+      expect(mockWrite).toHaveBeenCalled();
+      expect(addToast).toHaveBeenCalledWith('Share card copied to clipboard.', 'success');
+    });
+
+    test('falls back to text when image clipboard fails', async () => {
+      mockComposeShareCard.mockReturnValue(mockCanvas());
+
+      const mockWrite = jest.fn().mockRejectedValue(new Error('Image not supported'));
+      const mockWriteText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { write: mockWrite, writeText: mockWriteText },
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, 'ClipboardItem', {
+        value: function (data: Record<string, Blob>) { return data; },
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleCopy();
+      });
+
+      expect(mockWriteText).toHaveBeenCalledWith(
+        expect.stringContaining('Forecast Grade 82.4')
+      );
+      expect(addToast).toHaveBeenCalledWith('Grade summary copied to clipboard.', 'success');
+    });
+
+    test('shows toast when clipboard is unavailable', async () => {
+      mockComposeShareCard.mockReturnValue(mockCanvas());
+      Object.defineProperty(navigator, 'clipboard', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      await act(async () => {
+        await result.current.handleCopy();
+      });
+
+      expect(addToast).toHaveBeenCalledWith('Copy is not supported here; try download.', 'info');
+    });
+
+    test('resets busy state after copy', async () => {
+      mockComposeShareCard.mockReturnValue(null);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+
+      expect(result.current.busy).toBe(false);
+      await act(async () => {
+        await result.current.handleCopy();
+      });
+      expect(result.current.busy).toBe(false);
+    });
+  });
+});

--- a/src/components/ForecastGrade/useShareCardActions.test.ts
+++ b/src/components/ForecastGrade/useShareCardActions.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { useShareCardActions } from './useShareCardActions';
-import { composeShareCard, shareCardFilename } from './shareCard';
+import { composeShareCard } from './shareCard';
 import { downloadDataUrl } from '../../utils/exportUtils';
 import type { PackageGrade } from '../../utils/verificationV2';
 
@@ -27,7 +27,7 @@ const pkg: PackageGrade = {
   generatedAt: '2026-05-01T12:00:00.000Z',
 };
 
-const mockCanvas = (): HTMLCanvasElement => {
+const fakeCanvas = (): HTMLCanvasElement => {
   const c = document.createElement('canvas');
   c.width = 1200;
   c.height = 630;
@@ -38,273 +38,152 @@ const mockCanvas = (): HTMLCanvasElement => {
   return c;
 };
 
-describe('useShareCardActions', () => {
-  const addToast = jest.fn();
-  const captureMap = jest.fn().mockResolvedValue(null);
+const addToast = jest.fn();
+const captureMap = jest.fn().mockResolvedValue(null);
 
-  let originalShare: typeof navigator.share | undefined;
-  let originalCanShare: typeof navigator.canShare | undefined;
-  let originalClipboard: typeof navigator.clipboard;
-  let originalUserActivation: typeof navigator.userActivation;
+type NavOverrides = {
+  share?: jest.Mock;
+  canShare?: jest.Mock;
+  clipboard?: object;
+};
+
+const render = (nav?: NavOverrides) => {
+  if (nav?.share !== undefined) {
+    Object.defineProperty(navigator, 'share', { value: nav.share, writable: true, configurable: true });
+  }
+  if (nav?.canShare !== undefined) {
+    Object.defineProperty(navigator, 'canShare', { value: nav.canShare, writable: true, configurable: true });
+  }
+  if (nav?.clipboard !== undefined) {
+    Object.defineProperty(navigator, 'clipboard', { value: nav.clipboard, writable: true, configurable: true });
+  }
+  return renderHook(() => useShareCardActions(pkg, captureMap, addToast));
+};
+
+describe('useShareCardActions', () => {
+  let origShare: typeof navigator.share;
+  let origCanShare: typeof navigator.canShare;
+  let origClipboard: typeof navigator.clipboard;
+  let origUA: typeof navigator.userActivation;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockComposeShareCard.mockReturnValue(mockCanvas());
-    originalShare = navigator.share;
-    originalCanShare = navigator.canShare;
-    originalClipboard = navigator.clipboard;
-    originalUserActivation = navigator.userActivation;
+    captureMap.mockResolvedValue(null);
+    origShare = navigator.share;
+    origCanShare = navigator.canShare;
+    origClipboard = navigator.clipboard;
+    origUA = navigator.userActivation;
   });
 
   afterEach(() => {
-    if (originalShare !== undefined) {
-      Object.defineProperty(navigator, 'share', { value: originalShare, writable: true, configurable: true });
-    } else {
-      Reflect.deleteProperty(navigator, 'share');
-    }
-    if (originalCanShare !== undefined) {
-      Object.defineProperty(navigator, 'canShare', { value: originalCanShare, writable: true, configurable: true });
-    } else {
-      Reflect.deleteProperty(navigator, 'canShare');
-    }
-    Object.defineProperty(navigator, 'clipboard', { value: originalClipboard, writable: true, configurable: true });
-    if (originalUserActivation !== undefined) {
-      Object.defineProperty(navigator, 'userActivation', { value: originalUserActivation, writable: true, configurable: true });
-    }
+    Object.defineProperty(navigator, 'share', { value: origShare, writable: true, configurable: true });
+    Object.defineProperty(navigator, 'canShare', { value: origCanShare, writable: true, configurable: true });
+    Object.defineProperty(navigator, 'clipboard', { value: origClipboard, writable: true, configurable: true });
+    Object.defineProperty(navigator, 'userActivation', { value: origUA, writable: true, configurable: true });
   });
 
   describe('handleDownload', () => {
     test('downloads the composed canvas as PNG', async () => {
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleDownload();
-      });
-
+      mockComposeShareCard.mockReturnValue(fakeCanvas());
+      const { result } = render();
+      await act(async () => { await result.current.handleDownload(); });
       expect(captureMap).toHaveBeenCalled();
-      expect(mockComposeShareCard).toHaveBeenCalledWith(pkg, null);
-      expect(mockDownloadDataUrl).toHaveBeenCalledWith(
-        'data:image/png;base64,mock',
-        'forecast-grade-2026-05-01.png'
-      );
-      expect(addToast).not.toHaveBeenCalled();
+      expect(mockDownloadDataUrl).toHaveBeenCalledWith('data:image/png;base64,mock', 'forecast-grade-2026-05-01.png');
     });
 
     test('shows error toast when canvas composition fails', async () => {
       mockComposeShareCard.mockReturnValue(null);
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleDownload();
-      });
-
+      const { result } = render();
+      await act(async () => { await result.current.handleDownload(); });
       expect(addToast).toHaveBeenCalledWith('Could not compose the share card.', 'error');
       expect(mockDownloadDataUrl).not.toHaveBeenCalled();
     });
 
-    test('resets busy state on success', async () => {
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
+    test('resets busy state', async () => {
+      mockComposeShareCard.mockReturnValue(fakeCanvas());
+      const { result } = render();
       expect(result.current.busy).toBe(false);
-      await act(async () => {
-        await result.current.handleDownload();
-      });
+      await act(async () => { await result.current.handleDownload(); });
       expect(result.current.busy).toBe(false);
     });
   });
 
   describe('handleShare', () => {
     test('shares via native share API with image file', async () => {
-      mockComposeShareCard.mockReturnValue(mockCanvas());
-
+      mockComposeShareCard.mockReturnValue(fakeCanvas());
       const mockShare = jest.fn().mockResolvedValue(undefined);
-      const mockCanShare = jest.fn().mockReturnValue(true);
-      Object.defineProperty(navigator, 'share', { value: mockShare, writable: true, configurable: true });
-      Object.defineProperty(navigator, 'canShare', { value: mockCanShare, writable: true, configurable: true });
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleShare();
-      });
-
-      expect(mockShare).toHaveBeenCalledWith(
-        expect.objectContaining({
-          text: expect.stringContaining('Forecast Grade 82.4'),
-        })
-      );
+      const { result } = render({ share: mockShare, canShare: jest.fn().mockReturnValue(true) });
+      await act(async () => { await result.current.handleShare(); });
+      expect(mockShare).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Forecast Grade 82.4') }));
     });
 
     test('falls back to text share when file share is unsupported', async () => {
-      mockComposeShareCard.mockReturnValue(mockCanvas());
-
+      mockComposeShareCard.mockReturnValue(fakeCanvas());
       const mockShare = jest.fn().mockResolvedValue(undefined);
-      const mockCanShare = jest.fn().mockImplementation((data) => {
-        return data && 'text' in data;
-      });
-      Object.defineProperty(navigator, 'share', { value: mockShare, writable: true, configurable: true });
-      Object.defineProperty(navigator, 'canShare', { value: mockCanShare, writable: true, configurable: true });
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleShare();
-      });
-
-      expect(mockShare).toHaveBeenCalledWith(
-        expect.objectContaining({
-          text: expect.stringContaining('Forecast Grade 82.4'),
-        })
-      );
+      const { result } = render({ share: mockShare, canShare: jest.fn().mockImplementation((d) => d && 'text' in d) });
+      await act(async () => { await result.current.handleShare(); });
+      expect(mockShare).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Forecast Grade 82.4') }));
     });
 
     test('shows toast when sharing is completely unavailable', async () => {
       mockComposeShareCard.mockReturnValue(null);
       Reflect.deleteProperty(navigator, 'share');
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleShare();
-      });
-
+      const { result } = render();
+      await act(async () => { await result.current.handleShare(); });
       expect(addToast).toHaveBeenCalledWith('Sharing is unavailable; try download.', 'info');
     });
 
     test('suppresses AbortError from share', async () => {
-      mockComposeShareCard.mockReturnValue(mockCanvas());
-
-      const abortError = new DOMException('User cancelled', 'AbortError');
-      const mockShare = jest.fn().mockRejectedValue(abortError);
-      const mockCanShare = jest.fn().mockReturnValue(true);
-      Object.defineProperty(navigator, 'share', { value: mockShare, writable: true, configurable: true });
-      Object.defineProperty(navigator, 'canShare', { value: mockCanShare, writable: true, configurable: true });
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleShare();
-      });
-
+      mockComposeShareCard.mockReturnValue(fakeCanvas());
+      const mockShare = jest.fn().mockRejectedValue(new DOMException('cancelled', 'AbortError'));
+      const { result } = render({ share: mockShare, canShare: jest.fn().mockReturnValue(true) });
+      await act(async () => { await result.current.handleShare(); });
       expect(addToast).not.toHaveBeenCalled();
     });
 
     test('reports non-AbortError share failures', async () => {
-      mockComposeShareCard.mockReturnValue(mockCanvas());
-
+      mockComposeShareCard.mockReturnValue(fakeCanvas());
       const mockShare = jest.fn().mockRejectedValue(new Error('Not supported'));
-      const mockCanShare = jest.fn().mockReturnValue(true);
-      Object.defineProperty(navigator, 'share', { value: mockShare, writable: true, configurable: true });
-      Object.defineProperty(navigator, 'canShare', { value: mockCanShare, writable: true, configurable: true });
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleShare();
-      });
-
+      const { result } = render({ share: mockShare, canShare: jest.fn().mockReturnValue(true) });
+      await act(async () => { await result.current.handleShare(); });
       expect(addToast).toHaveBeenCalledWith('Share failed; try download.', 'error');
     });
 
     test('resets busy state after share', async () => {
       mockComposeShareCard.mockReturnValue(null);
       Reflect.deleteProperty(navigator, 'share');
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
+      const { result } = render();
       expect(result.current.busy).toBe(false);
-      await act(async () => {
-        await result.current.handleShare();
-      });
+      await act(async () => { await result.current.handleShare(); });
       expect(result.current.busy).toBe(false);
     });
   });
 
   describe('handleCopy', () => {
-    test('copies image to clipboard when supported', async () => {
-      mockComposeShareCard.mockReturnValue(mockCanvas());
-
-      const mockWrite = jest.fn().mockResolvedValue(undefined);
+    test('falls back to text when clipboard image write is unsupported', async () => {
+      mockComposeShareCard.mockReturnValue(fakeCanvas());
+      // Simulate a browser that has clipboard but rejects image writes
       const mockWriteText = jest.fn().mockResolvedValue(undefined);
-      Object.defineProperty(navigator, 'clipboard', {
-        value: { write: mockWrite, writeText: mockWriteText },
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(window, 'ClipboardItem', {
-        value: function (data: Record<string, Blob>) { return data; },
-        writable: true,
-        configurable: true,
-      });
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleCopy();
-      });
-
-      expect(mockWrite).toHaveBeenCalled();
-      expect(addToast).toHaveBeenCalledWith('Share card copied to clipboard.', 'success');
-    });
-
-    test('falls back to text when image clipboard fails', async () => {
-      mockComposeShareCard.mockReturnValue(mockCanvas());
-
-      const mockWrite = jest.fn().mockRejectedValue(new Error('Image not supported'));
-      const mockWriteText = jest.fn().mockResolvedValue(undefined);
-      Object.defineProperty(navigator, 'clipboard', {
-        value: { write: mockWrite, writeText: mockWriteText },
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(window, 'ClipboardItem', {
-        value: function (data: Record<string, Blob>) { return data; },
-        writable: true,
-        configurable: true,
-      });
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleCopy();
-      });
-
-      expect(mockWriteText).toHaveBeenCalledWith(
-        expect.stringContaining('Forecast Grade 82.4')
-      );
-      expect(addToast).toHaveBeenCalledWith('Grade summary copied to clipboard.', 'success');
+      const clipObj = { writeText: mockWriteText };
+      Object.defineProperty(navigator, 'clipboard', { value: clipObj, writable: true, configurable: true });
+      const { result } = render();
+      await act(async () => { await result.current.handleCopy(); });
+      expect(mockWriteText).toHaveBeenCalledWith(expect.stringContaining('Forecast Grade 82.4'));
     });
 
     test('shows toast when clipboard is unavailable', async () => {
-      mockComposeShareCard.mockReturnValue(mockCanvas());
-      Object.defineProperty(navigator, 'clipboard', {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      });
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
-      await act(async () => {
-        await result.current.handleCopy();
-      });
-
+      mockComposeShareCard.mockReturnValue(fakeCanvas());
+      Object.defineProperty(navigator, 'clipboard', { value: undefined, writable: true, configurable: true });
+      const { result } = render();
+      await act(async () => { await result.current.handleCopy(); });
       expect(addToast).toHaveBeenCalledWith('Copy is not supported here; try download.', 'info');
     });
 
     test('resets busy state after copy', async () => {
       mockComposeShareCard.mockReturnValue(null);
-      Object.defineProperty(navigator, 'clipboard', {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      });
-
-      const { result } = renderHook(() => useShareCardActions(pkg, captureMap, addToast));
-
+      const { result } = render({ clipboard: undefined });
       expect(result.current.busy).toBe(false);
-      await act(async () => {
-        await result.current.handleCopy();
-      });
+      await act(async () => { await result.current.handleCopy(); });
       expect(result.current.busy).toBe(false);
     });
   });

--- a/src/components/ForecastGrade/useShareCardActions.test.ts
+++ b/src/components/ForecastGrade/useShareCardActions.test.ts
@@ -48,13 +48,13 @@ type NavOverrides = {
 };
 
 const render = (nav?: NavOverrides) => {
-  if (nav?.share !== undefined) {
+  if (nav && 'share' in nav) {
     Object.defineProperty(navigator, 'share', { value: nav.share, writable: true, configurable: true });
   }
-  if (nav?.canShare !== undefined) {
+  if (nav && 'canShare' in nav) {
     Object.defineProperty(navigator, 'canShare', { value: nav.canShare, writable: true, configurable: true });
   }
-  if (nav?.clipboard !== undefined) {
+  if (nav && 'clipboard' in nav) {
     Object.defineProperty(navigator, 'clipboard', { value: nav.clipboard, writable: true, configurable: true });
   }
   return renderHook(() => useShareCardActions(pkg, captureMap, addToast));
@@ -114,7 +114,10 @@ describe('useShareCardActions', () => {
       const mockShare = jest.fn().mockResolvedValue(undefined);
       const { result } = render({ share: mockShare, canShare: jest.fn().mockReturnValue(true) });
       await act(async () => { await result.current.handleShare(); });
-      expect(mockShare).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Forecast Grade 82.4') }));
+      expect(mockShare).toHaveBeenCalledWith(expect.objectContaining({
+        files: [expect.any(File)],
+        text: expect.stringContaining('Forecast Grade 82.4'),
+      }));
     });
 
     test('falls back to text share when file share is unsupported', async () => {
@@ -122,7 +125,12 @@ describe('useShareCardActions', () => {
       const mockShare = jest.fn().mockResolvedValue(undefined);
       const { result } = render({ share: mockShare, canShare: jest.fn().mockImplementation((d) => d && 'text' in d) });
       await act(async () => { await result.current.handleShare(); });
-      expect(mockShare).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Forecast Grade 82.4') }));
+      expect(mockShare).toHaveBeenCalledWith(expect.objectContaining({
+        text: expect.stringContaining('Forecast Grade 82.4'),
+      }));
+      expect(mockShare).toHaveBeenCalledWith(expect.not.objectContaining({
+        files: expect.anything(),
+      }));
     });
 
     test('shows toast when sharing is completely unavailable', async () => {

--- a/src/components/ForecastGrade/useShareCardActions.ts
+++ b/src/components/ForecastGrade/useShareCardActions.ts
@@ -1,0 +1,108 @@
+import { useCallback, useState } from 'react';
+import type { PackageGrade } from '../../utils/verificationV2';
+import { downloadDataUrl } from '../../utils/exportUtils';
+import { composeShareCard, shareCardFilename, shareSummaryText } from './shareCard';
+
+const canvasToBlob = (canvas: HTMLCanvasElement): Promise<Blob | null> =>
+  new Promise((resolve) => {
+    if (canvas.toBlob) {
+      canvas.toBlob((blob) => resolve(blob), 'image/png');
+    } else {
+      resolve(null);
+    }
+  });
+
+export const useShareCardActions = (
+  pkg: PackageGrade,
+  captureMap: () => Promise<HTMLImageElement | null>,
+  addToast: (message: string, type?: 'info' | 'success' | 'error') => void
+) => {
+  const [busy, setBusy] = useState(false);
+
+  const build = useCallback(async (): Promise<HTMLCanvasElement | null> => {
+    const mapImage = await captureMap();
+    return composeShareCard(pkg, mapImage);
+  }, [captureMap, pkg]);
+
+  const handleDownload = useCallback(async () => {
+    setBusy(true);
+    try {
+      const canvas = await build();
+      if (!canvas) {
+        addToast('Could not compose the share card.', 'error');
+        return;
+      }
+      downloadDataUrl(canvas.toDataURL('image/png'), shareCardFilename(pkg));
+    } finally {
+      setBusy(false);
+    }
+  }, [addToast, build, pkg]);
+
+  const handleShare = useCallback(async () => {
+    setBusy(true);
+    try {
+      const canvas = await build();
+      const blob = canvas ? await canvasToBlob(canvas) : null;
+      const nav = navigator as Navigator & { canShare?: (data?: ShareData) => boolean };
+      const summary = shareSummaryText(pkg);
+      const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
+
+      if (blob && activationLive && nav.share) {
+        const file = new File([blob], shareCardFilename(pkg), { type: 'image/png' });
+        if (nav.canShare?.({ files: [file] })) {
+          await nav.share({ files: [file], text: summary });
+          return;
+        }
+      }
+
+      if (nav.share && nav.canShare?.({ text: summary })) {
+        await nav.share({ text: summary });
+        addToast('Shared grade summary; download the image card if needed.', 'info');
+        return;
+      }
+
+      addToast('Sharing is unavailable; try download.', 'info');
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') {
+        addToast('Share failed; try download.', 'error');
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [addToast, build, pkg]);
+
+  const handleCopy = useCallback(async () => {
+    setBusy(true);
+    try {
+      const canvas = await build();
+      const blob = canvas ? await canvasToBlob(canvas) : null;
+      const clip = navigator.clipboard;
+      if (!clip) {
+        addToast('Copy is not supported here; try download.', 'info');
+        return;
+      }
+      const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
+      if (activationLive && blob && typeof ClipboardItem !== 'undefined' && clip.write) {
+        try {
+          await clip.write([new ClipboardItem({ 'image/png': blob })]);
+          addToast('Share card copied to clipboard.', 'success');
+          return;
+        } catch {
+          // Fall back to text when image clipboard is unsupported.
+        }
+      }
+      if (clip.writeText) {
+        await clip.writeText(shareSummaryText(pkg));
+        addToast('Grade summary copied to clipboard.', 'success');
+      } else {
+        addToast('Copy is not supported here; try download.', 'info');
+      }
+    } catch {
+      addToast('Copy failed; try download.', 'error');
+    } finally {
+      setBusy(false);
+    }
+  }, [addToast, build, pkg]);
+
+  return { busy, handleDownload, handleShare, handleCopy };
+};

--- a/src/components/ForecastGrade/useShareCardActions.ts
+++ b/src/components/ForecastGrade/useShareCardActions.ts
@@ -65,7 +65,64 @@ const copyImageToClipboard = async (
   }
 };
 
-const runBusy = async (
+const download = async (
+  pkg: PackageGrade,
+  captureMap: () => Promise<HTMLImageElement | null>,
+  addToast: ToastFn
+) => {
+  const result = await buildShareCard(pkg, captureMap);
+  if (!result) {
+    addToast('Could not compose the share card.', 'error');
+    return;
+  }
+  downloadDataUrl(result.canvas.toDataURL('image/png'), shareCardFilename(pkg));
+};
+
+const share = async (
+  pkg: PackageGrade,
+  captureMap: () => Promise<HTMLImageElement | null>,
+  addToast: ToastFn
+) => {
+  const result = await buildShareCard(pkg, captureMap);
+  if (!result || !result.blob) {
+    addToast('Sharing is unavailable; try download.', 'info');
+    return;
+  }
+  const nav = navigator as Navigator & { canShare?: (data?: ShareData) => boolean };
+  const summary = shareSummaryText(pkg);
+  const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
+
+  if (activationLive && (await shareWithImage(result.blob, pkg, nav, summary))) return;
+  if (await shareWithText(nav, summary, addToast)) return;
+
+  addToast('Sharing is unavailable; try download.', 'info');
+};
+
+const copy = async (
+  pkg: PackageGrade,
+  captureMap: () => Promise<HTMLImageElement | null>,
+  addToast: ToastFn
+) => {
+  const result = await buildShareCard(pkg, captureMap);
+  const clip = navigator.clipboard;
+  if (!clip) {
+    addToast('Copy is not supported here; try download.', 'info');
+    return;
+  }
+  const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
+  if (result?.blob && (await copyImageToClipboard(result.blob, clip, activationLive))) {
+    addToast('Share card copied to clipboard.', 'success');
+    return;
+  }
+  if (clip.writeText) {
+    await clip.writeText(shareSummaryText(pkg));
+    addToast('Grade summary copied to clipboard.', 'success');
+  } else {
+    addToast('Copy is not supported here; try download.', 'info');
+  }
+};
+
+const withBusy = async (
   setBusy: (v: boolean) => void,
   fn: () => Promise<void>,
   addToast: ToastFn
@@ -90,59 +147,17 @@ export const useShareCardActions = (
   const [busy, setBusy] = useState(false);
 
   const handleDownload = useCallback(
-    () =>
-      runBusy(setBusy, async () => {
-        const result = await buildShareCard(pkg, captureMap);
-        if (!result) {
-          addToast('Could not compose the share card.', 'error');
-          return;
-        }
-        downloadDataUrl(result.canvas.toDataURL('image/png'), shareCardFilename(pkg));
-      }, addToast),
+    () => withBusy(setBusy, () => download(pkg, captureMap, addToast), addToast),
     [addToast, captureMap, pkg]
   );
 
   const handleShare = useCallback(
-    () =>
-      runBusy(setBusy, async () => {
-        const result = await buildShareCard(pkg, captureMap);
-        if (!result || !result.blob) {
-          addToast('Sharing is unavailable; try download.', 'info');
-          return;
-        }
-        const nav = navigator as Navigator & { canShare?: (data?: ShareData) => boolean };
-        const summary = shareSummaryText(pkg);
-        const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
-
-        if (activationLive && (await shareWithImage(result.blob, pkg, nav, summary))) return;
-        if (await shareWithText(nav, summary, addToast)) return;
-
-        addToast('Sharing is unavailable; try download.', 'info');
-      }, addToast),
+    () => withBusy(setBusy, () => share(pkg, captureMap, addToast), addToast),
     [addToast, captureMap, pkg]
   );
 
   const handleCopy = useCallback(
-    () =>
-      runBusy(setBusy, async () => {
-        const result = await buildShareCard(pkg, captureMap);
-        const clip = navigator.clipboard;
-        if (!clip) {
-          addToast('Copy is not supported here; try download.', 'info');
-          return;
-        }
-        const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
-        if (result?.blob && (await copyImageToClipboard(result.blob, clip, activationLive))) {
-          addToast('Share card copied to clipboard.', 'success');
-          return;
-        }
-        if (clip.writeText) {
-          await clip.writeText(shareSummaryText(pkg));
-          addToast('Grade summary copied to clipboard.', 'success');
-        } else {
-          addToast('Copy is not supported here; try download.', 'info');
-        }
-      }, addToast),
+    () => withBusy(setBusy, () => copy(pkg, captureMap, addToast), addToast),
     [addToast, captureMap, pkg]
   );
 

--- a/src/components/ForecastGrade/useShareCardActions.ts
+++ b/src/components/ForecastGrade/useShareCardActions.ts
@@ -12,10 +12,50 @@ const canvasToBlob = (canvas: HTMLCanvasElement): Promise<Blob | null> =>
     }
   });
 
+type ToastFn = (message: string, type?: 'info' | 'success' | 'error') => void;
+
+const tryShareImage = async (
+  blob: Blob,
+  pkg: PackageGrade,
+  nav: Navigator & { canShare?: (data?: ShareData) => boolean },
+  summary: string
+): Promise<boolean> => {
+  if (!nav.share) return false;
+  const file = new File([blob], shareCardFilename(pkg), { type: 'image/png' });
+  if (!nav.canShare?.({ files: [file] })) return false;
+  await nav.share({ files: [file], text: summary });
+  return true;
+};
+
+const tryShareText = async (
+  nav: Navigator & { canShare?: (data?: ShareData) => boolean },
+  summary: string,
+  addToast: ToastFn
+): Promise<boolean> => {
+  if (!nav.share || !nav.canShare?.({ text: summary })) return false;
+  await nav.share({ text: summary });
+  addToast('Shared grade summary; download the image card if needed.', 'info');
+  return true;
+};
+
+const tryCopyImage = async (
+  blob: Blob,
+  clip: Clipboard,
+  activationLive: boolean
+): Promise<boolean> => {
+  if (!activationLive || !blob || typeof ClipboardItem === 'undefined' || !clip.write) return false;
+  try {
+    await clip.write([new ClipboardItem({ 'image/png': blob })]);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export const useShareCardActions = (
   pkg: PackageGrade,
   captureMap: () => Promise<HTMLImageElement | null>,
-  addToast: (message: string, type?: 'info' | 'success' | 'error') => void
+  addToast: ToastFn
 ) => {
   const [busy, setBusy] = useState(false);
 
@@ -47,19 +87,8 @@ export const useShareCardActions = (
       const summary = shareSummaryText(pkg);
       const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
 
-      if (blob && activationLive && nav.share) {
-        const file = new File([blob], shareCardFilename(pkg), { type: 'image/png' });
-        if (nav.canShare?.({ files: [file] })) {
-          await nav.share({ files: [file], text: summary });
-          return;
-        }
-      }
-
-      if (nav.share && nav.canShare?.({ text: summary })) {
-        await nav.share({ text: summary });
-        addToast('Shared grade summary; download the image card if needed.', 'info');
-        return;
-      }
+      if (blob && activationLive && (await tryShareImage(blob, pkg, nav, summary))) return;
+      if (await tryShareText(nav, summary, addToast)) return;
 
       addToast('Sharing is unavailable; try download.', 'info');
     } catch (error) {
@@ -82,14 +111,9 @@ export const useShareCardActions = (
         return;
       }
       const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
-      if (activationLive && blob && typeof ClipboardItem !== 'undefined' && clip.write) {
-        try {
-          await clip.write([new ClipboardItem({ 'image/png': blob })]);
-          addToast('Share card copied to clipboard.', 'success');
-          return;
-        } catch {
-          // Fall back to text when image clipboard is unsupported.
-        }
+      if (await tryCopyImage(blob!, clip, activationLive)) {
+        addToast('Share card copied to clipboard.', 'success');
+        return;
       }
       if (clip.writeText) {
         await clip.writeText(shareSummaryText(pkg));

--- a/src/components/ForecastGrade/useShareCardActions.ts
+++ b/src/components/ForecastGrade/useShareCardActions.ts
@@ -65,6 +65,23 @@ const copyImageToClipboard = async (
   }
 };
 
+const runBusy = async (
+  setBusy: (v: boolean) => void,
+  fn: () => Promise<void>,
+  addToast: ToastFn
+) => {
+  setBusy(true);
+  try {
+    await fn();
+  } catch (error) {
+    if ((error as Error).name !== 'AbortError') {
+      addToast('An action failed; try download.', 'error');
+    }
+  } finally {
+    setBusy(false);
+  }
+};
+
 export const useShareCardActions = (
   pkg: PackageGrade,
   captureMap: () => Promise<HTMLImageElement | null>,
@@ -72,71 +89,62 @@ export const useShareCardActions = (
 ) => {
   const [busy, setBusy] = useState(false);
 
-  const handleDownload = useCallback(async () => {
-    setBusy(true);
-    try {
-      const result = await buildShareCard(pkg, captureMap);
-      if (!result) {
-        addToast('Could not compose the share card.', 'error');
-        return;
-      }
-      downloadDataUrl(result.canvas.toDataURL('image/png'), shareCardFilename(pkg));
-    } finally {
-      setBusy(false);
-    }
-  }, [addToast, captureMap, pkg]);
+  const handleDownload = useCallback(
+    () =>
+      runBusy(setBusy, async () => {
+        const result = await buildShareCard(pkg, captureMap);
+        if (!result) {
+          addToast('Could not compose the share card.', 'error');
+          return;
+        }
+        downloadDataUrl(result.canvas.toDataURL('image/png'), shareCardFilename(pkg));
+      }, addToast),
+    [addToast, captureMap, pkg]
+  );
 
-  const handleShare = useCallback(async () => {
-    setBusy(true);
-    try {
-      const result = await buildShareCard(pkg, captureMap);
-      if (!result || !result.blob) {
+  const handleShare = useCallback(
+    () =>
+      runBusy(setBusy, async () => {
+        const result = await buildShareCard(pkg, captureMap);
+        if (!result || !result.blob) {
+          addToast('Sharing is unavailable; try download.', 'info');
+          return;
+        }
+        const nav = navigator as Navigator & { canShare?: (data?: ShareData) => boolean };
+        const summary = shareSummaryText(pkg);
+        const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
+
+        if (activationLive && (await shareWithImage(result.blob, pkg, nav, summary))) return;
+        if (await shareWithText(nav, summary, addToast)) return;
+
         addToast('Sharing is unavailable; try download.', 'info');
-        return;
-      }
-      const nav = navigator as Navigator & { canShare?: (data?: ShareData) => boolean };
-      const summary = shareSummaryText(pkg);
-      const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
+      }, addToast),
+    [addToast, captureMap, pkg]
+  );
 
-      if (activationLive && (await shareWithImage(result.blob, pkg, nav, summary))) return;
-      if (await shareWithText(nav, summary, addToast)) return;
-
-      addToast('Sharing is unavailable; try download.', 'info');
-    } catch (error) {
-      if ((error as Error).name !== 'AbortError') {
-        addToast('Share failed; try download.', 'error');
-      }
-    } finally {
-      setBusy(false);
-    }
-  }, [addToast, captureMap, pkg]);
-
-  const handleCopy = useCallback(async () => {
-    setBusy(true);
-    try {
-      const result = await buildShareCard(pkg, captureMap);
-      const clip = navigator.clipboard;
-      if (!clip) {
-        addToast('Copy is not supported here; try download.', 'info');
-        return;
-      }
-      const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
-      if (result?.blob && (await copyImageToClipboard(result.blob, clip, activationLive))) {
-        addToast('Share card copied to clipboard.', 'success');
-        return;
-      }
-      if (clip.writeText) {
-        await clip.writeText(shareSummaryText(pkg));
-        addToast('Grade summary copied to clipboard.', 'success');
-      } else {
-        addToast('Copy is not supported here; try download.', 'info');
-      }
-    } catch {
-      addToast('Copy failed; try download.', 'error');
-    } finally {
-      setBusy(false);
-    }
-  }, [addToast, captureMap, pkg]);
+  const handleCopy = useCallback(
+    () =>
+      runBusy(setBusy, async () => {
+        const result = await buildShareCard(pkg, captureMap);
+        const clip = navigator.clipboard;
+        if (!clip) {
+          addToast('Copy is not supported here; try download.', 'info');
+          return;
+        }
+        const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
+        if (result?.blob && (await copyImageToClipboard(result.blob, clip, activationLive))) {
+          addToast('Share card copied to clipboard.', 'success');
+          return;
+        }
+        if (clip.writeText) {
+          await clip.writeText(shareSummaryText(pkg));
+          addToast('Grade summary copied to clipboard.', 'success');
+        } else {
+          addToast('Copy is not supported here; try download.', 'info');
+        }
+      }, addToast),
+    [addToast, captureMap, pkg]
+  );
 
   return { busy, handleDownload, handleShare, handleCopy };
 };

--- a/src/components/ForecastGrade/useShareCardActions.ts
+++ b/src/components/ForecastGrade/useShareCardActions.ts
@@ -14,7 +14,17 @@ const canvasToBlob = (canvas: HTMLCanvasElement): Promise<Blob | null> =>
 
 type ToastFn = (message: string, type?: 'info' | 'success' | 'error') => void;
 
-const tryShareImage = async (
+const buildShareCard = async (
+  pkg: PackageGrade,
+  captureMap: () => Promise<HTMLImageElement | null>
+): Promise<{ canvas: HTMLCanvasElement; blob: Blob | null } | null> => {
+  const mapImage = await captureMap();
+  const canvas = composeShareCard(pkg, mapImage);
+  if (!canvas) return null;
+  return { canvas, blob: await canvasToBlob(canvas) };
+};
+
+const shareWithImage = async (
   blob: Blob,
   pkg: PackageGrade,
   nav: Navigator & { canShare?: (data?: ShareData) => boolean },
@@ -27,7 +37,7 @@ const tryShareImage = async (
   return true;
 };
 
-const tryShareText = async (
+const shareWithText = async (
   nav: Navigator & { canShare?: (data?: ShareData) => boolean },
   summary: string,
   addToast: ToastFn
@@ -38,12 +48,15 @@ const tryShareText = async (
   return true;
 };
 
-const tryCopyImage = async (
+const copyImageToClipboard = async (
   blob: Blob,
   clip: Clipboard,
   activationLive: boolean
 ): Promise<boolean> => {
-  if (!activationLive || !blob || typeof ClipboardItem === 'undefined' || !clip.write) return false;
+  if (!activationLive) return false;
+  if (!blob) return false;
+  if (typeof ClipboardItem === 'undefined') return false;
+  if (!clip.write) return false;
   try {
     await clip.write([new ClipboardItem({ 'image/png': blob })]);
     return true;
@@ -59,36 +72,34 @@ export const useShareCardActions = (
 ) => {
   const [busy, setBusy] = useState(false);
 
-  const build = useCallback(async (): Promise<HTMLCanvasElement | null> => {
-    const mapImage = await captureMap();
-    return composeShareCard(pkg, mapImage);
-  }, [captureMap, pkg]);
-
   const handleDownload = useCallback(async () => {
     setBusy(true);
     try {
-      const canvas = await build();
-      if (!canvas) {
+      const result = await buildShareCard(pkg, captureMap);
+      if (!result) {
         addToast('Could not compose the share card.', 'error');
         return;
       }
-      downloadDataUrl(canvas.toDataURL('image/png'), shareCardFilename(pkg));
+      downloadDataUrl(result.canvas.toDataURL('image/png'), shareCardFilename(pkg));
     } finally {
       setBusy(false);
     }
-  }, [addToast, build, pkg]);
+  }, [addToast, captureMap, pkg]);
 
   const handleShare = useCallback(async () => {
     setBusy(true);
     try {
-      const canvas = await build();
-      const blob = canvas ? await canvasToBlob(canvas) : null;
+      const result = await buildShareCard(pkg, captureMap);
+      if (!result || !result.blob) {
+        addToast('Sharing is unavailable; try download.', 'info');
+        return;
+      }
       const nav = navigator as Navigator & { canShare?: (data?: ShareData) => boolean };
       const summary = shareSummaryText(pkg);
       const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
 
-      if (blob && activationLive && (await tryShareImage(blob, pkg, nav, summary))) return;
-      if (await tryShareText(nav, summary, addToast)) return;
+      if (activationLive && (await shareWithImage(result.blob, pkg, nav, summary))) return;
+      if (await shareWithText(nav, summary, addToast)) return;
 
       addToast('Sharing is unavailable; try download.', 'info');
     } catch (error) {
@@ -98,20 +109,19 @@ export const useShareCardActions = (
     } finally {
       setBusy(false);
     }
-  }, [addToast, build, pkg]);
+  }, [addToast, captureMap, pkg]);
 
   const handleCopy = useCallback(async () => {
     setBusy(true);
     try {
-      const canvas = await build();
-      const blob = canvas ? await canvasToBlob(canvas) : null;
+      const result = await buildShareCard(pkg, captureMap);
       const clip = navigator.clipboard;
       if (!clip) {
         addToast('Copy is not supported here; try download.', 'info');
         return;
       }
       const activationLive = !navigator.userActivation || navigator.userActivation.isActive;
-      if (await tryCopyImage(blob!, clip, activationLive)) {
+      if (result?.blob && (await copyImageToClipboard(result.blob, clip, activationLive))) {
         addToast('Share card copied to clipboard.', 'success');
         return;
       }
@@ -126,7 +136,7 @@ export const useShareCardActions = (
     } finally {
       setBusy(false);
     }
-  }, [addToast, build, pkg]);
+  }, [addToast, captureMap, pkg]);
 
   return { busy, handleDownload, handleShare, handleCopy };
 };


### PR DESCRIPTION
## Summary
- Anonymous share card + download/share/copy actions.
- Includes CodeScene UI complexity split (`useShareCardActions`, panel/dashboard splits).

## Stack
12/13 ┬╖ base `beta` (rebased after stack PRs 01-07 merged)

## Test plan
- [x] `pnpm test -- --runTestsByPath src/components/ForecastGrade/shareCard.test.ts`

## Changelog
- Stack PR 12/13: Anonymous share card export and wiring.
