### PR TITLE
docs: refresh agent project context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,219 +1,56 @@
 # AGENTS.md
 
-## Operating Mode
+## Term Definitions
 
-This repo uses an agentic development workflow: inspect the codebase, make the smallest coherent change, verify it, and leave the workspace in a state a human can immediately continue from.
+- **GFC**: Shorthand for Graphical Forecast Creator
+- **me**: The one speaking to you
+- **you**: The agent reading this.
+- **user**: The person using GFC, who could be a meteorologist, student, or weather enthusiast
+- **forecast**: What the user is creating in GFC
+- **owner / core maintainer / creator**: Wxboysuper/Weatherboysuper, the person writing this document and maintaining the project
 
-Agents should act like senior collaborators, not script runners. Prefer concrete progress over long proposals. When the user asks for an implementation, implement it. When the user reports a UI issue with screenshots, iterate directly against the actual behavior and verify the result.
+# GFC - Graphical Forecast Creator
 
-## Core Principles
+Graphical Forecast Creator is an application built to give weather enthusiasts the tools to build forecasts, monitor them, and reflect on their performance.
 
-- Read the relevant code before changing it.
-- Follow existing patterns before introducing new abstractions.
-- Keep changes scoped to the requested behavior.
-- Preserve unrelated worktree changes.
-- Do not revert, reset, delete, or overwrite work you did not create unless explicitly asked.
-- Prefer clear, testable fixes over broad rewrites.
-- Make UI changes with the real user workflow in mind, not just the component in isolation.
-- Treat mobile and responsive behavior as first-class product behavior.
+### Why is GFC so important?
 
-## Git Rules
+GFC was created to give users an easy way to create forecasts and reflect on and learn about different weather events in a hands-on format where they are in the driver's seat of the forecasts they see almost every day.
 
-- Make code changes on a branch based on `beta` unless the user specifies another base or the workspace is already on a fresh task branch.
-- If the current branch is not suitable for the requested change, create a new branch from `beta` before editing.
-- Do not implement on `beta` (or `main`) in place when the work is a discrete fix or feature—check out a new task branch first (for example `fix/sentry-gfc-web-7-short-description`).
-- For production bug fixes, Sentry investigations, and other shippable repairs: use a dedicated branch, commit there, push, and open a pull request targeting `beta` when the fix is complete and verified—unless the user explicitly asks to stay local-only.
-- Do not commit unless the user asks.
-- Do not push unless the user asks.
-- Do not open a pull request unless the user asks.
-- It is fine to inspect git status and diffs while working.
+Before GFC, users often had to create janky or unstable solutions for this task, such as manually drawing in Microsoft Paint or Photoshop, or using the public version of AWIPS, which is not modern enough for the average consumer. GFC set out to provide a modern solution.
 
-## Implementation Workflow
+For some users, GFC is a critical learning ground for understanding the atmosphere and predicting its behavior. That is why GFC and its core features should always remain freely available.
 
-1. **Investigate the task/issue relative to the codebase on the correct branch relative to the issue or task**
-   - Understand the problem scope
-   - Explore relevant code and existing tests
-   - Determine the correct branch (main or beta based on task type)
+### Where is GFC Available?
 
-2. **Create a plan for implementation to resolve the issue or complete the task**
-   - Document the approach
-   - Define expected changes
-   - Outline testing strategy
+GFC is available on the web at gfc.weatherboysuper.com and is accessible on any platform with a web browser. It is primarily built for desktop and large-screen users, with some mobile components.
 
-3. **Get approval for that plan**
-   - Share the plan with the human for review and approval
-   - Incorporate feedback
+### What can be done in GFC?
 
-4. **Implement that plan on a NEW branch from either main or beta depending on the issue/task**
-   - Create a dedicated branch for this task
-   - Use the approved plan as the implementation guide
-   - Follow coding standards and existing patterns
+GFC currently has four modes, each serving a distinct purpose:
+- **Forecast**: This is where the user builds a forecast
+- **Discussion**: This is where the user can build a text-based discussion to go along with their forecast
+- **Monitor**: Once a user finishes their forecast, they can monitor it while viewing the latest radar, satellite, reports, and alerts.
+- **Verification**: This allows the user to view their forecast, reflect on its performance, and find ways to learn and grow
 
-5. **Commit and push the changes and open a Draft PR**
-   - Make focused, minimal commits
-   - Push to the new branch
-   - Create a draft PR for review
+## Message from the creator
 
