### PR TITLE
[codex] fix beta Auto-TSTM Python runtime

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -176,6 +176,9 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 ### PR #723
 
 - Add hostile-client hosted authorization coverage, protect server-managed account fields, enforce trusted premium eligibility for cloud writes, and preserve bounded beta workflow data plus owner export/delete access after downgrade.
+### PR #788
+
+- Fix beta Auto-TSTM ingestion by configuring the analytics worker to use the project virtual-environment Python interpreter.
 
 ### PR #699
 

--- a/deploy/beta-deployment-config.json
+++ b/deploy/beta-deployment-config.json
@@ -1,5 +1,6 @@
 {
   "serverEnv": {
+    "PYTHON_BIN": "/opt/gfc-beta-analytics/.venv/bin/python",
     "TSTM_GENERATION_ENABLED": "true",
     "TSTM_INGESTION_ENABLED": "true"
   }

--- a/scripts/lib/deployment-config.test.mjs
+++ b/scripts/lib/deployment-config.test.mjs
@@ -87,6 +87,20 @@ describe('deployment config', () => {
     assert.ok(lines.every((line) => /^[A-Z][A-Z0-9_]*=.+$/.test(line)));
   });
 
+  it('renders the beta Auto-TSTM worker interpreter override', () => {
+    const output = execFileSync(process.execPath, [
+      WRITE_DEPLOYMENT_ENV_SCRIPT,
+      'deploy/beta-deployment-config.json',
+    ], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    assert.match(output, /^PYTHON_BIN=\/opt\/gfc-beta-analytics\/\.venv\/bin\/python$/m);
+    assert.match(output, /^TSTM_GENERATION_ENABLED=true$/m);
+    assert.match(output, /^TSTM_INGESTION_ENABLED=true$/m);
+  });
+
   it('rejects config paths outside deploy', () => {
     const outsideConfig = resolve(tmpdir(), `gfc-deploy-config-${Date.now()}.json`);
     writeFileSync(outsideConfig, '{"serverEnv":{"TSTM_GENERATION_ENABLED":"true"}}');

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -171,6 +171,25 @@ describe('Auto-TSTM server foundation', () => {
     await new Promise((r) => setTimeout(r, 10));
     assert.ok(spawnedArgs.includes('--ingestion-mode'));
   });
+
+  it('uses the configured Python interpreter for the generator', async () => {
+    const child = createFakeChild();
+    let spawnedCommand;
+    runTstmGenerator(
+      { day: 1, cycleDate: '2026-06-13' },
+      {
+        env: { PYTHON_BIN: '/opt/gfc-beta-analytics/.venv/bin/python' },
+        spawnProcess: (command) => {
+          spawnedCommand = command;
+          return child;
+        },
+      }
+    );
+    child.stdout.end('{}');
+    child.emit('close', 0);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(spawnedCommand, '/opt/gfc-beta-analytics/.venv/bin/python');
+  });
 });
 
 describe('GET /api/tstm/latest', () => {

--- a/server/tstm.test.js
+++ b/server/tstm.test.js
@@ -175,7 +175,7 @@ describe('Auto-TSTM server foundation', () => {
   it('uses the configured Python interpreter for the generator', async () => {
     const child = createFakeChild();
     let spawnedCommand;
-    runTstmGenerator(
+    const result = runTstmGenerator(
       { day: 1, cycleDate: '2026-06-13' },
       {
         env: { PYTHON_BIN: '/opt/gfc-beta-analytics/.venv/bin/python' },
@@ -187,7 +187,7 @@ describe('Auto-TSTM server foundation', () => {
     );
     child.stdout.end('{}');
     child.emit('close', 0);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await result;
     assert.equal(spawnedCommand, '/opt/gfc-beta-analytics/.venv/bin/python');
   });
 });


### PR DESCRIPTION
## Summary

Auto-TSTM beta ingestion was unable to refresh its cache even though the HREF upstream remained operational.

The beta analytics process was launching the generator with the bare `python` command. On the VPS, `python` is not available; the project virtual environment provides the required interpreter at `/opt/gfc-beta-analytics/.venv/bin/python`. Every scheduled ingestion attempt therefore failed with `spawn python ENOENT`, leaving the July 2 cache entries stale and causing users to see the generic unavailable-guidance message.

This change adds the explicit `PYTHON_BIN` override to the beta deployment configuration. The deployment workflow already renders this configuration into the analytics `.env` before restarting PM2. Regression coverage verifies both the rendered environment line and that the generator honors the configured interpreter.

## Verification

- `npm test` in `server/` — 94 passed
- `pnpm test` — 797 passed
- `pnpm run build` — passed; Sentry source-map upload reported the existing HTTP 403 telemetry limitation after the build completed
- deployment-config tests — 9 passed
- `git diff --check` — passed

## Deployment follow-up

After merge/deployment, verify PM2 logs no longer contain `spawn python ENOENT`, then confirm `/api/tstm/status` reports fresh available Day 1/Day 2 cache entries and `/api/tstm/latest` returns HTTP 200.
