### PR TITLE
[codex] Enable verification page on beta

### DIFF
--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #790
+
+- Enable the new Forecast Grade verification page for beta testers while keeping staging and production disabled.
+
 ### PR #778
 
 #### Added

--- a/src/config/featureExposure.acknowledgements.json
+++ b/src/config/featureExposure.acknowledgements.json
@@ -19,8 +19,9 @@
     "betaEnablementApproved": true
   },
   "verificationRelaunch": {
-    "reason": "Gate, surface, and classic coexistence wiring land in 06a so the Forecast Grade dashboard shell can dogfood in 06b/06c/07. The flag stays off on every build target until the shell PRs flip it; classic /verification remains the default. Disabled-side-effect coverage is in src/pages/verificationRelaunch.exposure.test.tsx (lazy route + FEATURE_SIDE_EFFECT_MODULES), gate coverage in src/pages/VerificationPage.test.tsx, and the adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts.",
-    "trackingIssue": 430
+    "reason": "The Forecast Grade dashboard shell and classic coexistence routing are complete for the beta tester rollout. Disabled-side-effect coverage is in src/pages/verificationRelaunch.exposure.test.tsx, gate coverage is in src/pages/VerificationPage.test.tsx, and the adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts.",
+    "trackingIssue": 430,
+    "betaEnablementApproved": true
   },
   "customProducts": {
     "reason": "Custom Products completed local implementation, UI review, and regression/E2E coverage under #431. Owner approval enables the beta tester rollout; staging and production remain disabled. Adoption contract is in src/config/v17WorkstreamAdoption.exposure.test.ts and end-to-end coverage is in e2e/custom-products.spec.ts.",

--- a/src/config/featureExposure.test.ts
+++ b/src/config/featureExposure.test.ts
@@ -122,16 +122,16 @@ describe('featureExposure registry', () => {
     ] as const;
 
     for (const feature of workstreamKeys.filter(
-      (feature) => !['forecastWorkflowV2', 'customProducts'].includes(feature)
+      (feature) => !['forecastWorkflowV2', 'verificationRelaunch', 'customProducts'].includes(feature)
     )) {
       for (const target of ['local', 'beta', 'staging', 'production'] as const) {
         expect(isFeatureExposedOnTarget(feature, target)).toBe(false);
       }
     }
 
-    // verificationRelaunch stays off on every target until the dashboard shell lands in 06b/06c/07.
+    // verificationRelaunch is approved for beta while staging and production remain disabled.
     for (const target of ['local', 'beta', 'staging', 'production'] as const) {
-      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(false);
+      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(target === 'beta');
     }
 
     expect(isFeatureExposedOnTarget('forecastWorkflowV2', 'local')).toBe(true);

--- a/src/config/featureExposure.ts
+++ b/src/config/featureExposure.ts
@@ -124,7 +124,7 @@ export const FEATURE_EXPOSURE_REGISTRY = {
     trackingIssue: 429,
   },
   verificationRelaunch: {
-    exposure: { ...ALL_TARGETS_OFF },
+    exposure: { ...ALL_TARGETS_OFF, beta: true },
     owner: 'WxboySuper',
     addedDate: '2026-06-20',
     temporary: true,

--- a/src/config/v17WorkstreamAdoption.exposure.test.ts
+++ b/src/config/v17WorkstreamAdoption.exposure.test.ts
@@ -30,7 +30,7 @@ describe('v1.7 workstream adoption contract', () => {
   test.each(
     V17_WORKSTREAM_KEYS.filter(
       (feature) =>
-        !['autoTstm', 'forecastWorkflowV2', 'customProducts'].includes(feature)
+        !['autoTstm', 'forecastWorkflowV2', 'verificationRelaunch', 'customProducts'].includes(feature)
     )
   )(
     '%s stays disabled on every build target',
@@ -42,10 +42,11 @@ describe('v1.7 workstream adoption contract', () => {
     }
   );
 
-  test('verificationRelaunch stays disabled until the dashboard shell lands', () => {
+  test('verificationRelaunch is enabled for beta testers only', () => {
     for (const target of BUILD_TARGETS) {
-      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(false);
-      expect(FEATURE_EXPOSURE_REGISTRY.verificationRelaunch.exposure[target]).toBe(false);
+      const expected = target === 'beta';
+      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(expected);
+      expect(FEATURE_EXPOSURE_REGISTRY.verificationRelaunch.exposure[target]).toBe(expected);
     }
   });
 

--- a/src/pages/verificationRelaunch.exposure.test.tsx
+++ b/src/pages/verificationRelaunch.exposure.test.tsx
@@ -60,11 +60,11 @@ describe('verificationRelaunch route gate', () => {
     expect(mockV2Load).toHaveBeenCalled();
   });
 
-  test('keeps verificationRelaunch off for every build target until the dashboard shell lands', () => {
+  test('exposes verificationRelaunch only on beta', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { isFeatureExposedOnTarget } = require('../config/featureExposure');
     for (const target of BUILD_TARGETS) {
-      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(false);
+      expect(isFeatureExposedOnTarget('verificationRelaunch', target)).toBe(target === 'beta');
     }
   });
 });


### PR DESCRIPTION
## Summary

Enable the new Forecast Grade verification page on the beta build target.

## Cause and effect

The complete verification relaunch dashboard and its classic-route coexistence wiring are already present, but the `verificationRelaunch` exposure registry still disables the feature for every deployment target. Beta users therefore continue to receive the classic verification page.

## Fix

- Expose `verificationRelaunch` on `beta` only.
- Record the explicit beta enablement acknowledgement required by the v1.7 exposure policy.
- Update the exposure contract tests to protect beta-only behavior while keeping staging and production disabled.
- Add the required PR-numbered beta changelog entry after PR creation.

## Validation

- `pnpm test -- --runTestsByPath src/pages/verificationRelaunch.exposure.test.tsx src/config/featureExposure.test.ts src/config/v17WorkstreamAdoption.exposure.test.ts`
- `pnpm test -- --runInBand` (180 suites, 1,047 tests)
- `pnpm run validate:feature-exposure`
- `pnpm run typecheck`
- `pnpm run typecheck:test`
- `pnpm run build` (successful; Sentry upload returned the known non-blocking 403)

## Scope

Staging and production remain disabled. This PR targets `beta`.