-6. **Wait on CI, make sure it is all green. All will run except Greptile**
-   - Wait for CI to complete
-   - Ensure all checks pass (except Greptile)
-   - Resolve any non-Greptile CI failures
+GFC is an important product. In a sense, it is my "baby" project and is extremely important to me. It may not have many users, but it leaves an impact on the knowledge and skill growth of the users it does have. It is important that those benefits remain freely available.
 
-7. **Mark the PR Ready for Review and wait on Greptile to run and get it green and resolve all of its comments**
-   - Mark PR as "Ready for Review"
-   - Wait for Greptile to run
-   - Address all Greptile comments and ensure it passes
+This project is also a learning experience for me as a developer. I am a meteorology student, not a computer science student, and I had never built an application used by others before GFC. There will be testing, experimentation, questions, and change. It is important to adapt quickly while keeping me and everyone developing on the project accountable. There may be architecture questions, and it is important to have an opinion and push back when a path is not right. We are not perfect, and we should always put the value of the product and its users first.
 
-8. **Once Greptile and CI are green stop and hand off to the human to manually review and handle the rest of the process**
-   - Final verification that both CI and Greptile pass
-   - Stop automated work
-   - Hand off to human for final review and any additional manual steps
+## Maintaining the Project
 
-If a test fails, fix the product code or the test based on the intended behavior. Do not weaken coverage just to make CI pass.
+GFC is open source. Keeping the code available to everyone is an intentional decision by the owner. It is a critical learning tool, and the owner cannot always maintain it alone, so leaving it open for others to understand and customize is important.
 
-New feature work should include reasonable test coverage for the behavior that is easily testable. Keep changed files above 80% coverage, preferably higher when the code is important or easy to exercise.
+The rules for maintaining the project change over time. If something seems off, use judgment and ask when needed. Keep building under the principles above, and test solutions with the tools appropriate to the task, including browsers, computer use, or Playwright when the product experience needs to be exercised.
 
-## Frontend Expectations
+## Project Locations
+- `.github/` - GitHub resources
+- `docs/` - Documentation
+    - `docs/personal/` - A git-ignored directory for local maintainer documents. It may not exist, but it is the place for local plans, one-time documents, and other personal artifacts that should not be committed.
+- `server/` - All backend code that runs on the VPS
+- `src/`
+    - `src/components/` - All the different components used in GFC
 
