### PR TITLE
[Port][Conflicts] fix: harden billing webhook state transitions → beta

### DIFF
--- a/server/billing-webhook-state.js
+++ b/server/billing-webhook-state.js
@@ -18,11 +18,36 @@ const isStaleStripeEvent = (existingData, event) => {
   );
 };
 
-/** Applies one verified Stripe event exactly once without allowing older state to win. */
-const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNextPayload }) => {
-  if (!db || !entitlementRef || !event?.id || !event?.type || typeof buildNextPayload !== 'function') {
+/** Throws when any required webhook processing input is missing. */
+const validateWebhookInputs = ({ db, entitlementRef, event, buildNextPayload }) => {
+  if (!db || !entitlementRef) {
     throw new Error('A verified Stripe event and entitlement target are required.');
   }
+  if (!event?.id || !event?.type) {
+    throw new Error('A verified Stripe event and entitlement target are required.');
+  }
+  if (typeof buildNextPayload !== 'function') {
+    throw new Error('A verified Stripe event and entitlement target are required.');
+  }
+};
+
+/** Reads the existing entitlement data or returns an empty object. */
+const resolveExistingEntitlementData = (entitlementSnapshot) =>
+  entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
+
+/** Builds the ledger entry that records how this event was processed. */
+const buildEventLedgerEntry = ({ event, entitlementRef, stale, processedAt }) => ({
+  eventType: event.type,
+  eventCreated: Number(event.created) || 0,
+  entitlementId: entitlementRef.id,
+  outcome: stale ? 'stale' : 'applied',
+  processedAt,
+  expiresAt: new Date(processedAt.getTime() + EVENT_LEDGER_RETENTION_MS),
+});
+
+/** Applies one verified Stripe event exactly once without allowing older state to win. */
+const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNextPayload }) => {
+  validateWebhookInputs({ db, entitlementRef, event, buildNextPayload });
 
   const eventRef = db.collection(EVENT_LEDGER_COLLECTION).doc(event.id);
   return db.runTransaction(async (transaction) => {
@@ -35,17 +60,10 @@ const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNe
       return { applied: false, reason: 'duplicate' };
     }
 
-    const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
+    const existingData = resolveExistingEntitlementData(entitlementSnapshot);
     const stale = isStaleStripeEvent(existingData, event);
     const processedAt = new Date();
-    transaction.set(eventRef, {
-      eventType: event.type,
-      eventCreated: Number(event.created) || 0,
-      entitlementId: entitlementRef.id,
-      outcome: stale ? 'stale' : 'applied',
-      processedAt,
-      expiresAt: new Date(processedAt.getTime() + EVENT_LEDGER_RETENTION_MS),
-    });
+    transaction.set(eventRef, buildEventLedgerEntry({ event, entitlementRef, stale, processedAt }));
 
     if (stale) {
       return { applied: false, reason: 'stale' };

--- a/server/billing-webhook-state.js
+++ b/server/billing-webhook-state.js
@@ -58,13 +58,17 @@ const processEventInTransaction = async (transaction, { eventRef, entitlementRef
   return { applied: true, reason: 'applied', nextPayload };
 };
 
+const WEBHOOK_MISSING_ERROR = 'A verified Stripe event and entitlement target are required.';
+
+/** Returns true when any required webhook processing input is missing. */
+const hasMissingInputs = ({ db, entitlementRef, event, buildNextPayload }) =>
+  !db || !entitlementRef || !event?.id || !event?.type || typeof buildNextPayload !== 'function';
+
 /** Applies one verified Stripe event exactly once without allowing older state to win. */
 const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNextPayload }) => {
-  if (!db) throw new Error('A verified Stripe event and entitlement target are required.');
-  if (!entitlementRef) throw new Error('A verified Stripe event and entitlement target are required.');
-  if (!event?.id) throw new Error('A verified Stripe event and entitlement target are required.');
-  if (!event?.type) throw new Error('A verified Stripe event and entitlement target are required.');
-  if (typeof buildNextPayload !== 'function') throw new Error('A verified Stripe event and entitlement target are required.');
+  if (hasMissingInputs({ db, entitlementRef, event, buildNextPayload })) {
+    throw new Error(WEBHOOK_MISSING_ERROR);
+  }
 
   const eventRef = db.collection(EVENT_LEDGER_COLLECTION).doc(event.id);
   return db.runTransaction((transaction) =>

--- a/server/billing-webhook-state.js
+++ b/server/billing-webhook-state.js
@@ -18,23 +18,6 @@ const isStaleStripeEvent = (existingData, event) => {
   );
 };
 
-/** Throws when any required webhook processing input is missing. */
-const validateWebhookInputs = ({ db, entitlementRef, event, buildNextPayload }) => {
-  if (!db || !entitlementRef) {
-    throw new Error('A verified Stripe event and entitlement target are required.');
-  }
-  if (!event?.id || !event?.type) {
-    throw new Error('A verified Stripe event and entitlement target are required.');
-  }
-  if (typeof buildNextPayload !== 'function') {
-    throw new Error('A verified Stripe event and entitlement target are required.');
-  }
-};
-
-/** Reads the existing entitlement data or returns an empty object. */
-const resolveExistingEntitlementData = (entitlementSnapshot) =>
-  entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
-
 /** Builds the ledger entry that records how this event was processed. */
 const buildEventLedgerEntry = ({ event, entitlementRef, stale, processedAt }) => ({
   eventType: event.type,
@@ -47,7 +30,11 @@ const buildEventLedgerEntry = ({ event, entitlementRef, stale, processedAt }) =>
 
 /** Applies one verified Stripe event exactly once without allowing older state to win. */
 const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNextPayload }) => {
-  validateWebhookInputs({ db, entitlementRef, event, buildNextPayload });
+  if (!db) throw new Error('A verified Stripe event and entitlement target are required.');
+  if (!entitlementRef) throw new Error('A verified Stripe event and entitlement target are required.');
+  if (!event?.id) throw new Error('A verified Stripe event and entitlement target are required.');
+  if (!event?.type) throw new Error('A verified Stripe event and entitlement target are required.');
+  if (typeof buildNextPayload !== 'function') throw new Error('A verified Stripe event and entitlement target are required.');
 
   const eventRef = db.collection(EVENT_LEDGER_COLLECTION).doc(event.id);
   return db.runTransaction(async (transaction) => {
@@ -60,7 +47,7 @@ const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNe
       return { applied: false, reason: 'duplicate' };
     }
 
-    const existingData = resolveExistingEntitlementData(entitlementSnapshot);
+    const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
     const stale = isStaleStripeEvent(existingData, event);
     const processedAt = new Date();
     transaction.set(eventRef, buildEventLedgerEntry({ event, entitlementRef, stale, processedAt }));

--- a/server/billing-webhook-state.js
+++ b/server/billing-webhook-state.js
@@ -28,6 +28,36 @@ const buildEventLedgerEntry = ({ event, entitlementRef, stale, processedAt }) =>
   expiresAt: new Date(processedAt.getTime() + EVENT_LEDGER_RETENTION_MS),
 });
 
+/** Executes the transactional deduplication and stale-event guard. */
+const processEventInTransaction = async (transaction, { eventRef, entitlementRef, event, buildNextPayload }) => {
+  const [eventSnapshot, entitlementSnapshot] = await Promise.all([
+    transaction.get(eventRef),
+    transaction.get(entitlementRef),
+  ]);
+
+  if (eventSnapshot.exists) {
+    return { applied: false, reason: 'duplicate' };
+  }
+
+  const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
+  const stale = isStaleStripeEvent(existingData, event);
+  const processedAt = new Date();
+  transaction.set(eventRef, buildEventLedgerEntry({ event, entitlementRef, stale, processedAt }));
+
+  if (stale) {
+    return { applied: false, reason: 'stale' };
+  }
+
+  const nextPayload = {
+    ...buildNextPayload(existingData),
+    lastStripeEventId: event.id,
+    lastStripeEventType: event.type,
+    lastStripeEventCreated: Number(event.created) || 0,
+  };
+  transaction.set(entitlementRef, nextPayload, { merge: true });
+  return { applied: true, reason: 'applied', nextPayload };
+};
+
 /** Applies one verified Stripe event exactly once without allowing older state to win. */
 const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNextPayload }) => {
   if (!db) throw new Error('A verified Stripe event and entitlement target are required.');
@@ -37,34 +67,9 @@ const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNe
   if (typeof buildNextPayload !== 'function') throw new Error('A verified Stripe event and entitlement target are required.');
 
   const eventRef = db.collection(EVENT_LEDGER_COLLECTION).doc(event.id);
-  return db.runTransaction(async (transaction) => {
-    const [eventSnapshot, entitlementSnapshot] = await Promise.all([
-      transaction.get(eventRef),
-      transaction.get(entitlementRef),
-    ]);
-
-    if (eventSnapshot.exists) {
-      return { applied: false, reason: 'duplicate' };
-    }
-
-    const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
-    const stale = isStaleStripeEvent(existingData, event);
-    const processedAt = new Date();
-    transaction.set(eventRef, buildEventLedgerEntry({ event, entitlementRef, stale, processedAt }));
-
-    if (stale) {
-      return { applied: false, reason: 'stale' };
-    }
-
-    const nextPayload = {
-      ...buildNextPayload(existingData),
-      lastStripeEventId: event.id,
-      lastStripeEventType: event.type,
-      lastStripeEventCreated: Number(event.created) || 0,
-    };
-    transaction.set(entitlementRef, nextPayload, { merge: true });
-    return { applied: true, reason: 'applied', nextPayload };
-  });
+  return db.runTransaction((transaction) =>
+    processEventInTransaction(transaction, { eventRef, entitlementRef, event, buildNextPayload })
+  );
 };
 
 module.exports = {

--- a/server/billing-webhook-state.js
+++ b/server/billing-webhook-state.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const EVENT_LEDGER_COLLECTION = 'processedStripeWebhookEvents';
+const EVENT_LEDGER_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Returns true when the incoming event would move entitlement state backward. */
+const isStaleStripeEvent = (existingData, event) => {
+  const lastCreated = Number(existingData.lastStripeEventCreated) || 0;
+  const eventCreated = Number(event.created) || 0;
+  if (eventCreated < lastCreated) {
+    return true;
+  }
+
+  return (
+    eventCreated === lastCreated &&
+    existingData.lastStripeEventType === 'customer.subscription.deleted' &&
+    event.type !== 'customer.subscription.deleted'
+  );
+};
+
+/** Applies one verified Stripe event exactly once without allowing older state to win. */
+const applyEntitlementWebhookEvent = async ({ db, entitlementRef, event, buildNextPayload }) => {
+  if (!db || !entitlementRef || !event?.id || !event?.type || typeof buildNextPayload !== 'function') {
+    throw new Error('A verified Stripe event and entitlement target are required.');
+  }
+
+  const eventRef = db.collection(EVENT_LEDGER_COLLECTION).doc(event.id);
+  return db.runTransaction(async (transaction) => {
+    const [eventSnapshot, entitlementSnapshot] = await Promise.all([
+      transaction.get(eventRef),
+      transaction.get(entitlementRef),
+    ]);
+
+    if (eventSnapshot.exists) {
+      return { applied: false, reason: 'duplicate' };
+    }
+
+    const existingData = entitlementSnapshot.exists ? entitlementSnapshot.data() || {} : {};
+    const stale = isStaleStripeEvent(existingData, event);
+    const processedAt = new Date();
+    transaction.set(eventRef, {
+      eventType: event.type,
+      eventCreated: Number(event.created) || 0,
+      entitlementId: entitlementRef.id,
+      outcome: stale ? 'stale' : 'applied',
+      processedAt,
+      expiresAt: new Date(processedAt.getTime() + EVENT_LEDGER_RETENTION_MS),
+    });
+
+    if (stale) {
+      return { applied: false, reason: 'stale' };
+    }
+
+    const nextPayload = {
+      ...buildNextPayload(existingData),
+      lastStripeEventId: event.id,
+      lastStripeEventType: event.type,
+      lastStripeEventCreated: Number(event.created) || 0,
+    };
+    transaction.set(entitlementRef, nextPayload, { merge: true });
+    return { applied: true, reason: 'applied', nextPayload };
+  });
+};
+
+module.exports = {
+  applyEntitlementWebhookEvent,
+  isStaleStripeEvent,
+};

--- a/server/billing-webhook-state.test.js
+++ b/server/billing-webhook-state.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { applyEntitlementWebhookEvent, isStaleStripeEvent } = require('./billing-webhook-state');
+
+const createFakeDb = () => {
+  const documents = new Map();
+  let queue = Promise.resolve();
+  let failNextCommit = false;
+  const ref = (collection, id) => ({ collection, id, key: `${collection}/${id}` });
+  const snapshot = (documentRef) => ({
+    exists: documents.has(documentRef.key),
+    data: () => documents.get(documentRef.key) || {},
+  });
+
+  return {
+    documents,
+    failNextCommit: () => { failNextCommit = true; },
+    collection: (collection) => ({ doc: (id) => ref(collection, id) }),
+    runTransaction: (callback) => {
+      const run = queue.then(async () => {
+        const writes = [];
+        const result = await callback({
+          get: async (documentRef) => snapshot(documentRef),
+          set: (documentRef, data, options) => writes.push({ documentRef, data, options }),
+        });
+        if (failNextCommit) {
+          failNextCommit = false;
+          throw new Error('simulated commit failure');
+        }
+        for (const write of writes) {
+          const previous = write.options?.merge ? documents.get(write.documentRef.key) || {} : {};
+          documents.set(write.documentRef.key, { ...previous, ...write.data });
+        }
+        return result;
+      });
+      queue = run.catch(() => undefined);
+      return run;
+    },
+  };
+};
+
+const applyStatus = (db, event, status) =>
+  applyEntitlementWebhookEvent({
+    db,
+    entitlementRef: db.collection('userEntitlements').doc('user-1'),
+    event,
+    buildNextPayload: (existing) => ({ ...existing, billingStatus: status }),
+  });
+
+describe('applyEntitlementWebhookEvent', () => {
+  it('commits concurrent duplicate deliveries only once', async () => {
+    const db = createFakeDb();
+    const event = { id: 'evt_once', type: 'customer.subscription.updated', created: 200 };
+    const results = await Promise.all([applyStatus(db, event, 'active'), applyStatus(db, event, 'past_due')]);
+
+    assert.deepEqual(results.map((result) => result.reason).sort(), ['applied', 'duplicate']);
+    assert.equal(db.documents.get('userEntitlements/user-1').billingStatus, 'active');
+    assert.equal(db.documents.get('processedStripeWebhookEvents/evt_once').outcome, 'applied');
+  });
+
+  it('records but does not apply an older delivery', async () => {
+    const db = createFakeDb();
+    await applyStatus(db, { id: 'evt_new', type: 'customer.subscription.deleted', created: 300 }, 'canceled');
+    const result = await applyStatus(db, { id: 'evt_old', type: 'customer.subscription.updated', created: 250 }, 'active');
+
+    assert.equal(result.reason, 'stale');
+    assert.equal(db.documents.get('userEntitlements/user-1').billingStatus, 'canceled');
+    assert.equal(db.documents.get('processedStripeWebhookEvents/evt_old').outcome, 'stale');
+  });
+
+  it('keeps a terminal subscription event when timestamps tie', () => {
+    assert.equal(
+      isStaleStripeEvent(
+        { lastStripeEventCreated: 400, lastStripeEventType: 'customer.subscription.deleted' },
+        { type: 'customer.subscription.updated', created: 400 }
+      ),
+      true
+    );
+  });
+
+  it('retries cleanly after a transaction commit failure', async () => {
+    const db = createFakeDb();
+    const event = { id: 'evt_retry', type: 'customer.subscription.updated', created: 500 };
+    db.failNextCommit();
+
+    await assert.rejects(applyStatus(db, event, 'active'), /simulated commit failure/);
+    const retry = await applyStatus(db, event, 'active');
+
+    assert.equal(retry.applied, true);
+    assert.equal(db.documents.get('userEntitlements/user-1').billingStatus, 'active');
+  });
+});

--- a/server/billing-webhook.test.js
+++ b/server/billing-webhook.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const { after, beforeEach, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const firebaseAdminPath = require.resolve('./firebase-admin');
+const metricsPath = require.resolve('./metrics');
+const billingPath = require.resolve('./billing');
+const originalFirebaseAdmin = require.cache[firebaseAdminPath];
+const originalMetrics = require.cache[metricsPath];
+const documents = new Map();
+let queue = Promise.resolve();
+
+const createRef = (collection, id) => ({
+  collection,
+  id,
+  key: `${collection}/${id}`,
+  get: async function get() { return getSnapshot(this); },
+});
+const getSnapshot = (ref) => ({
+  exists: documents.has(ref.key),
+  ref,
+  data: () => documents.get(ref.key) || {},
+});
+const db = {
+  collection: (collection) => ({
+    doc: (id) => createRef(collection, id),
+    where: (field, _operator, value) => ({
+      limit: () => ({
+        get: async () => {
+          const match = [...documents.entries()].find(
+            ([key, data]) => key.startsWith(`${collection}/`) && data[field] === value
+          );
+          if (!match) return { empty: true, docs: [] };
+          const id = match[0].slice(collection.length + 1);
+          return { empty: false, docs: [getSnapshot(createRef(collection, id))] };
+        },
+      }),
+    }),
+  }),
+  runTransaction: (callback) => {
+    const run = queue.then(async () => {
+      const writes = [];
+      const result = await callback({
+        get: async (ref) => getSnapshot(ref),
+        set: (ref, data, options) => writes.push({ ref, data, options }),
+      });
+      for (const write of writes) {
+        const previous = write.options?.merge ? documents.get(write.ref.key) || {} : {};
+        documents.set(write.ref.key, { ...previous, ...write.data });
+      }
+      return result;
+    });
+    queue = run.catch(() => undefined);
+    return run;
+  },
+};
+
+require.cache[firebaseAdminPath] = {
+  id: firebaseAdminPath,
+  filename: firebaseAdminPath,
+  loaded: true,
+  exports: { getAdminDb: () => db, getAdminAuth: () => null, hasFirebaseAdminConfig: () => true },
+};
+require.cache[metricsPath] = {
+  id: metricsPath,
+  filename: metricsPath,
+  loaded: true,
+  exports: { recordBillingMetricEvent: async () => true },
+};
+delete require.cache[billingPath];
+const { __testing } = require('./billing');
+
+const subscription = (status, overrides = {}) => ({
+  id: 'sub_1',
+  customer: 'cus_1',
+  status,
+  cancel_at_period_end: status === 'canceled',
+  current_period_end: 2_000_000_000,
+  metadata: { uid: 'user-1' },
+  items: { data: [{ price: { recurring: { interval: 'month' } } }] },
+  ...overrides,
+});
+
+beforeEach(() => {
+  documents.clear();
+  documents.set('userEntitlements/user-1', { uid: 'user-1', betaOverrideActive: false });
+  queue = Promise.resolve();
+});
+
+after(() => {
+  if (originalFirebaseAdmin) require.cache[firebaseAdminPath] = originalFirebaseAdmin;
+  else delete require.cache[firebaseAdminPath];
+  if (originalMetrics) require.cache[metricsPath] = originalMetrics;
+  else delete require.cache[metricsPath];
+  delete require.cache[billingPath];
+});
+
+describe('billing webhook state', () => {
+  it('derives invoice entitlement from the current subscription', async () => {
+    const retrieved = subscription('canceled');
+    const stripe = { subscriptions: { retrieve: async (id) => {
+      assert.equal(id, 'sub_1');
+      return retrieved;
+    } } };
+    const event = {
+      id: 'evt_invoice',
+      type: 'invoice.paid',
+      created: 200,
+      data: { object: { subscription: 'sub_1', customer: 'cus_1' } },
+    };
+
+    await __testing.handleWebhookEvent(event, stripe);
+
+    const entitlement = documents.get('userEntitlements/user-1');
+    assert.equal(entitlement.billingStatus, 'canceled');
+    assert.equal(entitlement.premiumActive, false);
+    assert.equal(entitlement.lastStripeEventId, 'evt_invoice');
+  });
+
+  it('does not let an older subscription update reverse a deletion', async () => {
+    const stripe = { subscriptions: { retrieve: async () => { throw new Error('not expected'); } } };
+    await __testing.handleWebhookEvent({
+      id: 'evt_deleted',
+      type: 'customer.subscription.deleted',
+      created: 300,
+      data: { object: subscription('canceled') },
+    }, stripe);
+    await __testing.handleWebhookEvent({
+      id: 'evt_delayed',
+      type: 'customer.subscription.updated',
+      created: 250,
+      data: { object: subscription('active') },
+    }, stripe);
+
+    const entitlement = documents.get('userEntitlements/user-1');
+    assert.equal(entitlement.billingStatus, 'canceled');
+    assert.equal(entitlement.lastStripeEventId, 'evt_deleted');
+    assert.equal(documents.get('processedStripeWebhookEvents/evt_delayed').outcome, 'stale');
+  });
+
+  it('applies a replayed event id once', async () => {
+    const stripe = { subscriptions: { retrieve: async () => { throw new Error('not expected'); } } };
+    const event = {
+      id: 'evt_replay',
+      type: 'customer.subscription.updated',
+      created: 400,
+      data: { object: subscription('active') },
+    };
+
+    await Promise.all([
+      __testing.handleWebhookEvent(event, stripe),
+      __testing.handleWebhookEvent(event, stripe),
+    ]);
+
+    assert.equal(documents.get('userEntitlements/user-1').billingStatus, 'active');
+    assert.equal(documents.get('processedStripeWebhookEvents/evt_replay').outcome, 'applied');
+  });
+});

--- a/server/billing.js
+++ b/server/billing.js
@@ -3,6 +3,7 @@
 const Stripe = require('stripe');
 const rateLimit = require('express-rate-limit');
 const { getSubscriptionPeriodEndUnix } = require('./billing-stripe-period');
+const { applyEntitlementWebhookEvent } = require('./billing-webhook-state');
 const { getAdminAuth, getAdminDb, hasFirebaseAdminConfig } = require('./firebase-admin');
 const { getBaseUrl, getBillingRuntimeConfig, getPublicBillingConfig } = require('./billing-config');
 const { recordBillingMetricEvent } = require('./metrics');
@@ -156,8 +157,8 @@ const getExistingEntitlementData = async (uid, stripeIds = {}) => {
   return createNewEntitlementTarget(uid);
 };
 
-/** Writes the merged entitlement payload into Firestore. */
-const writeEntitlement = async ({ uid, stripeCustomerId, stripeSubscriptionId, payload }) => {
+/** Writes the merged entitlement payload into Firestore once for the verified webhook event. */
+const writeEntitlement = async ({ uid, stripeCustomerId, stripeSubscriptionId, payload }, event) => {
   console.log('[billing] writeEntitlement:start', {
     uid,
     stripeCustomerId: redactIdentifier(stripeCustomerId),
@@ -169,27 +170,37 @@ const writeEntitlement = async ({ uid, stripeCustomerId, stripeSubscriptionId, p
   const existing = await getExistingEntitlementData(uid, { stripeCustomerId, stripeSubscriptionId });
   if (!existing) {
     logSkippedEntitlementWrite({ uid, stripeCustomerId, stripeSubscriptionId });
-    return;
+    return { applied: false, reason: 'missing-target' };
   }
-
-  const nextPayload = computeEffectiveEntitlement({
-    ...createBaseEntitlementPayload(uid, existing.data),
-    ...payload,
-  });
 
   try {
-    await existing.ref.set(nextPayload, { merge: true });
+    const result = await applyEntitlementWebhookEvent({
+      db: getAdminDb(),
+      entitlementRef: existing.ref,
+      event,
+      buildNextPayload: (currentData) =>
+        computeEffectiveEntitlement({
+          ...createBaseEntitlementPayload(uid, currentData),
+          ...payload,
+        }),
+    });
+    if (!result.applied) {
+      console.log('[billing] writeEntitlement:skipped', { eventId: event.id, reason: result.reason });
+      return result;
+    }
+
+    const nextPayload = result.nextPayload;
+    console.log('[billing] writeEntitlement:success', {
+      uid: nextPayload.uid,
+      premiumActive: nextPayload.premiumActive,
+      effectiveSource: nextPayload.effectiveSource,
+      billingStatus: nextPayload.billingStatus,
+    });
+    return result;
   } catch (error) {
-    logEntitlementWriteError({ uid, stripeCustomerId, stripeSubscriptionId, nextPayload, error });
+    logEntitlementWriteError({ uid, stripeCustomerId, stripeSubscriptionId, nextPayload: payload, error });
     throw error;
   }
-
-  console.log('[billing] writeEntitlement:success', {
-    uid: nextPayload.uid,
-    premiumActive: nextPayload.premiumActive,
-    effectiveSource: nextPayload.effectiveSource,
-    billingStatus: nextPayload.billingStatus,
-  });
 };
 
 /** Extracts a verified Firebase user from the Authorization header. */
@@ -309,10 +320,6 @@ const handleBillingPortal = async (req, res) => {
 /** Maps Stripe recurring intervals into the entitlement interval shape. */
 const getPlanInterval = (interval) => (interval === 'year' ? 'annual' : 'monthly');
 
-/** Extracts the most reliable UID from an invoice payload. */
-const getInvoiceUid = (invoice) =>
-  invoice.parent?.subscription_details?.metadata?.uid || invoice.subscription_details?.metadata?.uid || '';
-
 /** Normalizes a Stripe API customer id into a nullable string. */
 const getStripeCustomerId = (value) => (typeof value === 'string' ? value : null);
 
@@ -371,33 +378,17 @@ const createSubscriptionEntitlementWrite = (subscription) => {
   };
 };
 
-/** Builds the entitlement payload for invoice payment events. */
-const createInvoiceEntitlementWrite = (eventType, invoice) => {
-  const uid = getInvoiceUid(invoice);
-  const stripeCustomerId = getStripeCustomerId(invoice.customer);
-  const stripeSubscriptionId = getStripeSubscriptionId(invoice.subscription);
-
-  return {
-    uid,
-    stripeCustomerId,
-    stripeSubscriptionId,
-    payload: {
-      uid,
-      planInterval: getPlanInterval(invoice.lines?.data?.[0]?.price?.recurring?.interval),
-      billingStatus: eventType === 'invoice.paid' ? 'active' : 'past_due',
-      stripeCustomerId,
-      stripeSubscriptionId,
-    },
-  };
-};
-
 /** Applies the checkout-complete event to the entitlement document. */
 const recordBillingMetricEventSafely = async (eventType, webhookEventId) => {
   try {
+<<<<<<< HEAD
     const recorded = await recordBillingMetricEvent(eventType, webhookEventId);
     if (!recorded) {
       console.log('[billing] metrics:duplicate-or-skipped', { eventType, webhookEventId });
     }
+=======
+    await recordBillingMetricEvent(eventType, webhookEventId);
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   } catch (error) {
     console.warn('[billing] metrics:nonfatal', {
       eventType,
@@ -407,37 +398,100 @@ const recordBillingMetricEventSafely = async (eventType, webhookEventId) => {
 };
 
 /** Applies the checkout-complete event to the entitlement document. */
+<<<<<<< HEAD
 const handleCheckoutSessionCompleted = async (event) => {
   const session = event.data.object;
   await writeEntitlement(createCheckoutEntitlementWrite(session));
+=======
+const getInvoiceSubscription = (invoice) =>
+  invoice.subscription || invoice.parent?.subscription_details?.subscription || null;
+
+/** Resolves a subscription id or expanded object from a supported webhook payload. */
+const getWebhookSubscription = (event) => {
+  const object = event.data.object;
+  if (event.type.startsWith('customer.subscription.')) {
+    return object;
+  }
+  if (event.type === 'checkout.session.completed') {
+    return object.subscription || null;
+  }
+  return getInvoiceSubscription(object);
+};
+
+/** Retrieves current Stripe lifecycle state for convenience events such as invoices. */
+const resolveAuthoritativeSubscription = async (stripe, event) => {
+  const subscription = getWebhookSubscription(event);
+  if (!subscription) {
+    return null;
+  }
+  if (typeof subscription === 'object') {
+    return subscription;
+  }
+  return stripe.subscriptions.retrieve(subscription);
+};
+
+/** Preserves the checkout UID if Stripe has not copied metadata onto the subscription yet. */
+const withFallbackSubscriptionUid = (subscription, fallbackUid) => ({
+  ...subscription,
+  metadata: {
+    ...(subscription.metadata || {}),
+    ...(subscription.metadata?.uid || !fallbackUid ? {} : { uid: fallbackUid }),
+  },
+});
+
+/** Applies checkout completion using current subscription state when available. */
+const handleCheckoutSessionCompleted = async (event, stripe) => {
+  const session = event.data.object;
+  const subscription = await resolveAuthoritativeSubscription(stripe, event);
+  const entitlementWrite = subscription
+    ? createSubscriptionEntitlementWrite(withFallbackSubscriptionUid(subscription, session.metadata?.uid))
+    : createCheckoutEntitlementWrite(session);
+  await writeEntitlement(entitlementWrite, event);
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   await recordBillingMetricEventSafely('premium_upgrade', event.id);
 };
 
 /** Applies the subscription lifecycle event to the entitlement document. */
 const handleSubscriptionEvent = async (event) => {
+<<<<<<< HEAD
   const subscription = event.data.object;
   await writeEntitlement(createSubscriptionEntitlementWrite(subscription));
+=======
+  await writeEntitlement(createSubscriptionEntitlementWrite(event.data.object), event);
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   if (event.type === 'customer.subscription.deleted') {
     await recordBillingMetricEventSafely('premium_cancellation', event.id);
   }
 };
 
-/** Applies invoice payment results to the entitlement document. */
-const handleInvoiceEvent = (eventType, invoice) => writeEntitlement(createInvoiceEntitlementWrite(eventType, invoice));
+/** Applies invoice notifications from the current authoritative subscription state. */
+const handleInvoiceEvent = async (event, stripe) => {
+  const subscription = await resolveAuthoritativeSubscription(stripe, event);
+  if (!subscription) {
+    console.warn('[billing] invoice:skipped-no-subscription', { eventId: event.id, eventType: event.type });
+    return;
+  }
+  await writeEntitlement(createSubscriptionEntitlementWrite(subscription), event);
+};
 
 const webhookHandlers = {
   'checkout.session.completed': handleCheckoutSessionCompleted,
   'customer.subscription.updated': handleSubscriptionEvent,
   'customer.subscription.deleted': handleSubscriptionEvent,
+<<<<<<< HEAD
   'invoice.paid': (event) => handleInvoiceEvent(event.type, event.data.object),
   'invoice.payment_failed': (event) => handleInvoiceEvent(event.type, event.data.object),
+=======
+  'invoice.paid': handleInvoiceEvent,
+  'invoice.payment_failed': handleInvoiceEvent,
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
 };
 
 /** Returns the event handler for a Stripe webhook type, if the app cares about it. */
 const getWebhookHandler = (eventType) => webhookHandlers[eventType] || null;
 
 /** Handles checkout completion and subscription lifecycle events from Stripe. */
-const handleWebhookEvent = async (event) => {
+const handleWebhookEvent = async (event, stripe) => {
   console.log('[billing] webhook:event', event.type);
 
   const handler = getWebhookHandler(event.type);
@@ -446,7 +500,7 @@ const handleWebhookEvent = async (event) => {
     return;
   }
 
-  await handler(event);
+  await handler(event, stripe);
 };
 
 /** Writes the public billing config response used by the client. */
@@ -465,7 +519,7 @@ const handleBillingConfig = (_req, res) => {
 const processWebhookRequest = async (req, res, stripe, webhookSecret) => {
   try {
     const event = stripe.webhooks.constructEvent(req.body, req.headers['stripe-signature'], webhookSecret);
-    await handleWebhookEvent(event);
+    await handleWebhookEvent(event, stripe);
     res.status(200).json({ received: true });
   } catch (error) {
     console.error('[billing] webhook:error', error);
@@ -525,4 +579,8 @@ const registerBillingRoutes = (app, express) => {
 
 module.exports = {
   registerBillingRoutes,
+  __testing: {
+    handleWebhookEvent,
+    resolveAuthoritativeSubscription,
+  },
 };

--- a/server/billing.js
+++ b/server/billing.js
@@ -381,14 +381,10 @@ const createSubscriptionEntitlementWrite = (subscription) => {
 /** Applies the checkout-complete event to the entitlement document. */
 const recordBillingMetricEventSafely = async (eventType, webhookEventId) => {
   try {
-<<<<<<< HEAD
     const recorded = await recordBillingMetricEvent(eventType, webhookEventId);
     if (!recorded) {
       console.log('[billing] metrics:duplicate-or-skipped', { eventType, webhookEventId });
     }
-=======
-    await recordBillingMetricEvent(eventType, webhookEventId);
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   } catch (error) {
     console.warn('[billing] metrics:nonfatal', {
       eventType,
@@ -397,12 +393,7 @@ const recordBillingMetricEventSafely = async (eventType, webhookEventId) => {
   }
 };
 
-/** Applies the checkout-complete event to the entitlement document. */
-<<<<<<< HEAD
-const handleCheckoutSessionCompleted = async (event) => {
-  const session = event.data.object;
-  await writeEntitlement(createCheckoutEntitlementWrite(session));
-=======
+/** Resolves a subscription id or expanded object from a supported webhook payload. */
 const getInvoiceSubscription = (invoice) =>
   invoice.subscription || invoice.parent?.subscription_details?.subscription || null;
 
@@ -447,18 +438,12 @@ const handleCheckoutSessionCompleted = async (event, stripe) => {
     ? createSubscriptionEntitlementWrite(withFallbackSubscriptionUid(subscription, session.metadata?.uid))
     : createCheckoutEntitlementWrite(session);
   await writeEntitlement(entitlementWrite, event);
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   await recordBillingMetricEventSafely('premium_upgrade', event.id);
 };
 
 /** Applies the subscription lifecycle event to the entitlement document. */
 const handleSubscriptionEvent = async (event) => {
-<<<<<<< HEAD
-  const subscription = event.data.object;
-  await writeEntitlement(createSubscriptionEntitlementWrite(subscription));
-=======
   await writeEntitlement(createSubscriptionEntitlementWrite(event.data.object), event);
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   if (event.type === 'customer.subscription.deleted') {
     await recordBillingMetricEventSafely('premium_cancellation', event.id);
   }
@@ -478,13 +463,8 @@ const webhookHandlers = {
   'checkout.session.completed': handleCheckoutSessionCompleted,
   'customer.subscription.updated': handleSubscriptionEvent,
   'customer.subscription.deleted': handleSubscriptionEvent,
-<<<<<<< HEAD
-  'invoice.paid': (event) => handleInvoiceEvent(event.type, event.data.object),
-  'invoice.payment_failed': (event) => handleInvoiceEvent(event.type, event.data.object),
-=======
   'invoice.paid': handleInvoiceEvent,
   'invoice.payment_failed': handleInvoiceEvent,
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
 };
 
 /** Returns the event handler for a Stripe webhook type, if the app cares about it. */

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -591,20 +591,28 @@ const recordMetricEvent = async ({ eventType, installationId, uid }) => {
 const normalizeBillingWebhookEventId = (value) =>
   typeof value === 'string' && value.trim() ? value.trim().slice(0, 256) : null;
 
+<<<<<<< HEAD
 /** True when a trusted webhook provides all data needed for one billable metric write. */
 const hasBillingMetricWriteInput = ({ db, eventType, webhookEventId }) =>
   Boolean(db && eventType && webhookEventId);
 
 /** Records admin-only billing metric events once per trusted Stripe webhook delivery id. */
+=======
+/** Records admin-only billing metric events once per trusted Stripe webhook event. */
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
 const recordBillingMetricEvent = async (eventType, webhookEventId) => {
   const normalizedEventType = normalizeBillingMetricEventType(eventType);
   const normalizedWebhookEventId = normalizeBillingWebhookEventId(webhookEventId);
   const db = getAdminDb();
+<<<<<<< HEAD
   if (!hasBillingMetricWriteInput({
     db,
     eventType: normalizedEventType,
     webhookEventId: normalizedWebhookEventId,
   })) {
+=======
+  if (!db || !normalizedEventType || !normalizedWebhookEventId) {
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
     return false;
   }
 
@@ -622,9 +630,17 @@ const recordBillingMetricEvent = async (eventType, webhookEventId) => {
       return false;
     }
 
+<<<<<<< HEAD
     transaction.set(processedEventRef, {
       eventType: normalizedEventType,
       processedAt: new Date(),
+=======
+    const processedAt = new Date();
+    transaction.set(processedEventRef, {
+      eventType: normalizedEventType,
+      processedAt,
+      expiresAt: new Date(processedAt.getTime() + 30 * 24 * 60 * 60 * 1000),
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
     });
     transaction.set(
       dailyRef,

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -591,28 +591,20 @@ const recordMetricEvent = async ({ eventType, installationId, uid }) => {
 const normalizeBillingWebhookEventId = (value) =>
   typeof value === 'string' && value.trim() ? value.trim().slice(0, 256) : null;
 
-<<<<<<< HEAD
 /** True when a trusted webhook provides all data needed for one billable metric write. */
 const hasBillingMetricWriteInput = ({ db, eventType, webhookEventId }) =>
   Boolean(db && eventType && webhookEventId);
 
 /** Records admin-only billing metric events once per trusted Stripe webhook delivery id. */
-=======
-/** Records admin-only billing metric events once per trusted Stripe webhook event. */
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
 const recordBillingMetricEvent = async (eventType, webhookEventId) => {
   const normalizedEventType = normalizeBillingMetricEventType(eventType);
   const normalizedWebhookEventId = normalizeBillingWebhookEventId(webhookEventId);
   const db = getAdminDb();
-<<<<<<< HEAD
   if (!hasBillingMetricWriteInput({
     db,
     eventType: normalizedEventType,
     webhookEventId: normalizedWebhookEventId,
   })) {
-=======
-  if (!db || !normalizedEventType || !normalizedWebhookEventId) {
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
     return false;
   }
 
@@ -630,17 +622,11 @@ const recordBillingMetricEvent = async (eventType, webhookEventId) => {
       return false;
     }
 
-<<<<<<< HEAD
-    transaction.set(processedEventRef, {
-      eventType: normalizedEventType,
-      processedAt: new Date(),
-=======
     const processedAt = new Date();
     transaction.set(processedEventRef, {
       eventType: normalizedEventType,
       processedAt,
       expiresAt: new Date(processedAt.getTime() + 30 * 24 * 60 * 60 * 1000),
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
     });
     transaction.set(
       dailyRef,

--- a/server/metrics.test.js
+++ b/server/metrics.test.js
@@ -1,27 +1,15 @@
 'use strict';
 
-<<<<<<< HEAD
-const { after, describe, it } = require('node:test');
-=======
 const { after, beforeEach, describe, it } = require('node:test');
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
 const assert = require('node:assert/strict');
 
 const firebaseAdminPath = require.resolve('./firebase-admin');
 const metricsPath = require.resolve('./metrics');
 const originalFirebaseAdmin = require.cache[firebaseAdminPath];
 const documents = new Map();
-<<<<<<< HEAD
 
 const createRef = (collection, id) => ({ collection, id, key: `${collection}/${id}` });
-const getSnapshot = (ref) => {
-  const data = documents.get(ref.key);
-  return { exists: Boolean(data), data: () => data || {} };
-};
-=======
-const createRef = (collection, id) => ({ collection, id, key: `${collection}/${id}` });
 const snapshot = (ref) => ({ exists: documents.has(ref.key), data: () => documents.get(ref.key) || {} });
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
 const db = {
   collection: (collection) => ({
     doc: (id) => createRef(collection, id),
@@ -29,16 +17,10 @@ const db = {
   }),
   runTransaction: async (callback) =>
     callback({
-<<<<<<< HEAD
-      get: async (ref) => getSnapshot(ref),
-      set: (ref, data, options) => {
-        documents.set(ref.key, options?.merge ? { ...(documents.get(ref.key) || {}), ...data } : data);
-=======
       get: async (ref) => snapshot(ref),
       set: (ref, data, options) => {
         const previous = options?.merge ? documents.get(ref.key) || {} : {};
         documents.set(ref.key, { ...previous, ...data });
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
       },
     }),
 };
@@ -52,40 +34,14 @@ require.cache[firebaseAdminPath] = {
 delete require.cache[metricsPath];
 const { recordBillingMetricEvent } = require('./metrics');
 
-<<<<<<< HEAD
-after(() => {
-  documents.clear();
-=======
 beforeEach(() => documents.clear());
 after(() => {
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   if (originalFirebaseAdmin) require.cache[firebaseAdminPath] = originalFirebaseAdmin;
   else delete require.cache[firebaseAdminPath];
   delete require.cache[metricsPath];
 });
 
 describe('recordBillingMetricEvent', () => {
-<<<<<<< HEAD
-  it('records each Stripe webhook event id only once', async () => {
-    const first = await recordBillingMetricEvent('premium_upgrade', 'evt_checkout_123');
-    const replay = await recordBillingMetricEvent('premium_upgrade', 'evt_checkout_123');
-    const dailyMetrics = [...documents.entries()].find(([key]) => key.startsWith('adminDailyMetrics/'))?.[1];
-
-    assert.equal(first, true);
-    assert.equal(replay, false);
-    assert.equal(dailyMetrics.upgrades, 1);
-    assert.equal(documents.get('processedBillingWebhookEvents/evt_checkout_123').eventType, 'premium_upgrade');
-  });
-
-  it('counts distinct cancellation events and rejects missing event ids', async () => {
-    const accepted = await recordBillingMetricEvent('premium_cancellation', 'evt_cancel_456');
-    const missingId = await recordBillingMetricEvent('premium_cancellation', '');
-    const dailyMetrics = [...documents.entries()].find(([key]) => key.startsWith('adminDailyMetrics/'))?.[1];
-
-    assert.equal(accepted, true);
-    assert.equal(missingId, false);
-    assert.equal(dailyMetrics.cancellations, 1);
-=======
   it('counts a replayed Stripe event id only once', async () => {
     assert.equal(await recordBillingMetricEvent('premium_upgrade', 'evt_upgrade'), true);
     assert.equal(await recordBillingMetricEvent('premium_upgrade', 'evt_upgrade'), false);
@@ -98,6 +54,5 @@ describe('recordBillingMetricEvent', () => {
   it('rejects billing metrics without a delivery id', async () => {
     assert.equal(await recordBillingMetricEvent('premium_cancellation', ''), false);
     assert.equal([...documents.keys()].some((key) => key.startsWith('adminDailyMetrics/')), false);
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   });
 });

--- a/server/metrics.test.js
+++ b/server/metrics.test.js
@@ -1,18 +1,27 @@
 'use strict';
 
+<<<<<<< HEAD
 const { after, describe, it } = require('node:test');
+=======
+const { after, beforeEach, describe, it } = require('node:test');
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
 const assert = require('node:assert/strict');
 
 const firebaseAdminPath = require.resolve('./firebase-admin');
 const metricsPath = require.resolve('./metrics');
 const originalFirebaseAdmin = require.cache[firebaseAdminPath];
 const documents = new Map();
+<<<<<<< HEAD
 
 const createRef = (collection, id) => ({ collection, id, key: `${collection}/${id}` });
 const getSnapshot = (ref) => {
   const data = documents.get(ref.key);
   return { exists: Boolean(data), data: () => data || {} };
 };
+=======
+const createRef = (collection, id) => ({ collection, id, key: `${collection}/${id}` });
+const snapshot = (ref) => ({ exists: documents.has(ref.key), data: () => documents.get(ref.key) || {} });
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
 const db = {
   collection: (collection) => ({
     doc: (id) => createRef(collection, id),
@@ -20,9 +29,16 @@ const db = {
   }),
   runTransaction: async (callback) =>
     callback({
+<<<<<<< HEAD
       get: async (ref) => getSnapshot(ref),
       set: (ref, data, options) => {
         documents.set(ref.key, options?.merge ? { ...(documents.get(ref.key) || {}), ...data } : data);
+=======
+      get: async (ref) => snapshot(ref),
+      set: (ref, data, options) => {
+        const previous = options?.merge ? documents.get(ref.key) || {} : {};
+        documents.set(ref.key, { ...previous, ...data });
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
       },
     }),
 };
@@ -36,14 +52,20 @@ require.cache[firebaseAdminPath] = {
 delete require.cache[metricsPath];
 const { recordBillingMetricEvent } = require('./metrics');
 
+<<<<<<< HEAD
 after(() => {
   documents.clear();
+=======
+beforeEach(() => documents.clear());
+after(() => {
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   if (originalFirebaseAdmin) require.cache[firebaseAdminPath] = originalFirebaseAdmin;
   else delete require.cache[firebaseAdminPath];
   delete require.cache[metricsPath];
 });
 
 describe('recordBillingMetricEvent', () => {
+<<<<<<< HEAD
   it('records each Stripe webhook event id only once', async () => {
     const first = await recordBillingMetricEvent('premium_upgrade', 'evt_checkout_123');
     const replay = await recordBillingMetricEvent('premium_upgrade', 'evt_checkout_123');
@@ -63,5 +85,19 @@ describe('recordBillingMetricEvent', () => {
     assert.equal(accepted, true);
     assert.equal(missingId, false);
     assert.equal(dailyMetrics.cancellations, 1);
+=======
+  it('counts a replayed Stripe event id only once', async () => {
+    assert.equal(await recordBillingMetricEvent('premium_upgrade', 'evt_upgrade'), true);
+    assert.equal(await recordBillingMetricEvent('premium_upgrade', 'evt_upgrade'), false);
+
+    const dailyMetrics = [...documents.entries()].find(([key]) => key.startsWith('adminDailyMetrics/'))[1];
+    assert.equal(dailyMetrics.upgrades, 1);
+    assert.equal(documents.get('processedBillingWebhookEvents/evt_upgrade').eventType, 'premium_upgrade');
+  });
+
+  it('rejects billing metrics without a delivery id', async () => {
+    assert.equal(await recordBillingMetricEvent('premium_cancellation', ''), false);
+    assert.equal([...documents.keys()].some((key) => key.startsWith('adminDailyMetrics/')), false);
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   });
 });

--- a/server/package.json
+++ b/server/package.json
@@ -6,11 +6,7 @@
   "main": "analytics.js",
   "scripts": {
     "start": "node analytics.js",
-<<<<<<< HEAD
-    "test": "node --test billing-stripe-period.test.js metrics.test.js qs-dos.test.js lib/serverTarget.test.js lib/featureCapabilities.test.js server-stack.test.js tstm.test.js tstm-ingestion.test.js testing/featureExposureHarness.test.js testing/autoTstm.exposure.test.js lib/capabilityStatus.test.js"
-=======
-    "test": "node --test billing-stripe-period.test.js billing-webhook-state.test.js billing-webhook.test.js metrics.test.js qs-dos.test.js server-stack.test.js"
->>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
+    "test": "node --test billing-stripe-period.test.js billing-webhook-state.test.js billing-webhook.test.js metrics.test.js qs-dos.test.js lib/serverTarget.test.js lib/featureCapabilities.test.js server-stack.test.js tstm.test.js tstm-ingestion.test.js testing/featureExposureHarness.test.js testing/autoTstm.exposure.test.js lib/capabilityStatus.test.js"
   },
   "dependencies": {
     "@sentry/node": "^10.67.0",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,11 @@
   "main": "analytics.js",
   "scripts": {
     "start": "node analytics.js",
+<<<<<<< HEAD
     "test": "node --test billing-stripe-period.test.js metrics.test.js qs-dos.test.js lib/serverTarget.test.js lib/featureCapabilities.test.js server-stack.test.js tstm.test.js tstm-ingestion.test.js testing/featureExposureHarness.test.js testing/autoTstm.exposure.test.js lib/capabilityStatus.test.js"
+=======
+    "test": "node --test billing-stripe-period.test.js billing-webhook-state.test.js billing-webhook.test.js metrics.test.js qs-dos.test.js server-stack.test.js"
+>>>>>>> 7feb9ce (fix: harden billing webhook state transitions)
   },
   "dependencies": {
     "@sentry/node": "^10.67.0",


### PR DESCRIPTION
## Automated port needs conflict resolution

This **draft** PR was opened because the porting workflow could not apply the changes cleanly onto `beta`.

| | |
| --- | --- |
| Original PR | #762 — fix: harden billing webhook state transitions |
| Source branch | `hotfix/stripe-webhook-integrity` (merged into `main`) |
| Port method attempted | cherry-pick (conflicts) |

### Conflicted files


- `server/billing.js`
- `server/metrics.js`
- `server/metrics.test.js`
- `server/package.json`

### What to do

1. Open this draft PR and edit the conflicted files (GitHub UI or local checkout of `port/762-to-beta`).
2. Remove conflict markers. For `pnpm-lock.yaml` / `package-lock.json` conflicts, prefer checking out this branch locally, aligning `package.json` with #762, then running `pnpm install` and committing the regenerated lockfile.
3. Mark this PR **ready for review**, then merge when CI passes.

The branch intentionally contains unresolved conflict markers so you are not left rebuilding the port from scratch.

Keeping this branch current avoids `beta` drifting behind `main`.