### PR TITLE
[codex] Add right-aligned map undo and redo controls

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -10,6 +10,13 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 - Forecast Grade dashboard shell: replace the 06b stub with the map-first workspace chrome (`ForecastGradeDashboard` plus dedicated `ForecastGradeMapPane` / `ForecastGradeMapControls`), categorical map layer as a display-only toggle, and `applyGradeSnapshot` to reopen premium cards through the shared verification map.
 - `useForecastGrade` gains `activeMapLayer` state, `deserializeForecast` import, and the `applyGradeSnapshot` callback alongside the 06b `runGeneration` / `hasReachedReportDate` stale-run and future-date guards that the rebase would otherwise drop.
+
+### PR #789
+
+#### Added
+
+- Add icon-based Undo and Redo controls to the map tools panel, aligned to the right of the Pan, Draw, Delete, and Key controls on desktop and mobile.
+
 ### PR #775
 
 #### Added

--- a/e2e/custom-layers.spec.ts
+++ b/e2e/custom-layers.spec.ts
@@ -66,9 +66,10 @@ test.describe('local-only custom layers', () => {
 
     await page.getByRole('button', { name: 'Delete polygons' }).click();
     await page.mouse.click(box.x + box.width * .51, box.y + box.height * .46);
-    await page.getByRole('tab', { name: 'Tools' }).click();
-    await page.getByRole('button', { name: 'Undo' }).first().click();
-    await expect(page.getByRole('button', { name: 'Redo' }).first()).toBeEnabled();
+    await page.locator('.map-history-button[aria-label="Undo"]').click();
+    await expect(page.locator('.map-history-button[aria-label="Redo"]')).toBeEnabled();
+    await page.locator('.map-history-button[aria-label="Redo"]').click();
+    await expect(page.locator('.map-history-button[aria-label="Undo"]')).toBeEnabled();
   });
 
   for (const viewport of [

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -66,7 +66,8 @@ test.describe('App smoke tests', () => {
         if (element.classList.contains('mode-key')) return 'key';
         if (element.classList.contains('mode-delete')) return 'delete';
         if (element.classList.contains('mode-draw')) return 'draw';
-        return 'pan';
+        if (element.classList.contains('mode-pan')) return 'pan';
+        throw new Error(`Unexpected map toolbar child: ${element.className}`);
       })
     );
     expect(mapToolbarOrder).toEqual(['pan', 'draw', 'delete', 'divider', 'key', 'spacer', 'history']);

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -57,6 +57,19 @@ test.describe('App smoke tests', () => {
     await expect(page.locator('.map-history-button[aria-label="Undo"]')).toBeVisible();
     await expect(page.locator('.map-history-button[aria-label="Undo"]')).toBeDisabled();
     await expect(page.locator('.map-history-button[aria-label="Redo"]')).toBeDisabled();
+    await expect(page.locator('.map-toolbar-surface > *')).toHaveCount(7);
+    const mapToolbarOrder = await page.locator('.map-toolbar-surface > *').evaluateAll((elements) =>
+      elements.map((element) => {
+        if (element.classList.contains('map-history-group')) return 'history';
+        if (element.classList.contains('map-toolbar-spacer')) return 'spacer';
+        if (element.classList.contains('map-toolbar-divider')) return 'divider';
+        if (element.classList.contains('mode-key')) return 'key';
+        if (element.classList.contains('mode-delete')) return 'delete';
+        if (element.classList.contains('mode-draw')) return 'draw';
+        return 'pan';
+      })
+    );
+    expect(mapToolbarOrder).toEqual(['pan', 'draw', 'delete', 'divider', 'key', 'spacer', 'history']);
     await expect(page.getByRole('complementary', { name: /map legend/i })).not.toBeVisible();
     await page.getByRole('button', { name: /show map key/i }).click();
     await expect(page.getByRole('complementary', { name: /map legend/i })).toBeVisible();

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -54,6 +54,9 @@ test.describe('App smoke tests', () => {
 
     await expect(page.locator('.map-container')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('.tabbed-integrated-toolbar')).toBeVisible();
+    await expect(page.locator('.map-history-button[aria-label="Undo"]')).toBeVisible();
+    await expect(page.locator('.map-history-button[aria-label="Undo"]')).toBeDisabled();
+    await expect(page.locator('.map-history-button[aria-label="Redo"]')).toBeDisabled();
     await expect(page.getByRole('complementary', { name: /map legend/i })).not.toBeVisible();
     await page.getByRole('button', { name: /show map key/i }).click();
     await expect(page.getByRole('complementary', { name: /map legend/i })).toBeVisible();
@@ -92,6 +95,7 @@ test.describe('App smoke tests', () => {
     await expect(page.locator('.map-container')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('.tabbed-integrated-toolbar__status-bar')).not.toBeVisible();
     await expect(page.locator('.map-toolbar-help-surface')).not.toBeVisible();
+    await expect(page.locator('.map-history-button[aria-label="Undo"]')).toBeVisible();
     await expect(page.getByRole('button', { name: /show map key/i })).toBeVisible();
 
     await page.getByRole('button', { name: /show map key/i }).click();

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -58,17 +58,23 @@ test.describe('App smoke tests', () => {
     await expect(page.locator('.map-history-button[aria-label="Undo"]')).toBeDisabled();
     await expect(page.locator('.map-history-button[aria-label="Redo"]')).toBeDisabled();
     await expect(page.locator('.map-toolbar-surface > *')).toHaveCount(7);
-    const mapToolbarOrder = await page.locator('.map-toolbar-surface > *').evaluateAll((elements) =>
-      elements.map((element) => {
-        if (element.classList.contains('map-history-group')) return 'history';
-        if (element.classList.contains('map-toolbar-spacer')) return 'spacer';
-        if (element.classList.contains('map-toolbar-divider')) return 'divider';
-        if (element.classList.contains('mode-key')) return 'key';
-        if (element.classList.contains('mode-delete')) return 'delete';
-        if (element.classList.contains('mode-draw')) return 'draw';
-        if (element.classList.contains('mode-pan')) return 'pan';
-        throw new Error(`Unexpected map toolbar child: ${element.className}`);
-      })
+    const toolbarClassifications = [
+      ['map-history-group', 'history'],
+      ['map-toolbar-spacer', 'spacer'],
+      ['map-toolbar-divider', 'divider'],
+      ['mode-key', 'key'],
+      ['mode-delete', 'delete'],
+      ['mode-draw', 'draw'],
+      ['mode-pan', 'pan'],
+    ] as const;
+    const mapToolbarOrder = await page.locator('.map-toolbar-surface > *').evaluateAll(
+      (elements, classifications) =>
+        elements.map((element) => {
+          const classification = classifications.find(([className]) => element.classList.contains(className));
+          if (classification) return classification[1];
+          throw new Error(`Unexpected map toolbar child: ${element.className}`);
+        }),
+      toolbarClassifications
     );
     expect(mapToolbarOrder).toEqual(['pan', 'draw', 'delete', 'divider', 'key', 'spacer', 'history']);
     await expect(page.getByRole('complementary', { name: /map legend/i })).not.toBeVisible();

--- a/e2e/testSetup.ts
+++ b/e2e/testSetup.ts
@@ -5,6 +5,6 @@ export const prepareAppState = async (page: Page): Promise<void> => {
   await page.addInitScript(() => {
     localStorage.setItem('gfc-local-beta-bypass', 'true');
     localStorage.setItem('gfc-tos-accepted', '2.0.0');
-    localStorage.setItem('gfc-privacy-policy-accepted', '1.3.0');
+    localStorage.setItem('gfc-privacy-policy-accepted', '1.7.0');
   });
 };

--- a/src/components/Map/ForecastMap.css
+++ b/src/components/Map/ForecastMap.css
@@ -226,6 +226,36 @@
   padding-right: 16px;
 }
 
+.map-history-group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 2px;
+  padding-left: 6px;
+  border-left: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.map-history-button {
+  gap: 5px;
+  color: #9a650e;
+}
+
+.map-history-button:hover:not(:disabled) {
+  color: #704a08;
+  background-color: rgba(245, 158, 11, 0.14);
+}
+
+.map-history-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.map-history-icon {
+  display: none;
+  width: 17px;
+  height: 17px;
+}
+
 .map-toolbar-button:hover {
   background-color: rgba(148, 163, 184, 0.18);
 }
@@ -279,6 +309,19 @@
 
 .dark-mode .map-toolbar-button:hover {
   background-color: rgba(148, 163, 184, 0.2);
+}
+
+.dark-mode .map-history-group {
+  border-left-color: rgba(148, 163, 184, 0.32);
+}
+
+.dark-mode .map-history-button {
+  color: #f6c453;
+}
+
+.dark-mode .map-history-button:hover:not(:disabled) {
+  color: #ffe3a0;
+  background-color: rgba(245, 158, 11, 0.18);
 }
 
 .dark-mode .map-toolbar-surface,
@@ -352,6 +395,29 @@
     padding: 8px 8px;
     border-radius: 9px;
     font-size: 0.74rem;
+  }
+
+  .map-history-group {
+    margin-left: 0;
+    padding-left: 2px;
+  }
+
+  .map-history-button {
+    min-width: 36px;
+    padding: 8px 7px;
+  }
+
+  .map-history-icon {
+    display: block;
+  }
+
+  .map-history-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
   }
 
   .map-toolbar-button.mode-key {

--- a/src/components/Map/ForecastMap.css
+++ b/src/components/Map/ForecastMap.css
@@ -437,7 +437,8 @@
   }
 
   .map-history-button {
-    min-width: 36px;
+    min-width: 44px;
+    min-height: 44px;
     padding: 8px 7px;
   }
 

--- a/src/components/Map/ForecastMap.css
+++ b/src/components/Map/ForecastMap.css
@@ -191,6 +191,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  width: min(440px, calc(100vw - 16px));
   border-radius: 18px;
   padding: 6px;
 }
@@ -221,22 +222,35 @@
   transition: background-color 0.2s, color 0.2s, transform 0.2s;
 }
 
-.map-toolbar-surface .map-toolbar-button:last-child {
-  padding-left: 16px;
-  padding-right: 16px;
+.map-toolbar-surface .map-toolbar-button.mode-delete,
+.map-toolbar-surface .map-toolbar-button.mode-key {
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.map-toolbar-divider {
+  width: 1px;
+  height: 30px;
+  flex: 0 0 1px;
+  margin: 0 4px;
+  background: rgba(148, 163, 184, 0.4);
+}
+
+.map-toolbar-spacer {
+  min-width: 20px;
+  flex: 1 1 auto;
 }
 
 .map-history-group {
   display: flex;
   align-items: center;
   gap: 2px;
-  margin-left: 2px;
-  padding-left: 6px;
-  border-left: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .map-history-button {
+  min-width: 38px;
   gap: 5px;
+  padding: 10px 9px;
   color: #9a650e;
 }
 
@@ -251,9 +265,18 @@
 }
 
 .map-history-icon {
-  display: none;
+  display: block;
   width: 17px;
   height: 17px;
+}
+
+.map-history-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
 }
 
 .map-toolbar-button:hover {
@@ -309,10 +332,6 @@
 
 .dark-mode .map-toolbar-button:hover {
   background-color: rgba(148, 163, 184, 0.2);
-}
-
-.dark-mode .map-history-group {
-  border-left-color: rgba(148, 163, 184, 0.32);
 }
 
 .dark-mode .map-history-button {
@@ -389,12 +408,27 @@
     border-radius: 12px;
   }
 
+  .map-toolbar-divider {
+    height: 28px;
+    margin: 0 3px;
+  }
+
+  .map-toolbar-spacer {
+    min-width: 16px;
+  }
+
   .map-toolbar-button {
     min-width: 44px;
     min-height: 36px;
     padding: 8px 8px;
     border-radius: 9px;
     font-size: 0.74rem;
+  }
+
+  .map-toolbar-surface .map-toolbar-button.mode-delete,
+  .map-toolbar-surface .map-toolbar-button.mode-key {
+    padding-left: 8px;
+    padding-right: 8px;
   }
 
   .map-history-group {
@@ -405,19 +439,6 @@
   .map-history-button {
     min-width: 36px;
     padding: 8px 7px;
-  }
-
-  .map-history-icon {
-    display: block;
-  }
-
-  .map-history-label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    white-space: nowrap;
   }
 
   .map-toolbar-button.mode-key {

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -1763,6 +1763,18 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
             >
               Delete
             </button>
+            <span className="map-toolbar-divider" aria-hidden="true" />
+            <button
+              type="button"
+              className={`map-toolbar-button mode-key ${showDesktopLegend ? "active" : ""}`}
+              onClick={() => setShowDesktopLegend((isVisible) => !isVisible)}
+              title={showDesktopLegend ? "Hide map key" : "Show map key"}
+              aria-label={showDesktopLegend ? "Hide map key" : "Show map key"}
+              aria-expanded={showDesktopLegend}
+            >
+              Key
+            </button>
+            <span className="map-toolbar-spacer" aria-hidden="true" />
             <div className="map-history-group" aria-label="Map edit history">
               <button
                 type="button"
@@ -1787,16 +1799,6 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
                 <span className="map-history-label">Redo</span>
               </button>
             </div>
-            <button
-              type="button"
-              className={`map-toolbar-button mode-key ${showDesktopLegend ? "active" : ""}`}
-              onClick={() => setShowDesktopLegend((isVisible) => !isVisible)}
-              title={showDesktopLegend ? "Hide map key" : "Show map key"}
-              aria-label={showDesktopLegend ? "Hide map key" : "Show map key"}
-              aria-expanded={showDesktopLegend}
-            >
-              Key
-            </button>
           </div>
           <div className="map-toolbar-help-surface">
             {interactionMode === "draw" &&

--- a/src/components/Map/OpenLayersForecastMap.tsx
+++ b/src/components/Map/OpenLayersForecastMap.tsx
@@ -26,15 +26,20 @@ import type OLFeature from "ol/Feature";
 import type Geometry from "ol/geom/Geometry";
 import { click } from "ol/events/condition";
 import { v4 as uuidv4 } from "uuid";
+import { Redo2, Undo2 } from "lucide-react";
 import { RootState } from "../../store";
 import {
   addFeature,
   addCustomFeature,
   removeFeature,
   removeCustomFeature,
+  redoLastEdit,
+  selectCanRedo,
+  selectCanUndo,
   selectCurrentCustomLayers,
   selectCurrentOutlooks,
   setMapView,
+  undoLastEdit,
   updateFeature,
   updateCustomFeature,
 } from "../../store/forecastSlice";
@@ -734,6 +739,8 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
     const drawingState = useSelector(
       (state: RootState) => state.forecast.drawingState,
     );
+    const canUndo = useSelector(selectCanUndo);
+    const canRedo = useSelector(selectCanRedo);
     const customEditor = useSelector((state: RootState) => state.forecast.customEditor);
     const customLayers = useSelector(selectCurrentCustomLayers);
     const customMode = isFeatureExposed("customProducts") && customEditor.mode === "custom";
@@ -1756,6 +1763,30 @@ const OpenLayersForecastMap = forwardRef<MapAdapterHandle<OLMap> | null, OpenLay
             >
               Delete
             </button>
+            <div className="map-history-group" aria-label="Map edit history">
+              <button
+                type="button"
+                className="map-toolbar-button map-history-button"
+                onClick={() => dispatch(undoLastEdit())}
+                disabled={!canUndo}
+                title="Undo last map edit (Ctrl/Cmd+Z)"
+                aria-label="Undo"
+              >
+                <Undo2 className="map-history-icon" aria-hidden="true" />
+                <span className="map-history-label">Undo</span>
+              </button>
+              <button
+                type="button"
+                className="map-toolbar-button map-history-button"
+                onClick={() => dispatch(redoLastEdit())}
+                disabled={!canRedo}
+                title="Redo last map edit (Ctrl/Cmd+Y)"
+                aria-label="Redo"
+              >
+                <Redo2 className="map-history-icon" aria-hidden="true" />
+                <span className="map-history-label">Redo</span>
+              </button>
+            </div>
             <button
               type="button"
               className={`map-toolbar-button mode-key ${showDesktopLegend ? "active" : ""}`}


### PR DESCRIPTION
## Summary

Adds quick-access undo and redo controls to the map tools panel and keeps the interaction consistent across desktop and mobile.

## User impact

Undo and redo are now available beside the map mode controls where users are already working. The controls remain icon-based at both breakpoints, stay at the far right of the panel, and preserve accessible names, keyboard shortcut hints, and disabled states.

## Root cause

Undo and redo were previously only easy to reach through the Tools tab or were visually mixed into the map toolbar without a stable right-aligned group. The divider spacing also made the Delete/Key boundary look uneven.

## Fix

- Added map-panel Undo and Redo actions backed by the existing forecast history selectors and reducers.
- Ordered the panel as `Pan / Draw / Delete | Key | gap | Undo / Redo`.
- Balanced the divider spacing on desktop and mobile.
- Added responsive smoke assertions for button visibility, disabled states, and toolbar order.
- Updated the shared e2e privacy-policy fixture to the current policy version so the custom-layer flow can run.

## Verification

- `pnpm test -- --runTestsByPath src/components/IntegratedToolbar/IntegratedToolbar.test.tsx src/store/forecastSlice.test.ts src/store/forecastSlice.custom.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm exec playwright test e2e/smoke.spec.ts e2e/custom-layers.spec.ts -g "forecast editor|switches cleanly" --workers=1`
- Responsive smoke coverage passed at portrait phone and landscape phone sizes.
- Production build passed; Sentry sourcemap/release upload remains blocked by the existing 403 telemetry permission.