-- Build the actual usable experience, not a placeholder or marketing surface.
-- Validate responsive layouts at realistic viewport sizes.
-- For forecast editor work, verify both portrait and landscape phone layouts.
-- Avoid horizontal page overflow.
-- Avoid controls that require both vertical and horizontal scrolling in the same toolbar surface.
-- Keep map workspace usable and visible on mobile.
-- Keep touch targets large enough for phone use.
-- Prefer CSS and existing component architecture before introducing mobile-only duplicates.
-- If screenshots show overlap, clipping, unreachable controls, or awkward placement, treat that as a product bug.
-
-## Forecast Editor Notes
-
-The forecast editor is the highest-priority workflow. The map should remain the primary workspace, with toolbar controls adapting around it.
-
-For mobile work, check:
-
-- Navbar does not overflow.
-- Map remains visible and usable.
-- Floating map controls do not collide with the toolbar, legend, credits, or warning badge.
-- Bottom toolbar tabs are reachable.
-- Draw, Days, Layers, and Tools controls remain accessible.
-- Legend/key can be hidden by default and opened intentionally.
-- Landscape phone layout uses the mobile interaction model when height is constrained.
-
-## Testing Guidance
-
-Use the narrowest useful verification first, then broaden as risk increases.
-
-Coverage matters. When adding features, update or add tests in the same change so behavior is protected and file coverage stays above 80%.
-
-Common focused unit test command:
-
-```powershell
-pnpm test -- --runTestsByPath <test-file-1> <test-file-2>
-```
-
-Common build command:
-
-```powershell
-pnpm run build
-```
-
-Common Playwright command:
-
-```powershell
-pnpm exec playwright test e2e/smoke.spec.ts
-```
-
-When testing against an already-running local dev server:
-
-```powershell
-$env:PLAYWRIGHT_BASE_URL='http://127.0.0.1:3001'
-$env:PLAYWRIGHT_SKIP_WEBSERVER='1'
-pnpm exec playwright test e2e/smoke.spec.ts
-```
-
-## Cursor Cloud specific instructions
-
-Dependencies are installed automatically by the startup update script (`pnpm install --frozen-lockfile` for the root frontend, `npm --prefix server install` for the backend). The two packages use **different package managers** - pnpm at the repo root, npm in `server/` - so they are installed separately and have separate lockfiles.
-
-Services (standard commands are in `README.md` / `package.json`):
-
-- **Frontend (the core product):** `pnpm run dev` → http://localhost:3000. This is sufficient on its own; forecast/verification/discussion data persists to browser `localStorage`, and no database is required.
-- **Analytics/billing backend (optional):** `cd server && npm start` → binds `127.0.0.1:3006`. Only needed for auth/billing/analytics/Sentry-tunnel flows. Vite proxies `/api` → `127.0.0.1:3006`, so start the backend if you exercise `/api`.
-
-Non-obvious notes:
-
-- **Lint:** there is no ESLint setup (no eslint dependency, no `lint` script). CI runs build, tests, `pnpm typecheck`, and `pnpm typecheck:test`. Do not expect a lint command; the closest static check is the Vite build plus `pnpm test`.
-- **Run `pnpm typecheck` for production type validation and `pnpm typecheck:test` for test-type regressions.** Jest executes TypeScript through Babel; the separate test check rejects diagnostics beyond the checked-in legacy baseline.
-- **Checks that mirror CI:** `pnpm run build` (frontend), `pnpm test` (Jest), and `cd server && npm test` (`node --test`). Run `pnpm test` from the repo root - running it from `server/` invokes the backend's test script instead.
-- pnpm reports "Ignored build scripts" for `esbuild`/`@sentry/cli`/etc.; the dev server and build still work fine via prebuilt platform binaries, so this warning is safe to ignore.
-- Firebase, Stripe, and Sentry are all optional and degrade gracefully when their env vars are absent; the app and backend boot without any secrets.
-
-## Communication
-
-- Keep updates short and concrete while working.
-- Tell the user what you changed and what passed.
-- Call out any verification that could not be run.
-- Mention unrelated dirty files only when they matter.
-- Do not bury the result under process narration.
-
-## GitHub PR and issue bodies
-
-When writing or updating PR descriptions, issue comments, or `gh pr create` / `gh pr edit` bodies:
-
-- Use real Markdown backticks for inline code: `` `ci.yml` ``, `` `$GITHUB_HEAD_REF` ``, `` `main` ``.
-- Never escape backticks for the shell (`\``) inside PR/issue bodies — that renders as garbage on GitHub.
-- On Windows/PowerShell, prefer `gh pr edit <n> --body-file path/to/body.md` (or a here-string written to a temp file) instead of passing `--body` with nested quotes and backticks on the command line.
-- Use normal Markdown structure: `##` headings, `- [ ]` checklists, and fenced code blocks only for multi-line snippets.
-- File paths and branch names belong in backticks; issue/PR references use `#123` without backticks.
-
-## Porting main → beta
-
-Use this when you need to land a **main** change on **beta** yourself, or when automated porting opened a draft conflict PR.
-
-### When automation runs
-
-| Merge | What happens |
-|-------|----------------|
-| `hotfix/*` → `main` | Automation opens a `[Port] … to beta` PR after merge |
-| `beta` → `main`, `release/*` → `main`, `feature/release-*` → `main` | Post-merge automation syncs beta directly (no port PR) |
-| Anything → `beta` | No downstream porting |
-
-### When to port manually
-
-- The user asks you to port before or instead of waiting on automation.
-- A `[Port][Conflicts]` draft PR has real code conflicts (not just version files).
-- You want the beta change reviewed and merged on your timeline.
-
-### Block duplicate automated ports
-
-Before merging the source PR on `main`, either:
-
-- Add the **`porting/manual`** label to that PR, or
-- Open a non-`port/*` PR to `beta` first (same head branch as the main PR, or title/body referencing `#<sourcePr>`).
-
-Automation detects both and skips creating a duplicate `port/*` PR.
-
-### Manual port workflow
-
-1. Branch from **`beta`** (not `main`).
-2. Cherry-pick or merge only the commits you need from the main PR.
-3. **Keep beta's versions** of `package.json`, lockfiles, `CHANGELOG.md`, and `deploy/production-release.json` unless the port intentionally changes dependencies.
-4. Open a PR **`your-branch → beta`**; include `Ports #<sourcePr>` in the title or body.
-5. Run targeted tests. Beta PRs follow normal changelog policy.
-6. Use a `port/*` branch only when finishing an automated draft port PR.
-
-### Resolving an automated draft port PR
-
-1. Check out `port/<n>-to-beta`.
-2. Fix remaining conflict markers (version-policy files are usually auto-resolved now).
-3. Mark the draft PR ready for review and merge when CI passes.
-4. Close any duplicate manual PR if automation already opened the port PR.
-
-### Do not
-
-- Fan out to `feature/*` branches (removed; not supported).
-- Open redundant `port/* → beta` PRs for merges post-merge already synced (CI blocks these via `scripts/lib/port-pr-policy.mjs`).
-- Push directly to `beta` for port work — always use a PR.
-
-Full release policy: [`docs/operations/release-workflow.md`](docs/operations/release-workflow.md). Key automation: [`.github/scripts/port-changes.sh`](.github/scripts/port-changes.sh), [`scripts/lib/port-targets.mjs`](scripts/lib/port-targets.mjs), [`scripts/lib/port-conflicts.mjs`](scripts/lib/port-conflicts.mjs).
-
+Anything else I can trust you to find what you need. The codebase isn't too hard to navigate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,12 @@ Currently there are 4 modes within GFC all serving a purpose:
 - **Monitor**: Once a user finishes their forecast they can monitor their forecast, this allows them to watch the latest radar, satellite, reports, and alerts while also viewing their forecast.
 - **Verification**: This allows the user to view their forecast and reflect on it's performance and find ways to learn and grow in their skills
 
+## Premium Model
+
+GFC does have a premium tier powered by Stripe. The idea behind premium is premium features are behind premium. Meaning if a feature will cost me money to operate that feature (ex. cloud storage) then that is a premium feature. No, running on a VPS doesn't count, that's a expected expense in operating the app, premium is built to try to bite some of that VPS cost out.
+
+If a feature is core, it's always free, no questions asked. If a feature is bonus and could cost money in just operating that feature, then it's in major premium conversations. Otherwise, default to free unless those conditions warrent.
+
 ## Message from the creator
 
 GFC is an important product. In a sense it is my "baby" project where it is extremely important to me. It may not have a ton of users but in the users it has it leaves an impact in the knowledge and skill growth of the user. It's important that those things stay freely available always.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,50 +5,50 @@
 - **GFC**: Shorthand for Graphical Forecast Creator
 - **me**: The one speaking to you
 - **you**: The agent reading this.
-- **user**: The person using GFC, who could be a meteorologist, student, or weather enthusiast
+- **user**: The person using GFC, could be a meteorologist, student, or weather enthusiest
 - **forecast**: What the user is creating in GFC
-- **owner / core maintainer / creator**: Wxboysuper/Weatherboysuper, the person writing this document and maintaining the project
+- **owner/ core maintainer/ creator**: Wxboysuper/Weatherboysuper, the one writing this document and the core maintainer of the project
 
 # GFC - Graphical Forecast Creator
 
-Graphical Forecast Creator is an application built to give weather enthusiasts the tools to build forecasts, monitor them, and reflect on their performance.
+Graphical Forecast Creator is a application built to give weather enthsiests alike the tools to build forecasts, monitor their forecasts, and reflect on their forecasts.
 
-### Why is GFC so important?
+## Why is GFC so important?
 
-GFC was created to give users an easy way to create forecasts and reflect on and learn about different weather events in a hands-on format where they are in the driver's seat of the forecasts they see almost every day.
+GFC was created to give users an easy way to create forecasts and reflect and learn about different weather events in a hands on format where they are in the drivers seat of the type of forecasts they see almost every day.
 
-Before GFC, users often had to create janky or unstable solutions for this task, such as manually drawing in Microsoft Paint or Photoshop, or using the public version of AWIPS, which is not modern enough for the average consumer. GFC set out to provide a modern solution.
+Before GFC users would have to create janky or sometimes unstable solutions to do this task. Like manually drawing in mspaint, or photoshop or using the public version of AWIPS which isn't modern at all for the average consumer. GFC set out to find a modern solution for users.
 
-For some users, GFC is a critical learning ground for understanding the atmosphere and predicting its behavior. That is why GFC and its core features should always remain freely available.
+To some this is a critical learning ground in their knowledge of the atmosphere and how to predict it. That's why having GFC and it's core features always and freely available is critical and that should always be maintained.
 
-### Where is GFC Available?
+## Where is GFC Available?
 
-GFC is available on the web at gfc.weatherboysuper.com and is accessible on any platform with a web browser. It is primarily built for desktop and large-screen users, with some mobile components.
+Right now GFC is available on the web at gfc.weatherboysuper.com and is accessible on any platform with a web browser, though it's primarily built for desktop/large screen users, it has some mobile components.
 
-### What can be done in GFC?
+## What can be done in GFC?
 
-GFC currently has four modes, each serving a distinct purpose:
+Currently there are 4 modes within GFC all serving a purpose:
 - **Forecast**: This is where the user builds a forecast
-- **Discussion**: This is where the user can build a text-based discussion to go along with their forecast
-- **Monitor**: Once a user finishes their forecast, they can monitor it while viewing the latest radar, satellite, reports, and alerts.
-- **Verification**: This allows the user to view their forecast, reflect on its performance, and find ways to learn and grow
+- **Discussion**: This is where the user can build a text based discussion to go along with their forecast
+- **Monitor**: Once a user finishes their forecast they can monitor their forecast, this allows them to watch the latest radar, satellite, reports, and alerts while also viewing their forecast.
+- **Verification**: This allows the user to view their forecast and reflect on it's performance and find ways to learn and grow in their skills
 
 ## Message from the creator
 
-GFC is an important product. In a sense, it is my "baby" project and is extremely important to me. It may not have many users, but it leaves an impact on the knowledge and skill growth of the users it does have. It is important that those benefits remain freely available.
+GFC is an important product. In a sense it is my "baby" project where it is extremely important to me. It may not have a ton of users but in the users it has it leaves an impact in the knowledge and skill growth of the user. It's important that those things stay freely available always.
 
-This project is also a learning experience for me as a developer. I am a meteorology student, not a computer science student, and I had never built an application used by others before GFC. There will be testing, experimentation, questions, and change. It is important to adapt quickly while keeping me and everyone developing on the project accountable. There may be architecture questions, and it is important to have an opinion and push back when a path is not right. We are not perfect, and we should always put the value of the product and its users first.
+But this project is a learning experience for me as a developer. I'm a student, no not in CS, in meteorology. I've never built a application used by users, and in such a large codebase with such importance in good code before. There will be lots of testing, lots of experimentation, lots of questions, and lots of changes. It's important to be able to quickly adapt, but also keep me and the people developing on this acocuntable. There may be architecture questions and it's important to have an opinion, and push back if it isn't the right path. We aren't perfect, and it's always important to put the value of the product and the users first when developing.
 
 ## Maintaining the Project
 
-GFC is open source. Keeping the code available to everyone is an intentional decision by the owner. It is a critical learning tool, and the owner cannot always maintain it alone, so leaving it open for others to understand and customize is important.
+GFC is open source. All the code is in the open. This is a decision by the owner as this is a project that should be available to everyone. It's a critical learning tool and also it's a project that sometimes the owner can't maintain himself but he doesn't have a team, so leaving it in the open to customize is important.
 
-The rules for maintaining the project change over time. If something seems off, use judgment and ask when needed. Keep building under the principles above, and test solutions with the tools appropriate to the task, including browsers, computer use, or Playwright when the product experience needs to be exercised.
+The rules regarding maintaining the project change all the time. If something seems off ask. Otherwise nowadays adding rules is outdated, it's important to keep building under the principles defined above. Always test your solutions, this isn't always static tests, but creating workflows and using tools to actually test the product (ex. browsers, computer use, playwright, etc.).
 
 ## Project Locations
-- `.github/` - GitHub resources
+- `.github/` - Github Resources
 - `docs/` - Documentation
-    - `docs/personal/` - A git-ignored directory for local maintainer documents. It may not exist, but it is the place for local plans, one-time documents, and other personal artifacts that should not be committed.
+    - `docs/personal/` - A git ignored directory for local docs for the local maintainer. It may or may not exist but is the place for things like local plans, one time documents, and other documents not to be commited.
 - `server/` - All backend code that runs on the VPS
 - `src/`
     - `src/components/` - All the different components used in GFC

--- a/CHANGELOG.beta.md
+++ b/CHANGELOG.beta.md
@@ -4,6 +4,10 @@ Development entries for pull requests targeting `beta`. These notes are consolid
 
 ## Unreleased
 
+### PR #792
+
+- Refresh `AGENTS.md` with durable GFC project context for modern coding agents.
+
 ### PR #790
 
 - Enable the new Forecast Grade verification page for beta testers while keeping staging and production disabled.


### PR DESCRIPTION
## Summary

- Replace the retired 219-line operational `AGENTS.md` with a lean project-context guide.
- Preserve the product mission, user impact, free/open-source principle, major GFC modes, and creator context that agents cannot infer from the codebase.
- Clarify wording and correct spelling without reintroducing command-by-command workflow guidance.

## Why

Modern agents can discover repository structure, package commands, Git workflows, and implementation patterns from the repository. The root instructions should instead provide durable product meaning and decision context; specialized workflows belong in callable skills or focused documentation.

## Validation

- `git diff --check`
- Documentation-only change; no application test suite was required.

## Scope

Only `AGENTS.md` is changed.
